### PR TITLE
chore: enforce Windows line endings for cross-platform consistency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,49 @@
+# Set default behavior to automatically normalize line endings to CRLF
+* text=auto eol=crlf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c text eol=crlf
+*.h text eol=crlf
+*.cpp text eol=crlf
+*.hpp text eol=crlf
+*.cs text eol=crlf
+*.xaml text eol=crlf
+*.xml text eol=crlf
+*.json text eol=crlf
+*.md text eol=crlf
+*.txt text eol=crlf
+*.yml text eol=crlf
+*.yaml text eol=crlf
+*.sln text eol=crlf
+*.csproj text eol=crlf
+*.vcxproj text eol=crlf
+*.props text eol=crlf
+*.targets text eol=crlf
+*.config text eol=crlf
+*.hconfig text eol=crlf
+*.proto text eol=crlf
+*.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.exe binary
+*.dll binary
+*.so binary
+*.a binary
+*.lib binary
+*.hex binary
+*.bin binary
+*.elf binary
+*.o binary
+*.obj binary
+
+# Preserve specific line endings where required
+Makefile text eol=lf
+makefile text eol=lf
+*.mk text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,4 +155,4 @@ A comprehensive technical analysis of the firmware has been completed and is ava
 - **Current SD**: ~2-5 MB/s → **Optimized**: 15-25 MB/s
 - **Current ADC**: ~1 kHz → **Optimized**: 10+ kHz sample rates
 
-The report includes detailed technical analysis, code examples, and a prioritized roadmap for optimization. Reference this document before making performance-critical modifications to understand current limitations and optimization opportunities.
+The report includes detailed technical analysis, code examples, and a prioritized roadmap for optimization. Reference this document before making performance-critical modifications to understand current limitations and optimization opportunities.


### PR DESCRIPTION
## Summary
Configures the repository to use Windows line endings (CRLF) for better cross-platform consistency.

## Changes
- Convert CLAUDE.md to use CRLF line endings
- Add .gitattributes file to enforce line ending rules

## Why Windows Line Endings?
Using CRLF ensures:
- Consistency across Windows development environments
- Better compatibility with Windows-based tools (MPLAB X, Visual Studio)
- Prevents line ending conflicts in pull requests
- Avoids "file changed" noise from line ending differences

## .gitattributes Configuration
- Text files: Automatically normalized to CRLF
- Shell scripts and makefiles: Preserved as LF (Unix requirement)
- Binary files: Left untouched

## Test plan
- [ ] Verify CLAUDE.md displays correctly in Windows editors
- [ ] Clone repository on Windows and verify line endings
- [ ] Clone repository on Linux/Mac and verify shell scripts still work
- [ ] Confirm no merge conflicts from line ending differences

## Breaking changes
None - only affects how files are checked out, not their content.

🤖 Generated with [Claude Code](https://claude.ai/code)