### PR TITLE
Fix SCPI error handling to prevent device hangs

### DIFF
--- a/firmware/src/libraries/scpi/libscpi/src/error.c
+++ b/firmware/src/libraries/scpi/libscpi/src/error.c
@@ -111,7 +111,9 @@ scpi_bool_t SCPI_ErrorPop(scpi_t * context, scpi_error_t * error) {
     SCPI_ERROR_SETVAL(error, 0, NULL);
     result = fifo_remove(&context->error_queue, error);
 
-    SCPI_ErrorEmitEmpty(context);
+    if (result) {
+        SCPI_ErrorEmitEmpty(context);
+    }
 
     return result;
 }

--- a/firmware/src/libraries/scpi/libscpi/src/error.c
+++ b/firmware/src/libraries/scpi/libscpi/src/error.c
@@ -106,13 +106,14 @@ void SCPI_ErrorClear(scpi_t * context) {
  * @return
  */
 scpi_bool_t SCPI_ErrorPop(scpi_t * context, scpi_error_t * error) {
+    scpi_bool_t result;
     if (!error || !context) return FALSE;
     SCPI_ERROR_SETVAL(error, 0, NULL);
-    fifo_remove(&context->error_queue, error);
+    result = fifo_remove(&context->error_queue, error);
 
     SCPI_ErrorEmitEmpty(context);
 
-    return TRUE;
+    return result;
 }
 
 /**

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -492,11 +492,11 @@ static scpi_result_t SCPI_USB_Flush(scpi_t * context) {
  */
 static int SCPI_USB_Error(scpi_t * context, int_fast16_t err) {
     char ip[100];
-    // If we wanted to do something in response to an error, we could do so here.
-    // I'm expecting the client to call 'SYSTem:ERRor?' if they want error information
-
-    sprintf(ip, "**ERROR: %d, \"%s\"\r\n", (int32_t) err, SCPI_ErrorTranslate(err));
-    context->interface->write(context, ip, strlen(ip));
+    // Don't print "No error" messages - err code 0 is used internally by SCPI lib
+    if (err != 0) {
+        sprintf(ip, "**ERROR: %d, \"%s\"\r\n", (int32_t) err, SCPI_ErrorTranslate(err));
+        context->interface->write(context, ip, strlen(ip));
+    }
     return 0;
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- Fixed infinite loop in `SCPI_ErrorPop` that was causing device hangs when unknown SCPI commands were entered
- Suppressed spurious "No error" messages in SCPI error output

## Details
The root cause was that `SCPI_ErrorPop` always returned TRUE even when the error queue was empty, causing an infinite loop in the error processing. The fix returns the actual result from `fifo_remove`.

Additionally, the SCPI library internally calls the error callback with err=0, which was causing "No error" messages to appear. These are now suppressed.

## Test plan
- [x] Verify unknown SCPI commands no longer hang the device
- [x] Verify proper error messages are displayed without spurious "No error" text
- [x] Test with commands like `poo`, `hello`, `test` that should return errors

Fixes #30

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix infinite loop in `SCPI_ErrorPop` causing device hangs

- Suppress spurious "No error" messages in SCPI output

- Return actual `fifo_remove` result instead of always TRUE

- Add error code check to prevent unnecessary error messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SCPI_ErrorPop"] --> B["fifo_remove result"]
  B --> C["Return actual result"]
  D["SCPI_USB_Error"] --> E["Check err != 0"]
  E --> F["Suppress 'No error' messages"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error.c</strong><dd><code>Fix SCPI error queue infinite loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/libraries/scpi/libscpi/src/error.c

<ul><li>Store <code>fifo_remove</code> result in local variable<br> <li> Return actual result instead of hardcoded TRUE<br> <li> Fix infinite loop in error queue processing</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/32/files#diff-a629f3d4ec543d5b1512f59a7681cb84eec79ac53a97feca8d3ee2363b74498c">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UsbCdc.c</strong><dd><code>Suppress spurious SCPI error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/services/UsbCdc/UsbCdc.c

<ul><li>Add error code check in <code>SCPI_USB_Error</code> callback<br> <li> Suppress "No error" messages when <code>err == 0</code><br> <li> Prevent spurious error output from SCPI library</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/32/files#diff-4be00b55e1c0f4e90190b1f3d6785eca700121c9e8816876b50d33c953b26c50">+724/-724</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

