### PR TITLE
fix: critical WiFi configuration issues

### DIFF
--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -149,7 +149,7 @@ bool ADC_TriggerConversion(const AInModule* module, MC12b_adcType_t adcChannelTy
 
     state = AINTASK_CONVSTART;
     BoardData_Set(
-            BOARDATA_AIN_MODULE,
+            BOARDDATA_AIN_MODULE,
             moduleId,
             &state);
 
@@ -164,7 +164,7 @@ bool ADC_TriggerConversion(const AInModule* module, MC12b_adcType_t adcChannelTy
 
     state = AINTASK_BUSY;
     BoardData_Set(
-            BOARDATA_AIN_MODULE,
+            BOARDDATA_AIN_MODULE,
             moduleId,
             &state);
 

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -101,7 +101,7 @@ static void app_WifiTask(void* p_arg) {
         APP_WIFI_STATE_WAIT_POWER_UP=0,
         APP_WIFI_STATE_PROCESS=1,
     };
-    const tPowerData *pPowerState=BoardData_Get(BOARDATA_POWER_DATA,0);
+    const tPowerData *pPowerState=BoardData_Get(BOARDDATA_POWER_DATA,0);
     uint8_t state = APP_WIFI_STATE_WAIT_POWER_UP;
     while (1) {     
         switch (state) {

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -112,7 +112,7 @@ static void app_WifiTask(void* p_arg) {
                         pPowerState->powerState != POWERED_UP_EXT_DOWN) {
                     state = APP_WIFI_STATE_WAIT_POWER_UP;
                 } else {
-                    wifi_manager_Init(&gpBoardData->wifiSettings);
+                    wifi_manager_Init(&gpBoardRuntimeConfig->wifiSettings);
                     state = APP_WIFI_STATE_PROCESS;
                 }
             }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -372,7 +372,7 @@ static scpi_result_t SCPI_SysLogClear(scpi_t * context) {
  */
 static scpi_result_t SCPI_BatteryStatusGet(scpi_t * context) {
     tPowerData *pPowerData = BoardData_Get(
-            BOARDATA_POWER_DATA,
+            BOARDDATA_POWER_DATA,
             0);
     SCPI_ResultInt32(context, (int) (pPowerData->externalPowerSource));
     return SCPI_RES_OK;
@@ -385,7 +385,7 @@ static scpi_result_t SCPI_BatteryStatusGet(scpi_t * context) {
  */
 static scpi_result_t SCPI_BatteryLevelGet(scpi_t * context) {
     tPowerData *pPowerData = BoardData_Get(
-            BOARDATA_POWER_DATA,
+            BOARDDATA_POWER_DATA,
             0);
     SCPI_ResultInt32(context, (int) (pPowerData->chargePct));
     return SCPI_RES_OK;
@@ -398,7 +398,7 @@ static scpi_result_t SCPI_BatteryLevelGet(scpi_t * context) {
  */
 static scpi_result_t SCPI_GetPowerState(scpi_t * context) {
     tPowerData *pPowerData = BoardData_Get(
-            BOARDATA_POWER_DATA,
+            BOARDDATA_POWER_DATA,
             0);
     SCPI_ResultInt32(context, (int) (pPowerData->powerState));
     return SCPI_RES_OK;
@@ -415,7 +415,7 @@ static scpi_result_t SCPI_SetPowerState(scpi_t * context) {
 
 
     tPowerData * pPowerData = BoardData_Get(
-            BOARDATA_POWER_DATA,
+            BOARDDATA_POWER_DATA,
             0);
 
     if (!SCPI_ParamInt32(context, &param1, TRUE)) {
@@ -425,13 +425,13 @@ static scpi_result_t SCPI_SetPowerState(scpi_t * context) {
     if (param1 != 0) {
         pPowerData->requestedPowerState = DO_POWER_UP;
         BoardData_Set(
-                BOARDATA_POWER_DATA,
+                BOARDDATA_POWER_DATA,
                 0,
                 pPowerData);
     } else {
         pPowerData->requestedPowerState = DO_POWER_DOWN;
         BoardData_Set(
-                BOARDATA_POWER_DATA,
+                BOARDDATA_POWER_DATA,
                 0,
                 pPowerData);
     }
@@ -675,7 +675,7 @@ scpi_result_t SCPI_Force5v5PowerStateSet(scpi_t * context) {
             BOARDRUNTIMECONFIG_ALL_CONFIG);
 
     tPowerData * pPowerData = BoardData_Get(
-            BOARDATA_POWER_DATA,
+            BOARDDATA_POWER_DATA,
             0);
 
     uint32_t param1;

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -316,9 +316,16 @@ scpi_result_t SCPI_LANMacGet(scpi_t * context) {
 }
 
 scpi_result_t SCPI_LANSsidGet(scpi_t * context) {
-    wifi_manager_settings_t * pWifiSettings = BoardData_Get(
-            BOARDDATA_WIFI_SETTINGS,
-            0);
+    // First try to get from runtime config (where uncommitted changes are stored)
+    wifi_manager_settings_t * pWifiSettings = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_WIFI_SETTINGS);
+    
+    // If runtime config is not available, fall back to BoardData
+    if (pWifiSettings == NULL) {
+        pWifiSettings = BoardData_Get(
+                BOARDDATA_WIFI_SETTINGS,
+                0);
+    }
 
     return SCPI_LANStringGetImpl(
             context,

--- a/firmware/src/state/data/BoardData.c
+++ b/firmware/src/state/data/BoardData.c
@@ -74,7 +74,7 @@ void *BoardData_Get(
         case BOARDDATA_DIO_SAMPLES:
             pRet= &g_BoardData.DIOSamples.List;
             break;
-        case BOARDATA_AIN_MODULE:
+        case BOARDDATA_AIN_MODULE:
             if (index < g_BoardData.AInState.Size) {
                 pRet= &g_BoardData.AInState.Data[ index ];
                 break;
@@ -101,7 +101,7 @@ void *BoardData_Get(
         case BOARDDATA_AIN_SAMPLES:
             pRet= &g_BoardData.AInSamples;
             break;
-        case BOARDATA_POWER_DATA:
+        case BOARDDATA_POWER_DATA:
             pRet= &g_BoardData.PowerData;
             break;
         case BOARDDATA_UI_VARIABLES:
@@ -151,7 +151,7 @@ void BoardData_Set(
                     pSetValue,
                     sizeof (g_BoardData.DIOSamples));
             break;
-        case BOARDATA_AIN_MODULE:
+        case BOARDDATA_AIN_MODULE:
             if (index < g_BoardData.AInState.Size) {
                 memcpy(
                         &g_BoardData.AInState.Data[ index ].AInTaskState,
@@ -179,7 +179,7 @@ void BoardData_Set(
                     pSetValue,
                     sizeof (HeapList));
             break;
-        case BOARDATA_POWER_DATA:
+        case BOARDDATA_POWER_DATA:
             memcpy(
                     &g_BoardData.PowerData,
                     pSetValue,

--- a/firmware/src/state/data/BoardData.h
+++ b/firmware/src/state/data/BoardData.h
@@ -37,7 +37,7 @@ extern "C" {
         //! DIO Samples list
         BOARDDATA_DIO_SAMPLES,
         //! State of the AIN module
-        BOARDATA_AIN_MODULE,
+        BOARDDATA_AIN_MODULE,
         //! Latest AIN SAMPLES
         BOARDDATA_AIN_LATEST,
         //! Latest AIN samples size
@@ -47,7 +47,7 @@ extern "C" {
         //! Collected analog input samples
         BOARDDATA_AIN_SAMPLES,
         //! Global power structure
-        BOARDATA_POWER_DATA,
+        BOARDDATA_POWER_DATA,
         //! UI Global structure
         BOARDDATA_UI_VARIABLES,
         //! Wifi settings


### PR DESCRIPTION
## Summary
- Fixed BOARDATA typo to BOARDDATA throughout codebase
- Fixed WiFi initialization to use runtime config instead of BoardData
- Fixed SSID getter to read from runtime config first

## Details
These critical fixes were missing from the main branch but were present in the `fix/wifi-settings-power-restriction` branch:

1. **BOARDATA typo fix**: Corrects long-standing typo in enum definitions (BOARDATA_POWER_DATA → BOARDDATA_POWER_DATA)
2. **WiFi initialization fix**: Ensures WiFi manager uses runtime config at startup instead of BoardData
3. **SSID getter fix**: Makes SSID queries return pending changes before they are applied

## Test plan
- [ ] Verify WiFi still initializes correctly on device power-up
- [ ] Test that SSID changes are visible immediately after setting (before APPLY)
- [ ] Confirm WiFi settings persist correctly after APPLY
- [ ] Test that power state transitions still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)