### PR TITLE
fix(adc): use sequential packing for analog data in protobuf encoder

### DIFF
--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -425,9 +425,10 @@ size_t Nanopb_Encode(tBoardData* state,
                         if (!pPublicSampleList->isSampleValid[i])
                             continue;
                         data = pPublicSampleList->sampleElement[i];
-                        if (data.Channel > maxDataIndex)
+                        if (message.analog_in_data_count > maxDataIndex)
                             continue;
-                        message.analog_in_data[data.Channel] = data.Value;
+                        // Use sequential packing like the old firmware
+                        message.analog_in_data[message.analog_in_data_count] = data.Value;
                         message.analog_in_data_count++;
                     }
 
@@ -641,7 +642,7 @@ size_t Nanopb_Encode(tBoardData* state,
                  * @brief Encodes the available range settings for analog input modules.
                  *
                  * This tag stores the supported voltage ranges for each analog input module,
-                 * indicating the possible ranges a module can operate within (e.g., 0-5V, ±10V).
+                 * indicating the possible ranges a module can operate within (e.g., 0-5V, ï¿½10V).
                  */
                 message.analog_in_port_av_range[0] =
                         pRuntimeAInModules->Data[AIn_MC12bADC].Range;


### PR DESCRIPTION
## Summary
- Changed analog_in_data array indexing from sparse (by channel ID) to sequential packing
- Matches old firmware behavior that was working correctly  
- Fixes channels 5-15 showing 0V or wrong values

## Root Cause
The firmware was changed at some point to use channel IDs as array indices instead of sequential packing. This caused data to appear in wrong positions when the receiving software expected sequential data.

**Old firmware (working):**
```c
uint32_t index = 0;
message.analog_in_data[index++] = aInData.Value;
```

**Current firmware (broken):**
```c
message.analog_in_data[data.Channel] = data.Value;
```

## Test Plan
- [ ] Enable all 16 ADC channels
- [ ] Apply test voltages to channels 5-15
- [ ] Verify correct voltage readings on all channels
- [ ] Verify no data appears on wrong channels

Fixes #22

🤖 Generated with [Claude Code](https://claude.ai/code)