### PR TITLE
fix(sd): enable SD card detection by increasing SPI client count

### DIFF
--- a/firmware/src/config/default/configuration.h
+++ b/firmware/src/config/default/configuration.h
@@ -182,7 +182,7 @@ extern "C" {
 
 /* SPI Driver Instance 0 Configuration Options */
 #define DRV_SPI_INDEX_0                       0
-#define DRV_SPI_CLIENTS_NUMBER_IDX0           1
+#define DRV_SPI_CLIENTS_NUMBER_IDX0           2
 #define DRV_SPI_DMA_MODE
 #define DRV_SPI_XMIT_DMA_CH_IDX0              SYS_DMA_CHANNEL_0
 #define DRV_SPI_RCV_DMA_CH_IDX0               SYS_DMA_CHANNEL_1

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -171,7 +171,7 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
     }
     
     // Check if SD card is actually present and mounted
-    if (!SYS_FS_MEDIA_MANAGER_MediaStatusGet("/mnt/Daqifi")) {
+    if (!SYS_FS_MEDIA_MANAGER_MediaStatusGet("/dev/mmcblka1")) {
         // Log the error but send nothing - SCPI handler adds termination
         LOG_E("SD:LIST? - No SD card detected\r\n");
         result = SCPI_RES_OK;
@@ -272,7 +272,7 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
     }
     
     // Double-check that SD card is actually present
-    if (!SYS_FS_MEDIA_MANAGER_MediaStatusGet("/mnt/Daqifi")) {
+    if (!SYS_FS_MEDIA_MANAGER_MediaStatusGet("/dev/mmcblka1")) {
         context->interface->write(context, SD_CARD_NOT_PRESENT_ERROR_MSG, strlen(SD_CARD_NOT_PRESENT_ERROR_MSG));
         result = SCPI_RES_ERR;
         goto __exit_point;


### PR DESCRIPTION
## Summary
This PR fixes the fundamental SD card detection issue by increasing the SPI driver client count from 1 to 2, allowing both WiFi and SD card modules to share the SPI bus.

## Root Cause
The SPI driver was configured to support only 1 client (`DRV_SPI_CLIENTS_NUMBER_IDX0 = 1`), but both the WiFi module (WINC) and SD card (SDSPI) need to access the same SPI bus (index 0). This prevented the SD card driver from opening the SPI interface, causing all SD operations to fail.

## Changes
1. **SPI client count fix**: Changed `DRV_SPI_CLIENTS_NUMBER_IDX0` from 1 to 2 in configuration.h
2. **Media detection path fix**: Updated media status checks to use device path `/dev/mmcblka1` instead of mount point

## Test Results
- ✅ SD card now detected properly on power-up
- ✅ SD card operations (write, read) working correctly
- ✅ Both Koonton and SanDisk cards tested successfully
- ✅ WiFi and SD mutual exclusion maintained (cannot use simultaneously)

## Technical Details
The WiFi and SD card modules share SPI index 0. With only 1 client slot available, whichever module initialized first would lock out the other. Increasing to 2 clients allows both to open the SPI driver, though they still require mutual exclusion during operation.

## Testing Steps
1. Program device with this firmware
2. Insert SD card (FAT32 formatted)
3. Power on and check SD detection: `SYST:STOR:SD:ENA 1`
4. Verify SD operations work

Fixes #66

🤖 Generated with [Claude Code](https://claude.ai/code)