### PR TITLE
feat(buffer): upgrade circular buffer to support 128KB+ sizes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -70,8 +70,7 @@
       "Bash(/tmp/test_sd_performance.sh:*)",
       "Bash(/tmp/test_sd_improvements.sh:*)",
       "Bash(/tmp/debug_sd_test.sh:*)",
-      "Bash(/tmp/test_sd_perf_128kb.sh:*)",
-      "Bash(git cherry-pick:*)"
+      "Bash(/tmp/test_sd_perf_128kb.sh:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -65,7 +65,13 @@
       "Bash(/mnt/c/Users/User/Documents/GitHub/daqifi-nyquist-firmware/sd_card_benchmark.sh \"SanDisk 256GB Extreme PRO microSD A2\")",
       "Bash(/tmp/random_pattern_baseline.sh:*)",
       "Bash(/tmp/test_mutex_comprehensive.sh:*)",
-      "Bash(/tmp/test_specific_mutex.sh:*)"
+      "Bash(/tmp/test_specific_mutex.sh:*)",
+      "Bash(./sd_card_benchmark.sh:*)",
+      "Bash(/tmp/test_sd_performance.sh:*)",
+      "Bash(/tmp/test_sd_improvements.sh:*)",
+      "Bash(/tmp/debug_sd_test.sh:*)",
+      "Bash(/tmp/test_sd_perf_128kb.sh:*)",
+      "Bash(git cherry-pick:*)"
     ],
     "deny": []
   }

--- a/firmware/src/Util/CircularBuffer.c
+++ b/firmware/src/Util/CircularBuffer.c
@@ -33,7 +33,7 @@
 #define BUF_START   cirbuf->buf_ptr
 #define BUF_END    (cirbuf->buf_ptr + cirbuf->buf_size - 1)
 
-void CircularBuf_Init(CircularBuf_t* cirbuf, int(*fp)(uint8_t*,uint16_t), uint16_t size)
+void CircularBuf_Init(CircularBuf_t* cirbuf, int(*fp)(uint8_t*,uint32_t), uint32_t size)
 {
     cirbuf->buf_ptr                = OSAL_Malloc(size);
     cirbuf->process_callback       = fp;
@@ -54,10 +54,10 @@ void CircularBuf_Init(CircularBuf_t* cirbuf, int(*fp)(uint8_t*,uint16_t), uint16
  *           while we are reading it, we read until we get the same answer twice in a row.  
  *           This method allows us to get a good reading without turning off interrupts to do it.
  *===========================================================================*/
-uint16_t CircularBuf_NumBytesAvailable(CircularBuf_t* cirbuf)
+uint32_t CircularBuf_NumBytesAvailable(CircularBuf_t* cirbuf)
 {
 
-    uint16_t num1,num2;
+    uint32_t num1,num2;
     do{
       num1 = cirbuf->totalBytes;
       num2 = cirbuf->totalBytes;
@@ -66,16 +66,16 @@ uint16_t CircularBuf_NumBytesAvailable(CircularBuf_t* cirbuf)
     return num1;
 }
 
-uint16_t CircularBuf_NumBytesFree(CircularBuf_t* cirbuf)
+uint32_t CircularBuf_NumBytesFree(CircularBuf_t* cirbuf)
 {
     return (cirbuf->buf_size - CircularBuf_NumBytesAvailable(cirbuf));
 }
 
 
-uint16_t CircularBuf_ProcessBytes(CircularBuf_t* cirbuf, uint8_t* bytesBuf, uint16_t maxBytes, int* error)
+uint32_t CircularBuf_ProcessBytes(CircularBuf_t* cirbuf, uint8_t* bytesBuf, uint32_t maxBytes, int* error)
 {
-    uint16_t bytesToSend  = 0;
-    uint16_t bytesRemoved = 0; 
+    uint32_t bytesToSend  = 0;
+    uint32_t bytesRemoved = 0; 
     *error = 0;
    
     bytesToSend = min(CircularBuf_NumBytesAvailable(cirbuf), maxBytes);
@@ -87,8 +87,8 @@ uint16_t CircularBuf_ProcessBytes(CircularBuf_t* cirbuf, uint8_t* bytesBuf, uint
             //start next transfer
             //make sure we don't transfer the out of bound data.
             if((cirbuf->removePtr + bytesToSend) > BUF_END){
-                uint16_t chunk1 = 0;
-                uint16_t chunk2 = 0;
+                uint32_t chunk1 = 0;
+                uint32_t chunk2 = 0;
 
                 // transfer the first part of data
                 chunk1 = (BUF_END - cirbuf->removePtr + 1);
@@ -145,7 +145,7 @@ uint16_t CircularBuf_ProcessBytes(CircularBuf_t* cirbuf, uint8_t* bytesBuf, uint
   CircularBuf_AddBytes
   Send out CF UDP Server message. Returns number of bytes sent.
   =====================================================================================*/
-uint16_t CircularBuf_AddBytes(CircularBuf_t* cirbuf, uint8_t* bytesBuf, uint16_t bytesToSend)
+uint32_t CircularBuf_AddBytes(CircularBuf_t* cirbuf, uint8_t* bytesBuf, uint32_t bytesToSend)
 {
     int numBytesCopied = 0;
     int wMaxPut;

--- a/firmware/src/Util/CircularBuffer.c
+++ b/firmware/src/Util/CircularBuffer.c
@@ -56,7 +56,10 @@ void CircularBuf_Init(CircularBuf_t* cirbuf, int(*fp)(uint8_t*,uint32_t), uint32
  *===========================================================================*/
 uint32_t CircularBuf_NumBytesAvailable(CircularBuf_t* cirbuf)
 {
-
+    // Note: This double-read pattern ensures we get a consistent value even if
+    // totalBytes is modified by an interrupt during the read. On PIC32MZ (32-bit
+    // MIPS), reading a 32-bit value is atomic, but this pattern provides extra
+    // safety and works correctly on both 16-bit and 32-bit architectures.
     uint32_t num1,num2;
     do{
       num1 = cirbuf->totalBytes;

--- a/firmware/src/Util/CircularBuffer.h
+++ b/firmware/src/Util/CircularBuffer.h
@@ -34,18 +34,18 @@ typedef struct s_CircularBuf
 {
     uint8_t*    insertPtr;
     uint8_t*    removePtr;
-    uint16_t    totalBytes;
+    uint32_t    totalBytes;
     uint8_t*    buf_ptr;
-    uint16_t    buf_size;
-    int        (*process_callback)(uint8_t*, uint16_t);
+    uint32_t    buf_size;
+    int        (*process_callback)(uint8_t*, uint32_t);
 }CircularBuf_t;
 
 
-void     CircularBuf_Init(CircularBuf_t*, int (*fp)(uint8_t*,uint16_t), uint16_t);
-uint16_t CircularBuf_AddBytes(CircularBuf_t*, uint8_t*, uint16_t);
-uint16_t CircularBuf_NumBytesAvailable(CircularBuf_t*);
-uint16_t CircularBuf_NumBytesFree(CircularBuf_t*);
-uint16_t CircularBuf_ProcessBytes(CircularBuf_t*,uint8_t*, uint16_t,int*);
+void     CircularBuf_Init(CircularBuf_t*, int (*fp)(uint8_t*,uint32_t), uint32_t);
+uint32_t CircularBuf_AddBytes(CircularBuf_t*, uint8_t*, uint32_t);
+uint32_t CircularBuf_NumBytesAvailable(CircularBuf_t*);
+uint32_t CircularBuf_NumBytesFree(CircularBuf_t*);
+uint32_t CircularBuf_ProcessBytes(CircularBuf_t*,uint8_t*, uint32_t,int*);
 void CircularBuf_Reset(CircularBuf_t* cirbuf);
     /* Provide C++ Compatibility */
 #ifdef __cplusplus

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -292,7 +292,11 @@ void UsbCdc_EventHandler(USB_DEVICE_EVENT event, void * eventData, uintptr_t con
 }
 
 int UsbCdc_Wrapper_Write(uint8_t* buf, uint32_t len) {
-
+    // Validate length against buffer size to prevent overflow
+    if (len > USBCDC_WBUFFER_SIZE) {
+        return -1;  // Buffer too small
+    }
+    
     memcpy(gRunTimeUsbSttings.writeBuffer, buf, len);
     gRunTimeUsbSttings.writeBufferLength = len;
     USB_DEVICE_CDC_RESULT writeResult = USB_DEVICE_CDC_Write(USB_DEVICE_CDC_INDEX_0,

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -291,7 +291,7 @@ void UsbCdc_EventHandler(USB_DEVICE_EVENT event, void * eventData, uintptr_t con
     }
 }
 
-int UsbCdc_Wrapper_Write(uint8_t* buf, uint16_t len) {
+int UsbCdc_Wrapper_Write(uint8_t* buf, uint32_t len) {
 
     memcpy(gRunTimeUsbSttings.writeBuffer, buf, len);
     gRunTimeUsbSttings.writeBufferLength = len;

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -297,7 +297,12 @@ int UsbCdc_Wrapper_Write(uint8_t* buf, uint32_t len) {
         return -1;  // Buffer too small
     }
     
-    memcpy(gRunTimeUsbSttings.writeBuffer, buf, len);
+    // Validate buffer pointer to prevent null dereference
+    if (len > 0 && buf == NULL) {
+        return -1;  // Invalid buffer pointer
+    }
+    
+    memcpy(gRunTimeUsbSttings.writeBuffer, buf, (size_t)len);
     gRunTimeUsbSttings.writeBufferLength = len;
     USB_DEVICE_CDC_RESULT writeResult = USB_DEVICE_CDC_Write(USB_DEVICE_CDC_INDEX_0,
             &gRunTimeUsbSttings.writeTransferHandle,

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -280,7 +280,7 @@ void sd_card_manager_ProcessState() {
                         (SYS_FS_FILE_OPEN_APPEND_PLUS));
                 gSdCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE;
                 gSdCardData.totalBytesFlushPending = 0;
-                gSdCardData.lastFlushMillis = xTaskGetTickCount() * portTICK_PERIOD_MS;
+                gSdCardData.lastFlushMillis = pdTICKS_TO_MS(xTaskGetTickCount());
             } else if (gpSdCardSettings->mode == SD_CARD_MANAGER_MODE_READ) {
                 gSdCardData.fileHandle = SYS_FS_FileOpen(gSdCardData.filePath,
                         (SYS_FS_FILE_OPEN_READ));
@@ -348,7 +348,7 @@ void sd_card_manager_ProcessState() {
                     }
                 }
             }
-            uint64_t currentMillis = xTaskGetTickCount() * portTICK_PERIOD_MS;
+            uint64_t currentMillis = pdTICKS_TO_MS(xTaskGetTickCount());
 
             xSemaphoreTake(gSdCardData.wMutex, portMAX_DELAY);
             bool needsFlush = (currentMillis - gSdCardData.lastFlushMillis > 5000 ||
@@ -456,7 +456,7 @@ size_t sd_card_manager_WriteToBuffer(const char* pData, size_t len) {
     // Wait for buffer space with mutex protection and timeout
     bool hasSpace = false;
     TickType_t startTime = xTaskGetTickCount();
-    TickType_t timeoutTicks = SD_CARD_MANAGER_WRITE_TIMEOUT_MS / portTICK_PERIOD_MS;
+    TickType_t timeoutTicks = pdMS_TO_TICKS(SD_CARD_MANAGER_WRITE_TIMEOUT_MS);
     
     while (!hasSpace) {
         // Check buffer space with mutex protection
@@ -470,7 +470,7 @@ size_t sd_card_manager_WriteToBuffer(const char* pData, size_t len) {
                 LOG_E("SD: WriteToBuffer timeout - buffer full for %u ms", SD_CARD_MANAGER_WRITE_TIMEOUT_MS);
                 return 0;
             }
-            vTaskDelay(SD_CARD_MANAGER_WRITE_WAIT_INTERVAL_MS / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(SD_CARD_MANAGER_WRITE_WAIT_INTERVAL_MS));
         }
     }
     

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2,7 +2,7 @@
 #include "Util/Logger.h"
 #include "sd_card_manager.h"
 
-#define SD_CARD_MANAGER_CIRCULAR_BUFFER_SIZE (SD_CARD_MANAGER_CONF_WBUFFER_SIZE*12)  // 60KB total
+#define SD_CARD_MANAGER_CIRCULAR_BUFFER_SIZE (128 * 1024)  // 128KB buffer
 #define SD_CARD_MANAGER_FILE_PATH_LEN_MAX (SYS_FS_FILE_NAME_LEN*2)
 #define SD_CARD_MANAGER_DISK_MOUNT_NAME    "/mnt/Daqifi"
 #define SD_CARD_MANAGER_DISK_DEV_NAME      "/dev/mmcblka1"
@@ -71,7 +71,7 @@ __exit:
     return writeLen;
 }
 
-static int CircularBufferToSDWrite(uint8_t* buf, uint16_t len) {
+static int CircularBufferToSDWrite(uint8_t* buf, uint32_t len) {
     if (len>sizeof (gSdCardData.writeBuffer))
         return false;
     memcpy(gSdCardData.writeBuffer, buf, len);

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -17,10 +17,10 @@
 #define SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX 40
 
 // Performance tuning parameters
-#define SD_CARD_MANAGER_WRITE_TIMEOUT_MS 2000    // Timeout for WriteToBuffer operation
-#define SD_CARD_MANAGER_WRITE_WAIT_INTERVAL_MS 10 // Wait interval when buffer is full
-#define SD_CARD_MANAGER_MAX_CHUNKS_PER_CYCLE 4   // Max chunks to process per task cycle (4 * 5KB = 20KB)
-#define SD_CARD_MANAGER_TASK_DELAY_MS 1          // Task delay for SD card processing (reduced from 5ms)
+#define SD_CARD_MANAGER_WRITE_TIMEOUT_MS 2000      // Timeout for WriteToBuffer operation
+#define SD_CARD_MANAGER_WRITE_WAIT_INTERVAL_MS 10  // Wait interval when buffer is full
+#define SD_CARD_MANAGER_MAX_CHUNKS_PER_CYCLE 4     // Max chunks to process per task cycle (4 * 5KB = 20KB)
+#define SD_CARD_MANAGER_TASK_DELAY_MS 1            // Task delay for SD card processing (reduced from 5ms)
 
 
 /* Provide C++ Compatibility */

--- a/firmware/src/services/wifi_services/wifi_tcp_server.c
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.c
@@ -256,7 +256,7 @@ static int microrl_commandComplete(microrl_t* context, size_t commandLen, const 
     return -1;
 }
 
-static int CircularBufferToTcpWrite(uint8_t* buf, uint16_t len) {
+static int CircularBufferToTcpWrite(uint8_t* buf, uint32_t len) {
 
     if (len>sizeof (gpServerData->client.writeBuffer))
         return false;

--- a/firmware/src/services/wifi_services/wifi_tcp_server.c
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.c
@@ -257,8 +257,8 @@ static int microrl_commandComplete(microrl_t* context, size_t commandLen, const 
 }
 
 static int CircularBufferToTcpWrite(uint8_t* buf, uint32_t len) {
-
-    if (len>sizeof (gpServerData->client.writeBuffer))
+    // Validate length against buffer size to prevent overflow
+    if (len > sizeof(gpServerData->client.writeBuffer))
         return false;
     memcpy(gpServerData->client.writeBuffer, buf, len);
     gpServerData->client.writeBufferLength = len;

--- a/firmware/src/shared/CircularBuf_Safe.h
+++ b/firmware/src/shared/CircularBuf_Safe.h
@@ -25,6 +25,7 @@
 #include "FreeRTOS.h"
 #include "semphr.h"
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -90,6 +91,10 @@ static inline size_t CircularBuf_TryAddBytes_Safe(CircularBuf_t* buf, SemaphoreH
                                                   uint8_t* data, size_t len,
                                                   TickType_t timeoutMs, 
                                                   unsigned int waitIntervalMs) {
+    // Guard against potential size_t to uint32_t truncation
+    if (len > UINT32_MAX) {
+        return 0;
+    }
     uint32_t len32 = (uint32_t)len;
     TickType_t startTicks = xTaskGetTickCount();
     TickType_t timeoutTicks = (timeoutMs == portMAX_DELAY) ? portMAX_DELAY : pdMS_TO_TICKS(timeoutMs);
@@ -193,6 +198,10 @@ static inline bool CircularBuf_HasData_Safe(CircularBuf_t* buf, SemaphoreHandle_
  */
 static inline size_t CircularBuf_AddBytesIfSpace_Safe(CircularBuf_t* buf, SemaphoreHandle_t mutex,
                                                       uint8_t* data, size_t len) {
+    // Guard against potential size_t to uint32_t truncation
+    if (len > UINT32_MAX) {
+        return 0;
+    }
     uint32_t len32 = (uint32_t)len;
     xSemaphoreTake(mutex, portMAX_DELAY);
     if (CircularBuf_NumBytesFree(buf) < len32) {

--- a/firmware/src/shared/CircularBuf_Safe.h
+++ b/firmware/src/shared/CircularBuf_Safe.h
@@ -36,9 +36,9 @@ extern "C" {
  * @param mutex Mutex protecting the buffer
  * @return Number of free bytes
  */
-static inline uint16_t CircularBuf_GetFreeSize_Safe(CircularBuf_t* buf, SemaphoreHandle_t mutex) {
+static inline uint32_t CircularBuf_GetFreeSize_Safe(CircularBuf_t* buf, SemaphoreHandle_t mutex) {
     xSemaphoreTake(mutex, portMAX_DELAY);
-    uint16_t freeSize = CircularBuf_NumBytesFree(buf);
+    uint32_t freeSize = CircularBuf_NumBytesFree(buf);
     xSemaphoreGive(mutex);
     return freeSize;
 }
@@ -49,9 +49,9 @@ static inline uint16_t CircularBuf_GetFreeSize_Safe(CircularBuf_t* buf, Semaphor
  * @param mutex Mutex protecting the buffer
  * @return Number of available bytes
  */
-static inline uint16_t CircularBuf_GetAvailableSize_Safe(CircularBuf_t* buf, SemaphoreHandle_t mutex) {
+static inline uint32_t CircularBuf_GetAvailableSize_Safe(CircularBuf_t* buf, SemaphoreHandle_t mutex) {
     xSemaphoreTake(mutex, portMAX_DELAY);
-    uint16_t availSize = CircularBuf_NumBytesAvailable(buf);
+    uint32_t availSize = CircularBuf_NumBytesAvailable(buf);
     xSemaphoreGive(mutex);
     return availSize;
 }
@@ -64,10 +64,10 @@ static inline uint16_t CircularBuf_GetAvailableSize_Safe(CircularBuf_t* buf, Sem
  * @param len Number of bytes to add
  * @return Number of bytes actually added
  */
-static inline uint16_t CircularBuf_AddBytes_Safe(CircularBuf_t* buf, SemaphoreHandle_t mutex,
-                                               uint8_t* data, uint16_t len) {
+static inline uint32_t CircularBuf_AddBytes_Safe(CircularBuf_t* buf, SemaphoreHandle_t mutex,
+                                               uint8_t* data, uint32_t len) {
     xSemaphoreTake(mutex, portMAX_DELAY);
-    uint16_t bytesAdded = CircularBuf_AddBytes(buf, data, len);
+    uint32_t bytesAdded = CircularBuf_AddBytes(buf, data, len);
     xSemaphoreGive(mutex);
     return bytesAdded;
 }
@@ -81,22 +81,16 @@ static inline uint16_t CircularBuf_AddBytes_Safe(CircularBuf_t* buf, SemaphoreHa
  * @param buf Pointer to the circular buffer
  * @param mutex Mutex protecting the buffer
  * @param data Pointer to data to add
- * @param len Number of bytes to add (must be <= 0xFFFF)
+ * @param len Number of bytes to add
  * @param timeoutMs Maximum time to wait in milliseconds (use portMAX_DELAY for infinite wait)
  * @param waitIntervalMs Interval between checks in milliseconds
- * @return Number of bytes actually added (0 if timeout or len > 0xFFFF)
+ * @return Number of bytes actually added (0 if timeout)
  */
 static inline size_t CircularBuf_TryAddBytes_Safe(CircularBuf_t* buf, SemaphoreHandle_t mutex,
                                                   uint8_t* data, size_t len,
                                                   TickType_t timeoutMs, 
                                                   unsigned int waitIntervalMs) {
-    // Reject requests larger than circular buffer can handle (16-bit limit)
-    // This prevents overflow when converting size_t to uint16_t
-    if (len > 0xFFFF) {
-        return 0;
-    }
-    
-    uint16_t len16 = (uint16_t)len;
+    uint32_t len32 = (uint32_t)len;
     TickType_t startTicks = xTaskGetTickCount();
     TickType_t timeoutTicks = (timeoutMs == portMAX_DELAY) ? portMAX_DELAY : pdMS_TO_TICKS(timeoutMs);
     TickType_t waitTicks = pdMS_TO_TICKS(waitIntervalMs);
@@ -117,9 +111,9 @@ static inline size_t CircularBuf_TryAddBytes_Safe(CircularBuf_t* buf, SemaphoreH
         }
         
         xSemaphoreTake(mutex, portMAX_DELAY);
-        if (CircularBuf_NumBytesFree(buf) >= len16) {
+        if (CircularBuf_NumBytesFree(buf) >= len32) {
             // Space available, add the data
-            uint16_t bytesAdded = CircularBuf_AddBytes(buf, data, len16);
+            uint32_t bytesAdded = CircularBuf_AddBytes(buf, data, len32);
             xSemaphoreGive(mutex);
             return (size_t)bytesAdded;
         }
@@ -146,7 +140,7 @@ static inline size_t CircularBuf_TryAddBytes_Safe(CircularBuf_t* buf, SemaphoreH
 static inline bool CircularBuf_ProcessIfAvailable_Safe(CircularBuf_t* buf, 
                                                        SemaphoreHandle_t mutex,
                                                        uint8_t* userData,
-                                                       uint16_t maxBytes,
+                                                       uint32_t maxBytes,
                                                        int* result) {
     xSemaphoreTake(mutex, portMAX_DELAY);
     bool hasData = (CircularBuf_NumBytesAvailable(buf) > 0);
@@ -166,12 +160,8 @@ static inline bool CircularBuf_ProcessIfAvailable_Safe(CircularBuf_t* buf,
  */
 static inline bool CircularBuf_HasSpace_Safe(CircularBuf_t* buf, SemaphoreHandle_t mutex,
                                              size_t requiredSpace) {
-    // Reject if required space exceeds what buffer can report
-    if (requiredSpace > 0xFFFF) {
-        return false;
-    }
     xSemaphoreTake(mutex, portMAX_DELAY);
-    bool hasSpace = (CircularBuf_NumBytesFree(buf) >= (uint16_t)requiredSpace);
+    bool hasSpace = (CircularBuf_NumBytesFree(buf) >= (uint32_t)requiredSpace);
     xSemaphoreGive(mutex);
     return hasSpace;
 }
@@ -198,24 +188,18 @@ static inline bool CircularBuf_HasData_Safe(CircularBuf_t* buf, SemaphoreHandle_
  * @param buf Pointer to the circular buffer
  * @param mutex Mutex protecting the buffer
  * @param data Pointer to data to add
- * @param len Number of bytes to add (must be <= 0xFFFF)
- * @return Number of bytes added (0 if insufficient space or len > 0xFFFF)
+ * @param len Number of bytes to add
+ * @return Number of bytes added (0 if insufficient space)
  */
 static inline size_t CircularBuf_AddBytesIfSpace_Safe(CircularBuf_t* buf, SemaphoreHandle_t mutex,
                                                       uint8_t* data, size_t len) {
-    // Reject requests larger than circular buffer can handle (16-bit limit)
-    // This prevents overflow when converting size_t to uint16_t
-    if (len > 0xFFFF) {
-        return 0;
-    }
-    
-    uint16_t len16 = (uint16_t)len;
+    uint32_t len32 = (uint32_t)len;
     xSemaphoreTake(mutex, portMAX_DELAY);
-    if (CircularBuf_NumBytesFree(buf) < len16) {
+    if (CircularBuf_NumBytesFree(buf) < len32) {
         xSemaphoreGive(mutex);
         return 0;
     }
-    uint16_t bytesAdded = CircularBuf_AddBytes(buf, data, len16);
+    uint32_t bytesAdded = CircularBuf_AddBytes(buf, data, len32);
     xSemaphoreGive(mutex);
     return (size_t)bytesAdded;
 }
@@ -239,7 +223,7 @@ static inline void CircularBuf_Clear_Safe(CircularBuf_t* buf, SemaphoreHandle_t 
  * 
  * @param buf Pointer to the circular buffer
  * @param mutex Mutex protecting the buffer
- * @return Number of free bytes as size_t (still limited to 64KB max)
+ * @return Number of free bytes as size_t
  */
 static inline size_t CircularBuf_GetFreeSize_Safe_SizeT(CircularBuf_t* buf, SemaphoreHandle_t mutex) {
     return (size_t)CircularBuf_GetFreeSize_Safe(buf, mutex);

--- a/sd_card_benchmark.sh
+++ b/sd_card_benchmark.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+# DAQiFi SD Card Benchmark Script
+# 
+# This script tests SD card write performance at various sizes using the
+# SYST:STOR:SD:BENCH SCPI command. It handles device initialization,
+# WiFi disabling, and SD card enabling.
+#
+# Usage: ./sd_card_benchmark.sh [card_description]
+# Example: ./sd_card_benchmark.sh "SanDisk Ultra 32GB"
+
+DEVICE="/dev/ttyACM0"
+CARD_DESC="${1:-Unknown SD Card}"
+SIZES=(1 5 10 25 50 100 250 500 750 1024)
+
+# Color codes for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "=========================================="
+echo "DAQiFi SD Card Performance Benchmark"
+echo "=========================================="
+echo "Date: $(date)"
+echo "Card: $CARD_DESC"
+echo ""
+
+# Check if device exists
+if [ ! -e "$DEVICE" ]; then
+    echo -e "${RED}Error: Device $DEVICE not found${NC}"
+    echo "Please ensure the DAQiFi device is connected and attached to WSL"
+    exit 1
+fi
+
+# Function to send SCPI command and check response
+send_scpi() {
+    local cmd="$1"
+    local wait="${2:-1}"
+    local timeout="${3:-2000}"
+    echo -e "${YELLOW}Sending: $cmd${NC}"
+    result=$(echo -e "$cmd\r" | picocom -b 115200 -q -x $timeout $DEVICE 2>&1)
+    echo "$result" | tail -10
+    sleep $wait
+}
+
+echo -e "${GREEN}Step 1: Checking device connection...${NC}"
+send_scpi "*IDN?" 0.5
+
+echo -e "\n${GREEN}Step 2: Powering up device...${NC}"
+send_scpi "SYST:POW:STAT 2" 3
+
+echo -e "\n${GREEN}Step 3: Disabling WiFi (required for SD card access)...${NC}"
+send_scpi "SYST:COMM:LAN:ENABLED 0" 1
+send_scpi "SYST:COMM:LAN:APPLY" 2
+
+echo -e "\n${GREEN}Step 4: Enabling SD card...${NC}"
+send_scpi "SYST:STOR:SD:ENABLE 1" 2
+
+echo -e "\n${GREEN}Step 5: Enabling SD logging mode...${NC}"
+send_scpi "SYST:STOR:SD:LOGGING 1" 1
+
+echo -e "\n${GREEN}Step 6: Running benchmark tests...${NC}"
+echo ""
+echo "| Test Size | Time (ms) | Speed (bytes/sec) | Speed (KB/s) | Speed (MB/s) | Status      |"
+echo "|-----------|-----------|-------------------|--------------|--------------|-------------|"
+
+# Run benchmark tests
+for size in "${SIZES[@]}"; do
+    printf "| %-9s | " "${size} KB"
+    
+    # Run benchmark command with pattern 0 (zeros)
+    # Timeout is set based on size (larger sizes need more time)
+    timeout_ms=$((6000 + size * 10))
+    result=$(echo -e "SYST:STOR:SD:BENCH $size,0\r" | picocom -b 115200 -q -x $timeout_ms $DEVICE 2>&1)
+    
+    # Check for various response patterns
+    if echo "$result" | grep -q "Benchmark complete:"; then
+        # Success - extract results
+        complete_line=$(echo "$result" | grep "Benchmark complete:" | tail -1)
+        bytes=$(echo "$complete_line" | sed -n 's/.*complete: \([0-9]\+\) bytes.*/\1/p')
+        time_ms=$(echo "$complete_line" | sed -n 's/.*in \([0-9]\+\) ms.*/\1/p')
+        speed_bps=$(echo "$complete_line" | sed -n 's/.*= \([0-9]\+\) bytes\/sec.*/\1/p')
+        
+        if [[ -n "$time_ms" && -n "$speed_bps" ]]; then
+            speed_kbs=$(awk "BEGIN {printf \"%.1f\", $speed_bps / 1024}")
+            speed_mbs=$(awk "BEGIN {printf \"%.2f\", $speed_bps / 1048576}")
+            printf "%-9s | %-17s | %-12s | %-12s | " "$time_ms" "$speed_bps" "$speed_kbs" "$speed_mbs"
+            echo -e "${GREEN}SUCCESS${NC}    |"
+        else
+            printf "%-9s | %-17s | %-12s | %-12s | " "ERROR" "-" "-" "-"
+            echo -e "${RED}PARSE ERR${NC}  |"
+        fi
+    elif echo "$result" | grep -q "Write failed"; then
+        # Write failure - check if it's a timeout
+        if echo "$result" | grep -q "buffer timeout"; then
+            printf "%-9s | %-17s | %-12s | %-12s | " "TIMEOUT" "-" "-" "-"
+            echo -e "${RED}BUF TIMEOUT${NC}|"
+        else
+            printf "%-9s | %-17s | %-12s | %-12s | " "FAILED" "-" "-" "-"
+            echo -e "${RED}WRITE FAIL${NC} |"
+        fi
+    else
+        # Other failure
+        printf "%-9s | %-17s | %-12s | %-12s | " "ERROR" "-" "-" "-"
+        echo -e "${RED}FAILED${NC}     |"
+    fi
+    
+    # Small delay between tests
+    sleep 1
+done
+
+echo ""
+echo "=========================================="
+echo "Benchmark complete!"
+echo "=========================================="
+
+# Optional: Save results to file
+if [ -n "$2" ]; then
+    echo -e "\nSaving results to: $2"
+    # Implementation for saving results could go here
+fi


### PR DESCRIPTION
### **User description**
## Summary
- Upgraded circular buffer implementation to support sizes larger than 64KB
- Changed buffer size types from uint16_t to uint32_t throughout the codebase
- Increased SD card buffer from 60KB to 128KB for improved performance

## Performance Improvements
Tested on hardware with SD card benchmark:
- **250KB writes**: 275 KB/s (previously 263 KB/s) - **+12 KB/s improvement**
- **500KB writes**: 290 KB/s (previously 263 KB/s) - **+27 KB/s improvement**
- Small writes (1-100KB) and large writes (1MB+) show similar performance

## Changes
- `CircularBuffer.h/c`: Changed all size-related types from uint16_t to uint32_t
- `sd_card_manager.c`: Increased buffer size from 60KB to 128KB
- `UsbCdc.c`, `wifi_tcp_server.c`: Updated callback signatures to accept uint32_t
- `CircularBuf_Safe.h`: Updated all wrapper functions to use uint32_t

## Test Results
```
| Size (KB) | Time (ms) | Speed (KB/s) |
|-----------|-----------|--------------|
| 100       | 426       | 234          |
| 250       | 909       | 275          |
| 500       | 1721      | 290          |
| 1024      | 3902      | 262          |
```

## Backward Compatibility
This change maintains API compatibility - all existing code continues to work, with the benefit of supporting larger buffers when needed.

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Upgrade circular buffer from uint16_t to uint32_t for 128KB+ support

- Increase SD card buffer from 60KB to 128KB

- Add multi-chunk processing and timeout protection for SD writes

- Include SD card benchmark script for performance testing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["uint16_t Buffer"] --> B["uint32_t Buffer"]
  B --> C["128KB SD Buffer"]
  C --> D["Multi-chunk Processing"]
  D --> E["Performance Boost"]
  F["Benchmark Script"] --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CircularBuffer.c</strong><dd><code>Convert buffer size types to uint32_t</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/Util/CircularBuffer.c

<ul><li>Changed all size-related types from uint16_t to uint32_t<br> <li> Updated function signatures and variable declarations<br> <li> Modified chunk processing logic for larger buffers</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/88/files#diff-ebb222d98e3ff3bc23679b2cd8b6235542a48f6c878c795476744a491f43fdc6">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CircularBuffer.h</strong><dd><code>Update header definitions for uint32_t support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/Util/CircularBuffer.h

<ul><li>Updated struct members <code>totalBytes</code> and <code>buf_size</code> to uint32_t<br> <li> Changed callback function pointer signature to accept uint32_t<br> <li> Updated all function declarations to use uint32_t parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/88/files#diff-e853b3bff188d3e81b597c645288d58b61bb7ccdcef7fb4c1f1b01e06989ac74">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UsbCdc.c</strong><dd><code>Update USB CDC callback signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/services/UsbCdc/UsbCdc.c

<ul><li>Updated <code>UsbCdc_Wrapper_Write</code> function signature to accept uint32_t <br>length</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/88/files#diff-4be00b55e1c0f4e90190b1f3d6785eca700121c9e8816876b50d33c953b26c50">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sd_card_manager.c</strong><dd><code>Enhance SD card performance with larger buffer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/services/sd_card_services/sd_card_manager.c

<ul><li>Increased buffer size from 60KB to 128KB<br> <li> Added multi-chunk processing (up to 4 chunks per cycle)<br> <li> Implemented timeout protection for WriteToBuffer operations<br> <li> Updated callback function signature to uint32_t</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/88/files#diff-ea4cfcca623ea4f66bbd7a8f05878de893fbbc548e4cddaac4e89ec01105963f">+52/-37</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wifi_tcp_server.c</strong><dd><code>Update WiFi TCP callback signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/services/wifi_services/wifi_tcp_server.c

<ul><li>Updated <code>CircularBufferToTcpWrite</code> function signature to accept uint32_t <br>length</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/88/files#diff-aa1f3edbe77f44ad412baa68c21e141fbeae939391ffef1e4183c82712c73e70">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CircularBuf_Safe.h</strong><dd><code>Update thread-safe wrappers for uint32_t</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/shared/CircularBuf_Safe.h

<ul><li>Updated all wrapper functions to use uint32_t instead of uint16_t<br> <li> Removed 16-bit size limit checks and overflow protection<br> <li> Updated function signatures and type conversions throughout</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/88/files#diff-6b9c58c0b8e0728ed767aa911bddacf2790a7b575700ca9833219c3ae47034a1">+20/-36</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sd_card_manager.h</strong><dd><code>Add SD performance tuning constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/services/sd_card_services/sd_card_manager.h

<ul><li>Added performance tuning constants for timeout and chunk processing<br> <li> Defined multi-chunk processing parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/88/files#diff-a1d2d5f3e774c683ab5abebcd1750f4f9a38ef4d833e34b888db23b7abd572b3">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sd_card_benchmark.sh</strong><dd><code>Add SD card benchmark testing script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sd_card_benchmark.sh

<ul><li>Added comprehensive SD card performance testing script<br> <li> Supports multiple test sizes from 1KB to 1024KB<br> <li> Includes device initialization and result formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/88/files#diff-9028bde619ebb12d5bb934b112b4e9e0fc6d717db9c517548dc431e944c02ee8">+122/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

