### PR TITLE
fix(scpi): MAC address command returns 00:00:00:00:00:00

### DIFF
--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -160,15 +160,15 @@ void app_SystemInit() {
     DaqifiSettings tmpTopLevelSettings;
     DaqifiSettings tmpSettings;
 
-    gpBoardData = (tBoardData*)BoardData_Get(
+    gpBoardData = BoardData_Get(
             BOARDDATA_ALL_DATA,
             0);
 
-    gpBoardConfig = (tBoardConfig*)BoardConfig_Get(
+    gpBoardConfig = BoardConfig_Get(
             BOARDCONFIG_ALL_CONFIG,
             0);
 
-    gpBoardRuntimeConfig = (tBoardRuntimeConfig*)BoardRunTimeConfig_Get(
+    gpBoardRuntimeConfig = BoardRunTimeConfig_Get(
             BOARDRUNTIMECONFIG_ALL_CONFIG);
 
 

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -160,15 +160,15 @@ void app_SystemInit() {
     DaqifiSettings tmpTopLevelSettings;
     DaqifiSettings tmpSettings;
 
-    gpBoardData = BoardData_Get(
+    gpBoardData = (tBoardData*)BoardData_Get(
             BOARDDATA_ALL_DATA,
             0);
 
-    gpBoardConfig = BoardConfig_Get(
+    gpBoardConfig = (tBoardConfig*)BoardConfig_Get(
             BOARDCONFIG_ALL_CONFIG,
             0);
 
-    gpBoardRuntimeConfig = BoardRunTimeConfig_Get(
+    gpBoardRuntimeConfig = (tBoardRuntimeConfig*)BoardRunTimeConfig_Get(
             BOARDRUNTIMECONFIG_ALL_CONFIG);
 
 

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -299,7 +299,7 @@ scpi_result_t SCPI_LANGatewaySet(scpi_t * context) {
 scpi_result_t SCPI_LANMacGet(scpi_t * context) {
     char buffer[MAX_MAC_ADDR_STR_LEN];
 
-    wifi_manager_settings_t * pWifiSettings = (wifi_manager_settings_t*)BoardData_Get(
+    wifi_manager_settings_t * pWifiSettings = BoardData_Get(
             BOARDDATA_WIFI_SETTINGS,0);
     if (MacAddr_ToString(pWifiSettings->macAddr.addr,
             buffer,

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -299,8 +299,8 @@ scpi_result_t SCPI_LANGatewaySet(scpi_t * context) {
 scpi_result_t SCPI_LANMacGet(scpi_t * context) {
     char buffer[MAX_MAC_ADDR_STR_LEN];
 
-    wifi_manager_settings_t * pWifiSettings = BoardRunTimeConfig_Get(
-            BOARDRUNTIME_WIFI_SETTINGS);
+    wifi_manager_settings_t * pWifiSettings = (wifi_manager_settings_t*)BoardData_Get(
+            BOARDDATA_WIFI_SETTINGS,0);
     if (MacAddr_ToString(pWifiSettings->macAddr.addr,
             buffer,
             MAX_MAC_ADDR_STR_LEN) < 1) {


### PR DESCRIPTION
### **User description**
## Summary
- Fixes issue #89 where SCPI MAC address query returns all zeros
- Changes MAC address retrieval from BoardRunTimeConfig to BoardData

## Problem
The `SYST:COMM:LAN:MAC?` SCPI command was returning `00:00:00:00:00:00` instead of the actual MAC address.

## Solution
The MAC address is stored in BoardData (actual runtime data), not BoardRunTimeConfig (configuration settings). This fix corrects the data source to retrieve the actual MAC address.

## Test Plan
1. Connect to device via USB serial
2. Send SCPI command: `SYST:COMM:LAN:MAC?`
3. Verify it returns the actual MAC address (not all zeros)

Fixes #89

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix SCPI MAC address query returning all zeros

- Change MAC address source from BoardRunTimeConfig to BoardData

- Add explicit type casting for board data structures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SCPI MAC Query"] --> B["BoardRunTimeConfig"] 
  A --> C["BoardData"]
  B --> D["Returns 00:00:00:00:00:00"]
  C --> E["Returns Actual MAC Address"]
  B -.-> C
  style B fill:#ffcccc
  style C fill:#ccffcc
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app_freertos.c</strong><dd><code>Add explicit type casting for board structures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/app_freertos.c

<ul><li>Add explicit type casting to board data structure pointers<br> <li> Cast <code>BoardData_Get</code>, <code>BoardConfig_Get</code>, and <code>BoardRunTimeConfig_Get</code> return <br>values</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/92/files#diff-b6f9c77eb951a3afed76cba2514e820829aa401451a58f7f0dd69f6a778b5bd7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SCPILAN.c</strong><dd><code>Fix MAC address data source in SCPI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/services/SCPI/SCPILAN.c

<ul><li>Change MAC address retrieval from <code>BoardRunTimeConfig_Get</code> to <br><code>BoardData_Get</code><br> <li> Update function call to use <code>BOARDDATA_WIFI_SETTINGS</code> instead of <br><code>BOARDRUNTIME_WIFI_SETTINGS</code><br> <li> Add explicit type casting for wifi settings pointer</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/92/files#diff-b160d415cb1438b9f19e8ad032b3446b86db0a8bf68111328bfb7ccb3e9420c1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

