### PR TITLE
fix(scpi): IP address command returns DHCP-assigned IP

### DIFF
--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -222,8 +222,8 @@ scpi_result_t SCPI_LANNetModeSet(scpi_t * context) {
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error
  */
 scpi_result_t SCPI_LANAddrGet(scpi_t * context) {
-    wifi_manager_settings_t * pWifiSettings = BoardRunTimeConfig_Get(
-            BOARDRUNTIME_WIFI_SETTINGS);
+    wifi_manager_settings_t * pWifiSettings = BoardData_Get(
+            BOARDDATA_WIFI_SETTINGS, 0);
 
     return SCPI_LANAddrGetImpl(
             context,


### PR DESCRIPTION
### **User description**
## Summary
Fixes issue #90 where SCPI IP address query returns configured default IP instead of DHCP-assigned address.

## Problem
The `SYST:COMM:LAN:ADDR?` SCPI command was returning the configured/default IP address (192.168.1.1) instead of the actual DHCP-assigned IP when in station mode with DHCP enabled.

## Solution
Changed from `BoardRunTimeConfig_Get` to `BoardData_Get` to retrieve the actual runtime IP address. This is the same pattern as the MAC address fix in PR #92.

## Test Plan
1. Configure device for STA mode with DHCP
2. Connect to WiFi network
3. Check router for DHCP-assigned IP (e.g., 192.168.1.207)
4. Query device: `SYST:COMM:LAN:ADDR?`
5. Verify it returns the actual DHCP-assigned IP

## Related Issues
- Fixes #90
- Similar to #89 (MAC address issue) - both involved reading from configuration instead of runtime data

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix SCPI IP address query to return DHCP-assigned IP

- Change from configuration data to runtime data retrieval

- Ensure actual network IP is returned instead of default


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SCPI IP Query"] --> B["BoardData_Get()"]
  B --> C["Runtime WiFi Settings"]
  C --> D["Actual DHCP IP Address"]
  E["Previous: BoardRunTimeConfig_Get()"] -.-> F["Default IP (192.168.1.1)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SCPILAN.c</strong><dd><code>Switch to runtime data for IP retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/services/SCPI/SCPILAN.c

<ul><li>Replace <code>BoardRunTimeConfig_Get</code> with <code>BoardData_Get</code> call<br> <li> Change function parameter from <code>BOARDRUNTIME_WIFI_SETTINGS</code> to <br><code>BOARDDATA_WIFI_SETTINGS</code><br> <li> Add second parameter <code>0</code> to new function call</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/95/files#diff-b160d415cb1438b9f19e8ad032b3446b86db0a8bf68111328bfb7ccb3e9420c1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

