### PR TITLE
feat(scpi): add input validation for power state and LAN commands

### DIFF
--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -204,11 +204,13 @@ scpi_result_t SCPI_LANNetModeSet(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
+    // Validate network mode: 1 = STA, 4 = AP
     switch (param1) {
-        case WIFI_MANAGER_NETWORK_MODE_AP:
-        case WIFI_MANAGER_NETWORK_MODE_STA:
+        case WIFI_MANAGER_NETWORK_MODE_STA:  // 1
+        case WIFI_MANAGER_NETWORK_MODE_AP:   // 4
             break;
         default:
+            SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
             return SCPI_RES_ERR;
     }
 
@@ -359,38 +361,29 @@ scpi_result_t SCPI_LANSecuritySet(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
+    // Validate security mode and handle supported/unsupported modes
     switch (param1) {
-        case WIFI_MANAGER_SECURITY_MODE_OPEN: // DAQiFi defines 0 = SECURITY_OPEN
+        case WIFI_MANAGER_SECURITY_MODE_OPEN: // 0 = SECURITY_OPEN
             pRunTimeWifiSettings->securityMode = WIFI_MANAGER_SECURITY_MODE_OPEN;
             break;
-        case WIFI_MANAGER_SECURITY_MODE_WEP_40: // DAQiFi defines 1 = WEP_40 which is now deprecated
-            return SCPI_RES_ERR;
-            break;
-        case WIFI_MANAGER_SECURITY_MODE_WEP_104: // DAQiFi defines 2 = WEP_104 which is now deprecated
-            return SCPI_RES_ERR;
-            break;
-        case WIFI_MANAGER_SECURITY_MODE_WPA_AUTO_WITH_PASS_PHRASE: // DAQiFi defines 3 = SECURITY_WPA_AUTO_WITH_PASS_PHRASE
-        case WIFI_MANAGER_SECURITY_MODE_WPA_DEPRECATED: //DAQiFi defines 4 = WIFI_API_SEC_WPA_DEPRECATED - keeping for backwards compatibility
+        case WIFI_MANAGER_SECURITY_MODE_WPA_AUTO_WITH_PASS_PHRASE: // 3 = SECURITY_WPA_AUTO_WITH_PASS_PHRASE
+        case WIFI_MANAGER_SECURITY_MODE_WPA_DEPRECATED: // 4 = WPA_DEPRECATED - keeping for backwards compatibility
             pRunTimeWifiSettings->securityMode = WIFI_MANAGER_SECURITY_MODE_WPA_AUTO_WITH_PASS_PHRASE;
             break;
-        case WIFI_MANAGER_SECURITY_MODE_802_1X: // DAQiFi defines 5 = WDRV_WINC_AUTH_TYPE_802_1X
-            return SCPI_RES_ERR; // Not currently implemented
-            pRunTimeWifiSettings->securityMode = WIFI_MANAGER_SECURITY_MODE_802_1X;
-            break;
-        case WIFI_MANAGER_SECURITY_MODE_SEC_802_1X_MSCHAPV2: // DAQiFi defines 6 = WDRV_WINC_AUTH_TYPE_802_1X_MSCHAPV2
-            return SCPI_RES_ERR; // Not currently implemented
-            pRunTimeWifiSettings->securityMode = WIFI_MANAGER_SECURITY_MODE_SEC_802_1X_MSCHAPV2;
-            break;
-        case WIFI_MANAGER_SECURITY_MODE_WPS_PUSH_BUTTON: // DAQiFi defines 7 = SECURITY_WPS_PUSH_BUTTON which is now deprecated
+        
+        // Deprecated/unsupported modes
+        case WIFI_MANAGER_SECURITY_MODE_WEP_40: // 1 = WEP_40 (deprecated)
+        case WIFI_MANAGER_SECURITY_MODE_WEP_104: // 2 = WEP_104 (deprecated)
+        case WIFI_MANAGER_SECURITY_MODE_802_1X: // 5 = 802.1X (not implemented)
+        case WIFI_MANAGER_SECURITY_MODE_SEC_802_1X_MSCHAPV2: // 6 = 802.1X_MSCHAPV2 (not implemented)
+        case WIFI_MANAGER_SECURITY_MODE_WPS_PUSH_BUTTON: // 7 = WPS_PUSH_BUTTON (deprecated)
+        case WIFI_MANAGER_SECURITY_MODE_SEC_WPS_PIN: // 8 = WPS_PIN (deprecated)
+        case WIFI_MANAGER_SECURITY_MODE_SEC_802_1X_TLS: // 9 = 802.1X_TLS (not implemented)
+            SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
             return SCPI_RES_ERR;
-        case WIFI_MANAGER_SECURITY_MODE_SEC_WPS_PIN: // DAQiFi defines 8 = SECURITY_WPS_PIN which is now deprecated
-            return SCPI_RES_ERR;
-        case WIFI_MANAGER_SECURITY_MODE_SEC_802_1X_TLS: // DAQiFi defines 9 = WDRV_WINC_AUTH_TYPE_802_1X_TLS
-            return SCPI_RES_ERR; // Not currently implemented
-            pRunTimeWifiSettings->securityMode = WIFI_MANAGER_SECURITY_MODE_SEC_802_1X_TLS;
-            break;
-
+            
         default:
+            SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
             return SCPI_RES_ERR;
     }
 


### PR DESCRIPTION
## Summary
This PR adds proper input validation for SCPI power state and LAN configuration commands, preventing invalid values from being accepted and ensuring the power state query returns the actual enum values.

## Changes

### 1. Power State Commands
- **SYST:POW:STAT?** now returns actual enum values (0, 1, 2) instead of binary (0/1)
- **SYST:POW:STAT** now validates input and supports all three power states:
  - `0` = STANDBY (CPU on but standby, powers off if disconnected)
  - `1` = POWERED_UP (fully powered)
  - `2` = POWERED_UP_EXT_DOWN (system powered but not user power)
- Invalid values (like 3, -1, etc.) return error `-224 "Illegal parameter value"`

### 2. LAN Network Type Validation
- **SYST:COMM:LAN:NETT** now validates input:
  - Valid: `1` (STA mode), `4` (AP mode)
  - Invalid values return proper SCPI error

### 3. LAN Security Mode Validation
- **SYST:COMM:LAN:SEC** now validates and rejects:
  - Deprecated modes (WEP, WPS)
  - Unimplemented modes (802.1X variants)
  - Returns proper error messages for invalid values

## Testing
All commands tested on hardware:
```
# Valid power states work
SYST:POW:STAT 0  → OK
SYST:POW:STAT 1  → OK
SYST:POW:STAT 2  → OK

# Invalid power states error
SYST:POW:STAT 3  → ERROR: -224, "Illegal parameter value"
SYST:POW:STAT -1 → ERROR: -224, "Illegal parameter value"

# LAN validation works
SYST:COMM:LAN:NETT 1  → OK (STA)
SYST:COMM:LAN:NETT 4  → OK (AP)
SYST:COMM:LAN:NETT 2  → ERROR: -224

SYST:COMM:LAN:SEC 0  → OK (OPEN)
SYST:COMM:LAN:SEC 3  → OK (WPA)
SYST:COMM:LAN:SEC 1  → ERROR: -224 (WEP deprecated)
```

## Benefits
- Prevents confusion when using incorrect values
- Provides immediate feedback for invalid commands
- Power state query now accurately reflects system state
- Follows SCPI standard error reporting practices
- Improves robustness and user experience

Fixes #91