### PR TITLE
feat(log): Add per-module compile-time logging control

### DIFF
--- a/firmware/src/HAL/BQ24297/BQ24297.c
+++ b/firmware/src/HAL/BQ24297/BQ24297.c
@@ -2,6 +2,8 @@
  * @file   BQ24297.c
  * @brief This file manages the BQ24297 module
  */
+#define LOG_EN  LOG_BQ24297
+
 #include "BQ24297.h"
 #include "Util/Logger.h"
 #include "services/UsbCdc/UsbCdc.h"

--- a/firmware/src/HAL/Power/PowerApi.c
+++ b/firmware/src/HAL/Power/PowerApi.c
@@ -2,6 +2,7 @@
  * 
  * This file implements the functions to manage power API
  */
+#define LOG_EN  LOG_POWER
 
 #include "HAL/Power/PowerApi.h"
 #include "definitions.h"

--- a/firmware/src/Util/Logger.h
+++ b/firmware/src/Util/Logger.h
@@ -37,6 +37,46 @@ extern "C" {
     #warning "ENABLE_ICSP_REALTIME_LOG is ENABLED. Set to 0 before release."
     #endif
 
+    
+    
+    /**
+     * @brief Library-level logging control macros and logging API
+     * Provides compile-time logging enable/disable control at a per-library/module level.
+     * -------------------------------
+     * HOW TO USE LOG ENABLE/DISABLE:
+     * -------------------------------
+     * 1. Each library/module can define its own LOG_xxx flag
+     *    (e.g., LOG_WIFI, LOG_SD) as either LOG_ENABLE or LOG_DISABLE.
+     * 2. At the first line in the library/module source file(.c), define a local alias:
+     *        #define LOG_EN LOG_WIFI
+     *    This links the module's logging to its specific enable flag.
+     * 3. When LOG_EN == LOG_ENABLE:
+     *        - LOG_D(), LOG_I(), and LOG_E() macros will call LogMessage()
+     *          and produce output.
+     *    When LOG_EN == LOG_DISABLE:
+     *        - LOG_D(), LOG_I(), and LOG_E() macros compile to nothing
+     *          (zero runtime cost).
+     * 4. Change the master switches below to enable/disable logs per module:
+     *        #define LOG_WIFI    LOG_DISABLE   // Turn off WiFi logs
+     *        #define LOG_SD      LOG_ENABLE    // Keep SD logs on
+     *
+     * Example in wifi_manager.c:
+     *    #define LOG_EN LOG_WIFI
+     *    LOG_D("WiFi connected, IP=%s\n", ipAddress);
+     */
+    
+    //Log enable definitions
+    #define LOG_DISABLE         0
+    #define LOG_ENABLE          1
+
+    //The master switches to enable/disable logs per module: 
+    #define LOG_POWER           LOG_ENABLE
+    #define LOG_WIFI            LOG_ENABLE
+    #define LOG_BQ24297         LOG_ENABLE
+    #define LOG_SD              LOG_ENABLE 
+    #define LOG_USB             LOG_ENABLE
+    #define LOG_SCPI            LOG_ENABLE
+
 /**
  * Logs a formatted message
  * @param format
@@ -48,9 +88,16 @@ size_t LogMessageCount();
 
 size_t LogMessagePop(uint8_t* buffer, size_t maxSize);
 
-#define LOG_D(fmt,...) LogMessage(fmt, ##__VA_ARGS__)
-#define LOG_E(fmt,...) LogMessage(fmt, ##__VA_ARGS__)
-#define LOG_I(fmt,...) LogMessage(fmt, ##__VA_ARGS__)
+
+#if defined(LOG_EN) && (LOG_EN == LOG_ENABLE)
+    #define LOG_D(fmt,...) LogMessage(fmt, ##__VA_ARGS__)
+    #define LOG_E(fmt,...) LogMessage(fmt, ##__VA_ARGS__)
+    #define LOG_I(fmt,...) LogMessage(fmt, ##__VA_ARGS__)
+#else
+    #define LOG_D(fmt,...)
+    #define LOG_E(fmt,...)
+    #define LOG_I(fmt,...)
+#endif//#if (LOG_EN == LOG_ENABLE)
 
 #ifdef	__cplusplus
 }

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -20,6 +20,7 @@
 /* Section: Included Files                                                    */
 /* ************************************************************************** */
 /* ************************************************************************** */
+#define LOG_EN      LOG_SCPI
 #include "SCPIStorageSD.h"
 #include "../sd_card_services/sd_card_manager.h"
 #include "../../state/runtime/BoardRuntimeConfig.h"

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -1,4 +1,4 @@
-
+#define LOG_EN  LOG_USB
 #include "UsbCdc.h"
 
 // libraries

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1,3 +1,5 @@
+#define LOG_EN  LOG_SD
+
 #include <string.h>
 #include "Util/Logger.h"
 #include "sd_card_manager.h"

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1,3 +1,4 @@
+#define LOG_EN  LOG_WIFI
 #include "wifi_manager.h"
 #include "wdrv_winc_client_api.h"
 #include "Util/Logger.h"


### PR DESCRIPTION
Added compile-time logging control for individual modules (e.g., WiFi, SD, USB, SCPI). Each module can enable/disable logging via its LOG_xxx flag, allowing zero runtime cost when disabled. Updated header file with detailed usage instructions and examples.