### PR TITLE
fix(wifi): enable OTA firmware update and refactor state management

### DIFF
--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -232,22 +232,23 @@ static void app_WifiTask(void* p_arg) {
  */
 static void app_SdCardTask(void* p_arg) {
     sd_card_manager_Init(&gpBoardRuntimeConfig->sdCardConfig);
-    while (1) {       
-        // Critical fix: Prevent SPI bus contention between WiFi streaming and SD operations
+    while (1) {
+        // Critical fix: Prevent SPI bus contention between WiFi streaming/OTA and SD operations
         // Background: SD operations every 1ms were causing WiFi streaming failures at ~590 seconds
-        // Solution: Suspend SD operations during WiFi streaming for exclusive SPI access
+        // Solution: Suspend SD operations during WiFi streaming AND OTA mode for exclusive SPI access
         StreamingRuntimeConfig* pStreamConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
         bool isStreaming = (pStreamConfig != NULL) && pStreamConfig->IsEnabled;
+        bool isOtaMode = wifi_manager_IsOtaModeActive();
 
-        if (isStreaming) {
-            // WiFi streaming active - suspend SD operations to avoid SPI bus contention
-            // This prevents the ~590 second streaming failure caused by competing SPI transactions
-            vTaskDelay(100 / portTICK_PERIOD_MS); // Reduced frequency check when streaming
+        if (isStreaming || isOtaMode) {
+            // WiFi streaming or OTA mode active - suspend SD operations to avoid SPI bus contention
+            // This prevents the ~590 second streaming failure and OTA flash erase failures
+            vTaskDelay(100 / portTICK_PERIOD_MS); // Reduced frequency check when SPI in use
         } else {
             // WiFi not streaming - safe to run full SD operations
             // Normal SD card maintenance: driver tasks, state processing, file system
             DRV_SDSPI_Tasks(sysObj.drvSDSPI0);      // Harmony SD driver background processing
-            sd_card_manager_ProcessState();         // SD card state management 
+            sd_card_manager_ProcessState();         // SD card state management
             SYS_FS_Tasks();                         // File system maintenance
             vTaskDelay(SD_CARD_MANAGER_TASK_DELAY_MS / portTICK_PERIOD_MS); // 1ms normal rate
         }

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -512,8 +512,9 @@ scpi_result_t SCPI_LANSettingsApply(scpi_t * context) {
     if (!wifi_manager_UpdateNetworkSettings(pRunTimeWifiSettings)) {
         return SCPI_RES_ERR;
     }
-    //once fw update mode is enabled it should be cleared to disable automatic fw update mode
-    pRunTimeWifiSettings->isOtaModeEnabled = false;
+    // Note: isOtaModeEnabled is intentionally NOT cleared here anymore.
+    // The WiFi manager will handle OTA mode entry and will clear the flag
+    // after OTA operations complete or when exiting OTA mode.
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -512,17 +512,15 @@ scpi_result_t SCPI_LANSettingsApply(scpi_t * context) {
     if (!wifi_manager_UpdateNetworkSettings(pRunTimeWifiSettings)) {
         return SCPI_RES_ERR;
     }
-    // Note: isOtaModeEnabled is intentionally NOT cleared here anymore.
-    // The WiFi manager will handle OTA mode entry and will clear the flag
-    // after OTA operations complete or when exiting OTA mode.
+    // Note: OTA mode request (if set via FWUPDATE) is handled by the WiFi state machine.
+    // The REQUESTED flag will be checked and cleared in ENTRY event handler.
     return SCPI_RES_OK;
 }
 
 scpi_result_t SCPI_LANFwUpdate(scpi_t * context) {
-    wifi_manager_settings_t * pRunTimeWifiSettings = BoardRunTimeConfig_Get(
-            BOARDRUNTIME_WIFI_SETTINGS);
-
-    pRunTimeWifiSettings->isOtaModeEnabled = true;
+    // Request OTA mode via state machine flag
+    // On next APPLY, state machine will transition to OTA mode instead of reconfiguring WiFi
+    wifi_manager_RequestOtaMode();
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -58,7 +58,9 @@ extern "C" {
          */
         bool isEnabled;
         /**
-         * this is true is ota mode is enabled
+         * DEPRECATED: No longer used. OTA mode is now managed via state machine flags.
+         * Use wifi_manager_RequestOtaMode() to request OTA and wifi_manager_IsOtaModeActive() to check status.
+         * Kept for NVM compatibility - do not remove.
          */
         bool isOtaModeEnabled;
         /**
@@ -258,6 +260,14 @@ extern "C" {
      *                           will contain the length of the formatted announcement packet.
      */
     void wifi_manager_FormUdpAnnouncePacketCB(const wifi_manager_settings_t *pWifiSettings, uint8_t *pBuffer, uint16_t *pPacketLen);
+
+    /**
+     * @brief Request WiFi OTA firmware update mode.
+     *
+     * Sets the OTA_MODE_REQUESTED flag in the state machine. On next UpdateNetworkSettings,
+     * the state machine will transition to OTA mode instead of reconfiguring WiFi.
+     */
+    void wifi_manager_RequestOtaMode(void);
 
     /**
      * @brief Check if WiFi OTA firmware update mode is currently active.

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -260,14 +260,21 @@ extern "C" {
     void wifi_manager_FormUdpAnnouncePacketCB(const wifi_manager_settings_t *pWifiSettings, uint8_t *pBuffer, uint16_t *pPacketLen);
 
     /**
+     * @brief Check if WiFi OTA firmware update mode is currently active.
+     *
+     * @return true if OTA mode is active, false otherwise.
+     */
+    bool wifi_manager_IsOtaModeActive(void);
+
+    /**
      * @brief Queries the current RSSI value on-demand with timeout.
-     * 
+     *
      * Attempts to get the current RSSI value from the WiFi module. Will wait up to
      * the specified timeout for a fresh value if the cached value is stale.
-     * 
+     *
      * @param[out] pRssi Pointer to store the RSSI value (in percentage 0-100).
      * @param[in] timeoutMs Maximum time to wait for fresh RSSI in milliseconds.
-     * 
+     *
      * @return true if RSSI was successfully retrieved, false otherwise.
      */
     bool wifi_manager_GetRSSI(uint8_t *pRssi, uint32_t timeoutMs);


### PR DESCRIPTION
## Summary
- Fixed WiFi OTA firmware update functionality
- Refactored OTA mode management to use state machine flags exclusively

## Changes

### OTA Functionality Fixes
- Added SD card suspension during OTA mode to prevent SPI bus contention
- Fixed circular buffer IsFull() macro
- Added `wifi_manager_IsOtaModeActive()` API

### Architecture Refactoring
- Replaced settings struct flag with state machine flags for OTA lifecycle
- Added `WIFI_MANAGER_STATE_FLAG_OTA_MODE_REQUESTED` and `WIFI_MANAGER_STATE_FLAG_OTA_MODE_READY`
- Created `wifi_manager_RequestOtaMode()` API for clean encapsulation
- Fixed MainState ENTRY to preserve OTA flag before clearing all flags
- Updated REINIT handler to route to MainState when OTA requested
- Deprecated `isOtaModeEnabled` field (kept for NVM compatibility)

## Test Plan
- [x] OTA mode entry via SCPI (`FWUPDATE` → `APPLY`)
- [x] SD operations suspended during OTA
- [x] Firmware update completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)