### PR TITLE
fix(protobuf): use sequential packing for ADC data in ProtoBuf encoder

### DIFF
--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -425,9 +425,10 @@ size_t Nanopb_Encode(tBoardData* state,
                         if (!pPublicSampleList->isSampleValid[i])
                             continue;
                         data = pPublicSampleList->sampleElement[i];
-                        if (data.Channel > maxDataIndex)
-                            continue;
-                        message.analog_in_data[data.Channel] = data.Value;
+                        if (message.analog_in_data_count > maxDataIndex)
+                            break;  // Array full
+                        // Use sequential packing
+                        message.analog_in_data[message.analog_in_data_count] = data.Value;
                         message.analog_in_data_count++;
                     }
 


### PR DESCRIPTION
### **User description**
## Summary
- Changed analog_in_data array indexing from sparse (by channel ID) to sequential packing
- Fixes selective channel enable streaming in ProtoBuf mode
- This fix was originally in PR #61 but was never merged

## Root Cause
ProtoBuf repeated fields send elements sequentially starting from index 0, not as a sparse array. The old code used channel ID as array index (`analog_in_data[channelID]`) and incremented count per channel. When only CH4 was enabled:
- Wrote data to `analog_in_data[4] = value`
- Set `count = 1`
- ProtoBuf sent only `analog_in_data[0]` (which was 0)

## Fix
Pack enabled channels sequentially:
```c
message.analog_in_data[message.analog_in_data_count] = data.Value;
message.analog_in_data_count++;
```

Now when CH4 is enabled, it goes to index 0 and count=1 correctly sends that data.

## Test Plan
- [x] Enable only CH4: `ENAble:AIN:CHANnel 4,1` - streams correctly
- [x] Enable CH0 and CH4 - both stream correctly
- [x] Enable all channels - works as before

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix selective channel enable streaming in ProtoBuf mode

- Changed ADC data array indexing from sparse to sequential packing

- Ensures enabled channels are packed starting at index 0

- Resolves issue where only first N elements were transmitted


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sparse indexing<br/>data.Channel as index"] -->|Issue: zeros sent| B["ProtoBuf repeated field<br/>sends from index 0"]
  C["Sequential packing<br/>count as index"] -->|Fix: correct data sent| B
  B --> D["Selective channel<br/>streaming works"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NanoPB_Encoder.c</strong><dd><code>Sequential packing for ADC data array indexing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

firmware/src/services/DaqifiPB/NanoPB_Encoder.c

<ul><li>Changed <code>analog_in_data</code> indexing from <code>data.Channel</code> (sparse) to <br><code>message.analog_in_data_count</code> (sequential)<br> <li> Updated boundary check from <code>data.Channel > maxDataIndex</code> to <br><code>message.analog_in_data_count >= maxDataIndex</code><br> <li> Added comment clarifying sequential packing approach<br> <li> Changed <code>continue</code> to <code>break</code> when array limit reached</ul>


</details>


  </td>
  <td><a href="https://github.com/daqifi/daqifi-nyquist-firmware/pull/137/files#diff-23d98b99764f637c88ff4417df4826489b0950b5b5b215186bef542eb4c4d1ae">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

