### PR TITLE
feat(sd): add SD write metrics to streaming stats

### DIFF
--- a/firmware/src/config/default/system/fs/fat_fs/hardware_access/diskio.c
+++ b/firmware/src/config/default/system/fs/fat_fs/hardware_access/diskio.c
@@ -10,8 +10,11 @@
 #include <string.h>
 #include "diskio.h"        /* FatFs lower layer API */
 #include "system/fs/sys_fs_media_manager.h"
+#include "FreeRTOS.h"
+#include "task.h"
 
 #include "sys/kmem.h"
+#include "services/sd_card_services/sd_card_manager.h"
 
 #define CACHE_ALIGN_CHECK  (CACHE_LINE_SIZE - 1)
 
@@ -234,16 +237,20 @@ DRESULT disk_write
         gDiskFormatSectorsWritten += count;
     }
 
+    TickType_t writeStart = xTaskGetTickCount();
     DRESULT result = RES_ERROR;
 
     uint32_t bytesToTransfer    = 0;
     uint32_t currentXferLen     = 0;
     uint32_t sectorXferCntr     = 0;
 
+    bool alignedCopy = false;
+
     /* Use Aligned Buffer if input buffer is in Cacheable address space and
      * is not aligned to cache line size */
     if ((IS_KVA0((uint8_t *)buff) == true) && (((uint32_t)buff & CACHE_ALIGN_CHECK) != 0))
     {
+        alignedCopy = true;
         /* When aligned buffer is used the total number of sectors will be divided by the aligned
          * buffer size and will be sent to drivers in iterations.
          * As the total sectors are now divided into chunks it may effect the overall throughput.
@@ -305,6 +312,10 @@ DRESULT disk_write
 
         result = disk_checkCommandStatus(pdrv);
     }
+
+    /* Track write metrics via sd_card_manager hook */
+    sd_card_manager_TrackWrite(count, (result == RES_OK),
+        pdTICKS_TO_MS(xTaskGetTickCount() - writeStart), alignedCopy);
 
     return result;
 }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -34,6 +34,8 @@
 #include "services/wifi_services/wifi_manager.h"
 #include "SCPIStorageSD.h"
 #include "../sd_card_services/sd_card_manager.h"
+
+/* SD write metrics accessed via sd_card_manager API */
 #include "../streaming.h"
 #include "../csv_encoder.h"
 #include "../JSON_Encoder.h"
@@ -1574,6 +1576,8 @@ static scpi_result_t SCPI_ClearStreamStats(scpi_t * context) {
         pTcp->client.lastSendSize = 0;
         taskEXIT_CRITICAL();
     }
+    // Reset SD write metrics
+    sd_card_manager_ResetWriteMetrics();
     SCPI_SyncQuesBits();
     return SCPI_RES_OK;
 }
@@ -1660,6 +1664,16 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
         scpi_printf(context, "WifiTcpPartialSends=%u\r\n", (unsigned)partialSends);
     }
     scpi_printf(context, "SdDroppedBytes=%u\r\n", (unsigned)s.sdDroppedBytes);
+    {
+        sd_card_write_metrics_t sdm;
+        sd_card_manager_GetWriteMetricsSnapshot(&sdm);
+        scpi_printf(context, "SdWriteCalls=%u\r\n", (unsigned)sdm.writeCallCount);
+        scpi_printf(context, "SdWriteSectors=%u\r\n", (unsigned)sdm.writeSectorCount);
+        scpi_printf(context, "SdBytesWritten=%llu\r\n", (unsigned long long)sdm.writeBytesTotal);
+        scpi_printf(context, "SdWriteErrors=%u\r\n", (unsigned)sdm.writeErrors);
+        scpi_printf(context, "SdWriteMaxLatencyMs=%u\r\n", (unsigned)sdm.writeMaxLatencyMs);
+        scpi_printf(context, "SdWriteAlignedCopies=%u\r\n", (unsigned)sdm.writeAlignedCopies);
+    }
     scpi_printf(context, "EncoderFailures=%u\r\n", (unsigned)s.encoderFailures);
 
     // Compute sample loss percentage (64-bit intermediate to avoid overflow)
@@ -1877,7 +1891,8 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         }
     }
 
-    // Reset WiFi TCP counters for new session (matches Streaming_ClearStats lifecycle)
+    // Reset per-session counters (matches Streaming_ClearStats lifecycle)
+    sd_card_manager_ResetWriteMetrics();
     {
         wifi_tcp_server_context_t* pTcp = wifi_manager_GetTcpServerContext();
         if (pTcp != NULL) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1611,4 +1611,35 @@ size_t sd_card_manager_GetWriteBuffFreeSize() {
     return freeSize;
 }
 
+// --- SD Write Metrics ---
+static sd_card_write_metrics_t gSdWriteMetrics = {0};
+
+void sd_card_manager_TrackWrite(uint32_t sectors, bool success, uint32_t elapsedMs, bool alignedCopy) {
+    taskENTER_CRITICAL();
+    gSdWriteMetrics.writeCallCount++;
+    gSdWriteMetrics.writeSectorCount += sectors;
+    gSdWriteMetrics.writeBytesTotal += (uint64_t)sectors * 512ULL;
+    if (!success) {
+        gSdWriteMetrics.writeErrors++;
+    }
+    if (elapsedMs > gSdWriteMetrics.writeMaxLatencyMs) {
+        gSdWriteMetrics.writeMaxLatencyMs = elapsedMs;
+    }
+    if (alignedCopy) {
+        gSdWriteMetrics.writeAlignedCopies++;
+    }
+    taskEXIT_CRITICAL();
+}
+
+void sd_card_manager_GetWriteMetricsSnapshot(sd_card_write_metrics_t* out) {
+    taskENTER_CRITICAL();
+    *out = gSdWriteMetrics;
+    taskEXIT_CRITICAL();
+}
+
+void sd_card_manager_ResetWriteMetrics(void) {
+    taskENTER_CRITICAL();
+    memset(&gSdWriteMetrics, 0, sizeof(gSdWriteMetrics));
+    taskEXIT_CRITICAL();
+}
 

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -262,6 +262,38 @@ extern "C" {
      */
     void sd_card_manager_DataReadyCB(sd_card_manager_mode_t mode, uint8_t *pDataBuff, size_t dataLen);
 
+    /**
+     * @brief SD write metrics for diagnosing performance and errors.
+     */
+    typedef struct {
+        uint32_t writeCallCount;      /**< Total disk_write invocations */
+        uint32_t writeSectorCount;    /**< Total sectors written */
+        uint64_t writeBytesTotal;     /**< Total bytes confirmed written to card */
+        uint32_t writeErrors;         /**< disk_write returned error */
+        uint32_t writeMaxLatencyMs;   /**< Worst-case single write latency */
+        uint32_t writeAlignedCopies;  /**< Writes needing aligned buffer copy */
+    } sd_card_write_metrics_t;
+
+    /**
+     * @brief Hook called from diskio.c after each disk_write().
+     * @param sectors  Number of sectors in this write
+     * @param success  true if write succeeded
+     * @param elapsedMs  Write duration in milliseconds
+     * @param alignedCopy  true if cacheable→aligned buffer copy was needed
+     */
+    void sd_card_manager_TrackWrite(uint32_t sectors, bool success, uint32_t elapsedMs, bool alignedCopy);
+
+    /**
+     * @brief Get atomic snapshot of SD write metrics (for SCPI stats).
+     * @param out  Destination struct to fill with current values.
+     */
+    void sd_card_manager_GetWriteMetricsSnapshot(sd_card_write_metrics_t* out);
+
+    /**
+     * @brief Reset SD write metrics (for session start / ClearStats).
+     */
+    void sd_card_manager_ResetWriteMetrics(void);
+
     /* Provide C++ Compatibility */
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
Add low-level SD write instrumentation to diagnose write performance and failures.

## New SYST:STR:STATS? fields
| Field | Type | Description |
|-------|------|-------------|
| SdWriteCalls | uint32 | Total disk_write() invocations |
| SdWriteSectors | uint32 | Total sectors written to SD card |
| SdWriteErrors | uint32 | disk_write() returned error |
| SdWriteMaxLatencyMs | uint32 | Worst-case single write latency |
| SdWriteAlignedCopies | uint32 | Writes needing aligned buffer copy (perf penalty) |

## Purpose
During SPI speed testing (#78), 5000 Hz SD streaming showed intermittent 12-13 byte drops at 20 MHz that don't occur at 16.67 MHz. These metrics help diagnose whether the issue is write latency, filesystem errors, or buffer alignment.

## Implementation
Instrumented diskio.c (FatFS glue layer). Future refactor: move metrics to sd_card_manager.c with minimal hook in diskio.c to survive MCC regeneration.

## Related
- #78: SPI clock speed optimization
- #224: Async SD write refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)