### PR TITLE
fix(wifi): clear lastSendSize after callback reads it

### DIFF
--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -339,6 +339,7 @@ static void SocketEventCallback(SOCKET socket, uint8_t messageType, void *pMessa
 
                 taskENTER_CRITICAL();
                 sendSize = client->lastSendSize;
+                client->lastSendSize = 0;  // One-shot: consumed by callback
                 if (sentBytes >= 0) {
                     client->wifiTcpBytesConfirmed += (uint16_t)sentBytes;
                     if (sendSize > 0 && (uint16_t)sentBytes < sendSize) {


### PR DESCRIPTION
One-line fix: clear `lastSendSize` to 0 after the SOCKET_MSG_SEND callback reads it, inside the existing critical section. Makes the value one-shot — prevents stale partial-send detection from a previous send cycle.

From Qodo /improve on merged PR #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)