### PR TITLE
fix(build): enable O3 optimization with FreeRTOS@O1 override (#271)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,16 +40,28 @@ Note: XC32 compiler is also available in Linux at `/opt/microchip/xc32/v4.60/bin
 
 ### Compiler Optimization Level
 
-The project builds with **-O3** (aggressive optimization including inlining and loop unrolling). This required four patches to fix false positives and third-party incompatibilities:
+The project builds with **-O3** globally, with per-file overrides where needed. This required patches to fix false positives and third-party incompatibilities:
+
+#### Per-File Optimization Overrides
+
+| File | Optimization | Reason | Permanent? |
+|------|-------------|--------|-----------|
+| `third_party/rtos/FreeRTOS/Source/FreeRTOS_tasks.c` | **-O1** | O2 miscompiles FreeRTOS list operations — `listINSERT_END` stores reordered so `pxContainer` is NULL when `xTaskResumeAll` reads it, causing crash (BadVAddr=4). See Issue #271. | **Yes** — common RTOS practice; kernel perf impact negligible |
+| `third_party/wolfssl/wolfcrypt/src/tfm.c` | -O3 with `-Wno-error=array-bounds` | GCC loses track of loop variable range after inlining in wolfSSL big-number math. Known third-party issue. | No — reevaluate after wolfSSL upgrade (currently pinned to v5.4.0) |
+
+#### Source Patches for -O2/-O3
 
 | File | Patch | Reason | Permanent? |
 |------|-------|--------|-----------|
 | `libraries/scpi/libscpi/src/utils_private.h:49` | Added platform guard to `__attribute__((visibility))` | ELF visibility is meaningless on bare-metal PIC32, errors at -O3 with -Werror | No — reevaluate after libscpi upgrade |
 | `Util/Logger.c:483` | `strncpy` → `memcpy` | `strncpy(dst, src, strlen(src))` never null-terminates; memcpy is what the code actually means (next line does manual null-term) | **Yes** — genuine bug fix |
 | `services/wifi_services/wifi_serial_bridge_interface.c:68,80` | `__attribute__((noinline))` on `UARTReadGetBuffer` | GCC -O3 inlines 512-byte ring buffer read into 1-byte caller, triggers false `-Warray-bounds`. Function takes a mutex so inlining is counterproductive anyway. | No — reevaluate after XC32/GCC upgrade |
-| `daqifi.X/nbproject/configurations.xml` (per-file) | `-Wno-error=array-bounds` on `wolfssl/wolfcrypt/src/tfm.c` | GCC loses track of loop variable range after inlining in wolfSSL big-number math. Known third-party issue. | No — reevaluate after wolfSSL upgrade (currently pinned to v5.4.0) |
 
-**When upgrading XC32 or third-party libraries**, try removing patches 1, 3, and 4 and rebuild with -O3 -Werror. If the build passes clean, the patches can be deleted.
+#### Known Linker Issue (Issue #271, informational)
+
+The XC32 linker script (`p32MZ2048EFM144.ld`) uses a "best-fit allocator" for `.bss.*` sections. At O2+ with `-fdata-sections`, this can place variables at two addresses (`.sbss` GP-relative vs `.bss.*` best-fit), causing dual-address bugs. This was the root cause of the O2 FreeRTOS crash. The fix is to keep `FreeRTOS_tasks.c` at O1 (which prevents `.bss.*` section creation for its statics). The linker script is left at Microchip default — no modification needed as long as FreeRTOS stays at O1.
+
+**When upgrading XC32 or third-party libraries**, try removing source patches 1 and 3 and rebuild with -Werror. If the build passes clean, the patches can be deleted. The FreeRTOS O1 override should be kept regardless of compiler version.
 
 ### Programming with PICkit 4 from Command Line
 1. Connect PICkit 4 to the device
@@ -1110,9 +1122,9 @@ USB streaming data delivery to the host is inherently bursty due to the firmware
 
 #### Important Testing Notes
 
-1. **Picocom Limitations — Use Python Libraries for Streaming Tests**
+1. **Picocom — ONLY for Simple Non-Streaming SCPI Queries**
 
-   Picocom is suitable ONLY for simple SCPI command/response testing (non-streaming). It has critical limitations that cause device crashes and test failures:
+   **Do NOT use picocom for streaming, benchmarking, or any multi-step test sequence.** Always use the Python test suite (`test_harness.py` → `ReliableSCPI` + `FastReader`) instead. Picocom has critical limitations that cause device crashes, false test results, and USB disconnects:
 
    **Problem 1: `-x` timeout is idle-based, not hard timeout.** When the device is streaming (PB or CSV), picocom receives continuous data and the "exit after N ms of inactivity" condition never triggers. The process hangs indefinitely.
 

--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -2443,6 +2443,369 @@
         <C32Global>
         </C32Global>
       </item>
+      <item path="../src/third_party/rtos/FreeRTOS/Source/FreeRTOS_tasks.c"
+            ex="false"
+            overriding="true">
+        <C32>
+          <property key="additional-warnings" value="true"/>
+          <property key="addresss-attribute-use" value="false"/>
+          <property key="cast-align" value="false"/>
+          <property key="code-model" value="default"/>
+          <property key="const-model" value="default"/>
+          <property key="data-model" value="default"/>
+          <property key="disable-instruction-scheduling" value="false"/>
+          <property key="enable-app-io" value="false"/>
+          <property key="enable-omit-frame-pointer" value="false"/>
+          <property key="enable-procedural-abstraction" value="false"/>
+          <property key="enable-short-double" value="false"/>
+          <property key="enable-symbols" value="true"/>
+          <property key="enable-unroll-loops" value="false"/>
+          <property key="exclude-floating-point" value="false"/>
+          <property key="expand-pragma-config" value="false"/>
+          <property key="extra-include-directories"
+                    value="../src;../src/config/default;../src/config/default/driver/winc/include/;../src/config/default/driver/winc/include/dev;../src/config/default/driver/winc/include/drv/bsp;../src/config/default/driver/winc/include/drv/bsp/include;../src/config/default/driver/winc/include/drv/common;../src/config/default/driver/winc/include/drv/driver;../src/config/default/driver/winc/include/drv/socket;../src/config/default/driver/winc/include/drv/spi_flash;../src/config/default/system/fs/fat_fs/file_system;../src/config/default/system/fs/fat_fs/hardware_access;../src/third_party/rtos/FreeRTOS/Source/include;../src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ;../src/third_party/wolfssl;../src/third_party/wolfssl/wolfssl;../src/third_party/zlib;../src/libraries/scpi/libscpi/inc"/>
+          <property key="generate-16-bit-code" value="false"/>
+          <property key="generate-micro-compressed-code" value="false"/>
+          <property key="isolate-each-function" value="true"/>
+          <property key="keep-inline" value="false"/>
+          <property key="make-warnings-into-errors" value="true"/>
+          <property key="oXC16gcc-errata" value=""/>
+          <property key="oXC16gcc-large-aggregate" value="false"/>
+          <property key="oXC16gcc-mpa-lvl" value=""/>
+          <property key="oXC16gcc-name-text-sec" value=""/>
+          <property key="oXC16gcc-near-chars" value="false"/>
+          <property key="oXC16gcc-no-isr-warn" value="false"/>
+          <property key="oXC16gcc-sfr-warn" value="false"/>
+          <property key="oXC16gcc-smar-io-lvl" value="1"/>
+          <property key="oXC16gcc-smart-io-fmt" value=""/>
+          <property key="optimization-level" value="-O1"/>
+          <property key="place-data-into-section" value="true"/>
+          <property key="post-instruction-scheduling" value="default"/>
+          <property key="pre-instruction-scheduling" value="default"/>
+          <property key="preprocessor-macros"
+                    value="FORCE_BOOTLOADER_FLAG_ADDR=&quot;0x80000000+0x80000-0x10&quot;;FORCE_BOOTLOADER_FLAG_VALUE=&quot;0xF4CEB007&quot;;HAVE_CONFIG_H;WOLFSSL_IGNORE_FILE_WARN"/>
+          <property key="scalar-model" value="default"/>
+          <property key="strict-ansi" value="false"/>
+          <property key="support-ansi" value="false"/>
+          <property key="tentative-definitions" value=""/>
+          <property key="toplevel-reordering" value=""/>
+          <property key="unaligned-access" value=""/>
+          <property key="use-cci" value="false"/>
+          <property key="use-iar" value="false"/>
+          <property key="use-indirect-calls" value="false"/>
+        </C32>
+        <C32-AR>
+          <property key="additional-options-chop-files" value="false"/>
+        </C32-AR>
+        <C32-AS>
+          <property key="assembler-symbols" value=""/>
+          <property key="enable-symbols" value="true"/>
+          <property key="exclude-floating-point-library" value="false"/>
+          <property key="expand-macros" value="false"/>
+          <property key="extra-include-directories-for-assembler"
+                    value="../src/config/default;../src/config/default/peripheral/cache;../src/third_party/rtos/FreeRTOS/Source/include;../src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ"/>
+          <property key="extra-include-directories-for-preprocessor"
+                    value="../src/config/default;../src/third_party/rtos/FreeRTOS/Source/include;../src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ"/>
+          <property key="false-conditionals" value="false"/>
+          <property key="generate-16-bit-code" value="false"/>
+          <property key="generate-micro-compressed-code" value="false"/>
+          <property key="keep-locals" value="false"/>
+          <property key="list-assembly" value="false"/>
+          <property key="list-section-info" value="false"/>
+          <property key="list-source" value="false"/>
+          <property key="list-symbols" value="false"/>
+          <property key="oXC16asm-extra-opts" value=""/>
+          <property key="oXC32asm-list-to-file" value="false"/>
+          <property key="omit-debug-dirs" value="false"/>
+          <property key="omit-forms" value="false"/>
+          <property key="preprocessor-macros" value=""/>
+          <property key="relax" value="false"/>
+          <property key="warning-level" value=""/>
+        </C32-AS>
+        <C32-CO>
+          <property key="coverage-enable" value=""/>
+          <property key="stack-guidance" value="false"/>
+        </C32-CO>
+        <C32-LD>
+          <property key="additional-options-use-response-files" value="false"/>
+          <property key="additional-options-write-sla" value="false"/>
+          <property key="allocate-dinit" value="false"/>
+          <property key="code-dinit" value="false"/>
+          <property key="ebase-addr" value=""/>
+          <property key="enable-check-sections" value="false"/>
+          <property key="enable-data-init" value="true"/>
+          <property key="enable-default-isr" value="true"/>
+          <property key="exclude-floating-point-library" value="false"/>
+          <property key="exclude-standard-libraries" value="false"/>
+          <property key="extra-lib-directories" value=""/>
+          <property key="fill-flash-options-addr" value=""/>
+          <property key="fill-flash-options-const" value=""/>
+          <property key="fill-flash-options-how" value="0"/>
+          <property key="fill-flash-options-inc-const" value="1"/>
+          <property key="fill-flash-options-increment" value=""/>
+          <property key="fill-flash-options-seq" value=""/>
+          <property key="fill-flash-options-what" value="0"/>
+          <property key="generate-16-bit-code" value="false"/>
+          <property key="generate-cross-reference-file" value="false"/>
+          <property key="generate-micro-compressed-code" value="false"/>
+          <property key="heap-size" value="1024"/>
+          <property key="input-libraries" value=""/>
+          <property key="kseg-length" value=""/>
+          <property key="kseg-origin" value=""/>
+          <property key="linker-symbols" value=""/>
+          <property key="map-file" value="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map"/>
+          <property key="no-device-startup-code" value="true"/>
+          <property key="no-ivt" value="false"/>
+          <property key="no-startup-files" value="false"/>
+          <property key="oXC16ld-force-link" value="false"/>
+          <property key="oXC16ld-no-smart-io" value="false"/>
+          <property key="oXC16ld-stackguard" value="16"/>
+          <property key="oXC32ld-extra-opts" value=""/>
+          <property key="optimization-level" value=""/>
+          <property key="preprocessor-macros" value=""/>
+          <property key="remove-unused-sections" value="true"/>
+          <property key="report-memory-usage" value="false"/>
+          <property key="serial-length" value=""/>
+          <property key="serial-origin" value=""/>
+          <property key="stack-size" value="8192"/>
+          <property key="symbol-stripping" value=""/>
+          <property key="trace-symbols" value=""/>
+          <property key="warn-section-align" value="false"/>
+          <appendMe value="-defsym=_ebase_address=0x9d010000"/>
+        </C32-LD>
+        <C32CPP>
+          <property key="additional-warnings" value="false"/>
+          <property key="addresss-attribute-use" value="false"/>
+          <property key="check-new" value="false"/>
+          <property key="eh-specs" value="true"/>
+          <property key="enable-app-io" value="false"/>
+          <property key="enable-omit-frame-pointer" value="false"/>
+          <property key="enable-symbols" value="true"/>
+          <property key="enable-unroll-loops" value="false"/>
+          <property key="exceptions" value="true"/>
+          <property key="exclude-floating-point" value="false"/>
+          <property key="extra-include-directories"
+                    value="../src;../src/config/default;../src/config/default/system/fs/fat_fs/file_system;../src/config/default/system/fs/fat_fs/hardware_access;../src/third_party/rtos/FreeRTOS/Source/include;../src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ"/>
+          <property key="generate-16-bit-code" value="false"/>
+          <property key="generate-micro-compressed-code" value="false"/>
+          <property key="isolate-each-function" value="true"/>
+          <property key="make-warnings-into-errors" value="false"/>
+          <property key="optimization-level" value="-O1"/>
+          <property key="place-data-into-section" value="false"/>
+          <property key="post-instruction-scheduling" value="default"/>
+          <property key="pre-instruction-scheduling" value="default"/>
+          <property key="preprocessor-macros" value=""/>
+          <property key="rtti" value="true"/>
+          <property key="strict-ansi" value="false"/>
+          <property key="toplevel-reordering" value=""/>
+          <property key="unaligned-access" value=""/>
+          <property key="use-cci" value="false"/>
+          <property key="use-iar" value="false"/>
+          <property key="use-indirect-calls" value="false"/>
+        </C32CPP>
+        <C32Global>
+          <property key="combine-sourcefiles" value="false"/>
+          <property key="common-include-directories" value=""/>
+          <property key="common-macros" value=""/>
+          <property key="dual-boot-partition" value="0"/>
+          <property key="generic-16-bit" value="false"/>
+          <property key="gp-relative-option" value=""/>
+          <property key="legacy-libc" value="true"/>
+          <property key="mdtcm" value=""/>
+          <property key="mitcm" value=""/>
+          <property key="mpreserve-all" value="false"/>
+          <property key="mstacktcm" value="false"/>
+          <property key="omit-pack-options" value="1"/>
+          <property key="preserve-all" value="false"/>
+          <property key="preserve-file" value=""/>
+          <property key="relaxed-math" value="false"/>
+          <property key="save-temps" value="false"/>
+          <property key="stack-smashing" value=""/>
+          <property key="wpo-lto" value="false"/>
+        </C32Global>
+      </item>
+      <item path="../src/third_party/wolfssl/wolfssl/wolfcrypt/src/tfm.c"
+            ex="false"
+            overriding="true">
+        <C32>
+          <property key="additional-warnings" value="true"/>
+          <property key="addresss-attribute-use" value="false"/>
+          <property key="cast-align" value="false"/>
+          <property key="code-model" value="default"/>
+          <property key="const-model" value="default"/>
+          <property key="data-model" value="default"/>
+          <property key="disable-instruction-scheduling" value="false"/>
+          <property key="enable-app-io" value="false"/>
+          <property key="enable-omit-frame-pointer" value="false"/>
+          <property key="enable-procedural-abstraction" value="false"/>
+          <property key="enable-short-double" value="false"/>
+          <property key="enable-symbols" value="true"/>
+          <property key="enable-unroll-loops" value="false"/>
+          <property key="exclude-floating-point" value="false"/>
+          <property key="expand-pragma-config" value="false"/>
+          <property key="extra-include-directories"
+                    value="../src;../src/config/default;../src/config/default/driver/winc/include/;../src/config/default/driver/winc/include/dev;../src/config/default/driver/winc/include/drv/bsp;../src/config/default/driver/winc/include/drv/bsp/include;../src/config/default/driver/winc/include/drv/common;../src/config/default/driver/winc/include/drv/driver;../src/config/default/driver/winc/include/drv/socket;../src/config/default/driver/winc/include/drv/spi_flash;../src/config/default/system/fs/fat_fs/file_system;../src/config/default/system/fs/fat_fs/hardware_access;../src/third_party/rtos/FreeRTOS/Source/include;../src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ;../src/third_party/wolfssl;../src/third_party/wolfssl/wolfssl;../src/third_party/zlib;../src/libraries/scpi/libscpi/inc"/>
+          <property key="generate-16-bit-code" value="false"/>
+          <property key="generate-micro-compressed-code" value="false"/>
+          <property key="isolate-each-function" value="true"/>
+          <property key="keep-inline" value="false"/>
+          <property key="make-warnings-into-errors" value="true"/>
+          <property key="oXC16gcc-errata" value=""/>
+          <property key="oXC16gcc-large-aggregate" value="false"/>
+          <property key="oXC16gcc-mpa-lvl" value=""/>
+          <property key="oXC16gcc-name-text-sec" value=""/>
+          <property key="oXC16gcc-near-chars" value="false"/>
+          <property key="oXC16gcc-no-isr-warn" value="false"/>
+          <property key="oXC16gcc-sfr-warn" value="false"/>
+          <property key="oXC16gcc-smar-io-lvl" value="1"/>
+          <property key="oXC16gcc-smart-io-fmt" value=""/>
+          <property key="optimization-level" value="-O3"/>
+          <property key="place-data-into-section" value="true"/>
+          <property key="post-instruction-scheduling" value="default"/>
+          <property key="pre-instruction-scheduling" value="default"/>
+          <property key="preprocessor-macros"
+                    value="FORCE_BOOTLOADER_FLAG_ADDR=&quot;0x80000000+0x80000-0x10&quot;;FORCE_BOOTLOADER_FLAG_VALUE=&quot;0xF4CEB007&quot;;HAVE_CONFIG_H;WOLFSSL_IGNORE_FILE_WARN"/>
+          <property key="scalar-model" value="default"/>
+          <property key="strict-ansi" value="false"/>
+          <property key="support-ansi" value="false"/>
+          <property key="tentative-definitions" value=""/>
+          <property key="toplevel-reordering" value=""/>
+          <property key="unaligned-access" value=""/>
+          <property key="use-cci" value="false"/>
+          <property key="use-iar" value="false"/>
+          <property key="use-indirect-calls" value="false"/>
+          <appendMe value="-Wno-error=array-bounds"/>
+        </C32>
+        <C32-AR>
+          <property key="additional-options-chop-files" value="false"/>
+        </C32-AR>
+        <C32-AS>
+          <property key="assembler-symbols" value=""/>
+          <property key="enable-symbols" value="true"/>
+          <property key="exclude-floating-point-library" value="false"/>
+          <property key="expand-macros" value="false"/>
+          <property key="extra-include-directories-for-assembler"
+                    value="../src/config/default;../src/config/default/peripheral/cache;../src/third_party/rtos/FreeRTOS/Source/include;../src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ"/>
+          <property key="extra-include-directories-for-preprocessor"
+                    value="../src/config/default;../src/third_party/rtos/FreeRTOS/Source/include;../src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ"/>
+          <property key="false-conditionals" value="false"/>
+          <property key="generate-16-bit-code" value="false"/>
+          <property key="generate-micro-compressed-code" value="false"/>
+          <property key="keep-locals" value="false"/>
+          <property key="list-assembly" value="false"/>
+          <property key="list-section-info" value="false"/>
+          <property key="list-source" value="false"/>
+          <property key="list-symbols" value="false"/>
+          <property key="oXC16asm-extra-opts" value=""/>
+          <property key="oXC32asm-list-to-file" value="false"/>
+          <property key="omit-debug-dirs" value="false"/>
+          <property key="omit-forms" value="false"/>
+          <property key="preprocessor-macros" value=""/>
+          <property key="relax" value="false"/>
+          <property key="warning-level" value=""/>
+        </C32-AS>
+        <C32-CO>
+          <property key="coverage-enable" value=""/>
+          <property key="stack-guidance" value="false"/>
+        </C32-CO>
+        <C32-LD>
+          <property key="additional-options-use-response-files" value="false"/>
+          <property key="additional-options-write-sla" value="false"/>
+          <property key="allocate-dinit" value="false"/>
+          <property key="code-dinit" value="false"/>
+          <property key="ebase-addr" value=""/>
+          <property key="enable-check-sections" value="false"/>
+          <property key="enable-data-init" value="true"/>
+          <property key="enable-default-isr" value="true"/>
+          <property key="exclude-floating-point-library" value="false"/>
+          <property key="exclude-standard-libraries" value="false"/>
+          <property key="extra-lib-directories" value=""/>
+          <property key="fill-flash-options-addr" value=""/>
+          <property key="fill-flash-options-const" value=""/>
+          <property key="fill-flash-options-how" value="0"/>
+          <property key="fill-flash-options-inc-const" value="1"/>
+          <property key="fill-flash-options-increment" value=""/>
+          <property key="fill-flash-options-seq" value=""/>
+          <property key="fill-flash-options-what" value="0"/>
+          <property key="generate-16-bit-code" value="false"/>
+          <property key="generate-cross-reference-file" value="false"/>
+          <property key="generate-micro-compressed-code" value="false"/>
+          <property key="heap-size" value="1024"/>
+          <property key="input-libraries" value=""/>
+          <property key="kseg-length" value=""/>
+          <property key="kseg-origin" value=""/>
+          <property key="linker-symbols" value=""/>
+          <property key="map-file" value="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map"/>
+          <property key="no-device-startup-code" value="true"/>
+          <property key="no-ivt" value="false"/>
+          <property key="no-startup-files" value="false"/>
+          <property key="oXC16ld-force-link" value="false"/>
+          <property key="oXC16ld-no-smart-io" value="false"/>
+          <property key="oXC16ld-stackguard" value="16"/>
+          <property key="oXC32ld-extra-opts" value=""/>
+          <property key="optimization-level" value=""/>
+          <property key="preprocessor-macros" value=""/>
+          <property key="remove-unused-sections" value="true"/>
+          <property key="report-memory-usage" value="false"/>
+          <property key="serial-length" value=""/>
+          <property key="serial-origin" value=""/>
+          <property key="stack-size" value="8192"/>
+          <property key="symbol-stripping" value=""/>
+          <property key="trace-symbols" value=""/>
+          <property key="warn-section-align" value="false"/>
+          <appendMe value="-defsym=_ebase_address=0x9d010000"/>
+        </C32-LD>
+        <C32CPP>
+          <property key="additional-warnings" value="false"/>
+          <property key="addresss-attribute-use" value="false"/>
+          <property key="check-new" value="false"/>
+          <property key="eh-specs" value="true"/>
+          <property key="enable-app-io" value="false"/>
+          <property key="enable-omit-frame-pointer" value="false"/>
+          <property key="enable-symbols" value="true"/>
+          <property key="enable-unroll-loops" value="false"/>
+          <property key="exceptions" value="true"/>
+          <property key="exclude-floating-point" value="false"/>
+          <property key="extra-include-directories"
+                    value="../src;../src/config/default;../src/config/default/system/fs/fat_fs/file_system;../src/config/default/system/fs/fat_fs/hardware_access;../src/third_party/rtos/FreeRTOS/Source/include;../src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ"/>
+          <property key="generate-16-bit-code" value="false"/>
+          <property key="generate-micro-compressed-code" value="false"/>
+          <property key="isolate-each-function" value="true"/>
+          <property key="make-warnings-into-errors" value="false"/>
+          <property key="optimization-level" value="-O1"/>
+          <property key="place-data-into-section" value="false"/>
+          <property key="post-instruction-scheduling" value="default"/>
+          <property key="pre-instruction-scheduling" value="default"/>
+          <property key="preprocessor-macros" value=""/>
+          <property key="rtti" value="true"/>
+          <property key="strict-ansi" value="false"/>
+          <property key="toplevel-reordering" value=""/>
+          <property key="unaligned-access" value=""/>
+          <property key="use-cci" value="false"/>
+          <property key="use-iar" value="false"/>
+          <property key="use-indirect-calls" value="false"/>
+        </C32CPP>
+        <C32Global>
+          <property key="combine-sourcefiles" value="false"/>
+          <property key="common-include-directories" value=""/>
+          <property key="common-macros" value=""/>
+          <property key="dual-boot-partition" value="0"/>
+          <property key="generic-16-bit" value="false"/>
+          <property key="gp-relative-option" value=""/>
+          <property key="legacy-libc" value="true"/>
+          <property key="mdtcm" value=""/>
+          <property key="mitcm" value=""/>
+          <property key="mpreserve-all" value="false"/>
+          <property key="mstacktcm" value="false"/>
+          <property key="omit-pack-options" value="1"/>
+          <property key="preserve-all" value="false"/>
+          <property key="preserve-file" value=""/>
+          <property key="relaxed-math" value="false"/>
+          <property key="save-temps" value="false"/>
+          <property key="stack-smashing" value=""/>
+          <property key="wpo-lto" value="false"/>
+        </C32Global>
+      </item>
       <C32>
         <property key="additional-warnings" value="true"/>
         <property key="addresss-attribute-use" value="false"/>
@@ -2475,7 +2838,7 @@
         <property key="oXC16gcc-sfr-warn" value="false"/>
         <property key="oXC16gcc-smar-io-lvl" value="1"/>
         <property key="oXC16gcc-smart-io-fmt" value=""/>
-        <property key="optimization-level" value="-O1"/>
+        <property key="optimization-level" value="-O3"/>
         <property key="place-data-into-section" value="true"/>
         <property key="post-instruction-scheduling" value="default"/>
         <property key="pre-instruction-scheduling" value="default"/>

--- a/firmware/src/Util/CircularBuffer.h
+++ b/firmware/src/Util/CircularBuffer.h
@@ -34,7 +34,7 @@ typedef struct s_CircularBuf
 {
     uint8_t*    insertPtr;
     uint8_t*    removePtr;
-    uint32_t    totalBytes;
+    volatile uint32_t    totalBytes;  // volatile: cross-task producer/consumer
     uint8_t*    buf_ptr;
     uint32_t    buf_size;
     int        (*process_callback)(uint8_t*, uint32_t);

--- a/firmware/src/Util/CircularBuffer.h
+++ b/firmware/src/Util/CircularBuffer.h
@@ -34,7 +34,9 @@ typedef struct s_CircularBuf
 {
     uint8_t*    insertPtr;
     uint8_t*    removePtr;
-    volatile uint32_t    totalBytes;  // volatile: cross-task producer/consumer
+    volatile uint32_t    totalBytes;  // volatile: single-producer (AddBytes +=)
+                                      // single-consumer (ProcessBytes -=). RMW is
+                                      // safe: only one writer per direction.
     uint8_t*    buf_ptr;
     uint32_t    buf_size;
     int        (*process_callback)(uint8_t*, uint32_t);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -167,13 +167,10 @@ static AInChannelMapping gChannelMapping = {0};
 // ENCODER_BUFFER_DEFAULT (8192) and ENCODER_BUFFER_MIN (1024) defined in
 // StreamingBufferPool.h. Benchmark: 8KB optimal for USB, 16KB helps SD.
 //
-// volatile: written by SCPI/USB task (Streaming_SetEncoderBuffer, called
-// during pool repartitioning at each StartStreamData), read by streaming_Task
-// in its while(1) loop.  Both are file-scope static with no escaped address
-// (&buffer / &bufferSize never taken), so without volatile the compiler at
-// -O2+ can prove no external function modifies them and cache them in
-// registers for the entire loop — making the streaming task blind to
-// repartitioned buffer pointers.  See Issue #271.
+// volatile: written by SCPI/USB task during StartStreamData (streaming is
+// stopped, so no torn-read risk — the streaming task is blocked on
+// ulTaskNotifyTake). Without volatile, -O2+ caches these in registers
+// across the while(1) loop since their addresses are never taken.
 static uint8_t* volatile buffer = NULL;
 static volatile uint32_t bufferSize = 0;
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -166,8 +166,16 @@ static AInChannelMapping gChannelMapping = {0};
 // Encoder buffer — allocated from StreamingBufferPool, runtime-adjustable.
 // ENCODER_BUFFER_DEFAULT (8192) and ENCODER_BUFFER_MIN (1024) defined in
 // StreamingBufferPool.h. Benchmark: 8KB optimal for USB, 16KB helps SD.
-static uint8_t* buffer = NULL;
-static uint32_t bufferSize = 0;
+//
+// volatile: written by SCPI/USB task (Streaming_SetEncoderBuffer, called
+// during pool repartitioning at each StartStreamData), read by streaming_Task
+// in its while(1) loop.  Both are file-scope static with no escaped address
+// (&buffer / &bufferSize never taken), so without volatile the compiler at
+// -O2+ can prove no external function modifies them and cache them in
+// registers for the entire loop — making the streaming task blind to
+// repartitioned buffer pointers.  See Issue #271.
+static uint8_t* volatile buffer = NULL;
+static volatile uint32_t bufferSize = 0;
 
 //! Pointer to the board configuration data structure to be set in 
 //! initialization
@@ -286,6 +294,7 @@ void _Streaming_Deferred_Interrupt_Task(void) {
     AInSample *pAiSample;
 
     uint64_t ChannelScanFreqDivCount = 0;
+
     while (1) {
         ulTaskNotifyTake(pdFALSE, xBlockTime);
 


### PR DESCRIPTION
## Summary

- **Root cause**: XC32/GCC at O2+ miscompiles FreeRTOS `listINSERT_END` — stores reordered so `pxContainer` is NULL when `xTaskResumeAll` reads it (BadVAddr=4 crash)
- **Fix**: Compile `FreeRTOS_tasks.c` at -O1 per-file override. Global optimization raised from O1 to **O3**.
- **Volatile best practice**: Added `volatile` to 3 cross-task shared variables (`buffer`, `bufferSize`, `totalBytes`)
- **Docs**: Updated CLAUDE.md compiler section, strengthened picocom warning

## Investigation Summary

| Test | Result |
|------|--------|
| O3 global + FreeRTOS@O1 | PASS — 16ch@3500Hz, 1ch@11kHz, zero drops |
| O2 global + FreeRTOS@O1 | PASS |
| O2 global + FreeRTOS@O2 | CRASH — BadVAddr=4 in `xTaskResumeAll` |
| Linker .bss.* fix | Not needed when FreeRTOS@O1 |
| `-mno-gpopt` flag | Not needed when FreeRTOS@O1 |
| Anti-starvation yield | Not needed — was masking the crash |
| Volatile tags removed | Still passes (best practice, not required for fix) |

## Benchmark (O3, USB, uncapped)

| Config | SPS | KB/s | Status |
|--------|-----|------|--------|
| PB 1ch@5kHz | 4,882 | 52 | CLEAN |
| PB 1ch@11kHz | 10,547 | 113 | CLEAN |
| PB 8ch@5kHz | 4,882 | 118 | CLEAN |
| PB 16ch@5kHz | 4,878 | 195 | CLEAN |
| CSV 1ch@11kHz | 10,534 | 165 | CLEAN |
| CSV 8ch@3kHz | 2,561 | 307 | CLEAN |
| CSV 16ch@5kHz | 4,792 | 1,179 | 2.6% USB drop (host-side limit) |

USB throughput ceiling ~250 KB/s for PB, higher for CSV. Host-side optimization tracked in daqifi/daqifi-python-test-suite#6. Firmware-side double-buffer DMA tracked in #273.

## Test plan
- [x] 16ch@3500Hz PB streaming 60s — no crash, zero drops
- [x] 1ch@11000Hz PB streaming 30s — no crash, zero drops  
- [x] Full USB PB+CSV uncapped benchmark — all clean below transport ceiling
- [x] O2 and O3 both verified working
- [ ] Qodo automated review

🤖 Generated with [Claude Code](https://claude.com/claude-code)