### PR TITLE
perf(adc): batch Type 1 ISRs into single CH3 trigger (#277)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,45 @@ Commit and push wiki changes after updating.
    - Streaming engine manages buffer flow and encoding
    - Supports multiple simultaneous outputs
 
+#### ADC Architecture & ISR Design
+
+The PIC32MZ ADCHS peripheral has two types of ADC channels with different ISR strategies:
+
+**Type 1 — Dedicated modules (simultaneous conversion):**
+- NQ1 channels: ch4 (MODULE4), ch8 (MODULE0), ch10 (MODULE1), ch12 (MODULE2), ch14 (MODULE3)
+- Each channel has its own SAR ADC module — all convert simultaneously on trigger
+- **Batched ISR**: A single data-ready interrupt (CH3/MODULE3) reads all Type 1 results. CH3 is always triggered when any Type 1 channel is active, even if ch14 itself is disabled. This eliminates N-1 redundant ISR entries per sample. See Issue #277.
+- Trigger: `ADCHS_ChannelConversionStart()` per enabled channel in `MC12b_TriggerConversion()`
+
+**Type 2 — Shared MODULE7 (sequential mux scan):**
+- NQ1 channels: ch0, ch1, ch2, ch3, ch5, ch6, ch7, ch9, ch11, ch13, ch15
+- All share MODULE7 — channels scanned sequentially via analog multiplexer
+- **Single EOS ISR**: `ADC_EOS_Handler` fires once after the entire scan completes
+- Results read by `MC12bADC_EosInterruptTask` (deferred task, priority 8)
+- Trigger: `ADCHS_GlobalEdgeConversionStart()` in `MC12b_TriggerConversion()`
+
+**ISR flow per streaming timer tick:**
+1. Streaming timer ISR (`Streaming_Defer_Interrupt`) fires → notifies deferred task
+2. Deferred task calls `MC12b_TriggerConversion(MC12B_ADC_TYPE_ALL)`
+3. Type 1: individual `ChannelConversionStart` + CH3 phantom trigger → single `ADC_DATA3_Handler` reads all
+4. Type 2: `GlobalEdgeConversionStart` → MODULE7 scans → `ADC_EOS_Handler` → `MC12bADC_EosInterruptTask` reads all
+5. Results stored via `ADC_ReadADCSampleFromISR()` → `BoardData_Set(BOARDDATA_AIN_LATEST)`
+
+**Key files:**
+- `config/default/interrupts.c` — `ADC_DATA3_Handler` (Type 1 batch), `ADC_EOS_Handler` (Type 2)
+- `HAL/ADC/MC12bADC.c` — `MC12b_TriggerConversion`, `MC12b_WriteStateAll` (batch interrupt setup)
+- `HAL/ADC.c` — `MC12bADC_EosInterruptTask`, `ADC_ReadADCSampleFromISR`
+
+**Characterization results (O3, USB PB, zero-loss ceiling):**
+
+| Config | Ceiling Hz | Notes |
+|--------|-----------|-------|
+| 1×T1 | ~15,000 | Single dedicated module |
+| 5×T1 | ~11,000 | All 5 simultaneous (batched ISR) |
+| 1×T2 | ~16,800 | Single mux channel |
+| 11×T2 | ~11,400 | Full mux scan |
+| 5T1+11T2 (16ch) | ~6,400 | Both ADC paths active |
+
 #### Voltage Output Precision
 
 Systemwide configurable voltage precision via `StreamingRuntimeConfig.VoltagePrecision`. Applies to CSV streaming, JSON streaming, and SCPI voltage queries (`MEAS:VOLT:DC?`, `SOUR:VOLT:LEV?`).

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -24,6 +24,13 @@
 #define max(x,y) x >= y ? x : y
 #endif // min
 
+//! Bitmask of enabled Type 1 ADCHS channels (bits 0-4).
+//! Set by MC12b_WriteStateAll; getter available for diagnostics.
+//! uint32_t (native bus width) — see Issue #277.
+static volatile uint32_t gType1EnabledMask = 0;
+
+uint32_t MC12b_GetType1EnabledMask(void) { return gType1EnabledMask; }
+
 //! Pointer to the module configuration data structure to be set in initialization
 static MC12bModuleConfig* gpModuleConfigMC12;
 //! Pointer to the module configuration data structure in runtime
@@ -120,24 +127,21 @@ bool MC12b_WriteStateAll(
                 &channelRuntimeConfig->Data[i]);
     }
 
-    // Batch interrupt for Type 1: enable only CH3's result interrupt
-    // (the batch trigger). All Type 1 results are read from CH3's ISR.
-    // Disable result interrupts for other Type 1 channels (CH0-CH2, CH4).
-    bool anyType1Enabled = false;
+    // Batch interrupt for Type 1: build bitmask of enabled ADCHS channels
+    // and enable only CH3's result interrupt (the batch trigger).
+    uint8_t mask = 0;
     for (i = 0; i < channelConfig->Size; ++i) {
         if (channelConfig->Data[i].Type == AIn_MC12bADC &&
-            channelConfig->Data[i].Config.MC12b.ChannelType == 1 &&
-            channelRuntimeConfig->Data[i].IsEnabled) {
-            anyType1Enabled = true;
-            // Disable this channel's individual result interrupt
-            ADCHS_ChannelResultInterruptDisable(
-                channelConfig->Data[i].Config.MC12b.ChannelId);
+            channelConfig->Data[i].Config.MC12b.ChannelType == 1) {
+            uint8_t chId = channelConfig->Data[i].Config.MC12b.ChannelId;
+            if (channelRuntimeConfig->Data[i].IsEnabled) {
+                mask |= (1U << chId);
+            }
+            ADCHS_ChannelResultInterruptDisable(chId);
         }
     }
-    if (anyType1Enabled) {
-        // Enable MODULE3 and its result interrupt as batch trigger.
-        // MODULE3 may not have an enabled user channel (ch14), but it
-        // must be active so its data-ready ISR fires and reads all results.
+    gType1EnabledMask = mask;
+    if (mask != 0) {
         ADCHS_ModulesEnable(ADCHS_MODULE3_MASK);
         ADCHS_ChannelResultInterruptEnable(ADCHS_CH3);
     } else {

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -114,9 +114,34 @@ bool MC12b_WriteStateAll(
     size_t i = 0;
     bool result = true;
     for (i = 0; i < channelConfig->Size; ++i) {
+        if (channelConfig->Data[i].Type != AIn_MC12bADC) continue;
         result &= MC12b_WriteStateSingle(
                 &(channelConfig->Data[i].Config.MC12b),
                 &channelRuntimeConfig->Data[i]);
+    }
+
+    // Batch interrupt for Type 1: enable only CH3's result interrupt
+    // (the batch trigger). All Type 1 results are read from CH3's ISR.
+    // Disable result interrupts for other Type 1 channels (CH0-CH2, CH4).
+    bool anyType1Enabled = false;
+    for (i = 0; i < channelConfig->Size; ++i) {
+        if (channelConfig->Data[i].Type == AIn_MC12bADC &&
+            channelConfig->Data[i].Config.MC12b.ChannelType == 1 &&
+            channelRuntimeConfig->Data[i].IsEnabled) {
+            anyType1Enabled = true;
+            // Disable this channel's individual result interrupt
+            ADCHS_ChannelResultInterruptDisable(
+                channelConfig->Data[i].Config.MC12b.ChannelId);
+        }
+    }
+    if (anyType1Enabled) {
+        // Enable MODULE3 and its result interrupt as batch trigger.
+        // MODULE3 may not have an enabled user channel (ch14), but it
+        // must be active so its data-ready ISR fires and reads all results.
+        ADCHS_ModulesEnable(ADCHS_MODULE3_MASK);
+        ADCHS_ChannelResultInterruptEnable(ADCHS_CH3);
+    } else {
+        ADCHS_ChannelResultInterruptDisable(ADCHS_CH3);
     }
 
     if (isEnabled) {
@@ -130,39 +155,41 @@ bool MC12b_WriteStateSingle(
         const MC12bChannelConfig* channelConfig,
         AInRuntimeConfig* channelRuntimeConfig) {
 
-
     if (channelConfig->ChannelType == 1) {
         if (channelRuntimeConfig->IsEnabled) {
             ADCHS_ModulesEnable(channelConfig->ModuleId);
-            ADCHS_ChannelResultInterruptEnable(channelConfig->ChannelId);
+            // Do NOT enable per-channel result interrupt here.
+            // Type 1 channels use batch ISR via CH3 (see WriteStateAll).
         } else {
             ADCHS_ModulesDisable(channelConfig->ModuleId);
             ADCHS_ChannelResultInterruptDisable(channelConfig->ChannelId);
         }
     }
-    //    else {
-    //        if (channelRuntimeConfig->IsEnabled) {
-    //            ADCHS_ChannelResultInterruptEnable(channelConfig->ChannelId);          
-    //        } else {
-    //            ADCHS_ChannelResultInterruptDisable(channelConfig->ChannelId);           
-    //            
-    //        }
-    //    }
-    // TODO: What about channel 2-3
     return true;
 }
 
 bool MC12b_TriggerConversion(AInRuntimeArray* pRunTimeChannlConfig, AInArray* pAIConfigArr, MC12b_adcType_t type) {
     int aiChannelSize = min(pRunTimeChannlConfig->Size, pAIConfigArr->Size);
     if (type == MC12B_ADC_TYPE_DEDICATED || type==MC12B_ADC_TYPE_ALL) {
+        bool anyType1Triggered = false;
+        bool triggerChTriggered = false;
         for (int i = 0; i < aiChannelSize; i++) {
-            if (pRunTimeChannlConfig->Data[i].IsEnabled) {
-                // Check Type before accessing union member
-                if (pAIConfigArr->Data[i].Type == AIn_MC12bADC &&
-                        pAIConfigArr->Data[i].Config.MC12b.ChannelType == 1){
-                    ADCHS_ChannelConversionStart(pAIConfigArr->Data[i].Config.MC12b.ChannelId);
+            if (pRunTimeChannlConfig->Data[i].IsEnabled &&
+                pAIConfigArr->Data[i].Type == AIn_MC12bADC &&
+                pAIConfigArr->Data[i].Config.MC12b.ChannelType == 1) {
+                ADCHS_ChannelConversionStart(pAIConfigArr->Data[i].Config.MC12b.ChannelId);
+                anyType1Triggered = true;
+                if (pAIConfigArr->Data[i].Config.MC12b.ChannelId == ADCHS_CH3) {
+                    triggerChTriggered = true;
                 }
             }
+        }
+        // Always trigger CH3 (batch trigger) so its data-ready ISR fires
+        // and reads all Type 1 results. If ch14 (CH3) is disabled, MODULE3
+        // converts but the result is harmlessly discarded by the ISR
+        // (no matching enabled channel in ADC_ReadADCSampleFromISR).
+        if (anyType1Triggered && !triggerChTriggered) {
+            ADCHS_ChannelConversionStart(ADCHS_CH3);
         }
     }
     if(type==MC12B_ADC_TYPE_SHARED || type==MC12B_ADC_TYPE_ALL)

--- a/firmware/src/HAL/ADC/MC12bADC.h
+++ b/firmware/src/HAL/ADC/MC12bADC.h
@@ -83,7 +83,13 @@ double MC12b_ConvertToVoltage(
                         const MC12bChannelConfig* channelConfig,
                         const AInRuntimeConfig* runtimeConfig,
                         uint32_t rawValue);
-bool MC12b_ReadResult(ADCHS_CHANNEL_NUM channel, uint32_t *pVal);    
+bool MC12b_ReadResult(ADCHS_CHANNEL_NUM channel, uint32_t *pVal);
+
+/**
+ * Returns bitmask of enabled Type 1 ADCHS channels (bits 0-4).
+ */
+uint32_t MC12b_GetType1EnabledMask(void);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/firmware/src/config/default/interrupts.c
+++ b/firmware/src/config/default/interrupts.c
@@ -177,11 +177,9 @@ void __attribute__((used)) ADC_DATA2_Handler(void) {
 
 void __attribute__((used)) ADC_DATA3_Handler(void) {
     // Batch trigger: read all Type 1 dedicated channel results (CH0-CH4).
-    // ChannelResultIsReady returns false for modules that weren't triggered
-    // (disabled channels), so only enabled channels' results are read.
-    static const uint8_t type1Channels[] = { 0, 1, 2, 3, 4 };
-    for (int i = 0; i < 5; i++) {
-        uint8_t ch = type1Channels[i];
+    // Fixed bound avoids cross-TU function call (O3-unsafe, see #277).
+    // ChannelResultIsReady filters disabled modules.
+    for (uint32_t ch = 0; ch < 5; ch++) {
         if (ADCHS_ChannelResultIsReady(ch)) {
             ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(ch), ch);
         }

--- a/firmware/src/config/default/interrupts.c
+++ b/firmware/src/config/default/interrupts.c
@@ -154,38 +154,42 @@ void __attribute__((used)) TIMER_7_Handler (void)
     TIMER_7_InterruptHandler();
 }
 
-void __attribute__((used)) ADC_DATA0_Handler(void) {    
-    if (ADCHS_ChannelResultIsReady(0)) {
-        ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(0), 0);
-    }
+// Type 1 (dedicated) ADC channels: batch-read all results from a single ISR.
+// All dedicated modules (0-4) convert simultaneously, so when CH3 (the batch
+// trigger) completes, all others are ready. This eliminates 4 redundant ISR
+// entries per sample period. See Issue #277.
+//
+// CH3 (MODULE3, DaqiFi ch14) is the batch trigger — always triggered when
+// any Type 1 channel is active (see MC12b_TriggerConversion).
+
+void __attribute__((used)) ADC_DATA0_Handler(void) {
+    // Interrupt disabled for batching — stub clears IFS only (safety)
     ADC_DATA0_InterruptHandler();
 }
 
-void __attribute__((used)) ADC_DATA1_Handler(void) {    
-    if (ADCHS_ChannelResultIsReady(1)) {
-        ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(1), 1);
-    }
+void __attribute__((used)) ADC_DATA1_Handler(void) {
     ADC_DATA1_InterruptHandler();
 }
 
-void __attribute__((used)) ADC_DATA2_Handler(void) {   
-    if (ADCHS_ChannelResultIsReady(2)) {
-        ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(2), 2);
-    }
+void __attribute__((used)) ADC_DATA2_Handler(void) {
     ADC_DATA2_InterruptHandler();
 }
 
-void __attribute__((used)) ADC_DATA3_Handler(void) {    
-    if (ADCHS_ChannelResultIsReady(3)) {
-        ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(3), 3);
+void __attribute__((used)) ADC_DATA3_Handler(void) {
+    // Batch trigger: read all Type 1 dedicated channel results (CH0-CH4).
+    // ChannelResultIsReady returns false for modules that weren't triggered
+    // (disabled channels), so only enabled channels' results are read.
+    static const uint8_t type1Channels[] = { 0, 1, 2, 3, 4 };
+    for (int i = 0; i < 5; i++) {
+        uint8_t ch = type1Channels[i];
+        if (ADCHS_ChannelResultIsReady(ch)) {
+            ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(ch), ch);
+        }
     }
     ADC_DATA3_InterruptHandler();
 }
 
-void __attribute__((used)) ADC_DATA4_Handler(void) {    
-    if (ADCHS_ChannelResultIsReady(4)) {
-        ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(4), 4);        
-    }
+void __attribute__((used)) ADC_DATA4_Handler(void) {
     ADC_DATA4_InterruptHandler();
 }
 


### PR DESCRIPTION
## Summary

- Batch all Type 1 (dedicated) ADC channel result reads into a single ISR (`ADC_DATA3_Handler`)
- Eliminates 4 redundant ISR entries per sample when 5 Type 1 channels are active
- CH3/MODULE3 always triggered as batch trigger when any Type 1 channel is enabled
- Documents ADC ISR architecture in CLAUDE.md

## Before/After (USB PB, zero-loss ceiling)

| Config | Before | After | Change |
|--------|--------|-------|--------|
| 5×T1 | 9,000 Hz | **11,000 Hz** | **+22%** |
| 3×T1 | 11,000 Hz | **12,200 Hz** | **+11%** |
| 5T1+4T2 (9ch) | 8,000 Hz | **10,000 Hz** | **+25%** |

## Before/After (USB CSV, zero-loss ceiling)

| Config | Before | After | Change |
|--------|--------|-------|--------|
| 5×T1 | 6,400 Hz | **9,600 Hz** | **+50%** |
| 5T1+4T2 (9ch) | 6,600 Hz | **7,800 Hz** | **+18%** |
| 5T1+8T2 (13ch) | 5,600 Hz | **6,400 Hz** | **+14%** |
| 5T1+11T2 (16ch) | 5,200 Hz | **6,000 Hz** | **+15%** |

Single-channel Type 1 shows ~4-8% regression (batch loop overhead) — optimization planned.

## Test plan
- [x] All 16ch streaming at 1kHz, 3.5kHz — no crash
- [x] Full ADC characterization (10 configs × PB + CSV)
- [x] Type 1 multi-channel: significant improvement confirmed
- [x] Mixed T1+T2: all configs improved
- [ ] Qodo review
- [ ] Partial Type 1 enable (e.g., ch4 + ch10 without ch14) — phantom trigger test

🤖 Generated with [Claude Code](https://claude.com/claude-code)