### PR TITLE
feat(adc): CONF:ADC:OBDiag — skip onboard diagnostics during streaming (#280)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1618,6 +1618,4 @@ python test_sd_card.py
 - all errors should go through the error logging function and doesn't need to be sent out in the stream at all. if there is an
  error, the SCPI command should return the error through its own handling. then the user calls SYSTem:LOG? to know what the
 error was.
-- all errors should go through the error logging function and doesn't need to be sent out in the stream at all. if there is an
- error, the SCPI command should return the error through its own handling. then the user calls SYSTem:LOG? to know what the
-error was.
+- SCPI data visibility principle: prevent users from operating with improper settings (return SCPI errors for config problems like reading disabled channels), but maximize visibility into device health. When data is stale (e.g., monitoring channels frozen during OBDiag=0 streaming), show last-known values with age indicators rather than hiding them. Error on config problems, inform on stale data.

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -685,6 +685,10 @@ scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context) {
     }
     StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
+    if (pStreamCfg->Running) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
     pStreamCfg->OnboardDiagEnabled = (val != 0);
     LOG_I("Onboard diagnostics during streaming: %s", val ? "enabled" : "disabled");
     return SCPI_RES_OK;

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -675,3 +675,24 @@ scpi_result_t SCPI_ADCUseCalGet(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 }
+
+scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context) {
+    int32_t val;
+    if (!SCPI_ParamInt32(context, &val, TRUE)) return SCPI_RES_ERR;
+    if (val < 0 || val > 1) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+    StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_STREAMING_CONFIGURATION);
+    pStreamCfg->OnboardDiagEnabled = (val != 0);
+    LOG_I("Onboard diagnostics during streaming: %s", val ? "enabled" : "disabled");
+    return SCPI_RES_OK;
+}
+
+scpi_result_t SCPI_ADCOnboardDiagGet(scpi_t * context) {
+    StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_STREAMING_CONFIGURATION);
+    SCPI_ResultInt32(context, pStreamCfg->OnboardDiagEnabled ? 1 : 0);
+    return SCPI_RES_OK;
+}

--- a/firmware/src/services/SCPI/SCPIADC.h
+++ b/firmware/src/services/SCPI/SCPIADC.h
@@ -151,7 +151,10 @@ extern "C" {
 
     /**
      * Enable/disable onboard diagnostic channel scanning during streaming.
-     *   CONFigure:ADC:OBDiag <0|1> - 0=skip MODULE7, 1=scan at divided rate (default)
+     *   CONFigure:ADC:OBDiag <0|1>
+     *     0 = skip shared/MODULE7 scanning entirely during streaming
+     *     1 = allow shared/MODULE7 scanning as configured by ChannelScanFreqDiv (default)
+     * Rejected while streaming is active (returns EXECUTION_ERROR).
      */
     scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context);
     scpi_result_t SCPI_ADCOnboardDiagGet(scpi_t * context);

--- a/firmware/src/services/SCPI/SCPIADC.h
+++ b/firmware/src/services/SCPI/SCPIADC.h
@@ -149,6 +149,13 @@ extern "C" {
      */        
     scpi_result_t SCPI_ADCUseCalGet(scpi_t * context);
 
+    /**
+     * Enable/disable onboard diagnostic channel scanning during streaming.
+     *   CONFigure:ADC:OBDiag <0|1> - 0=skip MODULE7, 1=scan at divided rate (default)
+     */
+    scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context);
+    scpi_result_t SCPI_ADCOnboardDiagGet(scpi_t * context);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3210,6 +3210,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:ADC:LOADFcal", .callback = SCPI_ADCCalFLoad,},
     {.pattern = "CONFigure:ADC:USECal", .callback = SCPI_ADCUseCalSet,},
     {.pattern = "CONFigure:ADC:USECal?", .callback = SCPI_ADCUseCalGet,},
+    {.pattern = "CONFigure:ADC:OBDiag", .callback = SCPI_ADCOnboardDiagSet,},
+    {.pattern = "CONFigure:ADC:OBDiag?", .callback = SCPI_ADCOnboardDiagGet,},
     //
     // Voltage output precision
     {.pattern = "CONFigure:VOLTage:PRECision", .callback = SCPI_SetDataPrecision,},

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -406,6 +406,7 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             if (gBenchmarkMode != BENCHMARK_PIPELINE) {
                 bool hwDed = MC12b_IsHwTriggerDedicated();
                 bool hwShd = MC12b_IsHwTriggerShared();
+                bool skipShared = !pRunTimeStreamConf->OnboardDiagEnabled;
 
                 if (pRunTimeStreamConf->ChannelScanFreqDiv == 1) {
                     for (i = 0; i < pRunTimeAInModules->Size; ++i) {
@@ -413,18 +414,20 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                             ADC_TriggerConversion(&pBoardConfig->AInModules.Data[i], MC12B_ADC_TYPE_ALL);
                             continue;
                         }
-                        // MC12bADC: software-trigger only the parts not
-                        // covered by hardware triggering.
-                        if (!hwDed || !hwShd) {
-                            MC12b_adcType_t swType = MC12B_ADC_TYPE_ALL;
-                            if (hwDed && !hwShd) swType = MC12B_ADC_TYPE_SHARED;
-                            else if (!hwDed && hwShd) swType = MC12B_ADC_TYPE_DEDICATED;
-                            ADC_TriggerConversion(&pBoardConfig->AInModules.Data[i], swType);
+                        // MC12bADC: determine which trigger types need software
+                        bool needSwDed = !hwDed;
+                        bool needSwShd = !hwShd && !skipShared;
+                        if (needSwDed && needSwShd) {
+                            ADC_TriggerConversion(&pBoardConfig->AInModules.Data[i], MC12B_ADC_TYPE_ALL);
+                        } else if (needSwDed) {
+                            ADC_TriggerConversion(&pBoardConfig->AInModules.Data[i], MC12B_ADC_TYPE_DEDICATED);
+                        } else if (needSwShd) {
+                            ADC_TriggerConversion(&pBoardConfig->AInModules.Data[i], MC12B_ADC_TYPE_SHARED);
                         }
+                        // else: both hw-triggered or shared skipped — no software trigger
                     }
                 } else if (pRunTimeStreamConf->ChannelScanFreqDiv != 0) {
                     // Dedicated at full rate, shared at divided rate.
-                    // Skip MC12bADC dedicated trigger when hardware does it.
                     for (i = 0; i < pRunTimeAInModules->Size; ++i) {
                         bool isMC12b = (pBoardConfig->AInModules.Data[i].Type == AIn_MC12bADC);
                         if (!(isMC12b && hwDed)) {
@@ -432,13 +435,17 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                         }
                     }
 
-                    if (ChannelScanFreqDivCount >= pRunTimeStreamConf->ChannelScanFreqDiv) {
-                        for (i = 0; i < pRunTimeAInModules->Size; ++i) {
-                            ADC_TriggerConversion(&pBoardConfig->AInModules.Data[i], MC12B_ADC_TYPE_SHARED);
+                    // Shared at divided rate — skip entirely when hw-triggered
+                    // or when onboard diagnostics are disabled.
+                    if (!hwShd && !skipShared) {
+                        if (ChannelScanFreqDivCount >= pRunTimeStreamConf->ChannelScanFreqDiv) {
+                            for (i = 0; i < pRunTimeAInModules->Size; ++i) {
+                                ADC_TriggerConversion(&pBoardConfig->AInModules.Data[i], MC12B_ADC_TYPE_SHARED);
+                            }
+                            ChannelScanFreqDivCount = 0;
                         }
-                        ChannelScanFreqDivCount = 0;
+                        ChannelScanFreqDivCount++;
                     }
-                    ChannelScanFreqDivCount++;
                 }
                 DIO_StreamingTrigger(&pBoardData->DIOLatest, &pBoardData->DIOSamples);
             }
@@ -704,7 +711,10 @@ static void Streaming_Start(void) {
         // Streaming_Start runs at boot (via Streaming_UpdateState) before
         // ADC_Init — must not write ADCTRG/ADCCON1 until ADC is ready.
         if (gpRuntimeConfigStream->IsEnabled) {
-            bool hwShared = (gpRuntimeConfigStream->ChannelScanFreqDiv <= 1);
+            // hwShared: enable MODULE7 scan trigger unless onboard diag is
+            // disabled (max dedicated throughput mode).
+            bool hwShared = gpRuntimeConfigStream->OnboardDiagEnabled &&
+                            (gpRuntimeConfigStream->ChannelScanFreqDiv <= 1);
             MC12b_ConfigureHardwareTrigger(true, hwShared);
         }
 

--- a/firmware/src/state/runtime/CommonRuntimeDefaults.h
+++ b/firmware/src/state/runtime/CommonRuntimeDefaults.h
@@ -99,6 +99,7 @@ _Static_assert(sizeof(DEFAULT_NETWORK_HOST_NAME) <= WIFI_MANAGER_DNS_CLIENT_MAX_
         .TSClockPeriod = 0xFFFFFFFF,   /* maximum */ \
         .ActiveInterface = StreamingInterface_USB,  /* Default: stream to single interface (USB) */ \
         .VoltagePrecision = 4,  /* Initial default; overridden by board config at boot */ \
+        .OnboardDiagEnabled = true, /* MODULE7 scans diag channels during streaming */ \
     }
 
 /**

--- a/firmware/src/state/runtime/StreamingRuntimeConfig.h
+++ b/firmware/src/state/runtime/StreamingRuntimeConfig.h
@@ -96,6 +96,14 @@ extern "C" {
          */
         uint8_t VoltagePrecision;
 
+        /**
+         * Enable onboard diagnostic channel scanning during streaming.
+         * true (default): MODULE7 scans monitoring channels at divided rate.
+         * false: Skip MODULE7 entirely for max dedicated channel throughput.
+         * Controlled via CONF:ADC:OBDiag.  Runtime-only, resets on reboot.
+         */
+        bool OnboardDiagEnabled;
+
     } StreamingRuntimeConfig;
 
     /**


### PR DESCRIPTION
## Summary

- New SCPI command `CONF:ADC:OBDiag <0|1>` to disable MODULE7 shared scan during streaming
- When disabled, all shared ADC triggers (hw and sw) are fully skipped — no `GlobalEdgeConversion`, no divided-rate scan
- Gives max dedicated channel throughput at the cost of no onboard health monitoring during streaming

## Benchmark Results (PB, USB, zero-loss ceiling)

| Config | OBDiag=1 (default) | OBDiag=0 | Improvement |
|--------|------------------:|---------:|-----------:|
| 1×T1 | 16,800 Hz | 18,350 Hz | **+9%** |
| 5×T1 | 12,837 Hz | 14,950 Hz | **+16%** |

## Test Plan

- [x] `CONF:ADC:OBDiag?` returns 1 at boot (default)
- [x] `CONF:ADC:OBDiag 0` / `CONF:ADC:OBDiag?` returns 0
- [x] OBDiag=0: measurable throughput improvement confirms shared scan is truly skipped
- [x] OBDiag=1: baseline throughput unchanged from prior benchmarks
- [ ] Verify `MEAS:VOLT:DC?` still works after streaming with OBDiag=0

**Firmware:** `6975b1ff` on `feat/obdiag-skip-shared`

Partially addresses #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)