### PR TITLE
feat(scpi): stale data indicators + EOS interrupt control (#288)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,19 +247,22 @@ The PIC32MZ ADCHS peripheral has two types of ADC channels with different ISR st
 - `HAL/ADC/MC12bADC.c` — `MC12b_TriggerConversion`, `MC12b_WriteStateAll` (batch interrupt setup)
 - `HAL/ADC.c` — `MC12bADC_EosInterruptTask`, `ADC_ReadADCSampleFromISR`
 
-**Characterization results (O3, USB, zero-loss ceiling, 2026-04-13):**
+**Characterization results (O3, USB, zero-loss ceiling, fullscale test pattern, NoCap benchmark mode):**
+
+PB columns updated 2026-04-15 after PR #290 (EOS interrupt disable during OBDiag=0 streaming — dedicated-module completions were falsely asserting EOSIF, causing per-sample EOS task wakeups). CSV columns still from 2026-04-13 (re-run pending).
 
 | Config | PB Ceiling | PB KB/s | CSV Ceiling | CSV KB/s |
 |--------|----------:|--------:|------------:|--------:|
-| 1×T1 | 13,800 Hz | 147 | 13,800 Hz | 217 |
-| 3×T1 | 12,200 Hz | 180 | 11,400 Hz | 543 |
-| 5×T1 | 11,000 Hz | 212 | 9,600 Hz | 755 |
-| 1×T2 | 16,200 Hz | 171 | 16,200 Hz | 255 |
-| 4×T2 | 12,800 Hz | 214 | 12,600 Hz | 771 |
-| 8×T2 | 12,200 Hz | 297 | 9,600 Hz | 1,160 |
-| 11×T2 | 11,000 Hz | 335 | 6,400 Hz | 1,125 |
-| 5T1+4T2 (9ch) | 10,000 Hz | 262 | 7,800 Hz | 1,077 |
-| 5T1+11T2 (16ch) | 6,400 Hz | 263 | 6,000 Hz | 1,464 |
+| 1×T1 | 15,000 Hz | 145 | 13,800 Hz | 217 |
+| 3×T1 | 14,000 Hz | 225 | 11,400 Hz | 543 |
+| 5×T1 | 13,000 Hz | 217 | 9,600 Hz | 755 |
+| 1×T2 | 21,000 Hz | 243 | 16,200 Hz | 255 |
+| 4×T2 | 17,000 Hz | 313 | 12,600 Hz | 771 |
+| 5×T2 | 16,000 Hz | 271 | — | — |
+| 8×T2 | 16,000 Hz | 354 | 9,600 Hz | 1,160 |
+| 11×T2 | 13,000 Hz | 361 | 6,400 Hz | 1,125 |
+| 5T1+4T2 (9ch) | 12,000 Hz | 294 | 7,800 Hz | 1,077 |
+| 5T1+11T2 (16ch) | 9,000 Hz | 399 | 6,000 Hz | 1,464 |
 
 #### Voltage Output Precision
 

--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -514,12 +514,12 @@ void ADC_SetEosInterruptEnabled(bool enabled) {
     if (enabled) {
         // Clear latched flag before re-enabling to prevent an immediate
         // spurious fire from a flag set while the interrupt was disabled.
-        IFS6CLR = _IFS6_ADCEOSIF_MASK;
-        IEC6SET = _IEC6_ADCEOSIE_MASK;
+        EVIC_SourceStatusClear(INT_SOURCE_ADC_EOS);
+        EVIC_SourceEnable(INT_SOURCE_ADC_EOS);
     } else {
         // Disable first, then clear pending flag to avoid a race where
         // EOS re-asserts between clear and disable.
-        IEC6CLR = _IEC6_ADCEOSIE_MASK;
-        IFS6CLR = _IFS6_ADCEOSIF_MASK;
+        EVIC_SourceDisable(INT_SOURCE_ADC_EOS);
+        EVIC_SourceStatusClear(INT_SOURCE_ADC_EOS);
     }
 }

--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -30,6 +30,12 @@ static TaskHandle_t gADCInterruptHandle;
 // Updated only when MC12bADC_EosInterruptTask actually reads private
 // (non-public) channels.  Used by SCPI info commands to detect stale data.
 static volatile uint32_t gLastDiagScanTick = 0;
+
+// Mirrors the hardware EOS interrupt enable state so the deferred task
+// can skip its body when a pending notification drains after the ISR
+// has already been disabled. Without this, a single stale read can
+// refresh gLastDiagScanTick post-disable and delay the stale indicator.
+static volatile bool gEosInterruptEnabled = true;
 /*!
  * Retrieves the index of a module
  * @param[in] pModule Pointer to the module to search for
@@ -110,6 +116,14 @@ void MC12bADC_EosInterruptTask(void) {
 
     while (1) {
         ulTaskNotifyTake(pdFALSE, xBlockTime);
+
+        // Skip body if the EOS interrupt has been disabled since this
+        // notification was queued. Prevents a late read from refreshing
+        // gLastDiagScanTick after Streaming_Start suppressed diag scans.
+        if (!gEosInterruptEnabled) {
+            continue;
+        }
+
         AInSample sample;
         int i = 0;
         uint32_t adcval;
@@ -511,12 +525,20 @@ uint32_t ADC_GetLastDiagScanTick(void) {
 }
 
 void ADC_SetEosInterruptEnabled(bool enabled) {
+    // Update the software mirror first on disable (and last on enable) so
+    // the deferred task sees the flag state that matches the hardware at
+    // the moment of its next notification drain. Setting the flag true
+    // AFTER re-enabling hardware avoids a window where the task could
+    // unblock early and see gEosInterruptEnabled=true but no valid ADC
+    // results yet.
     if (enabled) {
         // Clear latched flag before re-enabling to prevent an immediate
         // spurious fire from a flag set while the interrupt was disabled.
         EVIC_SourceStatusClear(INT_SOURCE_ADC_EOS);
         EVIC_SourceEnable(INT_SOURCE_ADC_EOS);
+        gEosInterruptEnabled = true;
     } else {
+        gEosInterruptEnabled = false;
         // Disable first, then clear pending flag to avoid a race where
         // EOS re-asserts between clear and disable.
         EVIC_SourceDisable(INT_SOURCE_ADC_EOS);

--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -511,6 +511,10 @@ uint32_t ADC_GetLastDiagScanTick(void) {
 }
 
 void ADC_SetEosInterruptEnabled(bool enabled) {
+    // Clear any latched EOS flag first to prevent an immediate spurious
+    // fire when re-enabling after a disabled period.
+    IFS6CLR = _IFS6_ADCEOSIF_MASK;
+
     if (enabled) {
         IEC6SET = _IEC6_ADCEOSIE_MASK;
     } else {

--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -12,6 +12,8 @@
 #include "ADC/MC12bADC.h"
 #include "DIO.h"
 #include "Util/Logger.h"
+#include "FreeRTOS.h"
+#include "task.h"
 
 #define UNUSED(x) (void)(x)
 
@@ -23,6 +25,11 @@ static tBoardRuntimeConfig *gpBoardRuntimeConfig;
 // Pointer to the BoardData data structure, to be set in initialization
 static tBoardData* gpBoardData;
 static TaskHandle_t gADCInterruptHandle;
+
+// FreeRTOS tick count of the last successful monitoring channel read.
+// Updated only when MC12bADC_EosInterruptTask actually reads private
+// (non-public) channels.  Used by SCPI info commands to detect stale data.
+static volatile uint32_t gLastDiagScanTick = 0;
 /*!
  * Retrieves the index of a module
  * @param[in] pModule Pointer to the module to search for
@@ -106,6 +113,7 @@ void MC12bADC_EosInterruptTask(void) {
         AInSample sample;
         int i = 0;
         uint32_t adcval;
+        bool anyMonitorRead = false;
         uint32_t *valueTMR = (uint32_t*) BoardData_Get(BOARDDATA_STREAMING_TIMESTAMP, 0);
 
         // Ensure timestamp pointer is valid; use 0 as safe fallback
@@ -127,7 +135,15 @@ void MC12bADC_EosInterruptTask(void) {
                         BOARDDATA_AIN_LATEST,
                         i,
                         &sample);
+                anyMonitorRead = true;
             }
+        }
+
+        // Only update last-scan tick when we actually read monitoring data.
+        // This prevents stale-tick updates from spurious EOS wakeups
+        // (e.g., dedicated channel completions firing EOS).
+        if (anyMonitorRead) {
+            gLastDiagScanTick = xTaskGetTickCount();
         }
     }
 }
@@ -488,4 +504,16 @@ void ADC_EOSInterruptCB(uintptr_t context) {
         portEND_SWITCHING_ISR(xHigherPriorityTaskWoken);
     }
     // If task creation failed, interrupt still clears but no notification sent
+}
+
+uint32_t ADC_GetLastDiagScanTick(void) {
+    return gLastDiagScanTick;   // 32-bit read is atomic on PIC32MZ
+}
+
+void ADC_SetEosInterruptEnabled(bool enabled) {
+    if (enabled) {
+        IEC6SET = _IEC6_ADCEOSIE_MASK;
+    } else {
+        IEC6CLR = _IEC6_ADCEOSIE_MASK;
+    }
 }

--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -511,13 +511,15 @@ uint32_t ADC_GetLastDiagScanTick(void) {
 }
 
 void ADC_SetEosInterruptEnabled(bool enabled) {
-    // Clear any latched EOS flag first to prevent an immediate spurious
-    // fire when re-enabling after a disabled period.
-    IFS6CLR = _IFS6_ADCEOSIF_MASK;
-
     if (enabled) {
+        // Clear latched flag before re-enabling to prevent an immediate
+        // spurious fire from a flag set while the interrupt was disabled.
+        IFS6CLR = _IFS6_ADCEOSIF_MASK;
         IEC6SET = _IEC6_ADCEOSIE_MASK;
     } else {
+        // Disable first, then clear pending flag to avoid a race where
+        // EOS re-asserts between clear and disable.
         IEC6CLR = _IEC6_ADCEOSIE_MASK;
+        IFS6CLR = _IFS6_ADCEOSIF_MASK;
     }
 }

--- a/firmware/src/HAL/ADC.h
+++ b/firmware/src/HAL/ADC.h
@@ -95,7 +95,7 @@ void ADC_EOSInterruptCB(uintptr_t context);
  *  read yet.  Use with xTaskGetTickCount() to compute stale age. */
 uint32_t ADC_GetLastDiagScanTick(void);
 
-/*! Enables or disables the ADC End-of-Scan interrupt (IEC6 ADCEOSIE bit).
+/*! Enables or disables the ADC End-of-Scan interrupt.
  *  Used by the streaming engine to suppress spurious EOS wakeups during
  *  dedicated-only streaming (OBDiag=0). */
 void ADC_SetEosInterruptEnabled(bool enabled);

--- a/firmware/src/HAL/ADC.h
+++ b/firmware/src/HAL/ADC.h
@@ -90,6 +90,16 @@ bool ADC_ReadADCSampleFromISR(uint32_t value,uint8_t bufferIndex);
 /*! Function to be called from the ISR for deferring the ADC interrupt */
 void ADC_EOSInterruptCB(uintptr_t context);
 
+/*! Returns the FreeRTOS tick count of the last successful monitoring channel
+ *  read by the EOS deferred task.  Returns 0 if no monitoring data has been
+ *  read yet.  Use with xTaskGetTickCount() to compute stale age. */
+uint32_t ADC_GetLastDiagScanTick(void);
+
+/*! Enables or disables the ADC End-of-Scan interrupt (IEC6 ADCEOSIE bit).
+ *  Used by the streaming engine to suppress spurious EOS wakeups during
+ *  dedicated-only streaming (OBDiag=0). */
+void ADC_SetEosInterruptEnabled(bool enabled);
+
 /*!
  * Handles AD7609 data acquisition from deferred interrupt task
  * Called when BSY pin interrupt signals conversion complete

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -54,10 +54,13 @@ scpi_result_t SCPI_ADCVoltageGet(scpi_t * context) {
         }
 
         // Monitoring channels (ID >= 248) are not being refreshed when
-        // OBDiag is disabled during streaming — return an error so the
-        // user knows the reading would be stale/meaningless.
+        // OBDiag is disabled during active streaming — return an error so
+        // the user knows the reading would be stale/meaningless. Gate on
+        // Running (actual hardware state) rather than IsEnabled (user
+        // intent) so the guard lifts the instant Streaming_Stop re-enables
+        // the EOS interrupt, even if IsEnabled is still mid-reconfig.
         if (ch >= ADC_CHANNEL_3_3V &&
-            pStreamCfg->IsEnabled && !pStreamCfg->OnboardDiagEnabled) {
+            pStreamCfg->Running && !pStreamCfg->OnboardDiagEnabled) {
             LOG_E("MEAS:VOLT:DC? ch%d: monitoring disabled (OBDiag=0 during streaming)", (int)ch);
             SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
             return SCPI_RES_ERR;

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -47,6 +47,16 @@ scpi_result_t SCPI_ADCVoltageGet(scpi_t * context) {
             return SCPI_RES_ERR;
         }
 
+        // Monitoring channels (ID >= 248) are not being refreshed when
+        // OBDiag is disabled during streaming — return an error so the
+        // user knows the reading would be stale/meaningless.
+        if (channel >= ADC_CHANNEL_3_3V &&
+            pStreamCfg->IsEnabled && !pStreamCfg->OnboardDiagEnabled) {
+            LOG_E("MEAS:VOLT:DC? ch%d: monitoring disabled (OBDiag=0 during streaming)", channel);
+            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+            return SCPI_RES_ERR;
+        }
+
         if (!pRuntimeAInChannels->Data[index].IsEnabled) {
             SCPI_ResultVoltage(context, 0.0, precision);
             return SCPI_RES_OK;
@@ -685,7 +695,7 @@ scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context) {
     }
     StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
-    if (pStreamCfg->Running) {
+    if (pStreamCfg->IsEnabled) {
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         return SCPI_RES_ERR;
     }

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -43,7 +43,8 @@ scpi_result_t SCPI_ADCVoltageGet(scpi_t * context) {
         // Get single
         volatile double val = 0;
         size_t index = ADC_FindChannelIndex((uint8_t) channel);
-        if (index > pBoardConfigAInChannels->Size) {
+        if (index >= pBoardConfigAInChannels->Size) {
+            SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
             return SCPI_RES_ERR;
         }
 

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -42,7 +42,12 @@ scpi_result_t SCPI_ADCVoltageGet(scpi_t * context) {
     if (SCPI_ParamInt32(context, &channel, FALSE)) {
         // Get single
         volatile double val = 0;
-        size_t index = ADC_FindChannelIndex((uint8_t) channel);
+        if (channel < 0 || channel > 255) {
+            SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+            return SCPI_RES_ERR;
+        }
+        uint8_t ch = (uint8_t)channel;
+        size_t index = ADC_FindChannelIndex(ch);
         if (index >= pBoardConfigAInChannels->Size) {
             SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
             return SCPI_RES_ERR;
@@ -51,9 +56,9 @@ scpi_result_t SCPI_ADCVoltageGet(scpi_t * context) {
         // Monitoring channels (ID >= 248) are not being refreshed when
         // OBDiag is disabled during streaming — return an error so the
         // user knows the reading would be stale/meaningless.
-        if (channel >= ADC_CHANNEL_3_3V &&
+        if (ch >= ADC_CHANNEL_3_3V &&
             pStreamCfg->IsEnabled && !pStreamCfg->OnboardDiagEnabled) {
-            LOG_E("MEAS:VOLT:DC? ch%d: monitoring disabled (OBDiag=0 during streaming)", channel);
+            LOG_E("MEAS:VOLT:DC? ch%d: monitoring disabled (OBDiag=0 during streaming)", (int)ch);
             SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
             return SCPI_RES_ERR;
         }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -857,6 +857,25 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
             snprintf(buffer, sizeof(buffer), "  2.5V Ref: %s | 5V Ref: %s\r\n",
                 str2_5Ref, str5Ref);
             context->interface->write(context, buffer, strlen(buffer));
+
+            // Stale data indicator: all monitoring channels are scanned
+            // together by MODULE7, so a single age applies to all rails.
+            uint32_t lastDiagTick = ADC_GetLastDiagScanTick();
+            if (lastDiagTick > 0) {
+                uint32_t ageTicks = xTaskGetTickCount() - lastDiagTick;
+                uint32_t ageSec = ageTicks / configTICK_RATE_HZ;
+                // Show stale indicator if data is older than 2 seconds
+                if (ageSec >= 2) {
+                    StreamingRuntimeConfig *pStrmCfg = BoardRunTimeConfig_Get(
+                            BOARDRUNTIME_STREAMING_CONFIGURATION);
+                    bool diagOff = pStrmCfg->IsEnabled && !pStrmCfg->OnboardDiagEnabled;
+                    snprintf(buffer, sizeof(buffer),
+                             "  * Stale: last update %lus ago%s\r\n",
+                             (unsigned long)ageSec,
+                             diagOff ? " (diag scanning disabled)" : "");
+                    context->interface->write(context, buffer, strlen(buffer));
+                }
+            }
         } else {
             context->interface->write(context, "  Voltage monitoring unavailable\r\n", 34);
         }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -868,7 +868,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
                 if (ageSec >= 2) {
                     StreamingRuntimeConfig *pStrmCfg = BoardRunTimeConfig_Get(
                             BOARDRUNTIME_STREAMING_CONFIGURATION);
-                    bool diagOff = pStrmCfg->IsEnabled && !pStrmCfg->OnboardDiagEnabled;
+                    bool diagOff = pStrmCfg->Running && !pStrmCfg->OnboardDiagEnabled;
                     snprintf(buffer, sizeof(buffer),
                              "  * Stale: last update %lus ago%s\r\n",
                              (unsigned long)ageSec,

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -716,6 +716,14 @@ static void Streaming_Start(void) {
             bool hwShared = gpRuntimeConfigStream->OnboardDiagEnabled &&
                             (gpRuntimeConfigStream->ChannelScanFreqDiv <= 1);
             MC12b_ConfigureHardwareTrigger(true, hwShared);
+
+            // When OBDiag is disabled, suppress the EOS interrupt entirely.
+            // Without this, dedicated channel completions fire EOS, the
+            // deferred task wakes and reads stale monitoring results, making
+            // stale-age detection impossible.  Re-enabled in Streaming_Stop.
+            if (!gpRuntimeConfigStream->OnboardDiagEnabled) {
+                ADC_SetEosInterruptEnabled(false);
+            }
         }
 
         TimerApi_Start(gpStreamingConfig->TimerIndex);
@@ -734,6 +742,9 @@ static void Streaming_Stop(void) {
         // Revert ADC to software triggering so non-streaming reads
         // (ADC_Tasks polling) still work.
         MC12b_ConfigureHardwareTrigger(false, false);
+        // Re-enable EOS interrupt unconditionally (safe even if already on).
+        // Needed after OBDiag=0 sessions that disabled it.
+        ADC_SetEosInterruptEnabled(true);
         gpRuntimeConfigStream->Running = false;
 
         // Log session summary if any data was lost


### PR DESCRIPTION
## Summary
- Disable EOS interrupt during OBDiag=0 streaming to prevent spurious monitoring reads from dedicated channel completions (root cause from PR #289 investigation)
- Add stale age indicator to `SYST:INFo?` voltage rails when monitoring data is older than 2 seconds
- Return `SCPI_ERROR_EXECUTION_ERROR` on `MEAS:VOLT:DC?` for monitoring channels (ID >= 248) when OBDiag=0 + streaming active
- Fix OBDiag set guard: check `IsEnabled` instead of `Running` (which is always true after boot timer starts)

## Test plan
- [x] Build succeeds at O3 with zero warnings
- [x] Device boots cleanly after flash
- [x] Normal mode: `SYST:INFo?` shows voltage rails without stale indicator
- [x] Normal mode: `MEAS:VOLT:DC? 248` returns voltage value
- [x] `CONF:ADC:OBDiag 0` succeeds before streaming, returns error during streaming
- [x] OBDiag=0 + SD streaming: `MEAS:VOLT:DC? 248` returns error -200
- [x] OBDiag=0 + SD streaming: `MEAS:VOLT:DC? 0` (user channel) still works
- [x] OBDiag=0 + SD streaming 10s: `SYST:INFo?` shows `* Stale: last update 14s ago (diag scanning disabled)`
- [x] After `StopStreamData`: stale indicator disappears, `MEAS:VOLT:DC? 248` works again
- [x] OPER condition register shows correct bits (1040 = Measuring + SD Logging)

**Firmware:** 1898c3fc
**Test environment:** NQ1, USB+SD, Python pyserial

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)