### PR TITLE
perf(adc): move T1 result reads from ADC_DATA3 ISR to EOS task (#292)

### DIFF
--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -118,7 +118,7 @@ void MC12bADC_EosInterruptTask(void) {
     const TickType_t xBlockTime = portMAX_DELAY;
 
     while (1) {
-        ulTaskNotifyTake(pdFALSE, xBlockTime);
+        ulTaskNotifyTake(pdTRUE, xBlockTime);
 
         AInSample sample;
         int i = 0;

--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -110,16 +110,21 @@ void ADC_HandleAD7609Interrupt(void) {
     }
 }
 
-// Internal PIC32 ADC End-of-Scan interrupt task (MC12bADC only)
+// ADC EOS deferred task: reads T1 user channels + monitoring channels.
+//
+// #292: T1 (dedicated) result reads moved here from ADC_DATA3_Handler,
+// eliminating ~5μs ISR entry/exit overhead per streaming tick. T2 (shared)
+// user channels stay on their priority-1 ADC_DATAx ISRs — adding them
+// here would double-write AInLatest and regress T2 ceilings (confirmed
+// empirically). Monitoring gating: when streaming with OBDiag=0,
+// MODULE7 monitoring results are stale — skip those reads so
+// gLastDiagScanTick goes stale for SYST:INFo? reporting.
 void MC12bADC_EosInterruptTask(void) {
     const TickType_t xBlockTime = portMAX_DELAY;
 
     while (1) {
         ulTaskNotifyTake(pdFALSE, xBlockTime);
 
-        // Skip body if the EOS interrupt has been disabled since this
-        // notification was queued. Prevents a late read from refreshing
-        // gLastDiagScanTick after Streaming_Start suppressed diag scans.
         if (!gEosInterruptEnabled) {
             continue;
         }
@@ -129,33 +134,33 @@ void MC12bADC_EosInterruptTask(void) {
         uint32_t adcval;
         bool anyMonitorRead = false;
         uint32_t *valueTMR = (uint32_t*) BoardData_Get(BOARDDATA_STREAMING_TIMESTAMP, 0);
-
-        // Ensure timestamp pointer is valid; use 0 as safe fallback
         uint32_t timestamp = (valueTMR != NULL) ? *valueTMR : 0;
 
-        // Read only the private internal ADC channels (MC12bADC)
-        // Note: AD7609 now uses interrupt-based reading via its own deferred task
+        bool streamingActive = gpBoardRuntimeConfig->StreamingConfig.Running;
+        bool diagScanning = !streamingActive ||
+                            gpBoardRuntimeConfig->StreamingConfig.OnboardDiagEnabled;
+
         for (i = 0; i < gpBoardConfig->AInChannels.Size; i++) {
-            if (gpBoardConfig->AInChannels.Data[i].Type == AIn_MC12bADC &&
-                gpBoardConfig->AInChannels.Data[i].Config.MC12b.IsPublic != 1
-                    && gpBoardRuntimeConfig->AInChannels.Data[i].IsEnabled == 1) {
-                if (!MC12b_ReadResult(gpBoardConfig->AInChannels.Data[i].Config.MC12b.ChannelId, &adcval)) {
-                    continue;
-                }
-                sample.Timestamp = timestamp;
-                sample.Channel = gpBoardConfig->AInChannels.Data[i].DaqifiAdcChannelId;
-                sample.Value = adcval;
-                BoardData_Set(
-                        BOARDDATA_AIN_LATEST,
-                        i,
-                        &sample);
-                anyMonitorRead = true;
-            }
+            const AInChannel* cfg = &gpBoardConfig->AInChannels.Data[i];
+            if (cfg->Type != AIn_MC12bADC) continue;
+            if (gpBoardRuntimeConfig->AInChannels.Data[i].IsEnabled != 1) continue;
+
+            bool isMonitoring = (cfg->Config.MC12b.IsPublic != 1);
+            bool isType1User = (!isMonitoring && cfg->Config.MC12b.ChannelType == 1);
+
+            if (isMonitoring && !diagScanning) continue;
+            if (!isMonitoring && !isType1User) continue; // T2 user → pri-1 ISRs
+
+            if (!MC12b_ReadResult(cfg->Config.MC12b.ChannelId, &adcval)) continue;
+
+            sample.Timestamp = timestamp;
+            sample.Channel = cfg->DaqifiAdcChannelId;
+            sample.Value = adcval;
+            BoardData_Set(BOARDDATA_AIN_LATEST, i, &sample);
+
+            if (isMonitoring) anyMonitorRead = true;
         }
 
-        // Only update last-scan tick when we actually read monitoring data.
-        // This prevents stale-tick updates from spurious EOS wakeups
-        // (e.g., dedicated channel completions firing EOS).
         if (anyMonitorRead) {
             gLastDiagScanTick = xTaskGetTickCount();
         }

--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -31,11 +31,6 @@ static TaskHandle_t gADCInterruptHandle;
 // (non-public) channels.  Used by SCPI info commands to detect stale data.
 static volatile uint32_t gLastDiagScanTick = 0;
 
-// Mirrors the hardware EOS interrupt enable state so the deferred task
-// can skip its body when a pending notification drains after the ISR
-// has already been disabled. Without this, a single stale read can
-// refresh gLastDiagScanTick post-disable and delay the stale indicator.
-static volatile bool gEosInterruptEnabled = true;
 /*!
  * Retrieves the index of a module
  * @param[in] pModule Pointer to the module to search for
@@ -124,10 +119,6 @@ void MC12bADC_EosInterruptTask(void) {
 
     while (1) {
         ulTaskNotifyTake(pdFALSE, xBlockTime);
-
-        if (!gEosInterruptEnabled) {
-            continue;
-        }
 
         AInSample sample;
         int i = 0;
@@ -529,24 +520,3 @@ uint32_t ADC_GetLastDiagScanTick(void) {
     return gLastDiagScanTick;   // 32-bit read is atomic on PIC32MZ
 }
 
-void ADC_SetEosInterruptEnabled(bool enabled) {
-    // Update the software mirror first on disable (and last on enable) so
-    // the deferred task sees the flag state that matches the hardware at
-    // the moment of its next notification drain. Setting the flag true
-    // AFTER re-enabling hardware avoids a window where the task could
-    // unblock early and see gEosInterruptEnabled=true but no valid ADC
-    // results yet.
-    if (enabled) {
-        // Clear latched flag before re-enabling to prevent an immediate
-        // spurious fire from a flag set while the interrupt was disabled.
-        EVIC_SourceStatusClear(INT_SOURCE_ADC_EOS);
-        EVIC_SourceEnable(INT_SOURCE_ADC_EOS);
-        gEosInterruptEnabled = true;
-    } else {
-        gEosInterruptEnabled = false;
-        // Disable first, then clear pending flag to avoid a race where
-        // EOS re-asserts between clear and disable.
-        EVIC_SourceDisable(INT_SOURCE_ADC_EOS);
-        EVIC_SourceStatusClear(INT_SOURCE_ADC_EOS);
-    }
-}

--- a/firmware/src/HAL/ADC.h
+++ b/firmware/src/HAL/ADC.h
@@ -95,11 +95,6 @@ void ADC_EOSInterruptCB(uintptr_t context);
  *  read yet.  Use with xTaskGetTickCount() to compute stale age. */
 uint32_t ADC_GetLastDiagScanTick(void);
 
-/*! Enables or disables the ADC End-of-Scan interrupt.
- *  Used by the streaming engine to suppress spurious EOS wakeups during
- *  dedicated-only streaming (OBDiag=0). */
-void ADC_SetEosInterruptEnabled(bool enabled);
-
 /*!
  * Handles AD7609 data acquisition from deferred interrupt task
  * Called when BSY pin interrupt signals conversion complete

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -154,8 +154,10 @@ bool MC12b_WriteStateAll(
                 &channelRuntimeConfig->Data[i]);
     }
 
-    // Batch interrupt for Type 1: build bitmask of enabled ADCHS channels
-    // and enable only CH3's result interrupt (the batch trigger).
+    // Type 1 enable mask (used by MC12b_TriggerConversion software path).
+    // Do NOT enable CH3 result interrupt — #292 moves T1 result reads to
+    // the EOS deferred task, eliminating the ~5μs ISR entry/exit overhead
+    // that was the T1 throughput bottleneck.
     uint8_t mask = 0;
     for (i = 0; i < channelConfig->Size; ++i) {
         if (channelConfig->Data[i].Type == AIn_MC12bADC &&
@@ -170,10 +172,8 @@ bool MC12b_WriteStateAll(
     gType1EnabledMask = mask;
     if (mask != 0) {
         ADCHS_ModulesEnable(ADCHS_MODULE3_MASK);
-        ADCHS_ChannelResultInterruptEnable(ADCHS_CH3);
-    } else {
-        ADCHS_ChannelResultInterruptDisable(ADCHS_CH3);
     }
+    ADCHS_ChannelResultInterruptDisable(ADCHS_CH3);
 
     if (isEnabled) {
         gpModuleRuntimeConfigMC12->IsEnabled = isEnabled;

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -172,6 +172,8 @@ bool MC12b_WriteStateAll(
     gType1EnabledMask = mask;
     if (mask != 0) {
         ADCHS_ModulesEnable(ADCHS_MODULE3_MASK);
+    } else {
+        ADCHS_ModulesDisable(ADCHS_MODULE3_MASK);
     }
     ADCHS_ChannelResultInterruptDisable(ADCHS_CH3);
 

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -158,7 +158,7 @@ bool MC12b_WriteStateAll(
     // Do NOT enable CH3 result interrupt — #292 moves T1 result reads to
     // the EOS deferred task, eliminating the ~5μs ISR entry/exit overhead
     // that was the T1 throughput bottleneck.
-    uint8_t mask = 0;
+    uint32_t mask = 0;
     for (i = 0; i < channelConfig->Size; ++i) {
         if (channelConfig->Data[i].Type == AIn_MC12bADC &&
             channelConfig->Data[i].Config.MC12b.ChannelType == 1) {

--- a/firmware/src/config/default/interrupts.c
+++ b/firmware/src/config/default/interrupts.c
@@ -154,13 +154,11 @@ void __attribute__((used)) TIMER_7_Handler (void)
     TIMER_7_InterruptHandler();
 }
 
-// Type 1 (dedicated) ADC channels: batch-read all results from a single ISR.
-// All dedicated modules (0-4) convert simultaneously, so when CH3 (the batch
-// trigger) completes, all others are ready. This eliminates 4 redundant ISR
-// entries per sample period. See Issue #277.
-//
-// CH3 (MODULE3, DaqiFi ch14) is the batch trigger — always triggered when
-// any Type 1 channel is active (see MC12b_TriggerConversion).
+// Type 1 (dedicated) ADC channels: results read by MC12bADC_EosInterruptTask
+// (task priority 8) after #292. The old batch-read ISR (ADC_DATA3_Handler,
+// #277) was eliminated because the ~5μs ISR entry/exit overhead was the T1
+// throughput bottleneck. CH3 result interrupt is disabled at peripheral level;
+// these handlers are safety stubs that only ack the PLIB flag.
 
 void __attribute__((used)) ADC_DATA0_Handler(void) {
     // Interrupt disabled for batching — stub clears IFS only (safety)

--- a/firmware/src/config/default/interrupts.c
+++ b/firmware/src/config/default/interrupts.c
@@ -176,14 +176,9 @@ void __attribute__((used)) ADC_DATA2_Handler(void) {
 }
 
 void __attribute__((used)) ADC_DATA3_Handler(void) {
-    // Batch trigger: read all Type 1 dedicated channel results (CH0-CH4).
-    // Fixed bound avoids cross-TU function call (O3-unsafe, see #277).
-    // ChannelResultIsReady filters disabled modules.
-    for (uint32_t ch = 0; ch < 5; ch++) {
-        if (ADCHS_ChannelResultIsReady(ch)) {
-            ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(ch), ch);
-        }
-    }
+    // #292: T1 result reads moved to MC12bADC_EosInterruptTask (task pri 8).
+    // CH3 result interrupt is disabled at peripheral level; this stub is a
+    // safety net — just acks the PLIB flag.
     ADC_DATA3_InterruptHandler();
 }
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -717,13 +717,11 @@ static void Streaming_Start(void) {
                             (gpRuntimeConfigStream->ChannelScanFreqDiv <= 1);
             MC12b_ConfigureHardwareTrigger(true, hwShared);
 
-            // When OBDiag is disabled, suppress the EOS interrupt entirely.
-            // Without this, dedicated channel completions fire EOS, the
-            // deferred task wakes and reads stale monitoring results, making
-            // stale-age detection impossible.  Re-enabled in Streaming_Stop.
-            if (!gpRuntimeConfigStream->OnboardDiagEnabled) {
-                ADC_SetEosInterruptEnabled(false);
-            }
+            // #292: EOS stays enabled across all modes. The EOS deferred
+            // task now reads T1 user channels (moved from ADC_DATA3 ISR),
+            // so disabling EOS would break T1 streaming. OBDiag=0 gating
+            // is handled in the task body (skips monitoring reads when
+            // Running && !OnboardDiagEnabled).
         }
 
         TimerApi_Start(gpStreamingConfig->TimerIndex);
@@ -742,9 +740,6 @@ static void Streaming_Stop(void) {
         // Revert ADC to software triggering so non-streaming reads
         // (ADC_Tasks polling) still work.
         MC12b_ConfigureHardwareTrigger(false, false);
-        // Re-enable EOS interrupt unconditionally (safe even if already on).
-        // Needed after OBDiag=0 sessions that disabled it.
-        ADC_SetEosInterruptEnabled(true);
         gpRuntimeConfigStream->Running = false;
 
         // Log session summary if any data was lost

--- a/firmware/src/state/data/BoardData.c
+++ b/firmware/src/state/data/BoardData.c
@@ -193,15 +193,22 @@ void BoardData_Set(
             break;
         case BOARDDATA_AIN_LATEST:
             if (index < g_BoardData.AInLatest.Size) {
-                // Atomic write to prevent torn reads by streaming task.
-                // Called from ADC ISR, so must use ISR-safe critical section.
-                // Without this, streaming task could read partial sample (old timestamp + new value).
-                UBaseType_t uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
-                memcpy(
-                        &g_BoardData.AInLatest.Data[ index ],
-                        pSetValue,
-                        sizeof (AInSample));
-                taskEXIT_CRITICAL_FROM_ISR(uxSavedInterruptStatus);
+                // Atomic write to prevent torn reads by the streaming task.
+                // Callable from ISR (ADC_DATAx pri-1 handlers for T2 user
+                // channels) and task context (MC12bADC_EosInterruptTask for
+                // T1 user + monitoring channels after #292). Use the
+                // matching FreeRTOS critical-section primitive per context.
+                if (uxInterruptNesting != 0u) {
+                    UBaseType_t uxSaved = taskENTER_CRITICAL_FROM_ISR();
+                    memcpy(&g_BoardData.AInLatest.Data[index],
+                           pSetValue, sizeof(AInSample));
+                    taskEXIT_CRITICAL_FROM_ISR(uxSaved);
+                } else {
+                    taskENTER_CRITICAL();
+                    memcpy(&g_BoardData.AInLatest.Data[index],
+                           pSetValue, sizeof(AInSample));
+                    taskEXIT_CRITICAL();
+                }
             }
             break;
         case BOARDDATA_AIN_LATEST_TIMESTAMP:


### PR DESCRIPTION
## Summary

- Disable ADC_DATA3 result interrupt at peripheral level; stub the ISR handler
- Extend `MC12bADC_EosInterruptTask` to read Type 1 user channels alongside monitoring channels
- Keep EOS hardware interrupt enabled during OBDiag=0 streaming; gate monitoring refresh in task body via `Running && !OnboardDiagEnabled`
- Remove `ADC_SetEosInterruptEnabled(false/true)` calls from `Streaming_Start`/`Streaming_Stop`

The bottleneck was **ISR entry/exit overhead** (~5μs per tick for PIC32 MIPS context save/restore), not priority-level competition with TIMER_5. A priority-1 demotion was tested and confirmed zero effect; eliminating the ISR entirely via task-context reads is what unlocks the gain.

T2 user channels stay on their priority-1 `ADC_DATAx` ISRs — moving them to the EOS task was tested and caused 10-12% T2 ceiling regression from double-writing `AInLatest` at priority 8.

## Benchmark (same-session, NQ1, USB PB, fullscale, NoCap)

| Config | main | #292 | Δ | % |
|--------|-----:|-----:|---:|---:|
| 1×T1 | 15,000 | **19,000** | +4,000 | +27% |
| 3×T1 | 12,000 | **16,000** | +4,000 | +33% |
| 5×T1 | 11,000 | **15,000** | +4,000 | +36% |
| 1×T2 | 17,000 | **19,000** | +2,000 | +12% |
| 4×T2 | 15,000 | 15,000 | 0 | — |
| 5×T2 | 14,000 | **16,000** | +2,000 | +14% |
| 8×T2 | 12,000 | **14,000** | +2,000 | +17% |
| 11×T2 | 11,000 | **13,000** | +2,000 | +18% |
| 5T1+4T2 | 10,000 | **12,000** | +2,000 | +20% |
| 5T1+11T2 | 9,000 | 9,000 | 0 | — |

8/10 configs improved. Zero regressions. Flat configs (4×T2, 16ch) are encoder/USB-bound.

## What was tried and rejected

1. **Priority-1 demotion of ADC_DATA3** — one-line change, full sweep showed zero improvement across all configs. The ~5μs ISR entry/exit cost is the same at any priority.
2. **EOS task reads ALL channels (T1+T2+monitoring)** — T2 ceiling regressed 10-12% from redundant writes to AInLatest competing with the streaming task at same priority 8.

## Test plan

- [x] Build clean at O3 with zero warnings
- [x] Device boots, `*IDN?` responds, monitoring channels refresh
- [x] Same-session A/B benchmark: main baseline → perf/292 → all results in commit message
- [x] OBDiag=0 streaming: T1 channels stream correctly (EOS stays enabled)
- [x] `SYST:INFo?` stale banner works correctly (monitoring gated in task body)

**Firmware:** `ed5ece98`
**Test suite:** `daqifi-python-test-suite/test_adc_t1_t2_characterization.py`
**CSV:** `benchmarks/t1_t2_characterization_20260415_2119.csv`

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)