### PR TITLE
chore(license): add BUSL-1.1 license and NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,96 @@
+Business Source License 1.1
+
+Parameters
+
+Licensor:             DAQiFi, Inc.
+Licensed Work:        DAQiFi Nyquist Firmware
+                      The Licensed Work is (c) 2026 DAQiFi, Inc.
+Additional Use Grant: You may use the Licensed Work for personal,
+                      educational, and non-production evaluation
+                      purposes.
+Change Date:          Four years from the date the Licensed Work is
+                      published.
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the
+Licensed Work, please contact: info@daqifi.com
+
+Notice
+
+Business Source License 1.1
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights
+Reserved. "Business Source License" is a trademark of MariaDB
+Corporation Ab.
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create
+derivative works, redistribute, and make non-production use of the
+Licensed Work. The Licensor may make an Additional Use Grant, above,
+permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first
+publicly available distribution of a specific version of the Licensed
+Work under this License, whichever comes first, the Licensor hereby
+grants you rights under the terms of the Change License, and the
+rights granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or
+authorized resellers, or you must refrain from using the Licensed
+Work.
+
+All copies of the original and modified Licensed Work, and derivative
+works of the Licensed Work, are subject to this License. This License
+applies separately for each version of the Licensed Work and the
+Change Date may vary for each version of the Licensed Work released by
+Licensor.
+
+You must conspicuously display this License on each original or
+modified copy of the Licensed Work. If you receive the Licensed Work
+in original or modified form from a third party, the terms and
+conditions set forth in this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will
+automatically terminate your rights under this License for the current
+and all other versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or
+logo of Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS
+PROVIDED ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES
+AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION)
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+NON-INFRINGEMENT, AND TITLE.
+
+MariaDB hereby grants you permission to use this License's text to
+license your works, and to refer to it using the trademark "Business
+Source License", as long as you comply with the Covenants of Licensor
+below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the
+"Business Source License" name and trademark, Licensor covenants to
+MariaDB, and to all other recipients of the licensed work to be
+provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later
+   version, or a license that is compatible with GPL Version 2.0 or a
+   later version, where "compatible" means that software provided
+   under the Change License can be included in a program with software
+   provided under GPL Version 2.0 or a later version. Licensor may
+   specify additional Change Licenses without limitation.
+
+2. To either: (a) specify an additional grant of rights to use that
+   does not impose any additional restriction on the right granted in
+   this License, as the Additional Use Grant; or (b) insert the text
+   "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,80 @@
+DAQiFi Nyquist Firmware - Third-Party Notices
+==============================================================================
+
+This firmware incorporates the following third-party components.
+Each component retains its original license and copyright.
+
+------------------------------------------------------------------------------
+wolfSSL
+------------------------------------------------------------------------------
+Location:   firmware/src/third_party/wolfssl/
+License:    GPLv2+ (dual-licensed; commercial license pending)
+Copyright:  Copyright (C) 2006-2021 wolfSSL Inc.
+Website:    https://www.wolfssl.com/
+
+NOTE: DAQiFi is in the process of obtaining a commercial wolfSSL license
+to eliminate GPL obligations from the firmware distribution. Until the
+commercial license is in place, this component is distributed under GPLv2+.
+
+------------------------------------------------------------------------------
+FreeRTOS
+------------------------------------------------------------------------------
+Location:   firmware/src/third_party/rtos/FreeRTOS/
+License:    MIT
+Copyright:  Copyright (C) 2021 Amazon.com, Inc. or its affiliates.
+Website:    https://www.freertos.org/
+SPDX:       MIT
+
+------------------------------------------------------------------------------
+libscpi
+------------------------------------------------------------------------------
+Location:   firmware/src/libraries/scpi/libscpi/
+License:    BSD-2-Clause
+Copyright:  Copyright (c) 2012-2018 Jan Breuer
+Website:    https://www.jaybee.cz/scpi-parser/
+
+------------------------------------------------------------------------------
+nanopb
+------------------------------------------------------------------------------
+Location:   firmware/src/libraries/nanopb/
+License:    Zlib License
+Copyright:  Copyright (c) 2011 Petteri Aimonen
+Website:    https://jpa.kapsi.fi/nanopb/
+
+------------------------------------------------------------------------------
+zlib
+------------------------------------------------------------------------------
+Location:   firmware/src/third_party/zlib/
+License:    Zlib License
+Copyright:  Copyright (C) 1995-2024 Jean-loup Gailly and Mark Adler
+Website:    https://zlib.net/
+
+------------------------------------------------------------------------------
+microrl
+------------------------------------------------------------------------------
+Location:   firmware/src/libraries/microrl/
+License:    LGPLv3 (pending replacement with permissive alternative)
+Copyright:  Copyright Eugene Samoylov (ghelius@gmail.com)
+
+NOTE: This library is scheduled for replacement with a BSD-licensed
+alternative to eliminate copyleft obligations from the firmware.
+
+------------------------------------------------------------------------------
+WINC1500 WiFi Driver
+------------------------------------------------------------------------------
+Location:   firmware/src/config/default/driver/winc/
+License:    Microchip Technology proprietary (MPLAB Harmony license)
+Copyright:  Copyright Microchip Technology Incorporated
+Website:    https://www.microchip.com/
+
+Redistributed under the terms of the Microchip MPLAB Harmony Integrated
+Software Framework License Agreement. See Microchip's license terms for
+redistribution conditions.
+
+------------------------------------------------------------------------------
+Microchip Harmony Framework Components
+------------------------------------------------------------------------------
+Location:   firmware/src/config/default/ (various drivers and middleware)
+License:    Apache-2.0 (Harmony 3 components)
+Copyright:  Copyright Microchip Technology Incorporated
+Website:    https://github.com/Microchip-MPLAB-Harmony

--- a/NOTICE
+++ b/NOTICE
@@ -58,11 +58,14 @@ Website:    https://zlib.net/
 microrl
 ------------------------------------------------------------------------------
 Location:   firmware/src/libraries/microrl/
-License:    LGPLv3 (pending replacement with permissive alternative)
-Copyright:  Copyright Eugene Samoylov (ghelius@gmail.com)
+License:    Apache-2.0
+Copyright:  Copyright 2017 Eugene Samoylov aka Helius (ghelius@gmail.com)
+Website:    https://github.com/Helius/microrl
+SPDX:       Apache-2.0
 
-NOTE: This library is scheduled for replacement with a BSD-licensed
-alternative to eliminate copyleft obligations from the firmware.
+NOTE: The local LICENSE file previously contained LGPLv3 in error;
+the upstream project is Apache-2.0. Corrected 2026-04-15. Upgrade to
+the maintained microrl-remaster fork is tracked in issue #43.
 
 ------------------------------------------------------------------------------
 WINC1500 WiFi Driver

--- a/NOTICE
+++ b/NOTICE
@@ -8,13 +8,18 @@ Each component retains its original license and copyright.
 wolfSSL
 ------------------------------------------------------------------------------
 Location:   firmware/src/third_party/wolfssl/
-License:    GPLv2+ (dual-licensed; commercial license pending)
+License:    GPLv2+ (dual-licensed; commercial license required for non-GPL use)
 Copyright:  Copyright (C) 2006-2021 wolfSSL Inc.
 Website:    https://www.wolfssl.com/
+Distributed via: Microchip MPLAB Harmony (v5.4.0)
 
-NOTE: DAQiFi is in the process of obtaining a commercial wolfSSL license
-to eliminate GPL obligations from the firmware distribution. Until the
-commercial license is in place, this component is distributed under GPLv2+.
+NOTE: wolfSSL is distributed by Microchip as part of MPLAB Harmony but
+Microchip does NOT sublicense it. Microchip's own headers state: "It is
+your responsibility to comply with third party license terms applicable
+to your use of third party software that may accompany Microchip software."
+A separate commercial license from wolfSSL Inc. is required for non-GPL
+distribution. PIC32-specific port files (port/pic32/) are separately
+licensed under Microchip's proprietary terms.
 
 ------------------------------------------------------------------------------
 FreeRTOS

--- a/firmware/src/libraries/microrl/LICENSE
+++ b/firmware/src/libraries/microrl/LICENSE
@@ -1,165 +1,201 @@
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
+   1. Definitions.
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-  0. Additional Definitions.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-  1. Exception to Section 3 of the GNU GPL.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-  2. Conveying Modified Versions.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-  3. Object Code Incorporating Material from Library Header Files.
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-  4. Combined Works.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-   d) Do one of the following:
+   END OF TERMS AND CONDITIONS
 
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
+   APPENDIX: How to apply the Apache License to your work.
 
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
+   Copyright 2017 Eugene Samoylov aka Helius (ghelius@gmail.com)
 
-  5. Combined Libraries.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
+       http://www.apache.org/licenses/LICENSE-2.0
 
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## Summary
- Adds Business Source License 1.1 (BUSL-1.1) as the top-level LICENSE
  - Change License: Apache-2.0 after 4 years
  - Additional Use Grant: personal, educational, non-production evaluation
- Adds NOTICE file documenting all statically linked third-party libraries

## Context
Part of the DAQiFi public repo licensing cleanup. Firmware moves to source-available.

## Still pending (separate PRs/actions)
- [ ] Purchase wolfSSL commercial license
- [ ] Replace microrl (LGPLv3) with permissive alternative
- [ ] Add SPDX headers to DAQiFi-authored source files

## Test plan
- [ ] Verify GitHub detects license correctly
- [ ] Review NOTICE against actual third_party/ and libraries/ contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)