### PR TITLE
fix(timer): correct off-by-one in streaming timer period (#291)

### DIFF
--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -285,7 +285,12 @@ scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
-    pRunTimeStreamConfig->ClockPeriod = clkFreq / freq;
+    // PIC32MZ type-B timer counts 0..PR inclusive (PR+1 cycles per match).
+    {
+        uint32_t periodCycles = (clkFreq + freq - 1) / freq;
+        if (periodCycles < 2) periodCycles = 2;
+        pRunTimeStreamConfig->ClockPeriod = periodCycles - 1;
+    }
     pRunTimeStreamConfig->Frequency = freq;
     pRunTimeStreamConfig->TSClockPeriod = 0xFFFFFFFF;
     if (freq > 1000) {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -1775,11 +1775,10 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
     // Set frequency and start
     const tBoardConfig* pBoardConfig = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
     uint32_t clkFreq = TimerApi_FrequencyGet(pBoardConfig->StreamingConfig.TimerIndex);
-    // Ceiling division to prevent actual freq exceeding requested freq
-    pStreamCfg->ClockPeriod = (clkFreq + freq - 1) / freq;
-    if (pStreamCfg->ClockPeriod == 0) {
-        pStreamCfg->ClockPeriod = 1;
-    }
+    // PIC32MZ type-B timer counts 0..PR inclusive (PR+1 cycles per match).
+    uint32_t periodCycles = (clkFreq + freq - 1) / freq;
+    if (periodCycles < 2) periodCycles = 2;
+    pStreamCfg->ClockPeriod = periodCycles - 1;
     pStreamCfg->Frequency = freq;
     pStreamCfg->IsEnabled = true;
     Streaming_UpdateState();
@@ -2151,11 +2150,12 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
 
             // Note: Internal monitoring channels have fixed 1Hz in NQ3 runtime config
 
-            // Ceiling division: ensures actual freq <= requested freq (no overspeed)
-            pRunTimeStreamConfig->ClockPeriod = (clkFreq + freq - 1) / freq;
-            if (pRunTimeStreamConfig->ClockPeriod == 0) {
-                pRunTimeStreamConfig->ClockPeriod = 1;
-            }
+            // PIC32MZ type-B timer counts 0..PR inclusive (PR+1 cycles per match).
+            // Compute the period in timer cycles, then subtract 1 for the PR value.
+            // Ceiling division ensures actual freq <= requested freq (no overspeed).
+            uint32_t periodCycles = (clkFreq + freq - 1) / freq;
+            if (periodCycles < 2) periodCycles = 2;  // PR must be >= 1
+            pRunTimeStreamConfig->ClockPeriod = periodCycles - 1;
             pRunTimeStreamConfig->Frequency = freq;
             pRunTimeStreamConfig->TSClockPeriod = 0xFFFFFFFF;
             if (freq > 1000) {


### PR DESCRIPTION
## Summary

PIC32MZ type-B timer counts 0..PR inclusive (PR+1 cycles per match). The ClockPeriod formula wrote ceil(clkFreq/freq) directly to PR, making the actual streaming rate 5-7% below commanded. Fix: subtract 1 before writing to PR.

## Hardware scope validation (DIO_0 toggle, logic analyzer)

| Commanded | Scope x2 | Theory | Match |
|----------:|----------:|-------:|------:|
| 100 Hz | 99.98 | 99.98 | 0.00% |
| 500 Hz | 499.52 | 499.52 | 0.00% |
| 1000 Hz | 999.05 | 999.04 | 0.00% |
| 2000 Hz | 1993.0 | 1993.0 | 0.00% |
| 5000 Hz | 4944.6 | 4944.6 | 0.00% |
| 8000 Hz | 7972.0 | 7971.9 | 0.00% |
| 10000 Hz | 9765.6 | 9765.6 | 0.00% |
| 13000 Hz | 12600.7 | 12600.8 | 0.00% |
| 15000 Hz | 14467.9 | 14467.6 | 0.00% |

9/9 match theory. Remaining error vs commanded is prescaler quantization (1:256). Prescaler fix tracked separately in #291.

## Test plan

- [x] Hardware scope validation (9 frequencies, 0.00% theory match)
- [ ] Overnight characterization regression check
- [ ] Frequency cap boundary test

🤖 Generated with [Claude Code](https://claude.com/claude-code)