### PR TITLE
perf(timer): change streaming timer prescaler 1:256 → 1:8 (#303)

### DIFF
--- a/firmware/src/config/default/peripheral/tmr/plib_tmr4.c
+++ b/firmware/src/config/default/peripheral/tmr/plib_tmr4.c
@@ -64,11 +64,11 @@ void TMR4_Initialize(void)
 
     /*
     SIDL = 0
-    TCKPS =7
+    TCKPS =3  (1:8 prescaler — 12.5 MHz base for <0.1% freq error)
     T32   = 1
     TCS = 0
     */
-    T4CONSET = 0x78;
+    T4CONSET = 0x38;
 
     /* Clear counter */
     TMR4 = 0x0;

--- a/firmware/src/config/default/peripheral/tmr/plib_tmr4.c
+++ b/firmware/src/config/default/peripheral/tmr/plib_tmr4.c
@@ -68,6 +68,7 @@ void TMR4_Initialize(void)
     T32   = 1
     TCS = 0
     */
+    T4CONCLR = 0x70;  // Clear TCKPS bits before setting (safe on soft reset)
     T4CONSET = 0x38;
 
     /* Clear counter */


### PR DESCRIPTION
## Summary

One-byte change: `T4CONSET = 0x78` → `0x38` (TCKPS=3 instead of 7). Base clock goes from 390,625 Hz to 12,500,000 Hz. Eliminates frequency quantization error and reduces jitter at all rates below 10kHz.

## Logic analyzer results (DIO_0 toggle)

| Freq | Before (1:256) | After (1:8) | Jitter before | Jitter after |
|-----:|---------------:|------------:|--------------:|-------------:|
| 1kHz | 999.05 Hz | **1,000.0 Hz** | +/-0.8% | **+/-0.08%** |
| 5kHz | 4,944.6 Hz | **5,000.0 Hz** | +/-8% | **+/-2%** |
| 10kHz | 9,765.6 Hz | **10,000.0 Hz** | +/-30% | **+/-11%** |
| 13kHz | 12,600.7 Hz | **12,993.8 Hz** | +/-38% | +/-24% (OBD off) |
| 15kHz | 14,467.9 Hz | **14,988.0 Hz** | +/-53% | +/-55% |

High-frequency jitter (>10kHz) is ISR-overhead-limited, not prescaler-limited.

## Note

MCC regeneration overwrites plib_tmr4.c. After any MCC session, verify `T4CONSET = 0x38`.

## Test plan

- [x] Logic analyzer validation across 1-15kHz
- [x] Jitter isolation: OBD OFF reduces 13kHz jitter from +/-56% to +/-24%
- [ ] Overnight characterization regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)