### PR TITLE
feat(debug): DIO debug probe framework for pipeline timing (#301)

### DIFF
--- a/docs/PIPELINE_TIMING.md
+++ b/docs/PIPELINE_TIMING.md
@@ -1,0 +1,247 @@
+# Streaming Pipeline Timing Measurements
+
+Scope-captured timing measurements of the streaming pipeline, gathered via
+the DIO debug probe framework (`firmware/src/HAL/DioProbe.*`, issue #301).
+
+This document is a living record. Add new capture sessions below the
+existing ones — do not overwrite prior data. Each session should note
+firmware SHA, board variant, streaming config, and analyzer details so
+measurements remain comparable over time.
+
+## How to capture
+
+1. Hook a logic analyzer to DIO_0..DIO_9 (10 probes, or subset).
+2. Power the device: `SYST:POW:STAT 1`.
+3. Assign probes — pipeline default map:
+   ```
+   SYST:DIOP:ASS 0,TOGGLE   ; streaming timer ISR entry
+   SYST:DIOP:ASS 1,TOGGLE   ; ADC EOS ISR entry
+   SYST:DIOP:ASS 2,TOGGLE   ; deferred task wake
+   SYST:DIOP:ASS 3,PULSE    ; deferred: alloc + channel loop + queue push
+   SYST:DIOP:ASS 4,PULSE    ; deferred: ADC trigger + DIO trigger
+   SYST:DIOP:ASS 5,TOGGLE   ; EOS task wake
+   SYST:DIOP:ASS 6,PULSE    ; EOS task: result read loop
+   SYST:DIOP:ASS 7,TOGGLE   ; encoder task wake
+   SYST:DIOP:ASS 8,PULSE    ; encoder: encode call
+   SYST:DIOP:ASS 9,PULSE    ; encoder: output write
+   ```
+   Or `SYST:DIOP:PIPEL TOGGLE` (then swap specific probes to PULSE as
+   desired).
+4. Enable channel(s), start stream: e.g. `ENAble:VOLTage:DC 1,1` then
+   `SYST:StartStreamData 1000`.
+5. Capture 5–10 seconds on the analyzer. Record stats per probe:
+   - TOGGLE probes: `fmean`, `fmin`, `fmax`, `Tstd`, edge counts.
+   - PULSE probes: all of the above plus `TposMean/Min/Max`, `TnegMean`.
+6. Stop: `SYST:StopStreamData`.
+
+## Probe map reference
+
+| Probe | DIO | Mode | What it measures |
+|---:|---:|:---:|---|
+| 0 | 0 | TOGGLE | `Streaming_TimerHandler` entry — true hardware timer rate |
+| 1 | 1 | TOGGLE | `ADC_EOSInterruptCB` entry — ADC end-of-scan ISR rate |
+| 2 | 2 | TOGGLE | `_Streaming_Deferred_Interrupt_Task` wake after `ulTaskNotifyTake` |
+| 3 | 3 | PULSE | Deferred task: sample pool alloc + channel loop + queue push |
+| 4 | 4 | PULSE | Deferred task: `ADC_TriggerConversion` + `DIO_StreamingTrigger` |
+| 5 | 5 | TOGGLE | `MC12bADC_EosInterruptTask` wake |
+| 6 | 6 | PULSE | EOS task: MC12b_ReadResult loop (skips + reads across 16 channels) |
+| 7 | 7 | TOGGLE | `streaming_Task` wake (encoder task) |
+| 8 | 8 | PULSE | `streaming_Task`: encoder call (CSV/PB/JSON) |
+| 9 | 9 | PULSE | `streaming_Task`: USB/WiFi/SD output write |
+
+## Jitter model
+
+Jitter grows as work moves down the scheduling hierarchy. This pattern
+repeats across captures — expect ISR work to be ~tens of nanoseconds,
+priority-8 tasks ~hundreds, priority-2 tasks ~microseconds.
+
+| Layer | Expected Tstd order of magnitude |
+|---|---:|
+| Hardware ISR (priority 1) | tens of ns |
+| FreeRTOS priority 8 task wake | 30–200 ns |
+| FreeRTOS priority 8 task work | 20–30 ns (under light load) |
+| FreeRTOS priority 2 task wake | ~1 µs |
+| FreeRTOS priority 2 task work | 10+ µs (preemption-dominated) |
+
+## Capture sessions
+
+---
+
+### Session 1 — 2026-04-17, 1 kHz / 1 Type-1 ADC ch / PB / USB
+
+- **Firmware**: `feat/301-dio-debug-framework` branch, HEAD `265e5580`
+  + DIO probe framework (uncommitted, this PR)
+- **Board**: NQ1
+- **Analyzer**: 8-channel Saleae Logic 8
+- **Stream config**: 1 kHz, 1 Type-1 ADC channel (`ENA:VOLT:DC 1,1`),
+  Protocol Buffers encoding, USB only
+- **Firmware stats**: 127,170 samples / 127,170 TimerISRCalls, 0 drops,
+  1,266,281 bytes streamed over ~127 seconds
+
+#### Toggle probes (ISR rate verification)
+
+| Probe | Description | fmean | Tstd | Nedges/ΔT |
+|---:|---|---:|---:|---:|
+| 0 | Timer ISR entry | 500.0002 Hz | **18.3 ns** | 7939 / 7.94s |
+| 1 | EOS ISR entry | 500.0002 Hz | **18.3 ns** | 7926 / 7.93s |
+| 2 | Deferred task wake | 500.0002 Hz | **149 ns** | 7863 / 7.86s |
+| 5 | EOS task wake | 500.0002 Hz | **29 ns** | 7876 / 7.88s |
+| 7 | Encoder task wake | 500.0000 Hz | **920 ns** | 9028 / 9.03s |
+
+All TOGGLE probes exactly 1:1 with 1 kHz timer (500 Hz square wave,
+rising+falling counts balanced). Zero spurious edges across ~8 seconds
+of capture — signal isolation working.
+
+#### Pulse probes (work duration)
+
+| Probe | Description | Tpos mean | Tpos min | Tpos max | Tstd |
+|---:|---|---:|---:|---:|---:|
+| 3 | Alloc + channel loop + queue push | **9.89 µs** | 9.76 µs | 10.76 µs | 149 ns |
+| 4 | ADC + DIO trigger | **23.22 µs** | 23.04 µs | 29.36 µs | 209 ns |
+| 6 | EOS task: read loop | **13.06 µs** | 12.88 µs | 17.48 µs | 25 ns |
+| 8 | Encode (PB, 1 ch) | **26.13 µs** | 17.48 µs | 74.08 µs | 14.17 µs |
+| 9 | Output write (USB) | **4.07 µs** | 0.56 µs | 39.64 µs | 11.67 µs |
+
+#### CPU budget at this config
+
+| Stage | Width (mean) | % of 1 ms tick |
+|---|---:|---:|
+| Deferred: alloc + loop + push (P3) | 9.89 µs | 0.99% |
+| Deferred: ADC + DIO trigger (P4) | 23.22 µs | 2.32% |
+| EOS task: read loop (P6) | 13.06 µs | 1.31% |
+| Encoder: encode call (P8) | 26.13 µs | 2.61% |
+| Encoder: output write (P9) | 4.07 µs | 0.41% |
+| **Measured total** | **76.37 µs** | **7.64%** |
+
+Remaining ~92% is FreeRTOS idle + uninstrumented paths (USB DMA callbacks,
+WiFi driver, power/UI task, etc.).
+
+#### Key findings
+
+1. **Encode is the dominant per-stage cost** even at 1 channel PB (26 µs,
+   2.6% of tick). Scales near-linearly with channel count — it's the
+   primary bottleneck at the high-rate / high-channel-count ceilings
+   shown in CLAUDE.md's characterization table.
+2. **P4 is mostly DIO, not ADC.** `MC12b_TriggerConversion` is close to
+   a no-op when hardware triggering is active (#282). The 23 µs is
+   dominated by `DIO_StreamingTrigger` scanning 16 DIO channels each tick.
+   Confirmation test: repeat with `ENA:DIO:GLOB 0` — probe 4 width should
+   drop to ~1–2 µs.
+3. **EOS path has lower jitter than deferred path** (29 ns vs 149 ns for
+   wake, 25 ns vs 209 ns for work). EOS task runs in a quiescent window
+   ~2 µs after the timer tick; deferred task races with priority-2
+   traffic that was preempted mid-cycle. May also reflect FPU save cost
+   in deferred (test pattern `sin()`).
+4. **Encoder wake jitter ~1 µs (probe 7), inter-arrival ±6% at probe 9.**
+   That's the scheduler's price for running encoder at priority 2. Under
+   load (WiFi+SD active) this jitter will grow; threshold at which it
+   causes backlog is a future measurement.
+5. **Framework overhead is negligible.** Per-toggle cost is
+   `if (!gDioProbeAnyActive) return` + slot copy + `GPIO_PortToggle`
+   — measured Tstd on P0/P1 matches what you'd expect from pure hardware
+   (18 ns), so the probe itself is not a significant contributor.
+
+---
+
+---
+
+### Session 2 — 2026-04-17, 13 kHz / 1 Type-1 ADC ch / PB / USB
+
+Same hardware and firmware as Session 1. Streamed at the firmware's
+frequency cap for 1 Type-1 channel (13 kHz), which corresponds to the
+constraint-model ceiling `min(ISR_MAX=13000, TYPE1_AGG=55000/1,
+BUDGET=110000/(6+1)=15714)`.
+
+- **Stream config**: 1 kHz → **13 kHz**, otherwise identical to Session 1
+- **Firmware stats**: 3,710,493 samples / 3,710,493 TimerISRCalls / **0 drops**
+  across the full 285-second session. 36,893,794 bytes streamed.
+
+#### Toggle probes (wake rate & ISR rate)
+
+| Probe | Description | fmean (Hz) | Tstd | Edge count |
+|---:|---|---:|---:|---:|
+| 0 | Timer ISR entry | 6496.87 (→ **12,994 Hz ISR**) | **912 ns** | 125,259 / 9.64s |
+| 1 | EOS ISR entry | 499.76 (→ **1,000 Hz**) | 2.2 µs | 9,593 / 9.60s |
+| 2 | Deferred task wake | 6496.87 (→ 12,994 Hz) | **5.42 µs** | 122,517 / 9.43s |
+| 5 | EOS task wake | 499.76 (→ 1,000 Hz) | 4.16 µs | 9,334 / 9.34s |
+
+**Probe 1 (EOS ISR) is at ~1 kHz, not 13 kHz.** Expected post-PR #290 —
+Type 1 dedicated-module conversions no longer fire EOS (the residual
+1 kHz rate is the divided-rate shared/OBDiag scan path).
+
+#### Pulse probes (work duration)
+
+| Probe | Description | Tpos mean | Tpos min | Tpos max | Tstd |
+|---:|---|---:|---:|---:|---:|
+| 3 | Alloc + channel loop + queue push | 9.81 µs | 5.80 µs | **73.56 µs** | 5.82 µs |
+| 4 | ADC + DIO trigger | **8.85 µs** (↓ from 23.22) | 5.92 µs | 59.72 µs | 15.6 µs |
+| 8 | Encode (PB, 1 ch) | 36.0 µs | 10.0 µs | **349 µs** | 42.4 µs |
+| 9 | Output write (USB) | **0.91 µs** (↓ from 4.07) | 240 ns | 206 µs | 63 µs |
+
+**Probe 8 only fires at 10,454 Hz (vs 13,000 Hz timer).** No drops occur
+because `streaming_Task` early-continues on empty queue — encoder runs
+in bursts and drains multiple accumulated samples when it gets CPU,
+then idles when queue is empty. Total encoded packets still match
+total timer ticks.
+
+#### Jitter comparison: 1 kHz → 13 kHz
+
+| Source | 1 kHz Tstd | 13 kHz Tstd | Ratio |
+|---|---:|---:|---:|
+| Timer ISR entry (P0) | 18 ns | 912 ns | **50×** |
+| EOS ISR entry (P1) | 18 ns | 2.2 µs | **122×** |
+| Deferred task wake (P2) | 149 ns | 5.42 µs | **36×** |
+| EOS task wake (P5) | 29 ns | 4.16 µs | **144×** |
+| Encoder wake (P7) | 920 ns | *not captured* | — |
+| Encoder work (P8 Tstd) | 14.17 µs | 42.4 µs | 3× |
+
+#### Key findings
+
+1. **Zero drops at 13 kHz** — the constraint-model ceiling is real and
+   sustainable. TimerISRCalls == TotalSamplesStreamed invariant holds
+   across 3.7M samples.
+2. **Probe 4 work dropped 23 µs → 8.85 µs** at the higher rate. Likely
+   cause: `ChannelScanFreqDiv` skips the shared-scan trigger at most
+   high-rate ticks — only DIO scan cost remains. Validate by capturing
+   with a shared channel enabled; P4 should split into two distinct
+   widths depending on whether that tick includes a shared scan.
+3. **Probe 9 work dropped 4.07 µs → 910 ns.** Small PB packets (~8 B)
+   pile into the USB circular buffer via fast memcpy; DMA flush rarely
+   triggers. Max 206 µs confirms DMA path is still there, just rare.
+4. **Encoder produces at 10.5 kHz, input is 13 kHz.** Reconciled by
+   early-continue-on-empty-queue — encoder processes in bursts. This is
+   why firmware stats show 0 drops despite the probe 8 rate mismatch.
+5. **Priority-8 task wake jitter blew up 36–144×.** Even tasks that
+   don't run often (EOS task at 1 kHz) suffer jitter from surrounding
+   13 kHz load — the scheduler isn't quiet enough to wake cleanly.
+6. **Encoder tail latency is the key bottleneck.** P8 max 349 µs is
+   4.5× the 77 µs tick budget. At higher channel counts this max will
+   grow until it exhausts the sample pool.
+7. **ISR-in-ISR contention was NOT the dominant timer-ISR jitter cause**
+   (as originally hypothesized during the capture session). Post-#290
+   EOS only fires ~1 kHz, so timer/EOS collisions happen only 1 in 13
+   ticks. The 912 ns P0 Tstd is more likely cache + bus contention from
+   the background tasks running constantly.
+
+---
+
+## Follow-up captures to run
+
+- [ ] **FPU contribution**: rerun Session 2 with `SYST:STR:TESTpattern 2`
+      (midscale — bypasses the sin() call). If P2/P3 jitter drops, FPU
+      context save is a real contributor.
+- [ ] **DIO isolation test**: rerun Session 1 with `ENA:DIO:GLOB 0`,
+      confirm P4 drops to ~1–2 µs. Separates DIO cost from ADC trigger.
+- [ ] **Shared-scan split**: Session 2 + enable a Type-2 channel
+      (e.g. `ENA:VOLT:DC 0,1`), verify P4 shows bimodal width
+      (shared-scan ticks vs non-shared ticks).
+- [ ] **Channel scaling**: 16 Type-1 ADC channels @ 1 kHz. Does P3 scale
+      linearly with channel count?
+- [ ] **Encode format scaling**: same config, compare P8 widths for
+      PB / CSV / JSON.
+- [ ] **Load test**: encode with WiFi + SD both active, watch P7 jitter
+      and P9 tail.
+- [ ] **Over-ceiling probe**: `SYST:STR:BENCH 1` + 20 kHz / 1 ch to force
+      failure, record where drops begin and which stage saturates first.
+- [ ] **Type 2 only**: stream with a MODULE7 channel only, watch P1 for
+      scan-rate vs tick-rate relationship.

--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -931,6 +931,7 @@
           <itemPath>../src/HAL/UI/UI.c</itemPath>
         </logicalFolder>
         <itemPath>../src/HAL/DIO.c</itemPath>
+        <itemPath>../src/HAL/DioProbe.c</itemPath>
         <itemPath>../src/HAL/ADC.c</itemPath>
       </logicalFolder>
       <logicalFolder name="libraries" displayName="libraries" projectFiles="true">

--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -11,6 +11,7 @@
 //#include "ADC/AD7173.h"
 #include "ADC/MC12bADC.h"
 #include "DIO.h"
+#include "DioProbe.h"
 #include "Util/Logger.h"
 #include "services/streaming.h"
 #include "FreeRTOS.h"
@@ -124,12 +125,14 @@ void MC12bADC_EosInterruptTask(void) {
         // busy — those ADC result registers were overwritten before we
         // could read them. Count these as result overruns (#295).
         uint32_t notifCount = ulTaskNotifyTake(pdTRUE, xBlockTime);
+        DioProbe_Toggle(5);  /* probe 5: EOS task wake rate */
         if (notifCount > 1) {
             Streaming_IncrEosOverruns(notifCount - 1);
             LOG_E_SESSION(LOG_SESSION_EOS_OVERRUN,
                 "EOS: %u result overruns", (unsigned)(notifCount - 1));
         }
 
+        DioProbe_PulseStart(6);  /* probe 6: result read loop duration */
         AInSample sample;
         int i = 0;
         uint32_t adcval;
@@ -165,6 +168,7 @@ void MC12bADC_EosInterruptTask(void) {
         if (anyMonitorRead) {
             gLastDiagScanTick = xTaskGetTickCount();
         }
+        DioProbe_PulseEnd(6);
     }
 }
 
@@ -516,6 +520,7 @@ static void GetModuleChannelRuntimeData(
 
 void ADC_EOSInterruptCB(uintptr_t context) {
     (void)context; // Unused
+    DioProbe_Toggle(1);  /* probe 1: EOS ISR entry rate */
 
     // Guard against NULL task handle (if task creation failed during init)
     if (gADCInterruptHandle != NULL) {

--- a/firmware/src/HAL/DIO.c
+++ b/firmware/src/HAL/DIO.c
@@ -15,6 +15,7 @@
 #include "OcmpApi/OcmpApi.h"
 #include "services/streaming.h"
 #include "Util/Logger.h"
+#include "DioProbe.h"
 //! Pointer to the board configuration. It must be set in the initialization
 static tBoardConfig *gpBoardConfig;
 //! Pointer to the runtime board configuration. It must be set in the initialization
@@ -83,6 +84,12 @@ bool DIO_WriteStateAll(void) {
 }
 
 bool DIO_WriteStateSingle(uint8_t dataIndex) {
+    /* Probe owns this channel — the debug probe drives TRIS/LAT
+     * exclusively. Skipping here is the primary isolation point;
+     * signal purity on the scope depends on it. */
+    if (DioProbe_IsChannelOwned(dataIndex)) {
+        return true;
+    }
     bool enableInverted = gpBoardConfig->DIOChannels.Data[ dataIndex ].EnableInverted;
     GPIO_PORT enableChannel = gpBoardConfig->DIOChannels.Data[ dataIndex ]. EnableChannel;
     uint8_t enableBitPos = gpBoardConfig->DIOChannels.Data[ dataIndex ].EnableBitPos;
@@ -115,6 +122,10 @@ bool DIO_WriteStateSingle(uint8_t dataIndex) {
 }
 
 bool DIO_ReadSampleByMask(DIOSample* sample, uint32_t mask) {
+    /* Filter out probe-owned channels — their toggle waveform is
+     * debug artifact, not user data. Including them in the stream
+     * would mislead the consumer reading DIO samples. */
+    mask = DioProbe_FilterReadMask(mask);
     sample->Mask = mask;
     sample->Values = 0;
     // Set module trigger timestamp
@@ -139,6 +150,9 @@ bool DIO_ReadSampleByMask(DIOSample* sample, uint32_t mask) {
 }
 
 bool DIO_PWMWriteStateSingle(uint8_t dataIndex) {
+    if (DioProbe_IsChannelOwned(dataIndex)) {
+        return false;
+    }
     bool enableInverted = gpBoardConfig->DIOChannels.Data[ dataIndex ].EnableInverted;
     GPIO_PORT enableChannel = gpBoardConfig->DIOChannels.Data[ dataIndex ]. EnableChannel;
     uint8_t enableBitPos = gpBoardConfig->DIOChannels.Data[ dataIndex ].EnableBitPos;
@@ -162,6 +176,9 @@ bool DIO_PWMWriteStateSingle(uint8_t dataIndex) {
 }
 
 bool DIO_PWMDutyCycleSetSingle(uint8_t dataIndex) {
+    if (DioProbe_IsChannelOwned(dataIndex)) {
+        return false;
+    }
     uint8_t pwmDriverInstance = gpBoardConfig->DIOChannels.Data[ dataIndex ].PwmOcmpId;
     uint32_t timerFreq = TimerApi_FrequencyGet(3);
     uint16_t pwmDutyCycle = gpRuntimeBoardConfig->DIOChannels.Data[ dataIndex ].PwmDutyCycle;
@@ -175,6 +192,9 @@ bool DIO_PWMDutyCycleSetSingle(uint8_t dataIndex) {
 }
 
 bool DIO_PWMFrequencySet(uint8_t dataIndex) {
+    if (DioProbe_IsChannelOwned(dataIndex)) {
+        return false;
+    }
 
     const uint16_t tim3PreScalers[8] = {1, 2, 4, 8, 16, 32, 64, 256};
     uint32_t timerClock = TIMER_CLOCK_FRQ;//TimerApi_FrequencyGet(3);
@@ -211,6 +231,11 @@ void DIO_StreamingTrigger(DIOSample* latest, DIOSampleList* streamingSamples) {
 
     // Write DIO values
     for (i = 0; i < DIOChruntimeConfig->Size; ++i) {
+        /* Skip probe-owned channels at the loop level to avoid the
+         * call overhead. DIO_WriteStateSingle also guards internally. */
+        if (DioProbe_IsChannelOwned((uint8_t)i)) {
+            continue;
+        }
         DIO_WriteStateSingle(i);
     }
 

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -18,7 +18,7 @@
 /* ---- globals ---- */
 
 volatile bool gDioProbeAnyActive = false;
-DioProbeSlot_t gDioProbeSlots[DIO_PROBE_SLOTS];
+volatile DioProbeSlot_t gDioProbeSlots[DIO_PROBE_SLOTS];
 volatile uint16_t gDioProbeOwnedMask = 0;
 
 /* ---- internal helpers ---- */
@@ -116,7 +116,7 @@ void DioProbe_Init(void) {
         tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
         const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
 
-        DioProbeSlot_t* slot = &gDioProbeSlots[i];
+        volatile DioProbeSlot_t* slot = &gDioProbeSlots[i];
         slot->port    = dio->DataChannel;
         slot->mask    = 1u << dio->DataBitPos;
         slot->channel = channel;
@@ -150,7 +150,7 @@ bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode) {
      * This protocol is safe even without the critical section; the
      * critical section is kept to also cover the volatile bitmask
      * updates (gDioProbeOwnedMask, gDioProbeAnyActive). */
-    DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
+    volatile DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
     slot->mode = DIO_PROBE_MODE_OFF;
 
     taskENTER_CRITICAL();
@@ -167,7 +167,7 @@ bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode) {
 
 bool DioProbe_Clear(uint8_t probeId) {
     if (probeId >= DIO_PROBE_STANDARD_COUNT) return false;
-    DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
+    volatile DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
     if (slot->mode == DIO_PROBE_MODE_OFF && slot->channel == 0xFF) {
         return true;  /* already clear */
     }

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -1,0 +1,189 @@
+#define LOG_LVL LOG_LEVEL_DEBUG
+#define LOG_MODULE LOG_MODULE_GENERAL
+/*! @file DioProbe.c
+ *
+ * Implementation of the DIO debug probe framework. See DioProbe.h for
+ * full API and isolation contract.
+ */
+
+#include "DioProbe.h"
+#include <string.h>
+#include "state/board/BoardConfig.h"
+#include "state/runtime/BoardRuntimeConfig.h"
+#include "Util/Logger.h"
+
+/* ---- globals ---- */
+
+volatile bool gDioProbeAnyActive = false;
+DioProbeSlot_t gDioProbeSlots[DIO_PROBE_SLOTS];
+volatile uint16_t gDioProbeOwnedMask = 0;
+
+/* ---- internal helpers ---- */
+
+static bool probe_configure_pin(uint8_t channel) {
+    tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+    tBoardRuntimeConfig* rt = BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_ALL_CONFIG);
+    if (cfg == NULL || rt == NULL) return false;
+    if (channel >= cfg->DIOChannels.Size) return false;
+
+    const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
+    const DIORuntimeConfig* rtch = &rt->DIOChannels.Data[channel];
+
+    /* Reject if PWM is currently active on this channel. PWM drives
+     * the pin from OCMP at interrupt time — incompatible with probe. */
+    if (rtch->IsPwmActive) {
+        LOG_E("DioProbe: channel %u rejected (PWM active)", (unsigned)channel);
+        return false;
+    }
+
+    /* Drive LOW *before* setting direction to output. The pin starts
+     * at a known level — scope triggers cleanly on first real edge. */
+    uint32_t dataMask = 1u << dio->DataBitPos;
+    uint32_t enMask   = 1u << dio->EnableBitPos;
+
+    GPIO_PortClear(dio->DataChannel, dataMask);
+    GPIO_PortOutputEnable(dio->DataChannel, dataMask);
+
+    /* Activate driver. EnableInverted means active-low. */
+    if (dio->EnableInverted) {
+        GPIO_PortClear(dio->EnableChannel, enMask);
+    } else {
+        GPIO_PortSet(dio->EnableChannel, enMask);
+    }
+    GPIO_PortOutputEnable(dio->EnableChannel, enMask);
+    return true;
+}
+
+static void probe_release_pin(uint8_t channel) {
+    tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+    if (cfg == NULL) return;
+    if (channel >= cfg->DIOChannels.Size) return;
+
+    const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
+    uint32_t dataMask = 1u << dio->DataBitPos;
+
+    /* Park pin LOW so the next stream sample reads a clean zero
+     * until DIO_WriteStateSingle re-applies user config. */
+    GPIO_PortClear(dio->DataChannel, dataMask);
+}
+
+static void recompute_any_active(void) {
+    bool any = false;
+    for (int i = 0; i < DIO_PROBE_SLOTS; ++i) {
+        if (gDioProbeSlots[i].mode != DIO_PROBE_MODE_OFF) {
+            any = true;
+            break;
+        }
+    }
+    gDioProbeAnyActive = any;
+}
+
+/* ---- public API ---- */
+
+void DioProbe_Init(void) {
+    memset((void*)gDioProbeSlots, 0, sizeof(gDioProbeSlots));
+    for (int i = 0; i < DIO_PROBE_SLOTS; ++i) {
+        gDioProbeSlots[i].channel = 0xFF;
+    }
+    gDioProbeOwnedMask = 0;
+    gDioProbeAnyActive = false;
+
+    /* Activate ad-hoc probes whose bit is set in the compile-time
+     * enable mask. Each ad-hoc probe i maps to DIO channel i. */
+#if (DIO_PROBE_ENABLE_MASK) != 0u
+    for (uint8_t i = DIO_PROBE_ADHOC_FIRST; i < DIO_PROBE_SLOTS; ++i) {
+        if (((DIO_PROBE_ENABLE_MASK) & (1u << i)) == 0u) continue;
+        if (i > DIO_PROBE_MAX_DIO_CHANNEL) continue;
+
+        uint8_t channel = i;
+        if (!probe_configure_pin(channel)) {
+            LOG_E("DioProbe: ad-hoc probe %u pin config failed", (unsigned)i);
+            continue;
+        }
+
+        tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+        const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
+
+        DioProbeSlot_t* slot = &gDioProbeSlots[i];
+        slot->port    = dio->DataChannel;
+        slot->mask    = 1u << dio->DataBitPos;
+        slot->channel = channel;
+        slot->mode    = DIO_PROBE_MODE_TOGGLE;  /* publish last */
+
+        gDioProbeOwnedMask |= (1u << channel);
+    }
+    recompute_any_active();
+#endif
+}
+
+bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode) {
+    if (probeId >= DIO_PROBE_STANDARD_COUNT) return false;
+    if (mode == DIO_PROBE_MODE_OFF) return DioProbe_Clear(probeId);
+
+    uint8_t channel = probeId;  /* standard probes: probe N -> DIO N */
+
+    if (!probe_configure_pin(channel)) {
+        return false;
+    }
+
+    tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+    const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
+
+    /* Write slot fields; mode LAST to publish. */
+    DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
+    slot->port    = dio->DataChannel;
+    slot->mask    = 1u << dio->DataBitPos;
+    slot->channel = channel;
+    slot->mode    = (uint8_t)mode;
+
+    gDioProbeOwnedMask |= (1u << channel);
+    gDioProbeAnyActive = true;  /* publish after all slot state valid */
+    return true;
+}
+
+bool DioProbe_Clear(uint8_t probeId) {
+    if (probeId >= DIO_PROBE_STANDARD_COUNT) return false;
+    DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
+    if (slot->mode == DIO_PROBE_MODE_OFF && slot->channel == 0xFF) {
+        return true;  /* already clear */
+    }
+
+    uint8_t channel = slot->channel;
+
+    /* Stop toggles first, then drive the pin LOW, then clear ownership.
+     * Readers seeing mode=OFF won't touch the pin even if they got a
+     * torn copy of the slot. */
+    slot->mode = DIO_PROBE_MODE_OFF;
+
+    if (channel <= DIO_PROBE_MAX_DIO_CHANNEL) {
+        probe_release_pin(channel);
+        gDioProbeOwnedMask &= (uint16_t)~(1u << channel);
+    }
+
+    slot->channel = 0xFF;
+    slot->mask = 0;
+    recompute_any_active();
+    return true;
+}
+
+void DioProbe_ClearAll(void) {
+    for (uint8_t i = 0; i < DIO_PROBE_STANDARD_COUNT; ++i) {
+        DioProbe_Clear(i);
+    }
+}
+
+void DioProbe_SetPipeline(DioProbeMode_t mode) {
+    for (uint8_t i = 0; i < DIO_PROBE_STANDARD_COUNT; ++i) {
+        DioProbe_Assign(i, mode);
+    }
+}
+
+void DioProbe_GetSlot(uint8_t probeId, DioProbeSlot_t* out) {
+    if (out == NULL) return;
+    if (probeId >= DIO_PROBE_SLOTS) {
+        memset(out, 0, sizeof(*out));
+        out->channel = 0xFF;
+        return;
+    }
+    *out = gDioProbeSlots[probeId];
+}

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -141,19 +141,27 @@ bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode) {
     tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
     const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
 
-    /* Critical section required for re-assign: without it, an ISR reader
-     * could see mode=ACTIVE (old) with port/mask partially updated,
-     * toggling the wrong pin. Mode-published-last is not enough here
-     * because mode may stay ACTIVE across the reassign. */
+    /* Publication protocol for re-assign:
+     *   1. Clear mode to OFF (ISR readers see OFF and bail)
+     *   2. Critical section: rewrite port/mask/channel + masks
+     *   3. Publish new mode LAST (outside critical section — readers
+     *      only ever see mode=OFF while fields are mid-update, then
+     *      mode=NEW with fully committed fields)
+     * This protocol is safe even without the critical section; the
+     * critical section is kept to also cover the volatile bitmask
+     * updates (gDioProbeOwnedMask, gDioProbeAnyActive). */
     DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
+    slot->mode = DIO_PROBE_MODE_OFF;
+
     taskENTER_CRITICAL();
     slot->port    = dio->DataChannel;
     slot->mask    = 1u << dio->DataBitPos;
     slot->channel = channel;
-    slot->mode    = (uint8_t)mode;
-    gDioProbeOwnedMask |= (1u << channel);
+    gDioProbeOwnedMask |= (uint16_t)(1u << channel);
     gDioProbeAnyActive = true;
     taskEXIT_CRITICAL();
+
+    slot->mode = (uint8_t)mode;
     return true;
 }
 

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -182,17 +182,16 @@ bool DioProbe_Clear(uint8_t probeId) {
     uint8_t channel = slot->channel;
 
     /* Mode=OFF first (stops any further toggles from ISR context),
-     * then wrap the rest in a critical section so the owned mask
-     * clear and slot field reset publish atomically relative to
-     * subsequent reads. */
+     * then wrap everything else in a single critical section: pin
+     * release + owned mask clear + slot field reset all publish
+     * together. Tightens the "owned" invariant — there's no window
+     * where the mask says owned but the pin has already been reverted
+     * to high-Z. probe_release_pin only does SFR writes, safe in CS. */
     slot->mode = DIO_PROBE_MODE_OFF;
-
-    if (channel <= DIO_PROBE_MAX_DIO_CHANNEL) {
-        probe_release_pin(channel);
-    }
 
     taskENTER_CRITICAL();
     if (channel <= DIO_PROBE_MAX_DIO_CHANNEL) {
+        probe_release_pin(channel);
         gDioProbeOwnedMask &= (uint16_t)~(1u << channel);
     }
     slot->channel = 0xFF;

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -232,9 +232,15 @@ void DioProbe_GetSlot(uint8_t probeId, DioProbeSlot_t* out) {
     }
     /* Critical section protects against a torn read if another SCPI
      * task (USB pri 7 vs WiFi pri 2) is concurrently modifying the
-     * same slot via Assign/Clear. Cost is negligible — this is called
-     * from LIST?/ASS? SCPI queries, not a hot path. */
+     * same slot via Assign/Clear. Copy fields explicitly rather than
+     * using struct assignment from volatile — makes the volatile
+     * loads explicit in generated code and portable across compilers. */
+    DioProbeSlot_t tmp;
     taskENTER_CRITICAL();
-    *out = gDioProbeSlots[probeId];
+    tmp.port    = gDioProbeSlots[probeId].port;
+    tmp.mask    = gDioProbeSlots[probeId].mask;
+    tmp.channel = gDioProbeSlots[probeId].channel;
+    tmp.mode    = gDioProbeSlots[probeId].mode;
     taskEXIT_CRITICAL();
+    *out = tmp;
 }

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -223,5 +223,11 @@ void DioProbe_GetSlot(uint8_t probeId, DioProbeSlot_t* out) {
         out->channel = 0xFF;
         return;
     }
+    /* Critical section protects against a torn read if another SCPI
+     * task (USB pri 7 vs WiFi pri 2) is concurrently modifying the
+     * same slot via Assign/Clear. Cost is negligible — this is called
+     * from LIST?/ASS? SCPI queries, not a hot path. */
+    taskENTER_CRITICAL();
     *out = gDioProbeSlots[probeId];
+    taskEXIT_CRITICAL();
 }

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -11,6 +11,7 @@
 #include "state/board/BoardConfig.h"
 #include "state/runtime/BoardRuntimeConfig.h"
 #include "Util/Logger.h"
+#include "DIO.h"
 #include "FreeRTOS.h"
 #include "task.h"
 
@@ -25,7 +26,6 @@ volatile uint16_t gDioProbeOwnedMask = 0;
 static bool probe_configure_pin(uint8_t channel) {
     tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
     tBoardRuntimeConfig* rt = BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_ALL_CONFIG);
-    if (cfg == NULL || rt == NULL) return false;
     if (channel >= cfg->DIOChannels.Size) return false;
 
     const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
@@ -58,7 +58,6 @@ static bool probe_configure_pin(uint8_t channel) {
 
 static void probe_release_pin(uint8_t channel) {
     tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
-    if (cfg == NULL) return;
     if (channel >= cfg->DIOChannels.Size) return;
 
     const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
@@ -184,6 +183,14 @@ bool DioProbe_Clear(uint8_t probeId) {
     slot->channel = 0xFF;
     slot->mask = 0;
     taskEXIT_CRITICAL();
+
+    /* Ownership is cleared — re-apply the user's runtime-configured
+     * DIO state so the channel returns to its pre-probe behavior
+     * (direction, value, enable) without requiring an external SCPI
+     * write from the host. */
+    if (channel <= DIO_PROBE_MAX_DIO_CHANNEL) {
+        (void)DIO_WriteStateSingle(channel);
+    }
 
     recompute_any_active();
     return true;

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -63,10 +63,21 @@ static void probe_release_pin(uint8_t channel) {
 
     const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
     uint32_t dataMask = 1u << dio->DataBitPos;
+    uint32_t enMask   = 1u << dio->EnableBitPos;
 
-    /* Park pin LOW so the next stream sample reads a clean zero
-     * until DIO_WriteStateSingle re-applies user config. */
+    /* Park outputs to inactive levels first (avoids a spurious edge
+     * during the direction change to input), then put both pins back
+     * to input / high-Z so normal DIO control can re-apply user
+     * config cleanly — including the case where the user had the
+     * channel configured as an input. */
     GPIO_PortClear(dio->DataChannel, dataMask);
+    if (dio->EnableInverted) {
+        GPIO_PortSet(dio->EnableChannel, enMask);   /* inactive-high */
+    } else {
+        GPIO_PortClear(dio->EnableChannel, enMask); /* inactive-low */
+    }
+    GPIO_PortInputEnable(dio->DataChannel, dataMask);
+    GPIO_PortInputEnable(dio->EnableChannel, enMask);
 }
 
 static void recompute_any_active(void) {

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -11,6 +11,8 @@
 #include "state/board/BoardConfig.h"
 #include "state/runtime/BoardRuntimeConfig.h"
 #include "Util/Logger.h"
+#include "FreeRTOS.h"
+#include "task.h"
 
 /* ---- globals ---- */
 
@@ -129,15 +131,19 @@ bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode) {
     tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
     const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
 
-    /* Write slot fields; mode LAST to publish. */
+    /* Critical section required for re-assign: without it, an ISR reader
+     * could see mode=ACTIVE (old) with port/mask partially updated,
+     * toggling the wrong pin. Mode-published-last is not enough here
+     * because mode may stay ACTIVE across the reassign. */
     DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
+    taskENTER_CRITICAL();
     slot->port    = dio->DataChannel;
     slot->mask    = 1u << dio->DataBitPos;
     slot->channel = channel;
     slot->mode    = (uint8_t)mode;
-
     gDioProbeOwnedMask |= (1u << channel);
-    gDioProbeAnyActive = true;  /* publish after all slot state valid */
+    gDioProbeAnyActive = true;
+    taskEXIT_CRITICAL();
     return true;
 }
 
@@ -150,18 +156,24 @@ bool DioProbe_Clear(uint8_t probeId) {
 
     uint8_t channel = slot->channel;
 
-    /* Stop toggles first, then drive the pin LOW, then clear ownership.
-     * Readers seeing mode=OFF won't touch the pin even if they got a
-     * torn copy of the slot. */
+    /* Mode=OFF first (stops any further toggles from ISR context),
+     * then wrap the rest in a critical section so the owned mask
+     * clear and slot field reset publish atomically relative to
+     * subsequent reads. */
     slot->mode = DIO_PROBE_MODE_OFF;
 
     if (channel <= DIO_PROBE_MAX_DIO_CHANNEL) {
         probe_release_pin(channel);
-        gDioProbeOwnedMask &= (uint16_t)~(1u << channel);
     }
 
+    taskENTER_CRITICAL();
+    if (channel <= DIO_PROBE_MAX_DIO_CHANNEL) {
+        gDioProbeOwnedMask &= (uint16_t)~(1u << channel);
+    }
     slot->channel = 0xFF;
     slot->mask = 0;
+    taskEXIT_CRITICAL();
+
     recompute_any_active();
     return true;
 }

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -80,7 +80,13 @@ static void probe_release_pin(uint8_t channel) {
 }
 
 static void recompute_any_active(void) {
+    /* Critical section: serializes this iteration with DioProbe_Assign
+     * and DioProbe_Clear on the other SCPI task. Without it, Assign
+     * on task B could publish mode=NEW right after our read of
+     * gDioProbeSlots[i].mode returned OFF, and we would then stomp
+     * Assign's gDioProbeAnyActive=true with a false. */
     bool any = false;
+    taskENTER_CRITICAL();
     for (int i = 0; i < DIO_PROBE_SLOTS; ++i) {
         if (gDioProbeSlots[i].mode != DIO_PROBE_MODE_OFF) {
             any = true;
@@ -88,6 +94,7 @@ static void recompute_any_active(void) {
         }
     }
     gDioProbeAnyActive = any;
+    taskEXIT_CRITICAL();
 }
 
 /* ---- public API ---- */
@@ -141,15 +148,16 @@ bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode) {
     tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
     const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
 
-    /* Publication protocol for re-assign:
-     *   1. Clear mode to OFF (ISR readers see OFF and bail)
-     *   2. Critical section: rewrite port/mask/channel + masks
-     *   3. Publish new mode LAST (outside critical section — readers
-     *      only ever see mode=OFF while fields are mid-update, then
-     *      mode=NEW with fully committed fields)
-     * This protocol is safe even without the critical section; the
-     * critical section is kept to also cover the volatile bitmask
-     * updates (gDioProbeOwnedMask, gDioProbeAnyActive). */
+    /* Publication protocol:
+     *   1. Clear mode to OFF (belt-and-suspenders — CS will block ISR
+     *      readers anyway, but any read that slips before the CS sees
+     *      OFF and bails)
+     *   2. Single critical section: rewrite fields + masks + publish
+     *      mode=NEW + set any_active. Mode publish MUST be inside the
+     *      CS so recompute_any_active on the other SCPI task cannot
+     *      observe mode=OFF and stomp any_active=false.
+     *   3. Volatile fields (see DioProbeSlot_t) prevent the compiler
+     *      from reordering writes out of the CS. */
     volatile DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
     slot->mode = DIO_PROBE_MODE_OFF;
 
@@ -157,11 +165,10 @@ bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode) {
     slot->port    = dio->DataChannel;
     slot->mask    = 1u << dio->DataBitPos;
     slot->channel = channel;
+    slot->mode    = (uint8_t)mode;
     gDioProbeOwnedMask |= (uint16_t)(1u << channel);
     gDioProbeAnyActive = true;
     taskEXIT_CRITICAL();
-
-    slot->mode = (uint8_t)mode;
     return true;
 }
 

--- a/firmware/src/HAL/DioProbe.h
+++ b/firmware/src/HAL/DioProbe.h
@@ -14,7 +14,8 @@
  *
  * 1) STANDARD probes 0..9 — permanently wired to streaming pipeline
  *    stages. Mapped 1:1 to DIO_0..DIO_9. Assigned at runtime via
- *    SCPI SYST:DIOPR:ASS <probe>,<mode>.
+ *    SCPI SYST:DIOP:ASS <probe>,<mode> (caps-only) or long form
+ *    SYSTem:DIOProbe:ASSign.
  *
  * 2) AD-HOC probes 10..15 — compile-time instrumentation. Drop
  *    `DIO_PROBE_TOGGLE(n)` or `DIO_PROBE_PULSE_START(n)/END(n)` into

--- a/firmware/src/HAL/DioProbe.h
+++ b/firmware/src/HAL/DioProbe.h
@@ -1,0 +1,175 @@
+/*! @file DioProbe.h
+ *
+ * Lightweight DIO debug probe framework for pipeline timing analysis.
+ *
+ * When a DIO channel is assigned to a probe, the normal DIO write path
+ * (DIO_WriteStateSingle, DIO_WriteStateAll, DIO_StreamingTrigger loop,
+ * DIO_ReadSampleByMask, PWM functions, SCPI user-DIO commands) is
+ * completely blocked for that channel. The probe owns both the data
+ * pin TRIS/LAT and the enable pin. This isolation is PARAMOUNT — a
+ * single spurious edge from another code path would make scope
+ * measurements untrustworthy.
+ *
+ * Two probe classes:
+ *
+ * 1) STANDARD probes 0..9 — permanently wired to streaming pipeline
+ *    stages. Mapped 1:1 to DIO_0..DIO_9. Assigned at runtime via
+ *    SCPI SYST:DIOPR:ASS <probe>,<mode>.
+ *
+ * 2) AD-HOC probes 10..15 — compile-time instrumentation. Drop
+ *    `DIO_PROBE_TOGGLE(n)` or `DIO_PROBE_PULSE_START(n)/END(n)` into
+ *    any code path, set the corresponding bit in
+ *    `DIO_PROBE_ENABLE_MASK`, recompile. Mapped 1:1 to DIO_10..DIO_15.
+ *
+ * Hot-path cost when disabled: one load + branch-if-zero. Zero cost
+ * for ad-hoc probes whose bit is not set in DIO_PROBE_ENABLE_MASK.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "../config/default/peripheral/gpio/plib_gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! Probe mode. OFF = inert; TOGGLE = single flip per call; PULSE = SET
+ *  on _Toggle/_PulseStart call, CLEAR on _PulseEnd call. */
+typedef enum {
+    DIO_PROBE_MODE_OFF    = 0,
+    DIO_PROBE_MODE_TOGGLE = 1,
+    DIO_PROBE_MODE_PULSE  = 2
+} DioProbeMode_t;
+
+/*! Per-probe slot. Written only by the SCPI task; read by many
+ *  contexts. Publish order: fill port/mask/channel first, mode last. */
+typedef struct {
+    GPIO_PORT port;       //!< Data pin GPIO port
+    uint32_t  mask;       //!< 1u << data bit position
+    uint8_t   channel;    //!< DIO channel index (0..15); 0xFF = unassigned
+    uint8_t   mode;       //!< DioProbeMode_t
+} DioProbeSlot_t;
+
+#define DIO_PROBE_SLOTS            16  //!< probe IDs 0..15
+#define DIO_PROBE_STANDARD_COUNT   10  //!< probes 0..9 SCPI-controlled
+#define DIO_PROBE_ADHOC_FIRST      10  //!< probes 10..15 compile-time
+#define DIO_PROBE_MAX_DIO_CHANNEL  15  //!< last valid DIO channel index
+
+/*! Compile-time enable mask for ad-hoc probes. Default 0 = all ad-hoc
+ *  probe calls expand to nothing. Developer sets bits in BoardConfig.h
+ *  or on the compiler command line for probes they want live. */
+#ifndef DIO_PROBE_ENABLE_MASK
+#define DIO_PROBE_ENABLE_MASK 0x0000u
+#endif
+
+/* ---- globals (defined in DioProbe.c) ---- */
+
+/*! Fast-path gate. When false, all probe calls short-circuit after
+ *  one load. Written last when any slot is activated. */
+extern volatile bool gDioProbeAnyActive;
+
+/*! Slot table. Single-writer (SCPI task); readers do atomic struct
+ *  copies on PIC32MZ's 32-bit bus. */
+extern DioProbeSlot_t gDioProbeSlots[DIO_PROBE_SLOTS];
+
+/*! Bitmask of DIO channels currently owned by a probe. Checked by
+ *  DIO.c write paths to skip stomping the pin. */
+extern volatile uint16_t gDioProbeOwnedMask;
+
+/* ---- public API (SCPI task + boot) ---- */
+
+/*! Zero all slots, masks, flags. Also activates any ad-hoc probes
+ *  whose bit is set in DIO_PROBE_ENABLE_MASK. Call AFTER
+ *  DIO_InitHardware so default DIO writes settle first. */
+void DioProbe_Init(void);
+
+/*! Assign a standard probe (0..9) to a mode. Channel = probeId.
+ *  Forces pin LOW then configures as output with driver enabled.
+ *  Rejects if PWM is active on the target channel.
+ *  @return true on success */
+bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode);
+
+/*! Release a standard probe. Drives pin LOW, clears ownership,
+ *  returns channel to normal DIO control. */
+bool DioProbe_Clear(uint8_t probeId);
+
+/*! Clear all standard probes (ad-hoc are not affected). */
+void DioProbe_ClearAll(void);
+
+/*! Set all 10 standard probes to the given mode in one call.
+ *  Convenience for capturing the whole pipeline at once. */
+void DioProbe_SetPipeline(DioProbeMode_t mode);
+
+/*! Lookup: is this DIO channel currently owned by a probe?
+ *  Used by DIO.c and SCPIDIO.c to enforce isolation. */
+static inline bool DioProbe_IsChannelOwned(uint8_t channel) {
+    return (gDioProbeOwnedMask & (1u << channel)) != 0;
+}
+
+/*! Remove owned bits from a DIO channel read mask. */
+static inline uint32_t DioProbe_FilterReadMask(uint32_t mask) {
+    return mask & ~(uint32_t)gDioProbeOwnedMask;
+}
+
+/*! Snapshot one slot (for LIST/ASS? SCPI). */
+void DioProbe_GetSlot(uint8_t probeId, DioProbeSlot_t* out);
+
+/* ---- hot path (called from pipeline) ---- */
+
+/*! Fire a probe event. TOGGLE: flip pin. PULSE: drive pin HIGH.
+ *  No-op if gDioProbeAnyActive is false or slot is OFF. */
+static inline void DioProbe_Toggle(uint8_t probeId) {
+    if (!gDioProbeAnyActive) return;
+    if (probeId >= DIO_PROBE_SLOTS) return;
+    /* Struct copy is a few LW instructions; safe against concurrent
+     * assign thanks to mode-published-last rule. */
+    const DioProbeSlot_t s = gDioProbeSlots[probeId];
+    if (s.mode == DIO_PROBE_MODE_TOGGLE) {
+        GPIO_PortToggle(s.port, s.mask);
+    } else if (s.mode == DIO_PROBE_MODE_PULSE) {
+        GPIO_PortSet(s.port, s.mask);
+    }
+}
+
+/*! Close a PULSE. No-op if the slot is not in PULSE mode. */
+static inline void DioProbe_PulseEnd(uint8_t probeId) {
+    if (!gDioProbeAnyActive) return;
+    if (probeId >= DIO_PROBE_SLOTS) return;
+    const DioProbeSlot_t s = gDioProbeSlots[probeId];
+    if (s.mode == DIO_PROBE_MODE_PULSE) {
+        GPIO_PortClear(s.port, s.mask);
+    }
+}
+
+/*! Alias — reads better at call sites that start a pulse. */
+static inline void DioProbe_PulseStart(uint8_t probeId) {
+    DioProbe_Toggle(probeId);
+}
+
+/* ---- ad-hoc compile-time macros ----
+ *
+ * These compile to nothing when the probe's bit is not set in
+ * DIO_PROBE_ENABLE_MASK. Use sparingly — the default is all-zero
+ * so a forgotten ad-hoc probe doesn't leak into production. */
+
+#define DIO_PROBE_TOGGLE(id) \
+    do { \
+        if ((DIO_PROBE_ENABLE_MASK) & (1u << (id))) { \
+            DioProbe_Toggle((uint8_t)(id)); \
+        } \
+    } while (0)
+
+#define DIO_PROBE_PULSE_START(id) DIO_PROBE_TOGGLE(id)
+
+#define DIO_PROBE_PULSE_END(id) \
+    do { \
+        if ((DIO_PROBE_ENABLE_MASK) & (1u << (id))) { \
+            DioProbe_PulseEnd((uint8_t)(id)); \
+        } \
+    } while (0)
+
+#ifdef __cplusplus
+}
+#endif

--- a/firmware/src/HAL/DioProbe.h
+++ b/firmware/src/HAL/DioProbe.h
@@ -106,7 +106,10 @@ void DioProbe_SetPipeline(DioProbeMode_t mode);
 /*! Lookup: is this DIO channel currently owned by a probe?
  *  Used by DIO.c and SCPIDIO.c to enforce isolation. */
 static inline bool DioProbe_IsChannelOwned(uint8_t channel) {
-    return (gDioProbeOwnedMask & (1u << channel)) != 0;
+    if (channel > DIO_PROBE_MAX_DIO_CHANNEL) {
+        return false;  /* shift by >=16 bits would be undefined behavior */
+    }
+    return (gDioProbeOwnedMask & (uint16_t)(1u << channel)) != 0;
 }
 
 /*! Remove owned bits from a DIO channel read mask. */

--- a/firmware/src/HAL/DioProbe.h
+++ b/firmware/src/HAL/DioProbe.h
@@ -123,17 +123,27 @@ void DioProbe_GetSlot(uint8_t probeId, DioProbeSlot_t* out);
 /* ---- hot path (called from pipeline) ---- */
 
 /*! Fire a probe event. TOGGLE: flip pin. PULSE: drive pin HIGH.
- *  No-op if gDioProbeAnyActive is false or slot is OFF. */
+ *  No-op if gDioProbeAnyActive is false or slot is OFF.
+ *
+ *  Tear-safe read order: load mode first, bail on OFF before reading
+ *  port/mask. The writer publishes mode last (after fields are fully
+ *  written) on assign, and clears mode first on clear — so reading
+ *  mode before port/mask guarantees we only use fields that are
+ *  committed when mode is ACTIVE. */
 static inline void DioProbe_Toggle(uint8_t probeId) {
     if (!gDioProbeAnyActive) return;
     if (probeId >= DIO_PROBE_SLOTS) return;
-    /* Struct copy is a few LW instructions; safe against concurrent
-     * assign thanks to mode-published-last rule. */
-    const DioProbeSlot_t s = gDioProbeSlots[probeId];
-    if (s.mode == DIO_PROBE_MODE_TOGGLE) {
-        GPIO_PortToggle(s.port, s.mask);
-    } else if (s.mode == DIO_PROBE_MODE_PULSE) {
-        GPIO_PortSet(s.port, s.mask);
+
+    uint8_t mode = gDioProbeSlots[probeId].mode;
+    if (mode == DIO_PROBE_MODE_OFF) return;
+
+    GPIO_PORT port = gDioProbeSlots[probeId].port;
+    uint32_t  mask = gDioProbeSlots[probeId].mask;
+
+    if (mode == DIO_PROBE_MODE_TOGGLE) {
+        GPIO_PortToggle(port, mask);
+    } else { /* DIO_PROBE_MODE_PULSE */
+        GPIO_PortSet(port, mask);
     }
 }
 
@@ -141,10 +151,10 @@ static inline void DioProbe_Toggle(uint8_t probeId) {
 static inline void DioProbe_PulseEnd(uint8_t probeId) {
     if (!gDioProbeAnyActive) return;
     if (probeId >= DIO_PROBE_SLOTS) return;
-    const DioProbeSlot_t s = gDioProbeSlots[probeId];
-    if (s.mode == DIO_PROBE_MODE_PULSE) {
-        GPIO_PortClear(s.port, s.mask);
-    }
+
+    if (gDioProbeSlots[probeId].mode != DIO_PROBE_MODE_PULSE) return;
+
+    GPIO_PortClear(gDioProbeSlots[probeId].port, gDioProbeSlots[probeId].mask);
 }
 
 /*! Alias — reads better at call sites that start a pulse. */

--- a/firmware/src/HAL/DioProbe.h
+++ b/firmware/src/HAL/DioProbe.h
@@ -44,13 +44,15 @@ typedef enum {
     DIO_PROBE_MODE_PULSE  = 2
 } DioProbeMode_t;
 
-/*! Per-probe slot. Written only by the SCPI task; read by many
- *  contexts. Publish order: fill port/mask/channel first, mode last. */
+/*! Per-probe slot. Written by the SCPI task; read by many contexts
+ *  including priority-1 ISRs. Fields are volatile so the compiler
+ *  cannot reorder or cache accesses across the publish-mode-last /
+ *  read-mode-first contract. */
 typedef struct {
-    GPIO_PORT port;       //!< Data pin GPIO port
-    uint32_t  mask;       //!< 1u << data bit position
-    uint8_t   channel;    //!< DIO channel index (0..15); 0xFF = unassigned
-    uint8_t   mode;       //!< DioProbeMode_t
+    volatile GPIO_PORT port;       //!< Data pin GPIO port
+    volatile uint32_t  mask;       //!< 1u << data bit position
+    volatile uint8_t   channel;    //!< DIO channel index (0..15); 0xFF = unassigned
+    volatile uint8_t   mode;       //!< DioProbeMode_t
 } DioProbeSlot_t;
 
 #define DIO_PROBE_SLOTS            16  //!< probe IDs 0..15
@@ -72,8 +74,9 @@ typedef struct {
 extern volatile bool gDioProbeAnyActive;
 
 /*! Slot table. Single-writer (SCPI task); readers do atomic struct
- *  copies on PIC32MZ's 32-bit bus. */
-extern DioProbeSlot_t gDioProbeSlots[DIO_PROBE_SLOTS];
+ *  copies on PIC32MZ's 32-bit bus. Volatile to match the per-field
+ *  qualification in DioProbeSlot_t. */
+extern volatile DioProbeSlot_t gDioProbeSlots[DIO_PROBE_SLOTS];
 
 /*! Bitmask of DIO channels currently owned by a probe. Checked by
  *  DIO.c write paths to skip stomping the pin. */

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -8,6 +8,7 @@
 #include "services/wifi_services/wifi_manager.h"
 #include "services/sd_card_services/sd_card_manager.h"
 #include "HAL/DIO.h"
+#include "HAL/DioProbe.h"
 #include "HAL/DAC7718/DAC7718.h"
 #include "Util/Logger.h"
 #include "Util/CoherentPool.h"
@@ -542,6 +543,10 @@ void app_SystemInit() {
     // Write initial values
     DIO_WriteStateAll();
     DIO_TIMING_TEST_INIT();
+
+    // Init DIO debug probe framework AFTER default DIO state is applied
+    // so ad-hoc probes start from a known quiescent pin state.
+    DioProbe_Init();
     Streaming_Init(&gpBoardConfig->StreamingConfig,
             &gpBoardRuntimeConfig->StreamingConfig);
     Streaming_UpdateState();

--- a/firmware/src/services/SCPI/SCPIDIO.c
+++ b/firmware/src/services/SCPI/SCPIDIO.c
@@ -17,6 +17,7 @@
 #include "state/board/BoardConfig.h"
 #include "state/runtime/BoardRuntimeConfig.h"
 #include "HAL/DIO.h"
+#include "HAL/DioProbe.h"
 #include "../../HAL/TimerApi/TimerApi.h"
 /**
  * Sets the GPIO direction for a single pin
@@ -91,7 +92,7 @@ scpi_result_t SCPI_GPIODirectionSet(scpi_t * context)
     {
         return SCPI_RES_ERR;
     }
-    
+
     // TODO: Validate channel
     if (!SCPI_ParamInt32(context, &param2, FALSE))
     {
@@ -99,6 +100,10 @@ scpi_result_t SCPI_GPIODirectionSet(scpi_t * context)
     }
     else
     {
+        if (DioProbe_IsChannelOwned((uint8_t)param1)) {
+            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+            return SCPI_RES_ERR;
+        }
         return SCPI_GPIOSingleDirectionSet((uint8_t)param1, !(bool)param2); // Interpret the input as a bit/direction pair (invert because 1=output but we use isInput as the test)
     }
 }
@@ -149,7 +154,7 @@ scpi_result_t SCPI_GPIOStateSet(scpi_t * context)
     {
         return SCPI_RES_ERR;
     }
-    
+
     // TODO: Validate channel
     if (!SCPI_ParamInt32(context, &param2, FALSE))
     {
@@ -157,6 +162,10 @@ scpi_result_t SCPI_GPIOStateSet(scpi_t * context)
     }
     else
     {
+        if (DioProbe_IsChannelOwned((uint8_t)param1)) {
+            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+            return SCPI_RES_ERR;
+        }
         return SCPI_GPIOSingleStateSet((uint8_t)param1, (bool)param2); // Interpret the input as a bit/direction pair
     }
 }
@@ -230,15 +239,18 @@ scpi_result_t SCPI_PWMChannelEnableSet (scpi_t * context){
     {
         return SCPI_RES_ERR;
     }
-    
+
     if (!SCPI_ParamInt32(context, &param2, TRUE))
     {
         return SCPI_RES_ERR;
     }
-    
+
+    if (DioProbe_IsChannelOwned((uint8_t)param1)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+
     return SCPI_PWMSingleStateSet((uint8_t)param1, (bool)param2);
-    return SCPI_RES_OK;
-   
 }
 scpi_result_t SCPI_PWMChannelEnableGet(scpi_t * context){
     int param1;
@@ -272,7 +284,11 @@ scpi_result_t SCPI_PWMChannelFrequencySet(scpi_t * context){
     {
         return SCPI_RES_ERR;
     }
-    DIORuntimeArray * pRunTimeDIOChannels = BoardRunTimeConfig_Get(         
+    if (DioProbe_IsChannelOwned((uint8_t)param1)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+    DIORuntimeArray * pRunTimeDIOChannels = BoardRunTimeConfig_Get(
                         BOARDRUNTIMECONFIG_DIO_CHANNELS);
     //only timer 3 is driving all the pwm so, channel independent frequency cannot be generated
     for(i=0;i<pRunTimeDIOChannels->Size;i++){
@@ -283,7 +299,7 @@ scpi_result_t SCPI_PWMChannelFrequencySet(scpi_t * context){
     //update the duty cycle period register of all the channels based on the new frequency
     for(i=0;i<pRunTimeDIOChannels->Size;i++){
         DIO_PWMDutyCycleSetSingle(i);
-    }   
+    }
     return SCPI_RES_OK;
 }
 scpi_result_t SCPI_PWMChannelFrequencyGet(scpi_t * context){
@@ -322,8 +338,12 @@ scpi_result_t SCPI_PWMChannelDUTYSet(scpi_t * context){
     if(param2>100){
         return SCPI_RES_ERR;
     }
-    
-    pRunTimeDIOChannels->Data[param1].PwmDutyCycle=param2;    
+    if (DioProbe_IsChannelOwned((uint8_t)param1)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+
+    pRunTimeDIOChannels->Data[param1].PwmDutyCycle=param2;
     DIO_PWMDutyCycleSetSingle(param1);
     return SCPI_RES_OK;
 }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -28,6 +28,7 @@
 #include "HAL/BQ24297/BQ24297.h"
 #include "HAL/ADC.h"
 #include "HAL/DIO.h"
+#include "HAL/DioProbe.h"
 #include "SCPIADC.h"
 #include "SCPIDAC.h" 
 #include "SCPIDIO.h"
@@ -3076,6 +3077,117 @@ static scpi_result_t SCPI_GetStackStats(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+// =============================================================================
+// DIO Debug Probe SCPI Callbacks
+// =============================================================================
+
+static bool dioprobe_parse_mode(const char* str, size_t len, DioProbeMode_t* out) {
+    if (len >= 3 && (str[0] == 'O' || str[0] == 'o') &&
+                    (str[1] == 'F' || str[1] == 'f') &&
+                    (str[2] == 'F' || str[2] == 'f')) {
+        *out = DIO_PROBE_MODE_OFF;
+        return true;
+    }
+    if (len >= 3 && (str[0] == 'T' || str[0] == 't') &&
+                    (str[1] == 'O' || str[1] == 'o') &&
+                    (str[2] == 'G' || str[2] == 'g')) {
+        *out = DIO_PROBE_MODE_TOGGLE;
+        return true;
+    }
+    if (len >= 3 && (str[0] == 'P' || str[0] == 'p') &&
+                    (str[1] == 'U' || str[1] == 'u') &&
+                    (str[2] == 'L' || str[2] == 'l')) {
+        *out = DIO_PROBE_MODE_PULSE;
+        return true;
+    }
+    return false;
+}
+
+static const char* dioprobe_mode_name(uint8_t mode) {
+    switch (mode) {
+        case DIO_PROBE_MODE_TOGGLE: return "TOGGLE";
+        case DIO_PROBE_MODE_PULSE:  return "PULSE";
+        default:                    return "OFF";
+    }
+}
+
+static scpi_result_t SCPI_DioProbeAssign(scpi_t * context) {
+    int32_t probeId;
+    if (!SCPI_ParamInt32(context, &probeId, TRUE)) return SCPI_RES_ERR;
+    if (probeId < 0 || probeId >= DIO_PROBE_STANDARD_COUNT) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    const char* modeStr;
+    size_t modeLen;
+    if (!SCPI_ParamCharacters(context, &modeStr, &modeLen, TRUE)) return SCPI_RES_ERR;
+    DioProbeMode_t mode;
+    if (!dioprobe_parse_mode(modeStr, modeLen, &mode)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    if (!DioProbe_Assign((uint8_t)probeId, mode)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_DioProbeAssignGet(scpi_t * context) {
+    int32_t probeId;
+    if (!SCPI_ParamInt32(context, &probeId, TRUE)) return SCPI_RES_ERR;
+    if (probeId < 0 || probeId >= DIO_PROBE_SLOTS) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    DioProbeSlot_t s;
+    DioProbe_GetSlot((uint8_t)probeId, &s);
+    SCPI_ResultText(context, dioprobe_mode_name(s.mode));
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_DioProbeClear(scpi_t * context) {
+    int32_t probeId;
+    if (!SCPI_ParamInt32(context, &probeId, TRUE)) return SCPI_RES_ERR;
+    if (probeId < 0 || probeId >= DIO_PROBE_STANDARD_COUNT) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    DioProbe_Clear((uint8_t)probeId);
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_DioProbeClearAll(scpi_t * context) {
+    (void)context;
+    DioProbe_ClearAll();
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_DioProbePipeline(scpi_t * context) {
+    const char* modeStr;
+    size_t modeLen;
+    if (!SCPI_ParamCharacters(context, &modeStr, &modeLen, TRUE)) return SCPI_RES_ERR;
+    DioProbeMode_t mode;
+    if (!dioprobe_parse_mode(modeStr, modeLen, &mode)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    DioProbe_SetPipeline(mode);
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_DioProbeList(scpi_t * context) {
+    for (uint8_t i = 0; i < DIO_PROBE_SLOTS; ++i) {
+        DioProbeSlot_t s;
+        DioProbe_GetSlot(i, &s);
+        const char* compile = (i >= DIO_PROBE_ADHOC_FIRST) ? "yes" : "no";
+        unsigned ch = (s.channel == 0xFF) ? 0xFFu : s.channel;
+        scpi_printf(context, "probe %u: channel=%u mode=%s compile_time=%s\r\n",
+                    (unsigned)i, ch, dioprobe_mode_name(s.mode), compile);
+    }
+    return SCPI_RES_OK;
+}
+
 static const scpi_command_t scpi_commands[] = {
     // Build into libscpi
     {.pattern = "*CLS", .callback = SCPI_CoreCls,},
@@ -3309,6 +3421,13 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:STORage:SD:SPACe?", .callback = SCPI_StorageSDSpaceGet},
     {.pattern = "SYSTem:STORage:SD:ABORt", .callback = SCPI_StorageSDAbort},
     {.pattern = "SYSTem:STORage:SD:INFO?", .callback = SCPI_StorageSDInfo},
+    // DIO debug probe framework
+    {.pattern = "SYSTem:DIOProbe:ASSign", .callback = SCPI_DioProbeAssign,},
+    {.pattern = "SYSTem:DIOProbe:ASSign?", .callback = SCPI_DioProbeAssignGet,},
+    {.pattern = "SYSTem:DIOProbe:CLEar", .callback = SCPI_DioProbeClear,},
+    {.pattern = "SYSTem:DIOProbe:CLEar:ALL", .callback = SCPI_DioProbeClearAll,},
+    {.pattern = "SYSTem:DIOProbe:PIPELine", .callback = SCPI_DioProbePipeline,},
+    {.pattern = "SYSTem:DIOProbe:LIST?", .callback = SCPI_DioProbeList,},
     // FreeRTOS
     //{.pattern = "SYSTem:OS:Stats?",           .callback = SCPI_GetFreeRtosStats,},
     // Testing

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -22,6 +22,7 @@
 #include <math.h>
 #include "HAL/ADC.h"
 #include "HAL/DIO.h"
+#include "HAL/DioProbe.h"
 #include "JSON_Encoder.h"
 #include "csv_encoder.h"
 #include "DaqifiPB/DaqifiOutMessage.pb.h"
@@ -294,8 +295,10 @@ void _Streaming_Deferred_Interrupt_Task(void) {
 
     while (1) {
         ulTaskNotifyTake(pdFALSE, xBlockTime);
+        DioProbe_Toggle(2);  /* probe 2: deferred task wake rate */
 
         if (pRunTimeStreamConf->IsEnabled) {
+            DioProbe_PulseStart(3);  /* probe 3: alloc + channel loop + queue push */
             // Use object pool instead of heap allocation (eliminates vPortFree overhead)
             // No heap check needed - pool uses pre-allocated static memory
             pPublicSampleList = AInSampleList_AllocateFromPool();
@@ -309,6 +312,7 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                     gTestPatternSampleCount++;
                     taskEXIT_CRITICAL();
                 }
+                DioProbe_PulseEnd(3);
                 continue;
             }
 
@@ -397,6 +401,7 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                 taskEXIT_CRITICAL();
                 Streaming_UpdateFlowWindow(false);
             }
+            DioProbe_PulseEnd(3);
 
             // Pipeline mode skips ADC hardware entirely (no triggers, no waits).
             // Normal/NoCap modes: with hardware triggering (#282), the timer
@@ -404,6 +409,7 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             // devices (AD7609, DIO) and divided-rate shared scans need software
             // triggers here.
             if (gBenchmarkMode != BENCHMARK_PIPELINE) {
+                DioProbe_PulseStart(4);  /* probe 4: ADC trigger duration */
                 bool hwDed = MC12b_IsHwTriggerDedicated();
                 bool hwShd = MC12b_IsHwTriggerShared();
                 bool skipShared = !pRunTimeStreamConf->OnboardDiagEnabled;
@@ -448,6 +454,7 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                     }
                 }
                 DIO_StreamingTrigger(&pBoardData->DIOLatest, &pBoardData->DIOSamples);
+                DioProbe_PulseEnd(4);
             }
 
             // Increment test pattern counter once per ISR tick (after all channels)
@@ -479,6 +486,7 @@ static void TSTimerCB(uintptr_t context, uint32_t alarmCount) {
  * @param[in] alarmCount unused
  */
 static void Streaming_TimerHandler(uintptr_t context, uint32_t alarmCount) {
+    DioProbe_Toggle(0);  /* probe 0: true timer ISR rate */
     uint32_t valueTMR = TimerApi_CounterGet(gpStreamingConfig->TSTimerIndex);
     BoardData_Set(BOARDDATA_STREAMING_TIMESTAMP, 0, (const void*) &valueTMR);
 
@@ -1001,6 +1009,7 @@ void streaming_Task(void) {
             BOARDRUNTIME_STREAMING_CONFIGURATION);
     while(1) {
         ulTaskNotifyTake(pdFALSE, xBlockTime);
+        DioProbe_Toggle(7);  /* probe 7: encoder task wake */
 
         // Don't process data or update QUES bits after streaming stops.
         // A notification may already be pending when Stop clears gQuesBits.
@@ -1144,6 +1153,7 @@ void streaming_Task(void) {
 
         packetSize = 0;
         if (nanopbFlag.Size > 0) {
+            DioProbe_PulseStart(8);  /* probe 8: encode duration */
             if(pRunTimeStreamConf->Encoding == Streaming_Csv){
                 DIO_TIMING_TEST_WRITE_STATE(1);
                 packetSize = csv_Encode(pBoardData, &nanopbFlag, (uint8_t *) buffer, maxSize);
@@ -1158,6 +1168,7 @@ void streaming_Task(void) {
                 packetSize = Nanopb_EncodeStreamingFast(pBoardData, &nanopbFlag, (uint8_t *) buffer, maxSize);
                 DIO_TIMING_TEST_WRITE_STATE(0);
             }
+            DioProbe_PulseEnd(8);
         }
         if (packetSize == 0 && nanopbFlag.Size > 0 && (AINDataAvailable || DIODataAvailable)) {
             gStreamStats.encoderFailures++;
@@ -1184,6 +1195,7 @@ void streaming_Task(void) {
         }
         DIO_TIMING_TEST_WRITE_STATE(1);
         if (packetSize > 0) {
+            DioProbe_PulseStart(9);  /* probe 9: output write duration */
             // All-or-nothing output writes. On timeout (10s), the interface
             // is assumed dead. Backpressure propagates to sample queue —
             // QueueDroppedSamples is the ONLY data loss mechanism.
@@ -1240,6 +1252,7 @@ void streaming_Task(void) {
                     LOG_E_SESSION(LOG_SESSION_SD_DROP, "Streaming: SD output skipped (buffer full or file not ready)");
                 }
             }
+            DioProbe_PulseEnd(9);
         }
         DIO_TIMING_TEST_WRITE_STATE(0);
     }

--- a/firmware/src/state/board/BoardConfig.h
+++ b/firmware/src/state/board/BoardConfig.h
@@ -14,6 +14,13 @@
 
 //#define DIO_TIMING_TEST
 
+/* Ad-hoc DIO probe enable mask. Each bit N enables DIO_PROBE_*(N)
+ * macro expansion for probe ID N (maps to DIO channel N). Bits 10-15
+ * are the ad-hoc probe range; bits 0-9 are reserved for standard
+ * pipeline probes. Default 0 = all ad-hoc probe macros compile to
+ * no-ops. See HAL/DioProbe.h. */
+#define DIO_PROBE_ENABLE_MASK 0x0000u
+
 #include "AInConfig.h"
 #include "AOutConfig.h"
 #include "DIOConfig.h"


### PR DESCRIPTION
## Summary

Lightweight, runtime-configurable probe framework that toggles or pulses DIO pins from anywhere in the firmware for logic-analyzer timing analysis. 10 standard probes are permanently wired to the streaming pipeline stages; 6 ad-hoc probes are compile-time via `DIO_PROBE_ENABLE_MASK` in `BoardConfig.h`.

Closes #301.

## Why this framework exists

Issue #301 captured the need: ad-hoc scope probes during PR #302 / #304 debugging proved invaluable for understanding pipeline timing, but the hack (hardcoded SFR writes on DIO_0) fought with `DIO_WriteStateSingle` and required source edits to move. This PR replaces that pattern with a clean, isolated, SCPI-controllable framework.

**Signal purity is the paramount design requirement** — a single spurious edge from another code path makes scope measurements untrustworthy. When a probe is assigned, the probe owns the channel's data and enable pins exclusively. `DIO_WriteStateSingle`, `DIO_StreamingTrigger` loop, `DIO_ReadSampleByMask`, and all PWM functions skip owned channels. SCPI DIO commands reject user writes on owned channels with `Execution error`.

## Standard probe map

| Probe | DIO | Mode | Signal |
|---:|---:|:---:|---|
| 0 | 0 | TOGGLE | `Streaming_TimerHandler` entry |
| 1 | 1 | TOGGLE | `ADC_EOSInterruptCB` entry |
| 2 | 2 | TOGGLE | Deferred task wake |
| 3 | 3 | PULSE | Deferred: alloc + channel loop + queue push |
| 4 | 4 | PULSE | Deferred: ADC + DIO trigger |
| 5 | 5 | TOGGLE | EOS task wake |
| 6 | 6 | PULSE | EOS task: result read loop |
| 7 | 7 | TOGGLE | Encoder task wake |
| 8 | 8 | PULSE | Encoder: encode call |
| 9 | 9 | PULSE | Encoder: output write |

## SCPI API

```
SYST:DIOP:ASS <0-9>,<OFF|TOGGLE|PULSE>   Assign standard probe (caps-only abbr)
SYST:DIOP:ASS? <0-15>                    Query probe mode
SYST:DIOP:CLE <0-9>                      Release probe, return DIO to normal
SYST:DIOP:CLE:ALL                        Clear all standard probes
SYST:DIOP:PIPEL <mode>                   Set all 10 standard probes at once
SYST:DIOP:LIST?                          Dump all 16 slot states
```

Long form: `SYSTem:DIOProbe:ASSign` etc.

## Hot-path cost

Inline API with early-out gate:
```c
if (!gDioProbeAnyActive) return;  // ~2 cycles when all probes off
```

Ad-hoc probes compile to nothing when their bit isn't set in `DIO_PROBE_ENABLE_MASK` — zero cost in production builds.

## Hardware validation

Flashed and verified on NQ1. Full measurements in `docs/PIPELINE_TIMING.md`.

**Session 1 — 1 kHz / 1 T1 ch / PB / USB** (baseline):
- Timer ISR Tstd = **18 ns** (matches hardware-only jitter — probe adds no measurable overhead)
- Zero spurious edges across 8 seconds of capture on 5 TOGGLE probes (signal isolation proven)
- Full pipeline budget: **76 µs / 1 ms tick = 7.6% CPU** at this config
- Encode (P8) = 26 µs, dominant stage

**Session 2 — 13 kHz / 1 T1 ch / PB / USB** (ceiling):
- **Zero drops over 285 seconds** (3.71M samples). `TimerISRCalls == TotalSamplesStreamed` holds.
- Jitter progression clearly visible: ISR (912 ns) → pri-8 task (5.4 µs) → pri-2 encoder (42 µs Tstd)
- Encoder P8 max = 349 µs (4.5× tick budget) — scheduler preemption tail exposed

## Test plan

- [x] Clean build at `-O3 -Werror`
- [x] `DIO_PROBE_ENABLE_MASK = 0` produces same binary behavior as pre-probe code (zero-cost when disabled)
- [x] SCPI assign/clear/list/pipeline commands work (caps-only and long form)
- [x] Owned channel rejects `DIO:POR:DIR` and `DIO:POR:STAT` with `-200 Execution error`
- [x] Non-owned channels accept normal DIO commands
- [x] After `SYST:DIOP:CLE N`, channel N accepts DIO commands again
- [x] `DioProbe_Init()` runs at boot after `DIO_InitHardware()` and wipes slots (power-cycle test confirms)
- [x] Streaming at 1 kHz with all probes active: 0 drops, clean 500 Hz square waves
- [x] Streaming at 13 kHz with all probes active: 0 drops, 3.71M samples
- [x] Scope confirms exactly N toggle edges for N timer ISR fires (no spurious edges)
- [ ] Multi-board verification (NQ2/NQ3) — only NQ1 tested; no board-specific code but worth confirming

## Out of scope (future work)

`docs/PIPELINE_TIMING.md` closes with a TODO list:
- FPU contribution test (rerun with test pattern vs sin())
- DIO isolation test (`ENA:DIO:GLOB 0` to confirm P4 = DIO scan)
- Channel scaling (1 → 16 ch)
- Encode format scaling (PB/CSV/JSON)
- Over-ceiling probe (20 kHz benchmark mode)
- Type 2 (MODULE7) scan rate characterization

Each follow-up appends a new session to the doc.