### PR TITLE
perf(streaming): use vTaskDelay in write retry so lower-priority SD drains (#312)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,7 +652,7 @@ Stack sizes profiled under stress: 16ch@5kHz PB/CSV/JSON + SD file ops + WiFi TC
 
 **WARNING**: If recursive SD directory listing is enabled, `app_SDCardTask` needs 10KB+ (~550 bytes per nesting level).
 
-**Scheduling implications**: Capture tasks at priority 9 preempt everything to guarantee deterministic sample timing. The encoder at priority 6 preempts WiFi/WINC/background (priority 2) and SD (priority 5), but stays below USB (7) so SCPI commands remain responsive during streaming. SD task at priority 5 sits above background transports but below encoder — prevents encoder from starving SD writes when USB+SD both active. See `docs/PIPELINE_TIMING.md` for measurements motivating these values (PR #308, Sessions 7-17).
+**Scheduling implications**: Capture tasks at priority 9 preempt everything to guarantee deterministic sample timing. The encoder at priority 6 preempts WiFi/WINC/background (priority 2) and SD (priority 5), but stays below USB (7) so SCPI commands remain responsive during streaming. SD task at priority 5 sits above background transports but below encoder — prevents encoder from starving SD writes when USB+SD both active. Encoder's `Streaming_WriteWithRetry` uses `vTaskDelay(1)` (not `taskYIELD()`) in its retry loop so lower-priority SD actually gets CPU to drain circular buffer (#312). See `docs/PIPELINE_TIMING.md` for measurements (PR #308, Sessions 7-17).
 
 #### Known Silicon Errata (DS80000663R, verified against PDF pages 6-15)
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -616,9 +616,12 @@ static size_t Streaming_WriteWithRetry(StreamWriteFn writeFn,
         if (writeFn((const char*)buf, len) == len) return len;
     }
 
-    // Phase 2: yield — let output tasks (same priority) drain
+    // Phase 2: short sleeps — let lower-priority output tasks drain.
+    // taskYIELD() only reschedules within the same priority; encoder at 6
+    // yielding to SD at 5 is a no-op. vTaskDelay(1) blocks for 1 tick so
+    // lower-priority SD task gets CPU to drain its circular buffer (#312).
     for (int i = 0; i < 50; i++) {
-        taskYIELD();
+        vTaskDelay(1);
         if (writeFn((const char*)buf, len) == len) return len;
     }
 


### PR DESCRIPTION
## Summary

Fixes #312. The 50× `taskYIELD()` retry phase in `Streaming_WriteWithRetry` became a no-op after PR #308 because `taskYIELD()` only reschedules within the same priority — encoder (6) yielding to SD (5) does nothing. Replacing it with `vTaskDelay(1)` blocks the encoder long enough for the lower-priority SD task to drain its circular buffer.

## Why this approach vs bumping SD to priority 6

Option A (SD 5→6, equal priority with encoder) was tried first. Flashed clean and `*IDN?` responded, but the firmware hung partway through the first SD streaming session — USB CDC became unresponsive and required a reflash. Equal-priority round-robin between encoder (FPU-registered) and SD (not FPU-registered) appears to introduce a runtime deadlock under load. Reverted to priority 5 and took the more surgical Option C instead.

## Measured results (15s NoCap probes, fullscale pattern)

| Config | main | this PR | pre-#308 | Δ vs main |
|---|---:|---:|---:|---:|
| SD PB 1×T1 | 10k | **11k** | 13k | +10% |
| SD PB 5×T1 | 7k | 7k | — | 0% |
| SD PB 11×T2 | 5k | 5k | — | 0% |
| SD CSV 1×T1 | 10k | 10k | 11k | 0% |
| SD CSV 16ch | 1k | **2k** | 2k | +100% |

Partial recovery. The configs that didn't move are hitting Phase-1 success (encoder writes succeed on first try), so Phase 2's change doesn't reach them. Full recovery there needs a different mechanism (dynamic priority, encoder/writer split, or SPI-side work) — tracked as #315.

## USB+SD concurrent (PR #308 primary win) — 30s @ 5kHz PB 1ch

```
Total samples: 145787
Queue dropped: 0
USB dropped:   0
SD dropped:    0
Encoder fails: 0
```

Zero drops. Win preserved.

## Test plan

- [x] Build clean (`bash ~/.claude/skills/build/build.sh --clean`)
- [x] `*IDN?` responds after reflash
- [x] SD-only ceiling probes run for all 5 configs above
- [x] USB+SD 30s concurrent test: 0 drops
- [x] Qodo /review + /improve convergence — no bugs, 1 defensive-only suggestion skipped (importance 1/10)

## Firmware/test SHAs

- Firmware: commit `bf775ae6` on `fix/312-sd-priority-rework`
- python-core: `main` (NyquistDevice)
- python-test-suite: `main` (`test_interface_ceilings.py`, `StreamingMeasurement`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)