### PR TITLE
feat(scpi): log every SCPI execution error via helper (#262)

### DIFF
--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -439,7 +439,7 @@ scpi_result_t SCPI_ADCChanRangeSet(scpi_t * context) {
     // Find the AD7609 module
     const AInModule* module = ADC_FindModule(AIn_AD7609);
     if (module == NULL) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "CONF:ADC:RANG: AD7609 module not found");
         return SCPI_RES_ERR;
     }
 
@@ -449,7 +449,7 @@ scpi_result_t SCPI_ADCChanRangeSet(scpi_t * context) {
 
     // Validate runtime configuration and module index
     if (pRuntimeModules == NULL || moduleIndex >= pRuntimeModules->Size) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "CONF:ADC:RANG: runtime module index invalid");
         return SCPI_RES_ERR;
     }
 
@@ -488,7 +488,7 @@ scpi_result_t SCPI_ADCChanRangeGet(scpi_t * context) {
     // Find the AD7609 module
     const AInModule* module = ADC_FindModule(AIn_AD7609);
     if (module == NULL) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "CONF:ADC:RANG?: AD7609 module not found");
         return SCPI_RES_ERR;
     }
 
@@ -710,7 +710,7 @@ scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context) {
     StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
     if (pStreamCfg->IsEnabled) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "CONF:ADC:OBDiag: cannot change while streaming");
         return SCPI_RES_ERR;
     }
     pStreamCfg->OnboardDiagEnabled = (val != 0);

--- a/firmware/src/services/SCPI/SCPIDAC.c
+++ b/firmware/src/services/SCPI/SCPIDAC.c
@@ -155,7 +155,7 @@ scpi_result_t SCPI_DACVoltageSet(scpi_t * context) {
 
     // Ensure DAC hardware is initialized (lazy initialization when power is up)
     if (!DAC_EnsureHardwareInitialized()) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "SOUR:VOLT:LEV: DAC not initialized (device powered up?)");
         return SCPI_RES_ERR;
     }
 
@@ -364,7 +364,7 @@ scpi_result_t SCPI_DACUseCalGet(scpi_t * context) {
 scpi_result_t SCPI_DACUpdate(scpi_t * context) {
     // Ensure DAC hardware is initialized and instance ID is valid
     if (!DAC_EnsureHardwareInitialized() || dacInstanceId == 0xFF) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "CONF:DAC:UPDATE: DAC not initialized");
         return SCPI_RES_ERR;
     }
 

--- a/firmware/src/services/SCPI/SCPIDIO.c
+++ b/firmware/src/services/SCPI/SCPIDIO.c
@@ -1,6 +1,7 @@
 #define LOG_LVL LOG_LEVEL_SCPI
 #define LOG_MODULE LOG_MODULE_SCPI
 #include "SCPIDIO.h"
+#include "SCPIInterface.h"
 
 // General
 #include <stdlib.h>
@@ -101,7 +102,7 @@ scpi_result_t SCPI_GPIODirectionSet(scpi_t * context)
     else
     {
         if (DioProbe_IsChannelOwned((uint8_t)param1)) {
-            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+            SCPI_ExecutionError(context, "DIO:DIR: channel owned by DIO probe");
             return SCPI_RES_ERR;
         }
         return SCPI_GPIOSingleDirectionSet((uint8_t)param1, !(bool)param2); // Interpret the input as a bit/direction pair (invert because 1=output but we use isInput as the test)
@@ -163,7 +164,7 @@ scpi_result_t SCPI_GPIOStateSet(scpi_t * context)
     else
     {
         if (DioProbe_IsChannelOwned((uint8_t)param1)) {
-            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+            SCPI_ExecutionError(context, "DIO:STATE: channel owned by DIO probe");
             return SCPI_RES_ERR;
         }
         return SCPI_GPIOSingleStateSet((uint8_t)param1, (bool)param2); // Interpret the input as a bit/direction pair
@@ -246,7 +247,7 @@ scpi_result_t SCPI_PWMChannelEnableSet (scpi_t * context){
     }
 
     if (DioProbe_IsChannelOwned((uint8_t)param1)) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "DIO:PWM:ENA: channel owned by DIO probe");
         return SCPI_RES_ERR;
     }
 
@@ -285,7 +286,7 @@ scpi_result_t SCPI_PWMChannelFrequencySet(scpi_t * context){
         return SCPI_RES_ERR;
     }
     if (DioProbe_IsChannelOwned((uint8_t)param1)) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "DIO:PWM:FREQ: channel owned by DIO probe");
         return SCPI_RES_ERR;
     }
     DIORuntimeArray * pRunTimeDIOChannels = BoardRunTimeConfig_Get(
@@ -339,7 +340,7 @@ scpi_result_t SCPI_PWMChannelDUTYSet(scpi_t * context){
         return SCPI_RES_ERR;
     }
     if (DioProbe_IsChannelOwned((uint8_t)param1)) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "DIO:PWM:DUTY: channel owned by DIO probe");
         return SCPI_RES_ERR;
     }
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -1711,7 +1711,7 @@ static scpi_result_t SCPI_SetBenchmarkMode(scpi_t * context) {
     StreamingRuntimeConfig* pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
     if (pStreamCfg->IsEnabled && pStreamCfg->Running) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "SYST:STR:BENCH: cannot change while streaming");
         return SCPI_RES_ERR;
     }
     Streaming_SetBenchmarkMode((uint32_t)val);
@@ -1748,7 +1748,7 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
     StreamingRuntimeConfig* pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
     if (pStreamCfg->Running) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "SYST:STR:THR: streaming already active");
         return SCPI_RES_ERR;
     }
 
@@ -2350,7 +2350,7 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         // Quiesce all DMA consumers (SD file close, WiFi SPI idle) and reset pool.
         // USB writeTransferHandle already waited above.
         if (!SCPI_QuiesceAndResetCoherentPool()) {
-            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+            SCPI_ExecutionError(context, "SYST:StartStreamData: coherent pool quiesce failed");
             return SCPI_RES_ERR;
         }
         uint8_t* sdDmaBuf = CoherentPool_Alloc("SD_write", sdDmaSize);
@@ -3004,7 +3004,7 @@ static scpi_result_t SCPI_MemAutoBalance(scpi_t * context) {
             wifiDmaSize = WIFI_DMA_MIN;
         }
         if (!SCPI_QuiesceAndResetCoherentPool()) {
-            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+            SCPI_ExecutionError(context, "SYST:MEM:AUTO: coherent pool quiesce failed");
             return SCPI_RES_ERR;
         }
         uint8_t* sdDmaBuf = CoherentPool_Alloc("SD_write", sdDmaSize);
@@ -3130,7 +3130,7 @@ static scpi_result_t SCPI_DioProbeModeSet(scpi_t * context) {
         return SCPI_RES_ERR;
     }
     if (!DioProbe_Assign((uint8_t)probeId, mode)) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "SYST:DIOP:MODE: probe assign failed (channel owned?)");
         return SCPI_RES_ERR;
     }
     return SCPI_RES_OK;

--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -1,4 +1,5 @@
 #include "libraries/scpi/libscpi/inc/scpi/scpi.h"
+#include "Util/Logger.h"
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -81,6 +82,20 @@ extern "C" {
                 SCPI_ResultDouble(context, voltage_v);
             }
         }
+    }
+
+    /**
+     * Push a SCPI EXECUTION_ERROR with a logged reason (#262).
+     * Every execution error should be discoverable via SYST:LOG? in addition
+     * to SYST:ERR?. The reason string identifies the command and failure mode.
+     * Expands LOG_E at the call site, so LOG_MODULE must be defined (SCPI files
+     * all define LOG_MODULE_SCPI at the top).
+     * @param context SCPI context
+     * @param reason  short human-readable rejection reason, e.g. "streaming active"
+     */
+    static inline void SCPI_ExecutionError(scpi_t *context, const char *reason) {
+        LOG_E("SCPI exec error: %s", reason);
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
     }
 
 #ifdef	__cplusplus

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -2,6 +2,7 @@
 #define LOG_MODULE LOG_MODULE_SCPI
 
 #include "SCPILAN.h"
+#include "SCPIInterface.h"
 
 // General
 #include <stdlib.h>
@@ -32,7 +33,7 @@
 static bool SCPI_LANRequireWiFiReady(scpi_t* context) {
     wifi_status_t status = wifi_manager_GetWiFiStatus();
     if (status == WIFI_STATUS_DISABLED) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "SYST:COMM:LAN: WiFi not ready (device powered up?)");
         return false;
     }
     return true;

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -335,7 +335,6 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
     // Check if a test is already in progress
     if (gSDBenchmarkResults.testInProgress) {
         SCPI_ExecutionError(context, "SYST:STOR:SD:BENCH: benchmark already in progress");
-        context->interface->write(context, "\r\nError: Benchmark already in progress\r\n", 40);
         result = SCPI_RES_ERR;
         goto __exit_point;
     }

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -24,6 +24,7 @@
 /* ************************************************************************** */
 /* ************************************************************************** */
 #include "SCPIStorageSD.h"
+#include "SCPIInterface.h"
 #include "../sd_card_services/sd_card_manager.h"
 #include "../../state/runtime/BoardRuntimeConfig.h"
 #include "system/fs/sys_fs_media_manager.h"
@@ -333,7 +334,7 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
     
     // Check if a test is already in progress
     if (gSDBenchmarkResults.testInProgress) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "SYST:STOR:SD:BENCH: benchmark already in progress");
         context->interface->write(context, "\r\nError: Benchmark already in progress\r\n", 40);
         result = SCPI_RES_ERR;
         goto __exit_point;
@@ -499,7 +500,7 @@ scpi_result_t SCPI_StorageSDBenchmarkQuery(scpi_t * context) {
     char resultStr[128];
     
     if (!gSDBenchmarkResults.resultAvailable) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "SYST:STOR:SD:BENCH?: no benchmark result available");
         context->interface->write(context, "0,0,0\r\n", 7);
         return SCPI_RES_ERR;
     }
@@ -580,7 +581,7 @@ scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
 
     // Check if the operation succeeded
     if (!sd_card_manager_GetLastOperationResult()) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        SCPI_ExecutionError(context, "SYST:STOR:SD:DELete: delete operation failed");
         result = SCPI_RES_ERR;
         goto __exit_point;
     }


### PR DESCRIPTION
## Summary

Fixes #262. Every `SCPI_ErrorPush(SCPI_ERROR_EXECUTION_ERROR)` call is now discoverable via `SYST:LOG?` in addition to `SYST:ERR?`.

### What changed

- **New helper `SCPI_ExecutionError(context, reason)`** in `SCPIInterface.h` — logs via `LOG_E` and pushes the SCPI error in one call.
- **Converted 20 bare `SCPI_ErrorPush` sites** that previously pushed errors silently:
  - SCPIADC.c (4) — range config, OBDiag
  - SCPIDAC.c (2) — DAC not initialized
  - SCPIDIO.c (5) — probe-owned channel rejection
  - SCPILAN.c (1) — WiFi not ready
  - SCPIInterface.c (5) — benchmark/throughput, coherent pool quiesce, probe mode
  - SCPIStorageSD.c (3) — benchmark, delete
- **Added `SCPIInterface.h` include** to SCPILAN.c, SCPIDIO.c, SCPIStorageSD.c so they see the new helper.

### What's intentionally NOT changed

Sites that already had a `LOG_E` before their `SCPI_ErrorPush` (or the `LOG_SD_BUSY` macro in SCPIStorageSD.c that expands to `LOG_E`) are unchanged. The goal was to eliminate silent errors, not to mass-refactor — those sites already log. Future SCPI commands should prefer `SCPI_ExecutionError()` to stay consistent.

## Test plan

- [x] Build clean
- [x] Flash on hardware
- [x] `*IDN?` responds
- [x] Trigger SCPI_ExecutionError via `SYST:STR:BENCH` during active streaming:
  - `SYST:ERR?` → `-200, "Execution error"`
  - `SYST:LOG?` → `SCPI exec error: SYST:STR:BENCH: cannot change while streaming`
- [ ] Qodo convergence

## Firmware/test SHAs

- Firmware: commit `3d5a45cb` on `feat/262-scpi-error-logging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)