### PR TITLE
refactor(scpi): rename STATS commands to eliminate single-letter short forms (#311)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,7 +322,7 @@ The streaming engine tracks data loss at every stage of the pipeline. Statistics
 **SCPI Commands:**
 ```bash
 SYSTem:STReam:STATS?       # Query all statistics
-SYSTem:STReam:CLEARSTATS   # Reset all counters
+SYSTem:STReam:STATS:CLEar  # Reset all counters
 ```
 
 **Response fields from `SYSTem:STReam:STATS?`:**

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3382,8 +3382,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:STReam:FORmat?", .callback = SCPI_GetStreamFormat,},
     {.pattern = "SYSTem:STReam:INTerface", .callback = SCPI_SetStreamInterface,}, // 0=USB, 1=WiFi, 2=SD, 3=USB+SD
     {.pattern = "SYSTem:STReam:INTerface?", .callback = SCPI_GetStreamInterface,},
-    {.pattern = "SYSTem:STReam:Stats?", .callback = SCPI_GetStreamStats,},
-    {.pattern = "SYSTem:STReam:ClearStats", .callback = SCPI_ClearStreamStats,},
+    {.pattern = "SYSTem:STReam:STATS?", .callback = SCPI_GetStreamStats,},
+    {.pattern = "SYSTem:STReam:STATS:CLEar", .callback = SCPI_ClearStreamStats,},
     {.pattern = "SYSTem:STReam:LOSS:THREshold", .callback = SCPI_SetLossThreshold,},
     {.pattern = "SYSTem:STReam:LOSS:THREshold?", .callback = SCPI_GetLossThreshold,},
     {.pattern = "SYSTem:STReam:LOSS:WINDow", .callback = SCPI_SetFlowWindow,},


### PR DESCRIPTION
## Summary

Completes #311 SCPI audit by renaming the two commands with problematic single-letter short forms:

- `SYSTem:STReam:Stats?` → `SYSTem:STReam:STATS?` (short: `STATS`)
- `SYSTem:STReam:ClearStats` → `SYSTem:STReam:STATS:CLEar` (short: `STATS:CLE`)

Old short forms were `S?` and `C` — single letters, poor SCPI style, collision-prone. New forms are readable and group related operations under a `STATS:` subtree (matches the `FAULT:CLEar` precedent from #316).

## Docs reconciliation

CLAUDE.md was already documenting `SYSTem:STReam:STATS?` and `CLEARSTATS` while the firmware pattern table said `Stats?` / `ClearStats`. This PR aligns docs and implementation.

## Breaking change — coordinated

- **daqifi-python-core**: PR updating `STATS_QUERY` / `STATS_CLEAR` constants → https://github.com/daqifi/daqifi-python-core/pull/new/refactor/scpi-stats-rename
- **daqifi-python-test-suite**: PR updating 11 call sites → https://github.com/daqifi/daqifi-python-test-suite/pull/new/refactor/scpi-stats-rename

No back-compat aliases (consistent with #310 and #316 clean-break precedents).

## Test plan

- [x] Build clean with -O3 -Werror
- [x] Flash hardware
- [x] Both new forms respond correctly:
  - `SYST:STR:STATS?` → full stats dump
  - `SYSTem:STReam:STATS?` → full stats dump (long form)
  - `SYST:STR:STATS:CLE` → silent OK (non-query)
  - `SYST:STR:STATS:CLEar` → silent OK (long form)
- [x] Old forms now reject with `-113, "Undefined header"` (expected)
- [ ] Qodo convergence
- [ ] Merge all three repos together once reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)