### PR TITLE
refactor(scpi): rename TESTpattern + LOGging (#311 cleanup round 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -450,8 +450,8 @@ Test pattern mode replaces real ADC values with synthetic data for deterministic
 
 **SCPI Commands:**
 ```bash
-SYSTem:STReam:TESTpattern <pattern>   # Set pattern (0=off, 1-6)
-SYSTem:STReam:TESTpattern?            # Query current pattern (0=disabled)
+SYSTem:STReam:TEST:PATtern <pattern>   # Set pattern (0=off, 1-6)
+SYSTem:STReam:TEST:PATtern?            # Query current pattern (0=disabled)
 ```
 
 **Pattern Types:**
@@ -484,7 +484,7 @@ SYSTem:STReam:BENCHmark?           # Query current mode
 
 Usage:
 ```bash
-SYST:STR:TESTpattern 2             # Midscale test data
+SYST:STR:TEST:PATtern 2             # Midscale test data
 SYST:STR:BENCHmark 1               # Uncap frequency
 SYST:StartStreamData 11000         # Start at 11kHz (normally capped)
 # ... wait ...

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3388,8 +3388,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:STReam:LOSS:THREshold?", .callback = SCPI_GetLossThreshold,},
     {.pattern = "SYSTem:STReam:LOSS:WINDow", .callback = SCPI_SetFlowWindow,},
     {.pattern = "SYSTem:STReam:LOSS:WINDow?", .callback = SCPI_GetFlowWindow,},
-    {.pattern = "SYSTem:STReam:TESTpattern", .callback = SCPI_SetTestPattern,}, // 0=off, 1=counter, 2=midscale, 3=fullscale, 4=walking, 5=triangle, 6=sine
-    {.pattern = "SYSTem:STReam:TESTpattern?", .callback = SCPI_GetTestPattern,},
+    {.pattern = "SYSTem:STReam:TEST:PATtern", .callback = SCPI_SetTestPattern,}, // 0=off, 1=counter, 2=midscale, 3=fullscale, 4=walking, 5=triangle, 6=sine
+    {.pattern = "SYSTem:STReam:TEST:PATtern?", .callback = SCPI_GetTestPattern,},
     {.pattern = "SYSTem:STReam:BENCHmark", .callback = SCPI_SetBenchmarkMode,}, // 0=normal, 1=nocap, 2=pipeline (skip ADC)
     {.pattern = "SYSTem:STReam:BENCHmark?", .callback = SCPI_GetBenchmarkMode,},
     {.pattern = "SYSTem:STReam:THRoughput", .callback = SCPI_RunThroughputBench,}, // <freq>,<duration_sec> — self-contained benchmark
@@ -3409,7 +3409,7 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:MEMory:RESet", .callback = SCPI_MemReset,},
     {.pattern = "SYSTem:MEMory:STACk?", .callback = SCPI_GetStackStats,},
     //
-    {.pattern = "SYSTem:STORage:SD:LOGging", .callback = SCPI_StorageSDLoggingSet,},
+    {.pattern = "SYSTem:STORage:SD:FILE", .callback = SCPI_StorageSDLoggingSet,},
     {.pattern = "SYSTem:STORage:SD:GET", .callback = SCPI_StorageSDGetData},
     {.pattern = "SYSTem:STORage:SD:LISt?", .callback = SCPI_StorageSDListDir},
     {.pattern = "SYSTem:STORage:SD:ENAble", .callback = SCPI_StorageSDEnableSet},

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -164,13 +164,14 @@ scpi_result_t SCPI_StorageSDLoggingSet(scpi_t * context) {
 
     if (fileLen > 0) {
         if (fileLen > SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX) {
-            LOG_E("SD:FILE - Filename too long: %d bytes, max: %d\r\n", fileLen, SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX);
+            LOG_E("SD:FILE - Filename too long: %zu bytes, max: %zu\r\n",
+                  fileLen, (size_t)SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX);
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
         memcpy(pSDCardRuntimeConfig->file, pBuff, fileLen);
         pSDCardRuntimeConfig->file[fileLen] = '\0';
-        LOG_D("SD:FILE - Set filename to '%s' (%d bytes) dir='%s'\r\n",
+        LOG_D("SD:FILE - Set filename to '%s' (%zu bytes) dir='%s'\r\n",
               pSDCardRuntimeConfig->file, fileLen, pSDCardRuntimeConfig->directory);
     } else {
         LOG_D("SD:FILE - No filename provided, using existing: '%s'\r\n", pSDCardRuntimeConfig->file);

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -148,7 +148,7 @@ scpi_result_t SCPI_StorageSDLoggingSet(scpi_t * context) {
 
     // Check if SD card is busy with another operation
     if (sd_card_manager_IsBusy()) {
-        LOG_SD_BUSY("LOGging");
+        LOG_SD_BUSY("FILE");
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         result = SCPI_RES_ERR;
         goto __exit_point;
@@ -164,16 +164,16 @@ scpi_result_t SCPI_StorageSDLoggingSet(scpi_t * context) {
 
     if (fileLen > 0) {
         if (fileLen > SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX) {
-            LOG_E("SD:LOGging - Filename too long: %d bytes, max: %d\r\n", fileLen, SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX);
+            LOG_E("SD:FILE - Filename too long: %d bytes, max: %d\r\n", fileLen, SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX);
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
         memcpy(pSDCardRuntimeConfig->file, pBuff, fileLen);
         pSDCardRuntimeConfig->file[fileLen] = '\0';
-        LOG_D("SD:LOGging - Set filename to '%s' (%d bytes) dir='%s'\r\n",
+        LOG_D("SD:FILE - Set filename to '%s' (%d bytes) dir='%s'\r\n",
               pSDCardRuntimeConfig->file, fileLen, pSDCardRuntimeConfig->directory);
     } else {
-        LOG_D("SD:LOGging - No filename provided, using existing: '%s'\r\n", pSDCardRuntimeConfig->file);
+        LOG_D("SD:FILE - No filename provided, using existing: '%s'\r\n", pSDCardRuntimeConfig->file);
     }
 
     // Note: Mode is set to WRITE when streaming actually starts (in SCPI_StartStreaming)

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -39,7 +39,7 @@
 
 // --- Test pattern streaming mode ---
 // When non-zero, overrides ADC sample values with synthetic data patterns.
-// Runtime-only (not persisted to NVM). Set via SCPI SYST:STR:TESTpattern.
+// Runtime-only (not persisted to NVM). Set via SCPI SYST:STR:TEST:PATtern.
 // 32-bit atomic read on PIC32MZ — no critical section needed for reads/writes.
 static volatile uint32_t gTestPattern = 0;       // 0=off, 1-4=pattern type
 static uint64_t gTestPatternSampleCount = 0;      // Monotonic counter, reset on start


### PR DESCRIPTION
## Summary

Second pass on #311, after PR #322's `Stats?`/`ClearStats` rename.

Two more renames following the same structured-naming precedent (`STATS:CLEar`, `FAULT:CLEar`):

| Old | New | Rationale |
|---|---|---|
| `SYSTem:STReam:TESTpattern` | `SYSTem:STReam:TEST:PATtern` | Structured namespace; enables `SYST:STR:TEST:*` expansion |
| `SYSTem:STORage:SD:LOGging` | `SYSTem:STORage:SD:FILE` | Eliminates visual ambiguity with `SYSTem:LOG?` (debug buffer) |

## What's intentionally NOT renamed

After re-examining the remaining items from #311:
- **`BENCHmark` vs `THRoughput`**: different semantics (mode toggle vs all-in-one run). Keeping both. `THR` short form is unambiguous.
- **`SAMPle:POOL`**: matches sibling pattern (`SD:BUFfer`, `ENCoder:BUFfer`). No improvement available without breaking consistency.

## Breaking change — coordinated

- **daqifi-python-core** PR: https://github.com/daqifi/daqifi-python-core/pull/new/refactor/scpi-more-renames
- **daqifi-python-test-suite** PR: https://github.com/daqifi/daqifi-python-test-suite/pull/new/refactor/scpi-more-renames

No back-compat aliases.

## Test plan

- [x] Build clean with -O3 -Werror
- [x] Flash hardware
- [x] `SYST:STR:TEST:PAT 3` + `SYST:STR:TEST:PAT?` → returns 3
- [x] `SYST:STOR:SD:FILE "test.csv"` → parser accepts (no -113 header error); -200 expected since no SD card
- [ ] Qodo convergence
- [ ] Merge alongside python-core + test-suite PRs

## After this ticket

#311 audit is substantively complete. Remaining items (`BENCHmark`/`THRoughput` consolidation, `SAMPle:POOL`) documented as intentional non-changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)