### PR TITLE
feat(scpi): expose streaming capabilities — MAXFreq + CAP:FORMula queries (#283)

### DIFF
--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -724,3 +724,68 @@ scpi_result_t SCPI_ADCOnboardDiagGet(scpi_t * context) {
     SCPI_ResultInt32(context, pStreamCfg->OnboardDiagEnabled ? 1 : 0);
     return SCPI_RES_OK;
 }
+
+/* Count currently enabled public ADC channels, split by type (#283). */
+static void SCPI_CountActiveAdcChannels(uint16_t* outType1, uint16_t* outTotal) {
+    tBoardConfig *pBoardConfig = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+    AInRuntimeArray *pRuntimeAIn = BoardRunTimeConfig_Get(
+            BOARDRUNTIMECONFIG_AIN_CHANNELS);
+    uint16_t type1 = 0;
+    uint16_t total = 0;
+    for (size_t i = 0; i < pBoardConfig->AInChannels.Size; i++) {
+        if (pRuntimeAIn->Data[i].IsEnabled != 1) continue;
+        const AInChannel* ch = &pBoardConfig->AInChannels.Data[i];
+        if (ch->Type == AIn_AD7609) {
+            if (ch->Config.AD7609.IsPublic) total++;
+        } else if (ch->Type == AIn_MC12bADC) {
+            if (ch->Config.MC12b.IsPublic) {
+                total++;
+                if (ch->Config.MC12b.ChannelType == 1) type1++;
+            }
+        }
+    }
+    *outType1 = type1;
+    *outTotal = total;
+}
+
+scpi_result_t SCPI_ADCMaxFreqGet(scpi_t * context) {
+    uint16_t type1 = 0;
+    uint16_t total = 0;
+    SCPI_CountActiveAdcChannels(&type1, &total);
+
+    uint32_t maxFreq = Streaming_ComputeMaxFreq(type1, total);
+    uint32_t type1Agg = (type1 > 0)
+        ? (STREAMING_TYPE1_AGG_MAX_HZ / type1)
+        : 0;  // 0 = constraint not applicable
+    uint32_t tickBudget = (total > 0)
+        ? (STREAMING_TICK_BUDGET / (STREAMING_TICK_OVERHEAD + total))
+        : 0;
+
+    scpi_printf(context,
+            "MaxFreqHz=%u\r\n"
+            "Type1Count=%u\r\n"
+            "TotalChannels=%u\r\n"
+            "IsrMaxHz=%u\r\n"
+            "Type1AggHz=%u\r\n"
+            "TickBudgetHz=%u\r\n",
+            (unsigned)maxFreq,
+            (unsigned)type1,
+            (unsigned)total,
+            (unsigned)STREAMING_ISR_MAX_HZ,
+            (unsigned)type1Agg,
+            (unsigned)tickBudget);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t SCPI_ADCCapFormulaGet(scpi_t * context) {
+    scpi_printf(context,
+            "IsrMaxHz=%u\r\n"
+            "Type1AggMaxHz=%u\r\n"
+            "TickBudget=%u\r\n"
+            "TickOverhead=%u\r\n",
+            (unsigned)STREAMING_ISR_MAX_HZ,
+            (unsigned)STREAMING_TYPE1_AGG_MAX_HZ,
+            (unsigned)STREAMING_TICK_BUDGET,
+            (unsigned)STREAMING_TICK_OVERHEAD);
+    return SCPI_RES_OK;
+}

--- a/firmware/src/services/SCPI/SCPIADC.h
+++ b/firmware/src/services/SCPI/SCPIADC.h
@@ -159,6 +159,31 @@ extern "C" {
     scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context);
     scpi_result_t SCPI_ADCOnboardDiagGet(scpi_t * context);
 
+    /**
+     * Query max safe streaming frequency for the current channel configuration.
+     *   CONFigure:ADC:MAXFreq?
+     * Response key=value pairs:
+     *   MaxFreqHz=<int>       effective cap applied by SYST:StartStreamData
+     *   Type1Count=<int>      count of enabled Type 1 (dedicated) channels
+     *   TotalChannels=<int>   count of all enabled public channels
+     *   IsrMaxHz=<int>        ISR-rate constraint (formula constant)
+     *   Type1AggHz=<int>      Type 1 aggregate constraint (0 if type1==0)
+     *   TickBudgetHz=<int>    per-tick budget constraint (0 if total==0)
+     */
+    scpi_result_t SCPI_ADCMaxFreqGet(scpi_t * context);
+
+    /**
+     * Query cap-formula constants so the client can compute caps for
+     * hypothetical configurations without round-tripping to the device.
+     *   CONFigure:ADC:CAP:FORMula?
+     * Formula: maxFreq = min(
+     *   IsrMaxHz,
+     *   Type1AggMaxHz / type1Count,                 // skip if type1Count==0
+     *   TickBudget / (TickOverhead + totalChannels) // skip if totalChannels==0
+     * )
+     */
+    scpi_result_t SCPI_ADCCapFormulaGet(scpi_t * context);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3349,6 +3349,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:ADC:USECal?", .callback = SCPI_ADCUseCalGet,},
     {.pattern = "CONFigure:ADC:OBDiag", .callback = SCPI_ADCOnboardDiagSet,},
     {.pattern = "CONFigure:ADC:OBDiag?", .callback = SCPI_ADCOnboardDiagGet,},
+    {.pattern = "CONFigure:ADC:MAXFreq?", .callback = SCPI_ADCMaxFreqGet,},
+    {.pattern = "CONFigure:ADC:CAP:FORMula?", .callback = SCPI_ADCCapFormulaGet,},
     //
     // Voltage output precision
     {.pattern = "CONFigure:VOLTage:PRECision", .callback = SCPI_SetDataPrecision,},


### PR DESCRIPTION
First chunk of the comprehensive capabilities discovery work tracked in #327.

Implements #283 — streaming rate cap + formula constants so clients can compute caps for hypothetical channel configurations without round-trip to the device.

Non-breaking (pure additions). Tested on hardware:

- Empty config → `MaxFreqHz=13000` (ISR cap)
- 3 channels (2×T1 + 1×T2) → `MaxFreqHz=12222` (tick-budget constraint, correct: 110000/(6+3))

```
CONF:ADC:MAXFreq?
  MaxFreqHz=12222
  Type1Count=2
  TotalChannels=3
  IsrMaxHz=13000
  Type1AggHz=27500
  TickBudgetHz=12222

CONF:ADC:CAP:FORMula?
  IsrMaxHz=13000
  Type1AggMaxHz=55000
  TickBudget=110000
  TickOverhead=6
```

Follow-up chunks (per #327):
- Channel topology (ain/aout/dio counts, types, features)
- DIO per-pin capability flags
- Board + firmware identity consolidation
- SCPI API version byte
- Unified \`CONF:CAPabilities?\` rollup

🤖 Generated with [Claude Code](https://claude.com/claude-code)