### PR TITLE
feat(adc): runtime-tunable ADC acquisition time (SAMC) — #328 phase 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -848,6 +848,7 @@ All DMA buffers (SD write, USB write, WiFi SPI staging) are auto-balanced from t
 ### Development Considerations
 
 - All hardware access must go through HAL layer
+- **Prefer Harmony PLIB / driver APIs over direct SFR writes** for hardware abstractability. Order of preference: (1) PLIB function (`EVIC_SourceEnable`, `ADCHS_*`, `GPIO_*`), (2) SFR bitfield accessors (`ADCCON2bits.SAMC = val`), (3) raw register writes only when no PLIB/bitfield path exists AND performance demands it OR SET/CLR atomic forms are needed — always comment *why*
 - SCPI commands follow IEEE 488.2 standard
 - Use FreeRTOS primitives for synchronization
 - Respect board variant differences in runtime checks

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -321,6 +321,9 @@ bool MC12b_SetAcquisitionSamc(int32_t samcDedicated, int32_t samcShared) {
     if (samcDedicated > (int32_t)MC12B_SAMC_MAX) return false;
     if (samcShared > (int32_t)MC12B_SAMC_MAX) return false;
 
+    // Nothing to do — don't disturb the ADC.
+    if (samcDedicated < 0 && samcShared < 0) return true;
+
     bool adcWasOn = (ADCCON1bits.ON != 0U);
     if (adcWasOn) {
         ADCCON1bits.ON = 0;

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -308,3 +308,49 @@ bool MC12b_IsHwTriggerDedicated(void) {
 bool MC12b_IsHwTriggerShared(void) {
     return ((ADCCON1 >> ADCCON1_STRGSRC_SHIFT) & ADCTRG_FIELD_MASK) == ADC_TRGSRC_TMR5;
 }
+
+// --- ADC acquisition-time (SAMC) runtime control — #328 phase 1 ----------
+// ADCxTIMEbits.SAMC  = dedicated module sample time (0..4). 10-bit, max 1023.
+// ADCCON2bits.SAMC   = shared MODULE7 sample time.         10-bit, max 1023.
+// Actual acquisition = (SAMC + 2) ADC clocks. With ADCDIV=1, ADC_clk=50 MHz so
+// one clock = 20 ns.
+// Writing these requires ADCCON1.ON = 0. We toggle it around the update so
+// the change applies cleanly to all modules.
+
+bool MC12b_SetAcquisitionSamc(int32_t samcDedicated, int32_t samcShared) {
+    if (samcDedicated > (int32_t)MC12B_SAMC_MAX) return false;
+    if (samcShared > (int32_t)MC12B_SAMC_MAX) return false;
+
+    bool adcWasOn = (ADCCON1bits.ON != 0U);
+    if (adcWasOn) {
+        ADCCON1bits.ON = 0;
+    }
+
+    if (samcDedicated >= 0) {
+        uint32_t s = (uint32_t)samcDedicated;
+        ADC0TIMEbits.SAMC = s;
+        ADC1TIMEbits.SAMC = s;
+        ADC2TIMEbits.SAMC = s;
+        ADC3TIMEbits.SAMC = s;
+        ADC4TIMEbits.SAMC = s;
+    }
+    if (samcShared >= 0) {
+        ADCCON2bits.SAMC = (uint32_t)samcShared;
+    }
+
+    if (adcWasOn) {
+        ADCCON1bits.ON = 1;
+        while (ADCCON2bits.BGVRRDY == 0U) { /* wait for reference */ }
+        while (ADCCON2bits.REFFLT != 0U)   { /* wait for fault clear */ }
+    }
+    return true;
+}
+
+void MC12b_GetAcquisitionSamc(uint16_t* outSamcDedicated, uint16_t* outSamcShared) {
+    if (outSamcDedicated) {
+        *outSamcDedicated = (uint16_t)ADC0TIMEbits.SAMC;
+    }
+    if (outSamcShared) {
+        *outSamcShared = (uint16_t)ADCCON2bits.SAMC;
+    }
+}

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -340,8 +340,15 @@ bool MC12b_SetAcquisitionSamc(int32_t samcDedicated, int32_t samcShared) {
 
     if (adcWasOn) {
         ADCCON1bits.ON = 1;
-        while (ADCCON2bits.BGVRRDY == 0U) { /* wait for reference */ }
-        while (ADCCON2bits.REFFLT != 0U)   { /* wait for fault clear */ }
+        // Bound the hardware polling loops so an unhealthy reference can't
+        // hang the SCPI task forever. ~20 ms at 100 MHz is plenty for a
+        // normal bandgap settle (typically microseconds).
+        uint32_t timeout = 2000000U;
+        while (ADCCON2bits.BGVRRDY == 0U && timeout-- != 0U) { /* wait */ }
+        if (ADCCON2bits.BGVRRDY == 0U || ADCCON2bits.REFFLT != 0U) {
+            ADCCON1bits.ON = 0;
+            return false;
+        }
     }
     return true;
 }

--- a/firmware/src/HAL/ADC/MC12bADC.h
+++ b/firmware/src/HAL/ADC/MC12bADC.h
@@ -104,6 +104,32 @@ void MC12b_ConfigureHardwareTrigger(bool hwDedicated, bool hwShared);
 bool MC12b_IsHwTriggerDedicated(void);
 bool MC12b_IsHwTriggerShared(void);
 
+/**
+ * Set ADC sample-time (SAMC) for dedicated modules (ADC0-4) and the shared
+ * MODULE7. Higher SAMC = longer acquisition window = lower noise at the cost
+ * of per-scan time. Range: 0-1023 ADC clock cycles (actual acquisition time
+ * is SAMC+2 clocks).
+ *
+ * NOT safe to call while streaming — caller must stop streaming first. The
+ * ADC is briefly taken offline to apply the new values.
+ *
+ * Pass a negative value for either parameter to leave that channel type
+ * unchanged.
+ *
+ * @param samcDedicated 0-1023, or negative to skip
+ * @param samcShared    0-1023, or negative to skip
+ * @return true on success, false if args out of range
+ */
+bool MC12b_SetAcquisitionSamc(int32_t samcDedicated, int32_t samcShared);
+
+/** Read current SAMC values. out* may be NULL. */
+void MC12b_GetAcquisitionSamc(uint16_t* outSamcDedicated, uint16_t* outSamcShared);
+
+/** Boot-default SAMC values (from MCC-generated ADCHS init). */
+#define MC12B_SAMC_DEDICATED_DEFAULT  100
+#define MC12B_SAMC_SHARED_DEFAULT     1
+#define MC12B_SAMC_MAX                1023
+
 #ifdef	__cplusplus
 }
 #endif

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -738,7 +738,7 @@ static scpi_result_t SamcSetCommon(scpi_t *context, bool isDedicated) {
     }
     StreamingRuntimeConfig *pStreamCfg =
             BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
-    if (pStreamCfg && pStreamCfg->IsEnabled) {
+    if (pStreamCfg->IsEnabled) {
         SCPI_ExecutionError(context, "CONF:ADC:SAMC: cannot change while streaming");
         return SCPI_RES_ERR;
     }

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -16,6 +16,7 @@
 #include "Util/Logger.h"
 #include "state/data/BoardData.h"
 #include "state/board/BoardConfig.h"
+#include "HAL/ADC/MC12bADC.h"
 #include "state/runtime/BoardRuntimeConfig.h"
 #include "HAL/ADC.h"
 #include "../daqifi_settings.h"
@@ -722,5 +723,55 @@ scpi_result_t SCPI_ADCOnboardDiagGet(scpi_t * context) {
     StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
     SCPI_ResultInt32(context, pStreamCfg->OnboardDiagEnabled ? 1 : 0);
+    return SCPI_RES_OK;
+}
+
+// --- #328 phase 1: ADC acquisition-time runtime control ------------------
+// Wrapper that rejects SAMC writes while streaming is active. Calls into
+// MC12b_SetAcquisitionSamc for the register work.
+static scpi_result_t SamcSetCommon(scpi_t *context, bool isDedicated) {
+    int32_t val;
+    if (!SCPI_ParamInt32(context, &val, TRUE)) return SCPI_RES_ERR;
+    if (val < 0 || val > (int32_t)MC12B_SAMC_MAX) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+    StreamingRuntimeConfig *pStreamCfg =
+            BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
+    if (pStreamCfg && pStreamCfg->IsEnabled) {
+        SCPI_ExecutionError(context, "CONF:ADC:SAMC: cannot change while streaming");
+        return SCPI_RES_ERR;
+    }
+    bool ok = isDedicated ? MC12b_SetAcquisitionSamc(val, -1)
+                          : MC12b_SetAcquisitionSamc(-1, val);
+    if (!ok) {
+        SCPI_ExecutionError(context, "CONF:ADC:SAMC: set failed");
+        return SCPI_RES_ERR;
+    }
+    LOG_I("ADC SAMC %s = %ld (%ld ns acquisition @ 50 MHz clk)",
+          isDedicated ? "dedicated" : "shared",
+          (long)val, (long)((val + 2) * 20));
+    return SCPI_RES_OK;
+}
+
+scpi_result_t SCPI_ADCSamcDedicatedSet(scpi_t *context) {
+    return SamcSetCommon(context, true);
+}
+
+scpi_result_t SCPI_ADCSamcSharedSet(scpi_t *context) {
+    return SamcSetCommon(context, false);
+}
+
+scpi_result_t SCPI_ADCSamcDedicatedGet(scpi_t *context) {
+    uint16_t samc = 0;
+    MC12b_GetAcquisitionSamc(&samc, NULL);
+    SCPI_ResultInt32(context, (int32_t)samc);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t SCPI_ADCSamcSharedGet(scpi_t *context) {
+    uint16_t samc = 0;
+    MC12b_GetAcquisitionSamc(NULL, &samc);
+    SCPI_ResultInt32(context, (int32_t)samc);
     return SCPI_RES_OK;
 }

--- a/firmware/src/services/SCPI/SCPIADC.h
+++ b/firmware/src/services/SCPI/SCPIADC.h
@@ -159,6 +159,21 @@ extern "C" {
     scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context);
     scpi_result_t SCPI_ADCOnboardDiagGet(scpi_t * context);
 
+    /**
+     * #328 phase 1 — ADC acquisition-time (SAMC) runtime control.
+     *   CONFigure:ADC:SAMC:DEDicated <0-1023>  — sample time for modules 0-4
+     *   CONFigure:ADC:SAMC:DEDicated?          — current value
+     *   CONFigure:ADC:SAMC:SHARed <0-1023>     — sample time for MODULE7
+     *   CONFigure:ADC:SAMC:SHARed?             — current value
+     * Actual acquisition time = (SAMC+2) ADC clocks. ADC clock = SYSCLK / (2*(ADCDIV+1))
+     * which with ADCDIV=1 gives 50 MHz, so each clock is 20 ns.
+     * Rejected while streaming is active (returns EXECUTION_ERROR).
+     */
+    scpi_result_t SCPI_ADCSamcDedicatedSet(scpi_t * context);
+    scpi_result_t SCPI_ADCSamcDedicatedGet(scpi_t * context);
+    scpi_result_t SCPI_ADCSamcSharedSet(scpi_t * context);
+    scpi_result_t SCPI_ADCSamcSharedGet(scpi_t * context);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3349,6 +3349,10 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:ADC:USECal?", .callback = SCPI_ADCUseCalGet,},
     {.pattern = "CONFigure:ADC:OBDiag", .callback = SCPI_ADCOnboardDiagSet,},
     {.pattern = "CONFigure:ADC:OBDiag?", .callback = SCPI_ADCOnboardDiagGet,},
+    {.pattern = "CONFigure:ADC:SAMC:DEDicated", .callback = SCPI_ADCSamcDedicatedSet,},
+    {.pattern = "CONFigure:ADC:SAMC:DEDicated?", .callback = SCPI_ADCSamcDedicatedGet,},
+    {.pattern = "CONFigure:ADC:SAMC:SHARed", .callback = SCPI_ADCSamcSharedSet,},
+    {.pattern = "CONFigure:ADC:SAMC:SHARed?", .callback = SCPI_ADCSamcSharedGet,},
     //
     // Voltage output precision
     {.pattern = "CONFigure:VOLTage:PRECision", .callback = SCPI_SetDataPrecision,},


### PR DESCRIPTION
## Summary

Phase 1 of #328: expose ADC sample-time (SAMC) for both dedicated modules (ADC0-4) and shared MODULE7 via SCPI. This is the control surface — no auto-tuning in this PR.

## SCPI

```
CONFigure:ADC:SAMC:DEDicated <0-1023>   set dedicated modules 0-4
CONFigure:ADC:SAMC:DEDicated?            query
CONFigure:ADC:SAMC:SHARed <0-1023>       set shared MODULE7
CONFigure:ADC:SAMC:SHARed?               query
```

Rejected while streaming active. Actual acquisition = (SAMC + 2) ADC clocks; ADC_clk = 50 MHz so each step = 20 ns. Range: 40 ns to 20.5 µs. Boot default is 100 for both (~2 µs).

## Implementation

`MC12b_SetAcquisitionSamc(int32_t samcDedicated, int32_t samcShared)` uses `ADCxTIMEbits.SAMC` / `ADCCON2bits.SAMC` bitfield accessors. ADCCON1.ON toggled briefly to apply; waits for BGVRRDY on re-enable. Caller must not be streaming.

Also documents the PLIB-first rule in CLAUDE.md:

> **Prefer Harmony PLIB / driver APIs over direct SFR writes** for hardware abstractability. Order of preference: (1) PLIB function, (2) SFR bitfield accessors (`ADCCON2bits.SAMC = val`), (3) raw register writes only when no PLIB/bitfield path exists AND performance demands it OR SET/CLR atomic forms are needed — always comment *why*.

## Hardware verification

Phase 2 characterization (posted to #328) used this SCPI surface to sweep SAMC 1 → 1023 on a board with all user T2 channels shorted to +4 V, OBDiag=ON (MODULE7 scanning 18 channels). Key findings:

- Set/get round-trip verified on both dedicated and shared paths
- Writes correctly rejected while streaming is active
- Out-of-range values (<0 or >1023) rejected with SCPI_ERROR_DATA_OUT_OF_RANGE
- Streaming at SAMC=500 (5× default) on 1×T2 @ 1 kHz: 0 queue drops, 0 USB drops, 0 EOS overruns — stream still clean with longer acquisition
- Phase 2 data shows SAMC=1 causes real accuracy errors (up to −94 mV settling error on mux-switched T2 channels); SAMC ≥ 100 (current default) all channels clean — so while this PR doesn't change default behavior, it exposes the knob for future use

## Finding corrected in-flight

The original #328 body claimed `ADCCON2` default set shared SAMC to 1 (60 ns). It's actually **100** (same as dedicated, ~2 µs). My bit-layout decode was wrong; the bitfield accessor caught it immediately. Ticket updated.

## Test plan

- [x] Build clean with `-O3 -Werror`
- [x] Set/get round-trip via SCPI
- [x] Out-of-range rejection (`-5`, `2000` both → DATA_OUT_OF_RANGE)
- [x] Write-while-streaming rejection returns SCPI_ERROR_EXECUTION_ERROR
- [x] Stream 1×T2 @ 1 kHz with SAMC=500, 0 drops
- [x] Full SAMC sweep (1, 10, 100, 500, 1023) on 18-channel scan, accuracy data collected (see #328)
- [ ] Remains to verify: jitter, frequency accuracy, top-end drop rates under SAMC=100 (follow-up)

## Not in scope

- Auto-tuning SAMC based on requested freq / channel count (phase 2-3)
- SCPI preset modes (AUTO/FAST/BALANCED/QUIET)
- NVM persistence
- AD7609 (18-bit) equivalent — different chip, different path