### PR TITLE
feat(scpi): expose streaming frequency cap via CONFigure:ADC:MAXFreq? (#283)

### DIFF
--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -222,32 +222,11 @@ scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
     }
     uint16_t activeType1ChannelCount = 0;
     uint16_t totalEnabledPublicChannels = 0;
-    bool hasActiveAD7609Channels __attribute__((unused)) = false;
+    Streaming_CountActiveChannels(&activeType1ChannelCount,
+                                  &totalEnabledPublicChannels,
+                                  NULL);
     uint64_t freq = pRunTimeStreamConfig->Frequency;
     uint32_t clkFreq = TimerApi_FrequencyGet(pBoardConfig->StreamingConfig.TimerIndex);
-    int i;
-
-    // Count active channels and detect AD7609 usage
-    for (i = 0; i < pBoardConfigAInChannels->Size; i++) {
-        if (pRuntimeAInChannels->Data[i].IsEnabled == 1) {
-            bool isPublic = false;
-            if (pBoardConfigAInChannels->Data[i].Type == AIn_AD7609) {
-                isPublic = pBoardConfigAInChannels->Data[i].Config.AD7609.IsPublic;
-                if (isPublic) {
-                    hasActiveAD7609Channels = true;
-                    totalEnabledPublicChannels++;
-                }
-            } else if (pBoardConfigAInChannels->Data[i].Type == AIn_MC12bADC) {
-                isPublic = pBoardConfigAInChannels->Data[i].Config.MC12b.IsPublic;
-                if (isPublic) {
-                    totalEnabledPublicChannels++;
-                    if (pBoardConfigAInChannels->Data[i].Config.MC12b.ChannelType == 1) {
-                        activeType1ChannelCount++;
-                    }
-                }
-            }
-        }
-    }
 
     // Three-constraint frequency capping (see streaming.h)
     {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2055,41 +2055,13 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     // timer running frequency
     uint32_t clkFreq = TimerApi_FrequencyGet(pBoardConfig->StreamingConfig.TimerIndex);
 
-    //int i;
     uint16_t activeType1ChannelCount = 0;
     uint16_t totalEnabledPublicChannels = 0;
-    bool hasActiveAD7609Channels __attribute__((unused)) = false;
-    int i;
-    bool hasEnabledChannels = false;
-
-    // Count active PUBLIC ADC channels and detect AD7609 usage
-    // Internal monitoring channels (IsPublic=false) don't count as user channels
-    // Use minimum of both array sizes to prevent out-of-bounds access
-    size_t adcCount = pBoardConfigADC->Size < pRuntimeAInChannels->Size ?
-                      pBoardConfigADC->Size : pRuntimeAInChannels->Size;
-    for (i = 0; i < (int)adcCount; i++) {
-        if (pRuntimeAInChannels->Data[i].IsEnabled == 1) {
-            // Check IsPublic based on channel type (it's in the union)
-            bool isPublic = false;
-            if (pBoardConfigADC->Data[i].Type == AIn_AD7609) {
-                isPublic = pBoardConfigADC->Data[i].Config.AD7609.IsPublic;
-                if (isPublic) {
-                    hasEnabledChannels = true;
-                    hasActiveAD7609Channels = true;
-                    totalEnabledPublicChannels++;
-                }
-            } else if (pBoardConfigADC->Data[i].Type == AIn_MC12bADC) {
-                isPublic = pBoardConfigADC->Data[i].Config.MC12b.IsPublic;
-                if (isPublic) {
-                    hasEnabledChannels = true;
-                    totalEnabledPublicChannels++;
-                    if (pBoardConfigADC->Data[i].Config.MC12b.ChannelType == 1) {
-                        activeType1ChannelCount++;
-                    }
-                }
-            }
-        }
-    }
+    bool hasActiveAD7609Channels = false;
+    Streaming_CountActiveChannels(&activeType1ChannelCount,
+                                  &totalEnabledPublicChannels,
+                                  &hasActiveAD7609Channels);
+    bool hasEnabledChannels = (totalEnabledPublicChannels > 0);
 
     // Build channel mapping for compact sample pool (#177).
     // Must happen before pool partitioning (needs channel count for element sizing).
@@ -2459,6 +2431,39 @@ static scpi_result_t SCPI_IsStreaming(scpi_t * context) {
             BOARDRUNTIME_STREAMING_CONFIGURATION);
 
     SCPI_ResultInt32(context, (int) pRunTimeStreamConfig->IsEnabled);
+    return SCPI_RES_OK;
+}
+
+/*
+ * CONFigure:ADC:MAXFreq?
+ * Reports the three-constraint streaming frequency cap for the currently
+ * enabled public ADC channels, plus the formula constants so clients can
+ * predict caps for hypothetical channel configurations without a round
+ * trip. Format: key=value pairs, comma-separated, so the existing
+ * key=value SCPI-response parsers in python-core / daqifi-core can split
+ * on ',' and '=' without a format bump. See #283.
+ */
+static scpi_result_t SCPI_GetMaxStreamFreq(scpi_t * context) {
+    uint16_t type1 = 0;
+    uint16_t total = 0;
+    Streaming_CountActiveChannels(&type1, &total, NULL);
+    uint32_t maxFreq = Streaming_ComputeMaxFreq(type1, total);
+
+    char buf[160];
+    int n = snprintf(buf, sizeof(buf),
+        "MaxFreqHz=%u,Type1Count=%u,TotalChannels=%u,"
+        "IsrMaxHz=%u,Type1AggMaxHz=%u,TickBudget=%u,TickOverhead=%u",
+        (unsigned)maxFreq,
+        (unsigned)type1,
+        (unsigned)total,
+        (unsigned)STREAMING_ISR_MAX_HZ,
+        (unsigned)STREAMING_TYPE1_AGG_MAX_HZ,
+        (unsigned)STREAMING_TICK_BUDGET,
+        (unsigned)STREAMING_TICK_OVERHEAD);
+    if (n < 0 || (size_t)n >= sizeof(buf)) {
+        return SCPI_RES_ERR;
+    }
+    SCPI_ResultText(context, buf);
     return SCPI_RES_OK;
 }
 
@@ -3360,6 +3365,7 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:ADC:RANGe?", .callback = SCPI_ADCChanRangeGet,},
     {.pattern = "CONFigure:ADC:CHANnel", .callback = SCPI_ADCChanEnableSet,},
     {.pattern = "CONFigure:ADC:CHANnel?", .callback = SCPI_ADCChanEnableGet,},
+    {.pattern = "CONFigure:ADC:MAXFreq?", .callback = SCPI_GetMaxStreamFreq,},
     {.pattern = "CONFigure:ADC:chanCALM", .callback = SCPI_ADCChanCalmSet,},
     {.pattern = "CONFigure:ADC:chanCALB", .callback = SCPI_ADCChanCalbSet,},
     {.pattern = "CONFigure:ADC:chanCALM?", .callback = SCPI_ADCChanCalmGet,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2447,7 +2447,10 @@ static scpi_result_t SCPI_GetMaxStreamFreq(scpi_t * context) {
     uint16_t type1 = 0;
     uint16_t total = 0;
     Streaming_CountActiveChannels(&type1, &total, NULL);
-    uint32_t maxFreq = Streaming_ComputeMaxFreq(type1, total);
+    /* Zero enabled channels → no valid stream rate. Report 0 instead of
+     * the ISR ceiling so a client that drives the UI from this response
+     * doesn't silently offer rates that StartStreamData would reject. */
+    uint32_t maxFreq = (total > 0) ? Streaming_ComputeMaxFreq(type1, total) : 0;
 
     char buf[160];
     int n = snprintf(buf, sizeof(buf),

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2463,7 +2463,10 @@ static scpi_result_t SCPI_GetMaxStreamFreq(scpi_t * context) {
     if (n < 0 || (size_t)n >= sizeof(buf)) {
         return SCPI_RES_ERR;
     }
-    SCPI_ResultText(context, buf);
+    /* SCPI_ResultCharacters emits raw bytes; SCPI_ResultText would wrap
+     * the payload in double quotes (see libscpi parser.c), which would
+     * break the unquoted key=value contract documented for this query. */
+    SCPI_ResultCharacters(context, buf, (size_t)n);
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -299,6 +299,44 @@ const AInChannelMapping* Streaming_GetChannelMapping(void) {
     return &gChannelMapping;
 }
 
+void Streaming_CountActiveChannels(uint16_t* out_type1Count,
+                                   uint16_t* out_totalPublic,
+                                   bool* out_hasAD7609) {
+    uint16_t type1 = 0;
+    uint16_t total = 0;
+    bool has7609 = false;
+
+    volatile AInRuntimeArray* rt =
+        BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_AIN_CHANNELS);
+    volatile AInArray* cfg =
+        BoardConfig_Get(BOARDCONFIG_AIN_CHANNELS, 0);
+
+    if (rt != NULL && cfg != NULL) {
+        size_t count = (cfg->Size < rt->Size) ? cfg->Size : rt->Size;
+        for (size_t i = 0; i < count; i++) {
+            if (rt->Data[i].IsEnabled != 1) continue;
+
+            if (cfg->Data[i].Type == AIn_AD7609) {
+                if (cfg->Data[i].Config.AD7609.IsPublic) {
+                    has7609 = true;
+                    total++;
+                }
+            } else if (cfg->Data[i].Type == AIn_MC12bADC) {
+                if (cfg->Data[i].Config.MC12b.IsPublic) {
+                    total++;
+                    if (cfg->Data[i].Config.MC12b.ChannelType == 1) {
+                        type1++;
+                    }
+                }
+            }
+        }
+    }
+
+    if (out_type1Count  != NULL) *out_type1Count  = type1;
+    if (out_totalPublic != NULL) *out_totalPublic = total;
+    if (out_hasAD7609   != NULL) *out_hasAD7609   = has7609;
+}
+
 /**
  * @brief Deferred interrupt handler for sample collection.
  *

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -306,27 +306,27 @@ void Streaming_CountActiveChannels(uint16_t* out_type1Count,
     uint16_t total = 0;
     bool has7609 = false;
 
+    /* Per CLAUDE.md: BoardRunTimeConfig_Get / BoardConfig_Get index into
+     * static arrays populated at boot and never return NULL. No guard. */
     volatile AInRuntimeArray* rt =
         BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_AIN_CHANNELS);
     volatile AInArray* cfg =
         BoardConfig_Get(BOARDCONFIG_AIN_CHANNELS, 0);
 
-    if (rt != NULL && cfg != NULL) {
-        size_t count = (cfg->Size < rt->Size) ? cfg->Size : rt->Size;
-        for (size_t i = 0; i < count; i++) {
-            if (rt->Data[i].IsEnabled != 1) continue;
+    size_t count = (cfg->Size < rt->Size) ? cfg->Size : rt->Size;
+    for (size_t i = 0; i < count; i++) {
+        if (rt->Data[i].IsEnabled != 1) continue;
 
-            if (cfg->Data[i].Type == AIn_AD7609) {
-                if (cfg->Data[i].Config.AD7609.IsPublic) {
-                    has7609 = true;
-                    total++;
-                }
-            } else if (cfg->Data[i].Type == AIn_MC12bADC) {
-                if (cfg->Data[i].Config.MC12b.IsPublic) {
-                    total++;
-                    if (cfg->Data[i].Config.MC12b.ChannelType == 1) {
-                        type1++;
-                    }
+        if (cfg->Data[i].Type == AIn_AD7609) {
+            if (cfg->Data[i].Config.AD7609.IsPublic) {
+                has7609 = true;
+                total++;
+            }
+        } else if (cfg->Data[i].Type == AIn_MC12bADC) {
+            if (cfg->Data[i].Config.MC12b.IsPublic) {
+                total++;
+                if (cfg->Data[i].Config.MC12b.ChannelType == 1) {
+                    type1++;
                 }
             }
         }

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "../state/board/BoardConfig.h"
 #include "../state/runtime/BoardRuntimeConfig.h"
 #include "../state/data/BoardData.h"
@@ -78,7 +81,22 @@ static inline uint32_t Streaming_ComputeMaxFreq(uint32_t type1Count, uint32_t to
     if (maxFreq == 0) maxFreq = 1;
     return maxFreq;
 }
-    
+
+/**
+ * Count enabled public ADC channels from current board + runtime config.
+ * Used by SCPI_StartStreaming, the ADC channel-enable path, and the
+ * MAXFreq query so they all agree on what counts toward the cap.
+ *
+ * @param[out] out_type1Count     Enabled MC12bADC ChannelType=1 (Type 1) channels
+ * @param[out] out_totalPublic    Total enabled IsPublic channels (both ADC types)
+ * @param[out] out_hasAD7609      true if any enabled IsPublic channel is AD7609
+ *
+ * Any out_* pointer may be NULL.
+ */
+void Streaming_CountActiveChannels(uint16_t* out_type1Count,
+                                   uint16_t* out_totalPublic,
+                                   bool* out_hasAD7609);
+
 /*! Initializes the streaming component
  * @param[in] pStreamingConfigInit Streaming configuration
  * @param[out] pStreamingRuntimeConfigInit Streaming configuration in runtime


### PR DESCRIPTION
## Summary

- New SCPI query `CONFigure:ADC:MAXFreq?` returns the current cap plus the formula constants so clients can predict caps for hypothetical channel configs without a round trip.
- Extracted `Streaming_CountActiveChannels()` from the two duplicate counting loops in `SCPI_StartStreaming` and `SCPI_ADCChanEnableSet` so the cap-enforcement path and the new query share one source of truth.
- Response is unquoted key=value via `SCPI_ResultCharacters` (libscpi `SCPI_ResultText` wraps in double quotes — caught in Qodo pass 1).

```
CONF:ADC:MAXF?
→ MaxFreqHz=5000,Type1Count=5,TotalChannels=16,IsrMaxHz=13000,Type1AggMaxHz=55000,TickBudget=110000,TickOverhead=6
```

Protobuf extension and the `CAPFormula?` split command are deferred per ticket scope — the single SCPI query with embedded formula constants covers the immediate use case (desktop app rate selector).

## Why

The frequency cap already exists in firmware (`Streaming_ComputeMaxFreq`), but a client has no way to discover it before asking the device to stream. Today the only feedback is a cap rejection logged to `SYST:LOG?` and a silently-adjusted frequency. With this query the desktop app can:

- Show the user what rates are achievable for their channel config
- Disable / gray out above-cap frequencies in the UI
- Dynamically update as channels toggle, without round-tripping

## Test plan

- [x] Build clean at `-Werror -O3`
- [x] Flash + `*IDN?` handshake
- [x] `CONF:ADC:MAXF?` returns correct response on 4 distinct configs:
  - [x] 0 channels (bitmask=0)        → `MaxFreqHz=0` (no stream possible)
  - [x] 1× Type 2 (ch 0 bitmask=1)    → `MaxFreqHz=13000, Type1Count=0, TotalChannels=1`
  - [x] 1× Type 1 (ch 4 bitmask=16)   → `MaxFreqHz=13000, Type1Count=1, TotalChannels=1`
  - [x] 16 channels (bitmask=65535)   → `MaxFreqHz=5000, Type1Count=5, TotalChannels=16`
- [x] Response is unquoted (no wrapping `"..."`) — parseable via `split(',') + split('=')`
- [x] Query works while streaming is stopped
- [x] Existing cap-enforcement path unchanged (`StartStreamData 20000` on 16 ch still streams — data flowed, device didn't crash). Helper extraction is semantics-preserving.

Closes #283 for the SCPI surface. Protobuf + `CAPFormula?` split command deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)