### PR TITLE
feat(scpi): capability framework foundation — APIVersion, AIN, DIO (#327)

### DIFF
--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -410,6 +410,7 @@
         <itemPath>../src/services/streaming.h</itemPath>
         <itemPath>../src/services/JSON_Encoder.h</itemPath>
         <itemPath>../src/services/csv_encoder.h</itemPath>
+        <itemPath>../src/services/Capabilities.h</itemPath>
       </logicalFolder>
       <logicalFolder name="state" displayName="state" projectFiles="true">
         <logicalFolder name="board" displayName="board" projectFiles="true">
@@ -984,6 +985,7 @@
         <itemPath>../src/services/streaming.c</itemPath>
         <itemPath>../src/services/JSON_Encoder.c</itemPath>
         <itemPath>../src/services/csv_encoder.c</itemPath>
+        <itemPath>../src/services/Capabilities.c</itemPath>
       </logicalFolder>
       <logicalFolder name="state" displayName="state" projectFiles="true">
         <logicalFolder name="board" displayName="board" projectFiles="true">

--- a/firmware/src/services/Capabilities.c
+++ b/firmware/src/services/Capabilities.c
@@ -81,6 +81,12 @@ void Capabilities_GetDioSummary(CapabilitiesDioSummary* out_summary) {
 
     const DIOArray* dio = &cfg->DIOChannels;
     out_summary->channelCount = (uint16_t)dio->Size;
+    /* INVARIANT: DIO channel number == DIOChannels.Data[] index. The
+     * DIOConfig struct has no explicit channel-ID field because the
+     * entire firmware relies on this mapping (see DIOProbe, DIO HAL,
+     * SCPI DIO callbacks). If a future board variant breaks that
+     * invariant, this mask becomes meaningless — add a ChannelId
+     * field to DIOConfig first and use it here. */
     for (uint32_t i = 0; i < dio->Size; i++) {
         if (dio->Data[i].IsPwmCapable && i < 16) {
             out_summary->pwmCapableMask |= (uint16_t)(1u << i);

--- a/firmware/src/services/Capabilities.c
+++ b/firmware/src/services/Capabilities.c
@@ -1,0 +1,83 @@
+#define LOG_LVL LOG_LEVEL_DEBUG
+#define LOG_MODULE LOG_MODULE_GENERAL
+/*! @file Capabilities.c
+ *
+ * Builds capability summaries from the live tBoardConfig. See
+ * Capabilities.h for API and issue #327 for the full framework.
+ */
+
+#include "Capabilities.h"
+
+#include <string.h>
+
+#include "state/board/BoardConfig.h"
+
+void Capabilities_GetAinSummary(CapabilitiesAinSummary* out_summary) {
+    if (out_summary == NULL) return;
+    memset(out_summary, 0, sizeof(*out_summary));
+
+    /* Per CLAUDE.md, BoardConfig_Get indexes a static array populated at
+     * boot and never returns NULL. No guard. */
+    const tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+
+    uint8_t resolution = 0;
+    const AInArray* channels = &cfg->AInChannels;
+    for (uint32_t i = 0; i < channels->Size; i++) {
+        const AInChannel* ch = &channels->Data[i];
+
+        bool isPublic = false;
+        uint8_t channelType = 0;     /* 1 = Type 1, 2 = Type 2 (shared) */
+        uint8_t channelBits = 0;
+        if (ch->Type == AIn_MC12bADC) {
+            isPublic = ch->Config.MC12b.IsPublic;
+            channelType = (ch->Config.MC12b.ChannelType == 1) ? 1 : 2;
+            channelBits = 12;
+        } else if (ch->Type == AIn_AD7609) {
+            isPublic = ch->Config.AD7609.IsPublic;
+            channelType = 1;  /* AD7609 converts all 8 channels simultaneously */
+            channelBits = 18;
+            if (isPublic) out_summary->hasAD7609 = true;
+        }
+
+        if (!isPublic) continue;
+
+        /* Bitmask index uses the DaqifiAdcChannelId (user-facing channel
+         * number), not the board-config array index. Keeps the mask
+         * meaningful to a client that already knows channels by ID. */
+        uint8_t channelId = ch->DaqifiAdcChannelId;
+        if (channelId < 16) {
+            if (channelType == 1) {
+                out_summary->type1Bitmask |= (uint16_t)(1u << channelId);
+                out_summary->type1Count++;
+            } else {
+                out_summary->type2Bitmask |= (uint16_t)(1u << channelId);
+                out_summary->type2Count++;
+            }
+        }
+        out_summary->publicChannelCount++;
+
+        /* Primary resolution = whichever ADC type the public channels
+         * are predominantly using. NQ1 is all MC12b (12-bit), NQ3 is
+         * all AD7609 (18-bit). NQ2 mixes — if any AD7609 channel is
+         * public, report the higher resolution. */
+        if (channelBits > resolution) resolution = channelBits;
+    }
+    out_summary->primaryResolutionBits = resolution;
+}
+
+void Capabilities_GetDioSummary(CapabilitiesDioSummary* out_summary) {
+    if (out_summary == NULL) return;
+    memset(out_summary, 0, sizeof(*out_summary));
+
+    /* Per CLAUDE.md, BoardConfig_Get indexes a static array populated at
+     * boot and never returns NULL. No guard. */
+    const tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+
+    const DIOArray* dio = &cfg->DIOChannels;
+    out_summary->channelCount = (uint16_t)dio->Size;
+    for (uint32_t i = 0; i < dio->Size; i++) {
+        if (dio->Data[i].IsPwmCapable && i < 16) {
+            out_summary->pwmCapableMask |= (uint16_t)(1u << i);
+        }
+    }
+}

--- a/firmware/src/services/Capabilities.c
+++ b/firmware/src/services/Capabilities.c
@@ -43,16 +43,22 @@ void Capabilities_GetAinSummary(CapabilitiesAinSummary* out_summary) {
 
         /* Bitmask index uses the DaqifiAdcChannelId (user-facing channel
          * number), not the board-config array index. Keeps the mask
-         * meaningful to a client that already knows channels by ID. */
+         * meaningful to a client that already knows channels by ID.
+         * Counts always increment so the invariant
+         *   type1Count + type2Count == publicChannelCount
+         * holds even for boards with channel IDs >= 16 where the
+         * bitmask can't represent them. */
         uint8_t channelId = ch->DaqifiAdcChannelId;
-        if (channelId < 16) {
-            if (channelType == 1) {
+        if (channelType == 1) {
+            if (channelId < 16) {
                 out_summary->type1Bitmask |= (uint16_t)(1u << channelId);
-                out_summary->type1Count++;
-            } else {
-                out_summary->type2Bitmask |= (uint16_t)(1u << channelId);
-                out_summary->type2Count++;
             }
+            out_summary->type1Count++;
+        } else {
+            if (channelId < 16) {
+                out_summary->type2Bitmask |= (uint16_t)(1u << channelId);
+            }
+            out_summary->type2Count++;
         }
         out_summary->publicChannelCount++;
 

--- a/firmware/src/services/Capabilities.h
+++ b/firmware/src/services/Capabilities.h
@@ -1,0 +1,88 @@
+#ifndef _DAQIFI_CAPABILITIES_H
+#define _DAQIFI_CAPABILITIES_H
+
+/*
+ * Capabilities.h — vendor-neutral capability framework for DAQiFi.
+ *
+ * See issue #327 for the full vision. This module is the firmware
+ * reference implementation of the capability schema: clients query
+ * SCPI capability commands and render themselves from the response
+ * rather than hard-coding board variants or channel counts.
+ *
+ * This PR introduces the foundation pieces (version byte, AIN
+ * topology summary, DIO topology summary). The unified
+ * `CONFigure:CAPabilities:JSON?` rollup + protobuf extension land
+ * in a follow-up PR that composes what's here.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * SCPI capability schema version byte.
+ *
+ * Clients use this to decide which parser to apply before issuing
+ * any other capability query. Increment on any BREAKING change to
+ * the capability schema — i.e. field renames/removals, type
+ * changes, semantics changes on existing fields.
+ *
+ * Do NOT bump for additive changes — adding a new capability
+ * command or a new key=value field in an existing response is
+ * additive and safe for older clients.
+ *
+ * History:
+ *   1 — Initial version. AIN/DIO capability summaries + API
+ *       version query. (#327)
+ */
+#define DAQIFI_CAPABILITIES_VERSION ((uint8_t)1)
+
+/*
+ * Summary of analog-input topology from the current board config.
+ * All counts are for PUBLIC channels (user-facing) — internal
+ * monitoring channels are excluded because clients rendering a UI
+ * shouldn't see or control them. See issue #327.
+ */
+typedef struct {
+    uint16_t publicChannelCount;   /* public AIn channels total */
+    uint16_t type1Count;           /* dedicated-ADC (simultaneous) channels */
+    uint16_t type2Count;           /* shared-ADC (muxed) channels */
+    uint16_t type1Bitmask;         /* bit N set ⇒ channel N is Type 1 */
+    uint16_t type2Bitmask;         /* bit N set ⇒ channel N is Type 2 */
+    bool     hasAD7609;            /* any AD7609 (external 18-bit) channel present */
+    uint8_t  primaryResolutionBits;/* dominant ADC resolution (12=MC12b, 18=AD7609) */
+} CapabilitiesAinSummary;
+
+/*
+ * Summary of DIO topology. Bitmasks are indexed by DIO channel
+ * number (bit 0 = DIO_0, etc). Clients use these to know which
+ * pins accept which runtime configurations without probing.
+ */
+typedef struct {
+    uint16_t channelCount;      /* configured DIO channels (typically 16) */
+    uint16_t pwmCapableMask;    /* bit N set ⇒ DIO_N has an OCMP mapping */
+} CapabilitiesDioSummary;
+
+/**
+ * Fill out_summary from the current tBoardConfig snapshot.
+ * Safe to call from any task context — reads are idempotent.
+ *
+ * @param[out] out_summary must not be NULL.
+ */
+void Capabilities_GetAinSummary(CapabilitiesAinSummary* out_summary);
+
+/**
+ * Fill out_summary from the current tBoardConfig snapshot.
+ *
+ * @param[out] out_summary must not be NULL.
+ */
+void Capabilities_GetDioSummary(CapabilitiesDioSummary* out_summary);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _DAQIFI_CAPABILITIES_H */

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -39,6 +39,7 @@
 
 /* SD write metrics accessed via sd_card_manager API */
 #include "../streaming.h"
+#include "../Capabilities.h"
 #include "Util/StreamingBufferPool.h"
 #include "state/data/AInSample.h"
 #include "../csv_encoder.h"
@@ -3214,6 +3215,63 @@ static scpi_result_t SCPI_WincGateQ(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+/*
+ * CONFigure:CAPabilities:APIVersion?
+ * Returns the capability schema version byte so clients can dispatch
+ * to the right parser before issuing any other capability query. See
+ * Capabilities.h (DAQIFI_CAPABILITIES_VERSION) and issue #327.
+ */
+static scpi_result_t SCPI_CapabilitiesApiVersionGet(scpi_t * context) {
+    SCPI_ResultUInt32(context, (uint32_t)DAQIFI_CAPABILITIES_VERSION);
+    return SCPI_RES_OK;
+}
+
+/*
+ * CONFigure:CAPabilities:AIN?
+ * Summary of public ADC topology for the current board. Bitmasks are
+ * indexed by DaqifiAdcChannelId so a client that already knows the
+ * user-facing channel numbers can index them directly.
+ */
+static scpi_result_t SCPI_CapabilitiesAinGet(scpi_t * context) {
+    CapabilitiesAinSummary s;
+    Capabilities_GetAinSummary(&s);
+
+    char buf[160];
+    int n = snprintf(buf, sizeof(buf),
+        "PublicCount=%u,Type1Count=%u,Type2Count=%u,"
+        "Type1Mask=%u,Type2Mask=%u,Resolution=%u,HasAD7609=%u",
+        (unsigned)s.publicChannelCount,
+        (unsigned)s.type1Count,
+        (unsigned)s.type2Count,
+        (unsigned)s.type1Bitmask,
+        (unsigned)s.type2Bitmask,
+        (unsigned)s.primaryResolutionBits,
+        (unsigned)s.hasAD7609);
+    if (n < 0 || (size_t)n >= sizeof(buf)) return SCPI_RES_ERR;
+    SCPI_ResultCharacters(context, buf, (size_t)n);
+    return SCPI_RES_OK;
+}
+
+/*
+ * CONFigure:CAPabilities:DIO?
+ * Summary of DIO topology + PWM-capable pin bitmask (bit N set ⇒
+ * DIO_N has an OCMP mapping and accepts PWM config). Clients gate
+ * their UI's PWM controls on this mask.
+ */
+static scpi_result_t SCPI_CapabilitiesDioGet(scpi_t * context) {
+    CapabilitiesDioSummary s;
+    Capabilities_GetDioSummary(&s);
+
+    char buf[96];
+    int n = snprintf(buf, sizeof(buf),
+        "ChannelCount=%u,PwmCapableMask=%u",
+        (unsigned)s.channelCount,
+        (unsigned)s.pwmCapableMask);
+    if (n < 0 || (size_t)n >= sizeof(buf)) return SCPI_RES_ERR;
+    SCPI_ResultCharacters(context, buf, (size_t)n);
+    return SCPI_RES_OK;
+}
+
 static const scpi_command_t scpi_commands[] = {
     // Build into libscpi
     {.pattern = "*CLS", .callback = SCPI_CoreCls,},
@@ -3360,6 +3418,10 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:ADC:RANGe?", .callback = SCPI_ADCChanRangeGet,},
     {.pattern = "CONFigure:ADC:CHANnel", .callback = SCPI_ADCChanEnableSet,},
     {.pattern = "CONFigure:ADC:CHANnel?", .callback = SCPI_ADCChanEnableGet,},
+    /* Capability framework (#327) — see Capabilities.h */
+    {.pattern = "CONFigure:CAPabilities:APIVersion?", .callback = SCPI_CapabilitiesApiVersionGet,},
+    {.pattern = "CONFigure:CAPabilities:AIN?", .callback = SCPI_CapabilitiesAinGet,},
+    {.pattern = "CONFigure:CAPabilities:DIO?", .callback = SCPI_CapabilitiesDioGet,},
     {.pattern = "CONFigure:ADC:chanCALM", .callback = SCPI_ADCChanCalmSet,},
     {.pattern = "CONFigure:ADC:chanCALB", .callback = SCPI_ADCChanCalbSet,},
     {.pattern = "CONFigure:ADC:chanCALM?", .callback = SCPI_ADCChanCalmGet,},


### PR DESCRIPTION
## Summary

First slice of the #327 capability framework — three SCPI queries that describe the instrument's topology plus a version byte for future parser dispatch.

```
CONFigure:CAPabilities:APIVersion?
→ 1

CONFigure:CAPabilities:AIN?
→ PublicCount=16,Type1Count=5,Type2Count=11,Type1Mask=21776,Type2Mask=43759,Resolution=12,HasAD7609=0

CONFigure:CAPabilities:DIO?
→ ChannelCount=16,PwmCapableMask=249
```

## Design

- **Bitmasks indexed by user-facing channel ID** (0..15), not board-config array index — clients go mask-in → channel-ID-out without translating.
- **Unquoted key=value responses** via `SCPI_ResultCharacters` (matches the contract established in #340 for `CONF:ADC:MAXFreq?`).
- **New `Capabilities.{c,h}` module** wraps board-config reads behind typed summary structs. The follow-up rollup PR (`CONFigure:CAPabilities:JSON?`) and the protobuf extension will reuse these without re-walking the board config.

## Scope

- ✅ Version byte (starts at 1; bump on breaking schema changes only)
- ✅ AIN topology summary
- ✅ DIO topology summary
- ❌ Per-channel introspection — deferred to the rollup PR
- ❌ Protobuf extension — deferred to the rollup PR
- ❌ Rollup `CONFigure:CAPabilities:JSON?` — follow-up PR

## Coordination

This PR, #340 (`CONF:ADC:MAXFreq?`), and the forthcoming rollup PR merge atomically — clients shouldn't see a partial capability set in the wild.

## Test plan

- [x] Clean build at `-Werror -O3`
- [x] Flash + `*IDN?` handshake
- [x] `CONF:CAP:APIV?` → `1`
- [x] `CONF:CAP:AIN?` on NQ1:
  - `Type1Mask=21776` = bits 4,8,10,12,14 (matches the CLAUDE.md "ADC Architecture" table — MODULE0..4 dedicated channels)
  - `Type2Mask=43759` = bits 0,1,2,3,5,6,7,9,11,13,15 (shared MODULE7)
  - `PublicCount=16`, `HasAD7609=0` (NQ1 is MC12b-only), `Resolution=12`
- [x] `CONF:CAP:DIO?`:
  - `PwmCapableMask=249` = bits 0,3,4,5,6,7 (from `DIOConfig.IsPwmCapable`)
  - `ChannelCount=16`

Part of #327. Companion PRs: #340 (streaming cap query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)