### PR TITLE
feat: capability rollup + protobuf extension (#327 final)

### DIFF
--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -410,6 +410,7 @@
         <itemPath>../src/services/streaming.h</itemPath>
         <itemPath>../src/services/JSON_Encoder.h</itemPath>
         <itemPath>../src/services/csv_encoder.h</itemPath>
+        <itemPath>../src/services/Capabilities.h</itemPath>
       </logicalFolder>
       <logicalFolder name="state" displayName="state" projectFiles="true">
         <logicalFolder name="board" displayName="board" projectFiles="true">
@@ -984,6 +985,7 @@
         <itemPath>../src/services/streaming.c</itemPath>
         <itemPath>../src/services/JSON_Encoder.c</itemPath>
         <itemPath>../src/services/csv_encoder.c</itemPath>
+        <itemPath>../src/services/Capabilities.c</itemPath>
       </logicalFolder>
       <logicalFolder name="state" displayName="state" projectFiles="true">
         <logicalFolder name="board" displayName="board" projectFiles="true">

--- a/firmware/src/services/Capabilities.c
+++ b/firmware/src/services/Capabilities.c
@@ -81,6 +81,12 @@ void Capabilities_GetDioSummary(CapabilitiesDioSummary* out_summary) {
 
     const DIOArray* dio = &cfg->DIOChannels;
     out_summary->channelCount = (uint16_t)dio->Size;
+    /* INVARIANT: DIO channel number == DIOChannels.Data[] index. The
+     * DIOConfig struct has no explicit channel-ID field because the
+     * entire firmware relies on this mapping (see DIOProbe, DIO HAL,
+     * SCPI DIO callbacks). If a future board variant breaks that
+     * invariant, this mask becomes meaningless — add a ChannelId
+     * field to DIOConfig first and use it here. */
     for (uint32_t i = 0; i < dio->Size; i++) {
         if (dio->Data[i].IsPwmCapable && i < 16) {
             out_summary->pwmCapableMask |= (uint16_t)(1u << i);

--- a/firmware/src/services/Capabilities.c
+++ b/firmware/src/services/Capabilities.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "state/board/BoardConfig.h"
+#include "services/streaming.h"
 
 void Capabilities_GetAinSummary(CapabilitiesAinSummary* out_summary) {
     if (out_summary == NULL) return;
@@ -81,6 +82,7 @@ void Capabilities_GetDioSummary(CapabilitiesDioSummary* out_summary) {
 
     const DIOArray* dio = &cfg->DIOChannels;
     out_summary->channelCount = (uint16_t)dio->Size;
+
     /* INVARIANT: DIO channel number == DIOChannels.Data[] index. The
      * DIOConfig struct has no explicit channel-ID field because the
      * entire firmware relies on this mapping (see DIOProbe, DIO HAL,
@@ -92,4 +94,21 @@ void Capabilities_GetDioSummary(CapabilitiesDioSummary* out_summary) {
             out_summary->pwmCapableMask |= (uint16_t)(1u << i);
         }
     }
+}
+
+void Capabilities_GetStreamingSummary(CapabilitiesStreamingSummary* out_summary) {
+    if (out_summary == NULL) return;
+    memset(out_summary, 0, sizeof(*out_summary));
+
+    uint16_t type1 = 0;
+    uint16_t total = 0;
+    Streaming_CountActiveChannels(&type1, &total, NULL);
+    /* Mirrors SCPI_GetMaxStreamFreq: 0 public channels → no valid
+     * streaming rate. Reporting the ISR ceiling in that state would
+     * advertise rates that StartStreamData would reject. */
+    out_summary->maxFreqHz = (total > 0) ? Streaming_ComputeMaxFreq(type1, total) : 0;
+    out_summary->isrMaxHz      = STREAMING_ISR_MAX_HZ;
+    out_summary->type1AggMaxHz = STREAMING_TYPE1_AGG_MAX_HZ;
+    out_summary->tickBudget    = STREAMING_TICK_BUDGET;
+    out_summary->tickOverhead  = STREAMING_TICK_OVERHEAD;
 }

--- a/firmware/src/services/Capabilities.c
+++ b/firmware/src/services/Capabilities.c
@@ -1,0 +1,83 @@
+#define LOG_LVL LOG_LEVEL_DEBUG
+#define LOG_MODULE LOG_MODULE_GENERAL
+/*! @file Capabilities.c
+ *
+ * Builds capability summaries from the live tBoardConfig. See
+ * Capabilities.h for API and issue #327 for the full framework.
+ */
+
+#include "Capabilities.h"
+
+#include <string.h>
+
+#include "state/board/BoardConfig.h"
+
+void Capabilities_GetAinSummary(CapabilitiesAinSummary* out_summary) {
+    if (out_summary == NULL) return;
+    memset(out_summary, 0, sizeof(*out_summary));
+
+    /* Per CLAUDE.md, BoardConfig_Get indexes a static array populated at
+     * boot and never returns NULL. No guard. */
+    const tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+
+    uint8_t resolution = 0;
+    const AInArray* channels = &cfg->AInChannels;
+    for (uint32_t i = 0; i < channels->Size; i++) {
+        const AInChannel* ch = &channels->Data[i];
+
+        bool isPublic = false;
+        uint8_t channelType = 0;     /* 1 = Type 1, 2 = Type 2 (shared) */
+        uint8_t channelBits = 0;
+        if (ch->Type == AIn_MC12bADC) {
+            isPublic = ch->Config.MC12b.IsPublic;
+            channelType = (ch->Config.MC12b.ChannelType == 1) ? 1 : 2;
+            channelBits = 12;
+        } else if (ch->Type == AIn_AD7609) {
+            isPublic = ch->Config.AD7609.IsPublic;
+            channelType = 1;  /* AD7609 converts all 8 channels simultaneously */
+            channelBits = 18;
+            if (isPublic) out_summary->hasAD7609 = true;
+        }
+
+        if (!isPublic) continue;
+
+        /* Bitmask index uses the DaqifiAdcChannelId (user-facing channel
+         * number), not the board-config array index. Keeps the mask
+         * meaningful to a client that already knows channels by ID. */
+        uint8_t channelId = ch->DaqifiAdcChannelId;
+        if (channelId < 16) {
+            if (channelType == 1) {
+                out_summary->type1Bitmask |= (uint16_t)(1u << channelId);
+                out_summary->type1Count++;
+            } else {
+                out_summary->type2Bitmask |= (uint16_t)(1u << channelId);
+                out_summary->type2Count++;
+            }
+        }
+        out_summary->publicChannelCount++;
+
+        /* Primary resolution = whichever ADC type the public channels
+         * are predominantly using. NQ1 is all MC12b (12-bit), NQ3 is
+         * all AD7609 (18-bit). NQ2 mixes — if any AD7609 channel is
+         * public, report the higher resolution. */
+        if (channelBits > resolution) resolution = channelBits;
+    }
+    out_summary->primaryResolutionBits = resolution;
+}
+
+void Capabilities_GetDioSummary(CapabilitiesDioSummary* out_summary) {
+    if (out_summary == NULL) return;
+    memset(out_summary, 0, sizeof(*out_summary));
+
+    /* Per CLAUDE.md, BoardConfig_Get indexes a static array populated at
+     * boot and never returns NULL. No guard. */
+    const tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+
+    const DIOArray* dio = &cfg->DIOChannels;
+    out_summary->channelCount = (uint16_t)dio->Size;
+    for (uint32_t i = 0; i < dio->Size; i++) {
+        if (dio->Data[i].IsPwmCapable && i < 16) {
+            out_summary->pwmCapableMask |= (uint16_t)(1u << i);
+        }
+    }
+}

--- a/firmware/src/services/Capabilities.c
+++ b/firmware/src/services/Capabilities.c
@@ -43,16 +43,22 @@ void Capabilities_GetAinSummary(CapabilitiesAinSummary* out_summary) {
 
         /* Bitmask index uses the DaqifiAdcChannelId (user-facing channel
          * number), not the board-config array index. Keeps the mask
-         * meaningful to a client that already knows channels by ID. */
+         * meaningful to a client that already knows channels by ID.
+         * Counts always increment so the invariant
+         *   type1Count + type2Count == publicChannelCount
+         * holds even for boards with channel IDs >= 16 where the
+         * bitmask can't represent them. */
         uint8_t channelId = ch->DaqifiAdcChannelId;
-        if (channelId < 16) {
-            if (channelType == 1) {
+        if (channelType == 1) {
+            if (channelId < 16) {
                 out_summary->type1Bitmask |= (uint16_t)(1u << channelId);
-                out_summary->type1Count++;
-            } else {
-                out_summary->type2Bitmask |= (uint16_t)(1u << channelId);
-                out_summary->type2Count++;
             }
+            out_summary->type1Count++;
+        } else {
+            if (channelId < 16) {
+                out_summary->type2Bitmask |= (uint16_t)(1u << channelId);
+            }
+            out_summary->type2Count++;
         }
         out_summary->publicChannelCount++;
 

--- a/firmware/src/services/Capabilities.h
+++ b/firmware/src/services/Capabilities.h
@@ -1,0 +1,88 @@
+#ifndef _DAQIFI_CAPABILITIES_H
+#define _DAQIFI_CAPABILITIES_H
+
+/*
+ * Capabilities.h — vendor-neutral capability framework for DAQiFi.
+ *
+ * See issue #327 for the full vision. This module is the firmware
+ * reference implementation of the capability schema: clients query
+ * SCPI capability commands and render themselves from the response
+ * rather than hard-coding board variants or channel counts.
+ *
+ * This PR introduces the foundation pieces (version byte, AIN
+ * topology summary, DIO topology summary). The unified
+ * `CONFigure:CAPabilities:JSON?` rollup + protobuf extension land
+ * in a follow-up PR that composes what's here.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * SCPI capability schema version byte.
+ *
+ * Clients use this to decide which parser to apply before issuing
+ * any other capability query. Increment on any BREAKING change to
+ * the capability schema — i.e. field renames/removals, type
+ * changes, semantics changes on existing fields.
+ *
+ * Do NOT bump for additive changes — adding a new capability
+ * command or a new key=value field in an existing response is
+ * additive and safe for older clients.
+ *
+ * History:
+ *   1 — Initial version. AIN/DIO capability summaries + API
+ *       version query. (#327)
+ */
+#define DAQIFI_CAPABILITIES_VERSION ((uint8_t)1)
+
+/*
+ * Summary of analog-input topology from the current board config.
+ * All counts are for PUBLIC channels (user-facing) — internal
+ * monitoring channels are excluded because clients rendering a UI
+ * shouldn't see or control them. See issue #327.
+ */
+typedef struct {
+    uint16_t publicChannelCount;   /* public AIn channels total */
+    uint16_t type1Count;           /* dedicated-ADC (simultaneous) channels */
+    uint16_t type2Count;           /* shared-ADC (muxed) channels */
+    uint16_t type1Bitmask;         /* bit N set ⇒ channel N is Type 1 */
+    uint16_t type2Bitmask;         /* bit N set ⇒ channel N is Type 2 */
+    bool     hasAD7609;            /* any AD7609 (external 18-bit) channel present */
+    uint8_t  primaryResolutionBits;/* dominant ADC resolution (12=MC12b, 18=AD7609) */
+} CapabilitiesAinSummary;
+
+/*
+ * Summary of DIO topology. Bitmasks are indexed by DIO channel
+ * number (bit 0 = DIO_0, etc). Clients use these to know which
+ * pins accept which runtime configurations without probing.
+ */
+typedef struct {
+    uint16_t channelCount;      /* configured DIO channels (typically 16) */
+    uint16_t pwmCapableMask;    /* bit N set ⇒ DIO_N has an OCMP mapping */
+} CapabilitiesDioSummary;
+
+/**
+ * Fill out_summary from the current tBoardConfig snapshot.
+ * Safe to call from any task context — reads are idempotent.
+ *
+ * @param[out] out_summary must not be NULL.
+ */
+void Capabilities_GetAinSummary(CapabilitiesAinSummary* out_summary);
+
+/**
+ * Fill out_summary from the current tBoardConfig snapshot.
+ *
+ * @param[out] out_summary must not be NULL.
+ */
+void Capabilities_GetDioSummary(CapabilitiesDioSummary* out_summary);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _DAQIFI_CAPABILITIES_H */

--- a/firmware/src/services/Capabilities.h
+++ b/firmware/src/services/Capabilities.h
@@ -66,6 +66,28 @@ typedef struct {
     uint16_t pwmCapableMask;    /* bit N set ⇒ DIO_N has an OCMP mapping */
 } CapabilitiesDioSummary;
 
+/*
+ * Streaming cap state for the currently-enabled channel set.
+ * The cap formula constants (ISR ceiling, Type 1 aggregate max,
+ * per-tick budget and overhead) are compile-time in the firmware
+ * but emitted here so clients can predict caps for hypothetical
+ * configurations locally without round-tripping.
+ */
+typedef struct {
+    uint32_t maxFreqHz;         /* current-config cap; 0 if no channels */
+    uint32_t isrMaxHz;
+    uint32_t type1AggMaxHz;
+    uint32_t tickBudget;
+    uint32_t tickOverhead;
+} CapabilitiesStreamingSummary;
+
+/**
+ * Fill out_summary with current streaming cap + formula constants.
+ *
+ * @param[out] out_summary must not be NULL.
+ */
+void Capabilities_GetStreamingSummary(CapabilitiesStreamingSummary* out_summary);
+
 /**
  * Fill out_summary from the current tBoardConfig snapshot.
  * Safe to call from any task context — reads are idempotent.

--- a/firmware/src/services/Capabilities.h
+++ b/firmware/src/services/Capabilities.h
@@ -9,10 +9,16 @@
  * SCPI capability commands and render themselves from the response
  * rather than hard-coding board variants or channel counts.
  *
- * This PR introduces the foundation pieces (version byte, AIN
- * topology summary, DIO topology summary). The unified
- * `CONFigure:CAPabilities:JSON?` rollup + protobuf extension land
- * in a follow-up PR that composes what's here.
+ * Current coverage:
+ *   - DAQIFI_CAPABILITIES_VERSION (schema version byte)
+ *   - Streaming cap + formula constants
+ *     (CONFigure:ADC:MAXFreq?)
+ *   - AIN / DIO topology summaries
+ *     (CONFigure:CAPabilities:AIN? / :DIO?)
+ *   - Unified JSON rollup
+ *     (CONFigure:CAPabilities:JSON?)
+ *   - Capability fields embedded in DaqifiOutMessage protobuf
+ *     (tags 70..75, see DaqifiOutMessage.proto)
  */
 
 #include <stdbool.h>

--- a/firmware/src/services/DaqifiPB/DaqifiOutMessage.pb.h
+++ b/firmware/src/services/DaqifiPB/DaqifiOutMessage.pb.h
@@ -125,6 +125,15 @@ typedef struct _DaqifiOutMessage { /* Put repetitive information in first 15 fie
     char device_hw_rev[16]; /* Device hardware revision */
     char device_fw_rev[16]; /* Device firmware revision */
     uint64_t device_sn; /* Device serial number */
+    /* Capability framework (#327) — streaming cap metadata emitted
+     * alongside device identity so a PB-only client can dispatch
+     * without issuing a parallel SCPI query. */
+    uint32_t cap_version;       /* DAQIFI_CAPABILITIES_VERSION */
+    uint32_t cap_max_freq_hz;   /* current-config streaming cap */
+    uint32_t cap_isr_max_hz;    /* formula constant */
+    uint32_t cap_type1_agg_hz;  /* formula constant */
+    uint32_t cap_tick_budget;   /* formula constant */
+    uint32_t cap_tick_overhead; /* formula constant */
 } DaqifiOutMessage;
 
 
@@ -202,6 +211,12 @@ extern "C" {
 #define DaqifiOutMessage_device_hw_rev_tag       67
 #define DaqifiOutMessage_device_fw_rev_tag       68
 #define DaqifiOutMessage_device_sn_tag           69
+#define DaqifiOutMessage_cap_version_tag         70
+#define DaqifiOutMessage_cap_max_freq_hz_tag     71
+#define DaqifiOutMessage_cap_isr_max_hz_tag      72
+#define DaqifiOutMessage_cap_type1_agg_hz_tag    73
+#define DaqifiOutMessage_cap_tick_budget_tag     74
+#define DaqifiOutMessage_cap_tick_overhead_tag   75
 
 /* Struct field encoding specification for nanopb */
 #define DaqifiOutMessage_FIELDLIST(X, a) \
@@ -269,7 +284,13 @@ X(a, STATIC,   REPEATED, UINT32,   av_wifi_inf_mode,  65) \
 X(a, STATIC,   SINGULAR, STRING,   device_pn,        66) \
 X(a, STATIC,   SINGULAR, STRING,   device_hw_rev,    67) \
 X(a, STATIC,   SINGULAR, STRING,   device_fw_rev,    68) \
-X(a, STATIC,   SINGULAR, UINT64,   device_sn,        69)
+X(a, STATIC,   SINGULAR, UINT64,   device_sn,        69) \
+X(a, STATIC,   SINGULAR, UINT32,   cap_version,      70) \
+X(a, STATIC,   SINGULAR, UINT32,   cap_max_freq_hz,  71) \
+X(a, STATIC,   SINGULAR, UINT32,   cap_isr_max_hz,   72) \
+X(a, STATIC,   SINGULAR, UINT32,   cap_type1_agg_hz, 73) \
+X(a, STATIC,   SINGULAR, UINT32,   cap_tick_budget,  74) \
+X(a, STATIC,   SINGULAR, UINT32,   cap_tick_overhead, 75)
 #define DaqifiOutMessage_CALLBACK NULL
 #define DaqifiOutMessage_DEFAULT NULL
 

--- a/firmware/src/services/DaqifiPB/DaqifiOutMessage.proto
+++ b/firmware/src/services/DaqifiPB/DaqifiOutMessage.proto
@@ -93,4 +93,17 @@ message DaqifiOutMessage
 	string device_hw_rev = 67;						//  Device hardware revision
 	string device_fw_rev = 68;						//  Device firmware revision
     uint64 device_sn = 69;                         //  Device serial number
+
+    // Capability framework (#327) — optional top-level fields so a
+    // client that receives a device-info message can learn the
+    // streaming frequency cap for the reported channel configuration
+    // without a second round-trip. Full capability schema is still
+    // owned by the SCPI CONFigure:CAPabilities:JSON? command; these
+    // fields carry the most actionable subset inline.
+    uint32 cap_version         = 70;  // DAQIFI_CAPABILITIES_VERSION
+    uint32 cap_max_freq_hz     = 71;  // current-config streaming cap
+    uint32 cap_isr_max_hz      = 72;  // formula constant
+    uint32 cap_type1_agg_hz    = 73;  // formula constant
+    uint32 cap_tick_budget     = 74;  // formula constant
+    uint32 cap_tick_overhead   = 75;  // formula constant
 }

--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -390,6 +390,12 @@ size_t Nanopb_Encode(tBoardData* state,
         return 0;
     }
 
+    /* Streaming cap summary is the same for every cap_* tag in this
+     * field list — lazy-init once here instead of re-walking the
+     * channel config on each case-block hit. */
+    CapabilitiesStreamingSummary capStream;
+    bool capStreamCached = false;
+
 
     for (i = 0; i < fields->Size; i++) {
         switch (fields->Data[i]) {
@@ -1071,18 +1077,16 @@ size_t Nanopb_Encode(tBoardData* state,
             case DaqifiOutMessage_cap_type1_agg_hz_tag:
             case DaqifiOutMessage_cap_tick_budget_tag:
             case DaqifiOutMessage_cap_tick_overhead_tag:
-            {
-                /* Pull all streaming cap fields in one summary call to
-                 * avoid re-walking the channel config once per field. */
-                CapabilitiesStreamingSummary cap;
-                Capabilities_GetStreamingSummary(&cap);
-                message.cap_max_freq_hz    = cap.maxFreqHz;
-                message.cap_isr_max_hz     = cap.isrMaxHz;
-                message.cap_type1_agg_hz   = cap.type1AggMaxHz;
-                message.cap_tick_budget    = cap.tickBudget;
-                message.cap_tick_overhead  = cap.tickOverhead;
+                if (!capStreamCached) {
+                    Capabilities_GetStreamingSummary(&capStream);
+                    capStreamCached = true;
+                }
+                message.cap_max_freq_hz    = capStream.maxFreqHz;
+                message.cap_isr_max_hz     = capStream.isrMaxHz;
+                message.cap_type1_agg_hz   = capStream.type1AggMaxHz;
+                message.cap_tick_budget    = capStream.tickBudget;
+                message.cap_tick_overhead  = capStream.tickOverhead;
                 break;
-            }
             default:
                 // Skip unknown fields
                 break;

--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -17,6 +17,7 @@
 #include "HAL/TimerApi/TimerApi.h"
 #include "state/board/BoardConfig.h"
 #include "HAL/DIO.h"
+#include "services/Capabilities.h"
 #ifndef min
 #define min(x,y) ((x) <= (y) ? (x) : (y))
 #endif // min
@@ -317,6 +318,15 @@ static int Nanopb_EncodeLength(const NanopbFlagsArray* fields) {
 
             case DaqifiOutMessage_device_sn_tag:
                 len += sizeof (out->device_sn);
+                break;
+
+            case DaqifiOutMessage_cap_version_tag:
+            case DaqifiOutMessage_cap_max_freq_hz_tag:
+            case DaqifiOutMessage_cap_isr_max_hz_tag:
+            case DaqifiOutMessage_cap_type1_agg_hz_tag:
+            case DaqifiOutMessage_cap_tick_budget_tag:
+            case DaqifiOutMessage_cap_tick_overhead_tag:
+                len += sizeof(uint32_t);
                 break;
 
             default:
@@ -1050,6 +1060,26 @@ size_t Nanopb_Encode(tBoardData* state,
             case DaqifiOutMessage_device_sn_tag:
                 message.device_sn = pBoardConfig->boardSerialNumber;
                 break;
+            case DaqifiOutMessage_cap_version_tag:
+                message.cap_version = DAQIFI_CAPABILITIES_VERSION;
+                break;
+            case DaqifiOutMessage_cap_max_freq_hz_tag:
+            case DaqifiOutMessage_cap_isr_max_hz_tag:
+            case DaqifiOutMessage_cap_type1_agg_hz_tag:
+            case DaqifiOutMessage_cap_tick_budget_tag:
+            case DaqifiOutMessage_cap_tick_overhead_tag:
+            {
+                /* Pull all streaming cap fields in one summary call to
+                 * avoid re-walking the channel config once per field. */
+                CapabilitiesStreamingSummary cap;
+                Capabilities_GetStreamingSummary(&cap);
+                message.cap_max_freq_hz    = cap.maxFreqHz;
+                message.cap_isr_max_hz     = cap.isrMaxHz;
+                message.cap_type1_agg_hz   = cap.type1AggMaxHz;
+                message.cap_tick_budget    = cap.tickBudget;
+                message.cap_tick_overhead  = cap.tickOverhead;
+                break;
+            }
             default:
                 // Skip unknown fields
                 break;

--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -326,7 +326,10 @@ static int Nanopb_EncodeLength(const NanopbFlagsArray* fields) {
             case DaqifiOutMessage_cap_type1_agg_hz_tag:
             case DaqifiOutMessage_cap_tick_budget_tag:
             case DaqifiOutMessage_cap_tick_overhead_tag:
-                len += sizeof(uint32_t);
+                /* Worst-case varint + 2-byte tag (field numbers 70–75
+                 * are > 15 so PB_TAG2_SIZE applies). sizeof(uint32_t)
+                 * would under-estimate by ~3 bytes per field. */
+                len += PB_VARINT32_MAX + PB_TAG2_SIZE;
                 break;
 
             default:

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -222,32 +222,11 @@ scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
     }
     uint16_t activeType1ChannelCount = 0;
     uint16_t totalEnabledPublicChannels = 0;
-    bool hasActiveAD7609Channels __attribute__((unused)) = false;
+    Streaming_CountActiveChannels(&activeType1ChannelCount,
+                                  &totalEnabledPublicChannels,
+                                  NULL);
     uint64_t freq = pRunTimeStreamConfig->Frequency;
     uint32_t clkFreq = TimerApi_FrequencyGet(pBoardConfig->StreamingConfig.TimerIndex);
-    int i;
-
-    // Count active channels and detect AD7609 usage
-    for (i = 0; i < pBoardConfigAInChannels->Size; i++) {
-        if (pRuntimeAInChannels->Data[i].IsEnabled == 1) {
-            bool isPublic = false;
-            if (pBoardConfigAInChannels->Data[i].Type == AIn_AD7609) {
-                isPublic = pBoardConfigAInChannels->Data[i].Config.AD7609.IsPublic;
-                if (isPublic) {
-                    hasActiveAD7609Channels = true;
-                    totalEnabledPublicChannels++;
-                }
-            } else if (pBoardConfigAInChannels->Data[i].Type == AIn_MC12bADC) {
-                isPublic = pBoardConfigAInChannels->Data[i].Config.MC12b.IsPublic;
-                if (isPublic) {
-                    totalEnabledPublicChannels++;
-                    if (pBoardConfigAInChannels->Data[i].Config.MC12b.ChannelType == 1) {
-                        activeType1ChannelCount++;
-                    }
-                }
-            }
-        }
-    }
 
     // Three-constraint frequency capping (see streaming.h)
     {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3283,6 +3283,73 @@ static scpi_result_t SCPI_CapabilitiesDioGet(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+/*
+ * CONFigure:CAPabilities:JSON?
+ * Unified capability rollup per issue #327. Composes APIVersion +
+ * identity + AIN + DIO + streaming cap into a single self-describing
+ * JSON document so a new client can populate an entire UI from one
+ * query instead of chaining four.
+ *
+ * Emits via scpi_printf in chunks. Each scpi_printf call writes
+ * directly to the libscpi transport via interface->write — same
+ * mechanism other diagnostic dumps use (SYST:POW:BQ:REGisters?,
+ * SYST:WINC:GATE?). Chunked so the formatted document can exceed
+ * the scpi_printf 192-byte buffer as the schema grows.
+ *
+ * Format is JSON rather than key=value because the schema has
+ * nested structure (identity, ain, dio, streaming) — that grows
+ * better as structured data than as a flat key list.
+ */
+static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
+    const tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+    CapabilitiesAinSummary a;
+    CapabilitiesDioSummary d;
+    CapabilitiesStreamingSummary st;
+    Capabilities_GetAinSummary(&a);
+    Capabilities_GetDioSummary(&d);
+    Capabilities_GetStreamingSummary(&st);
+
+    scpi_printf(context,
+        "{\"version\":%u,"
+        "\"identity\":{\"vendor\":\"DAQiFi\",\"model\":\"Nyquist\","
+        "\"variant\":%u,\"firmware\":\"%s\",\"hardware\":\"%s\","
+        "\"serial_hex\":\"%llX\"},",
+        (unsigned)DAQIFI_CAPABILITIES_VERSION,
+        (unsigned)cfg->BoardVariant,
+        cfg->boardFirmwareRev,
+        cfg->boardHardwareRev,
+        (unsigned long long)cfg->boardSerialNumber);
+
+    scpi_printf(context,
+        "\"ain\":{\"public_count\":%u,\"type1_count\":%u,\"type2_count\":%u,"
+        "\"type1_mask\":%u,\"type2_mask\":%u,\"resolution_bits\":%u,"
+        "\"has_ad7609\":%s},",
+        (unsigned)a.publicChannelCount,
+        (unsigned)a.type1Count,
+        (unsigned)a.type2Count,
+        (unsigned)a.type1Bitmask,
+        (unsigned)a.type2Bitmask,
+        (unsigned)a.primaryResolutionBits,
+        a.hasAD7609 ? "true" : "false");
+
+    scpi_printf(context,
+        "\"dio\":{\"channel_count\":%u,\"pwm_capable_mask\":%u},",
+        (unsigned)d.channelCount,
+        (unsigned)d.pwmCapableMask);
+
+    scpi_printf(context,
+        "\"streaming\":{\"max_freq_hz\":%u,\"isr_max_hz\":%u,"
+        "\"type1_agg_max_hz\":%u,\"tick_budget\":%u,\"tick_overhead\":%u}}"
+        "\r\n",
+        (unsigned)st.maxFreqHz,
+        (unsigned)st.isrMaxHz,
+        (unsigned)st.type1AggMaxHz,
+        (unsigned)st.tickBudget,
+        (unsigned)st.tickOverhead);
+
+    return SCPI_RES_OK;
+}
+
 static const scpi_command_t scpi_commands[] = {
     // Build into libscpi
     {.pattern = "*CLS", .callback = SCPI_CoreCls,},
@@ -3434,6 +3501,7 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:CAPabilities:APIVersion?", .callback = SCPI_CapabilitiesApiVersionGet,},
     {.pattern = "CONFigure:CAPabilities:AIN?", .callback = SCPI_CapabilitiesAinGet,},
     {.pattern = "CONFigure:CAPabilities:DIO?", .callback = SCPI_CapabilitiesDioGet,},
+    {.pattern = "CONFigure:CAPabilities:JSON?", .callback = SCPI_CapabilitiesJsonGet,},
     {.pattern = "CONFigure:ADC:chanCALM", .callback = SCPI_ADCChanCalmSet,},
     {.pattern = "CONFigure:ADC:chanCALB", .callback = SCPI_ADCChanCalbSet,},
     {.pattern = "CONFigure:ADC:chanCALM?", .callback = SCPI_ADCChanCalmGet,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2448,7 +2448,10 @@ static scpi_result_t SCPI_GetMaxStreamFreq(scpi_t * context) {
     uint16_t type1 = 0;
     uint16_t total = 0;
     Streaming_CountActiveChannels(&type1, &total, NULL);
-    uint32_t maxFreq = Streaming_ComputeMaxFreq(type1, total);
+    /* Zero enabled channels → no valid stream rate. Report 0 instead of
+     * the ISR ceiling so a client that drives the UI from this response
+     * doesn't silently offer rates that StartStreamData would reject. */
+    uint32_t maxFreq = (total > 0) ? Streaming_ComputeMaxFreq(type1, total) : 0;
 
     char buf[160];
     int n = snprintf(buf, sizeof(buf),

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2056,41 +2056,13 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     // timer running frequency
     uint32_t clkFreq = TimerApi_FrequencyGet(pBoardConfig->StreamingConfig.TimerIndex);
 
-    //int i;
     uint16_t activeType1ChannelCount = 0;
     uint16_t totalEnabledPublicChannels = 0;
-    bool hasActiveAD7609Channels __attribute__((unused)) = false;
-    int i;
-    bool hasEnabledChannels = false;
-
-    // Count active PUBLIC ADC channels and detect AD7609 usage
-    // Internal monitoring channels (IsPublic=false) don't count as user channels
-    // Use minimum of both array sizes to prevent out-of-bounds access
-    size_t adcCount = pBoardConfigADC->Size < pRuntimeAInChannels->Size ?
-                      pBoardConfigADC->Size : pRuntimeAInChannels->Size;
-    for (i = 0; i < (int)adcCount; i++) {
-        if (pRuntimeAInChannels->Data[i].IsEnabled == 1) {
-            // Check IsPublic based on channel type (it's in the union)
-            bool isPublic = false;
-            if (pBoardConfigADC->Data[i].Type == AIn_AD7609) {
-                isPublic = pBoardConfigADC->Data[i].Config.AD7609.IsPublic;
-                if (isPublic) {
-                    hasEnabledChannels = true;
-                    hasActiveAD7609Channels = true;
-                    totalEnabledPublicChannels++;
-                }
-            } else if (pBoardConfigADC->Data[i].Type == AIn_MC12bADC) {
-                isPublic = pBoardConfigADC->Data[i].Config.MC12b.IsPublic;
-                if (isPublic) {
-                    hasEnabledChannels = true;
-                    totalEnabledPublicChannels++;
-                    if (pBoardConfigADC->Data[i].Config.MC12b.ChannelType == 1) {
-                        activeType1ChannelCount++;
-                    }
-                }
-            }
-        }
-    }
+    bool hasActiveAD7609Channels = false;
+    Streaming_CountActiveChannels(&activeType1ChannelCount,
+                                  &totalEnabledPublicChannels,
+                                  &hasActiveAD7609Channels);
+    bool hasEnabledChannels = (totalEnabledPublicChannels > 0);
 
     // Build channel mapping for compact sample pool (#177).
     // Must happen before pool partitioning (needs channel count for element sizing).
@@ -2460,6 +2432,39 @@ static scpi_result_t SCPI_IsStreaming(scpi_t * context) {
             BOARDRUNTIME_STREAMING_CONFIGURATION);
 
     SCPI_ResultInt32(context, (int) pRunTimeStreamConfig->IsEnabled);
+    return SCPI_RES_OK;
+}
+
+/*
+ * CONFigure:ADC:MAXFreq?
+ * Reports the three-constraint streaming frequency cap for the currently
+ * enabled public ADC channels, plus the formula constants so clients can
+ * predict caps for hypothetical channel configurations without a round
+ * trip. Format: key=value pairs, comma-separated, so the existing
+ * key=value SCPI-response parsers in python-core / daqifi-core can split
+ * on ',' and '=' without a format bump. See #283.
+ */
+static scpi_result_t SCPI_GetMaxStreamFreq(scpi_t * context) {
+    uint16_t type1 = 0;
+    uint16_t total = 0;
+    Streaming_CountActiveChannels(&type1, &total, NULL);
+    uint32_t maxFreq = Streaming_ComputeMaxFreq(type1, total);
+
+    char buf[160];
+    int n = snprintf(buf, sizeof(buf),
+        "MaxFreqHz=%u,Type1Count=%u,TotalChannels=%u,"
+        "IsrMaxHz=%u,Type1AggMaxHz=%u,TickBudget=%u,TickOverhead=%u",
+        (unsigned)maxFreq,
+        (unsigned)type1,
+        (unsigned)total,
+        (unsigned)STREAMING_ISR_MAX_HZ,
+        (unsigned)STREAMING_TYPE1_AGG_MAX_HZ,
+        (unsigned)STREAMING_TICK_BUDGET,
+        (unsigned)STREAMING_TICK_OVERHEAD);
+    if (n < 0 || (size_t)n >= sizeof(buf)) {
+        return SCPI_RES_ERR;
+    }
+    SCPI_ResultText(context, buf);
     return SCPI_RES_OK;
 }
 
@@ -3418,6 +3423,7 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:ADC:RANGe?", .callback = SCPI_ADCChanRangeGet,},
     {.pattern = "CONFigure:ADC:CHANnel", .callback = SCPI_ADCChanEnableSet,},
     {.pattern = "CONFigure:ADC:CHANnel?", .callback = SCPI_ADCChanEnableGet,},
+    {.pattern = "CONFigure:ADC:MAXFreq?", .callback = SCPI_GetMaxStreamFreq,},
     /* Capability framework (#327) — see Capabilities.h */
     {.pattern = "CONFigure:CAPabilities:APIVersion?", .callback = SCPI_CapabilitiesApiVersionGet,},
     {.pattern = "CONFigure:CAPabilities:AIN?", .callback = SCPI_CapabilitiesAinGet,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -39,6 +39,7 @@
 
 /* SD write metrics accessed via sd_card_manager API */
 #include "../streaming.h"
+#include "../Capabilities.h"
 #include "Util/StreamingBufferPool.h"
 #include "state/data/AInSample.h"
 #include "../csv_encoder.h"
@@ -3214,6 +3215,63 @@ static scpi_result_t SCPI_WincGateQ(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+/*
+ * CONFigure:CAPabilities:APIVersion?
+ * Returns the capability schema version byte so clients can dispatch
+ * to the right parser before issuing any other capability query. See
+ * Capabilities.h (DAQIFI_CAPABILITIES_VERSION) and issue #327.
+ */
+static scpi_result_t SCPI_CapabilitiesApiVersionGet(scpi_t * context) {
+    SCPI_ResultUInt32(context, (uint32_t)DAQIFI_CAPABILITIES_VERSION);
+    return SCPI_RES_OK;
+}
+
+/*
+ * CONFigure:CAPabilities:AIN?
+ * Summary of public ADC topology for the current board. Bitmasks are
+ * indexed by DaqifiAdcChannelId so a client that already knows the
+ * user-facing channel numbers can index them directly.
+ */
+static scpi_result_t SCPI_CapabilitiesAinGet(scpi_t * context) {
+    CapabilitiesAinSummary s;
+    Capabilities_GetAinSummary(&s);
+
+    char buf[160];
+    int n = snprintf(buf, sizeof(buf),
+        "PublicCount=%u,Type1Count=%u,Type2Count=%u,"
+        "Type1Mask=%u,Type2Mask=%u,Resolution=%u,HasAD7609=%u",
+        (unsigned)s.publicChannelCount,
+        (unsigned)s.type1Count,
+        (unsigned)s.type2Count,
+        (unsigned)s.type1Bitmask,
+        (unsigned)s.type2Bitmask,
+        (unsigned)s.primaryResolutionBits,
+        (unsigned)s.hasAD7609);
+    if (n < 0 || (size_t)n >= sizeof(buf)) return SCPI_RES_ERR;
+    SCPI_ResultCharacters(context, buf, (size_t)n);
+    return SCPI_RES_OK;
+}
+
+/*
+ * CONFigure:CAPabilities:DIO?
+ * Summary of DIO topology + PWM-capable pin bitmask (bit N set ⇒
+ * DIO_N has an OCMP mapping and accepts PWM config). Clients gate
+ * their UI's PWM controls on this mask.
+ */
+static scpi_result_t SCPI_CapabilitiesDioGet(scpi_t * context) {
+    CapabilitiesDioSummary s;
+    Capabilities_GetDioSummary(&s);
+
+    char buf[96];
+    int n = snprintf(buf, sizeof(buf),
+        "ChannelCount=%u,PwmCapableMask=%u",
+        (unsigned)s.channelCount,
+        (unsigned)s.pwmCapableMask);
+    if (n < 0 || (size_t)n >= sizeof(buf)) return SCPI_RES_ERR;
+    SCPI_ResultCharacters(context, buf, (size_t)n);
+    return SCPI_RES_OK;
+}
+
 static const scpi_command_t scpi_commands[] = {
     // Build into libscpi
     {.pattern = "*CLS", .callback = SCPI_CoreCls,},
@@ -3360,6 +3418,10 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:ADC:RANGe?", .callback = SCPI_ADCChanRangeGet,},
     {.pattern = "CONFigure:ADC:CHANnel", .callback = SCPI_ADCChanEnableSet,},
     {.pattern = "CONFigure:ADC:CHANnel?", .callback = SCPI_ADCChanEnableGet,},
+    /* Capability framework (#327) — see Capabilities.h */
+    {.pattern = "CONFigure:CAPabilities:APIVersion?", .callback = SCPI_CapabilitiesApiVersionGet,},
+    {.pattern = "CONFigure:CAPabilities:AIN?", .callback = SCPI_CapabilitiesAinGet,},
+    {.pattern = "CONFigure:CAPabilities:DIO?", .callback = SCPI_CapabilitiesDioGet,},
     {.pattern = "CONFigure:ADC:chanCALM", .callback = SCPI_ADCChanCalmSet,},
     {.pattern = "CONFigure:ADC:chanCALB", .callback = SCPI_ADCChanCalbSet,},
     {.pattern = "CONFigure:ADC:chanCALM?", .callback = SCPI_ADCChanCalmGet,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2464,7 +2464,10 @@ static scpi_result_t SCPI_GetMaxStreamFreq(scpi_t * context) {
     if (n < 0 || (size_t)n >= sizeof(buf)) {
         return SCPI_RES_ERR;
     }
-    SCPI_ResultText(context, buf);
+    /* SCPI_ResultCharacters emits raw bytes; SCPI_ResultText would wrap
+     * the payload in double quotes (see libscpi parser.c), which would
+     * break the unquoted key=value contract documented for this query. */
+    SCPI_ResultCharacters(context, buf, (size_t)n);
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3309,6 +3309,12 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
     Capabilities_GetDioSummary(&d);
     Capabilities_GetStreamingSummary(&st);
 
+    /* INVARIANT: boardFirmwareRev and boardHardwareRev come from the
+     * FIRMWARE_REVISION / HARDWARE_REVISION macros in version.h and
+     * are version strings like "3.4.6b1" — no characters that need
+     * JSON escaping (no `"`, `\`, or control chars). If a future
+     * revision scheme ever introduces such characters, add a small
+     * JSON-string escaper before embedding these fields. */
     scpi_printf(context,
         "{\"version\":%u,"
         "\"identity\":{\"vendor\":\"DAQiFi\",\"model\":\"Nyquist\","

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -299,6 +299,44 @@ const AInChannelMapping* Streaming_GetChannelMapping(void) {
     return &gChannelMapping;
 }
 
+void Streaming_CountActiveChannels(uint16_t* out_type1Count,
+                                   uint16_t* out_totalPublic,
+                                   bool* out_hasAD7609) {
+    uint16_t type1 = 0;
+    uint16_t total = 0;
+    bool has7609 = false;
+
+    volatile AInRuntimeArray* rt =
+        BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_AIN_CHANNELS);
+    volatile AInArray* cfg =
+        BoardConfig_Get(BOARDCONFIG_AIN_CHANNELS, 0);
+
+    if (rt != NULL && cfg != NULL) {
+        size_t count = (cfg->Size < rt->Size) ? cfg->Size : rt->Size;
+        for (size_t i = 0; i < count; i++) {
+            if (rt->Data[i].IsEnabled != 1) continue;
+
+            if (cfg->Data[i].Type == AIn_AD7609) {
+                if (cfg->Data[i].Config.AD7609.IsPublic) {
+                    has7609 = true;
+                    total++;
+                }
+            } else if (cfg->Data[i].Type == AIn_MC12bADC) {
+                if (cfg->Data[i].Config.MC12b.IsPublic) {
+                    total++;
+                    if (cfg->Data[i].Config.MC12b.ChannelType == 1) {
+                        type1++;
+                    }
+                }
+            }
+        }
+    }
+
+    if (out_type1Count  != NULL) *out_type1Count  = type1;
+    if (out_totalPublic != NULL) *out_totalPublic = total;
+    if (out_hasAD7609   != NULL) *out_hasAD7609   = has7609;
+}
+
 /**
  * @brief Deferred interrupt handler for sample collection.
  *

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -306,27 +306,27 @@ void Streaming_CountActiveChannels(uint16_t* out_type1Count,
     uint16_t total = 0;
     bool has7609 = false;
 
+    /* Per CLAUDE.md: BoardRunTimeConfig_Get / BoardConfig_Get index into
+     * static arrays populated at boot and never return NULL. No guard. */
     volatile AInRuntimeArray* rt =
         BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_AIN_CHANNELS);
     volatile AInArray* cfg =
         BoardConfig_Get(BOARDCONFIG_AIN_CHANNELS, 0);
 
-    if (rt != NULL && cfg != NULL) {
-        size_t count = (cfg->Size < rt->Size) ? cfg->Size : rt->Size;
-        for (size_t i = 0; i < count; i++) {
-            if (rt->Data[i].IsEnabled != 1) continue;
+    size_t count = (cfg->Size < rt->Size) ? cfg->Size : rt->Size;
+    for (size_t i = 0; i < count; i++) {
+        if (rt->Data[i].IsEnabled != 1) continue;
 
-            if (cfg->Data[i].Type == AIn_AD7609) {
-                if (cfg->Data[i].Config.AD7609.IsPublic) {
-                    has7609 = true;
-                    total++;
-                }
-            } else if (cfg->Data[i].Type == AIn_MC12bADC) {
-                if (cfg->Data[i].Config.MC12b.IsPublic) {
-                    total++;
-                    if (cfg->Data[i].Config.MC12b.ChannelType == 1) {
-                        type1++;
-                    }
+        if (cfg->Data[i].Type == AIn_AD7609) {
+            if (cfg->Data[i].Config.AD7609.IsPublic) {
+                has7609 = true;
+                total++;
+            }
+        } else if (cfg->Data[i].Type == AIn_MC12bADC) {
+            if (cfg->Data[i].Config.MC12b.IsPublic) {
+                total++;
+                if (cfg->Data[i].Config.MC12b.ChannelType == 1) {
+                    type1++;
                 }
             }
         }

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "../state/board/BoardConfig.h"
 #include "../state/runtime/BoardRuntimeConfig.h"
 #include "../state/data/BoardData.h"
@@ -78,7 +81,22 @@ static inline uint32_t Streaming_ComputeMaxFreq(uint32_t type1Count, uint32_t to
     if (maxFreq == 0) maxFreq = 1;
     return maxFreq;
 }
-    
+
+/**
+ * Count enabled public ADC channels from current board + runtime config.
+ * Used by SCPI_StartStreaming, the ADC channel-enable path, and the
+ * MAXFreq query so they all agree on what counts toward the cap.
+ *
+ * @param[out] out_type1Count     Enabled MC12bADC ChannelType=1 (Type 1) channels
+ * @param[out] out_totalPublic    Total enabled IsPublic channels (both ADC types)
+ * @param[out] out_hasAD7609      true if any enabled IsPublic channel is AD7609
+ *
+ * Any out_* pointer may be NULL.
+ */
+void Streaming_CountActiveChannels(uint16_t* out_type1Count,
+                                   uint16_t* out_totalPublic,
+                                   bool* out_hasAD7609);
+
 /*! Initializes the streaming component
  * @param[in] pStreamingConfigInit Streaming configuration
  * @param[out] pStreamingRuntimeConfigInit Streaming configuration in runtime


### PR DESCRIPTION
## Summary

Final PR in the three-PR capability bundle. Composes the pieces from #340 and #341 into a single unified rollup query and extends the protobuf device-info message with streaming cap metadata. Stacked on top of #340 + #341 — cherry-picks #340's commits so this branch is reviewable end-to-end.

```
CONFigure:CAPabilities:JSON?
→ {"version":1,
   "identity":{"vendor":"DAQiFi","model":"Nyquist","variant":1,
               "firmware":"3.4.6b1","hardware":"2.0.0","serial_hex":"..."},
   "ain":{"public_count":16,"type1_count":5,"type2_count":11,
          "type1_mask":21776,"type2_mask":43759,
          "resolution_bits":12,"has_ad7609":false},
   "dio":{"channel_count":16,"pwm_capable_mask":249},
   "streaming":{"max_freq_hz":0,"isr_max_hz":13000,
                "type1_agg_max_hz":55000,"tick_budget":110000,
                "tick_overhead":6}}
```

Plus six new optional `uint32` fields in `DaqifiOutMessage.proto` (tags 70–75) carrying streaming-cap metadata so a PB-only client can learn the cap without a parallel SCPI query.

## Design notes

- **JSON over key=value** for the rollup because the schema has nested structure (`identity`, `ain`, `dio`, `streaming`) and grows better as structured data. The flat `key=value` queries from #341 stay for quick targeted access; JSON is for the full UI-populating rollup.
- **Chunked `scpi_printf`** (same mechanism as `SYST:POW:BQ:REGisters?`, `SYST:WINC:GATE?`) so the document can exceed 192 bytes as the schema grows — no fixed-size buffer ceiling.
- **Shared streaming-cap helper** (`Capabilities_GetStreamingSummary`) factors the `Streaming_ComputeMaxFreq + formula-constants` read so the JSON rollup and the PB encoder get their cap numbers from one place. `CONF:ADC:MAXFreq?` (from #340) behaves identically.

## Scope vs #327 spec

- ✅ Unified rollup command
- ✅ Protobuf top-level fields (streaming-cap subset)
- ✅ Identity block (vendor/model/variant/fw/hw/serial)
- ✅ AIN + DIO topology (composed from #341)
- ✅ Streaming cap composed from #340
- ❌ Per-channel introspection — deferred; flat `:AIN?/:DIO?` queries cover the common case
- ❌ Broader DIO flags (input/output/counter/trigger) — current schema only exposes `pwm_capable_mask`; the others can grow additively without a version bump
- ❌ Analog outputs / storage / transports / power / triggers blocks — additive future expansion

## Test plan

- [x] Clean build at `-Werror -O3`
- [x] Flash + `*IDN?` handshake
- [x] `CONF:CAP:JSON?` returns parseable JSON on NQ1:
  - All sections present (`version`, `identity`, `ain`, `dio`, `streaming`)
  - Fields match individual queries (`:APIV?`, `:AIN?`, `:DIO?`, `CONF:ADC:MAXF?`)
- [x] Older individual queries still work unchanged
- [x] Protobuf encoder compiles with new tags — full device-info message still within buffer limits

## Coordination

This PR chains on #340 (`CONF:ADC:MAXFreq?`) and #341 (building blocks) — the three PRs merge atomically so clients never see a partial capability schema in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)