### PR TITLE
fix(scpi): move SYSInfoPB buffer to static to avoid WifiTask stack overflow (#347)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2,6 +2,7 @@
 #define LOG_MODULE LOG_MODULE_SCPI
 
 #include "SCPIInterface.h"
+#include "semphr.h"  // #347: mutex for SysInfoGet static buffer
 
 
 //// General
@@ -394,6 +395,19 @@ scpi_result_t SCPI_Help(scpi_t* context);
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error
  */
 
+// #347: mutex guarding gSysInfoBuffer. Created once in CreateSCPIContext().
+// USB and TCP SCPI run on separate tasks at different priorities; both may
+// call SCPI_SysInfoGet concurrently, so the shared buffer must be serialized.
+static SemaphoreHandle_t gSysInfoMutex = NULL;
+
+// #347: moved from stack to BSS to avoid WifiTask stack overflow. WifiTask
+// has a 1024-word stack; TCP → microrl → libscpi already consumes ~808
+// words on entry, leaving only ~216 free. A 2008-byte stack-local buffer
+// plus Nanopb frame overhead would push total demand past the stack end,
+// corrupting adjacent FreeRTOS state (observed: USB CDC + TCP both hang
+// until power cycle). USB CDC path has a 3 KB+ stack so it was safe there.
+static uint8_t gSysInfoBuffer[DaqifiOutMessage_size];
+
 static scpi_result_t SCPI_SysInfoGet(scpi_t * context) {
     int param1;
     tBoardData * pBoardData = BoardData_Get(BOARDDATA_ALL_DATA, 0);
@@ -402,22 +416,26 @@ static scpi_result_t SCPI_SysInfoGet(scpi_t * context) {
         param1 = 0;
     }
 
-    // #347: static (not stack-allocated). The TCP path runs this callback on
-    // WifiTask (1024-word / 4 KB stack). Measured depth at entry via TCP was
-    // 808 words; adding a 2008-byte stack buffer plus Nanopb frame overhead
-    // overflows the stack by ~280+ words, corrupting adjacent FreeRTOS state
-    // and killing USB CDC + TCP until power cycle. USB CDC path has a 3 KB+
-    // stack and had always been safe — that's why it wasn't caught before.
-    static uint8_t buffer[DaqifiOutMessage_size];
+    if (gSysInfoMutex != NULL &&
+        xSemaphoreTake(gSysInfoMutex, portMAX_DELAY) != pdTRUE) {
+        return SCPI_RES_ERR;
+    }
+
     size_t count = Nanopb_Encode(
             pBoardData,
             (const NanopbFlagsArray *) &fields_info,
-            buffer, DaqifiOutMessage_size);
+            gSysInfoBuffer, DaqifiOutMessage_size);
+    scpi_result_t result = SCPI_RES_OK;
     if (count < 1) {
-        return SCPI_RES_ERR;
+        result = SCPI_RES_ERR;
+    } else {
+        context->interface->write(context, (char*) gSysInfoBuffer, count);
     }
-    context->interface->write(context, (char*) buffer, count);
-    return SCPI_RES_OK;
+
+    if (gSysInfoMutex != NULL) {
+        xSemaphoreGive(gSysInfoMutex);
+    }
+    return result;
 }
 
 
@@ -3541,6 +3559,12 @@ size_t SCPI_WriteWithRetry(ScpiTransportWriteFn writeFn,
 }
 
 scpi_t CreateSCPIContext(scpi_interface_t* interface, void* user_context) {
+    // #347: init the SysInfoGet buffer mutex once (both USB and WiFi init
+    // call this during boot; boot is single-threaded so no race here).
+    if (gSysInfoMutex == NULL) {
+        gSysInfoMutex = xSemaphoreCreateMutex();
+    }
+
     // Construct model string from BoardConfig.BoardVariant (e.g., "Nq3")
     static char modelString[8] = {0};  // Initialize to prevent garbage data
     const tBoardConfig* pBoardConfig = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3561,8 +3561,15 @@ size_t SCPI_WriteWithRetry(ScpiTransportWriteFn writeFn,
 scpi_t CreateSCPIContext(scpi_interface_t* interface, void* user_context) {
     // #347: init the SysInfoGet buffer mutex once (both USB and WiFi init
     // call this during boot; boot is single-threaded so no race here).
+    // If creation fails (OOM at boot — extremely unlikely since heap is
+    // fresh), SCPI_SysInfoGet falls through without serialization. This
+    // LOG_E surfaces the degraded state so operators can notice.
     if (gSysInfoMutex == NULL) {
         gSysInfoMutex = xSemaphoreCreateMutex();
+        if (gSysInfoMutex == NULL) {
+            LOG_E("SCPI: failed to create SysInfoGet mutex — concurrent "
+                  "USB+TCP SysInfoPB may corrupt responses");
+        }
     }
 
     // Construct model string from BoardConfig.BoardVariant (e.g., "Nq3")

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -402,7 +402,13 @@ static scpi_result_t SCPI_SysInfoGet(scpi_t * context) {
         param1 = 0;
     }
 
-    uint8_t buffer[DaqifiOutMessage_size];
+    // #347: static (not stack-allocated). The TCP path runs this callback on
+    // WifiTask (1024-word / 4 KB stack). Measured depth at entry via TCP was
+    // 808 words; adding a 2008-byte stack buffer plus Nanopb frame overhead
+    // overflows the stack by ~280+ words, corrupting adjacent FreeRTOS state
+    // and killing USB CDC + TCP until power cycle. USB CDC path has a 3 KB+
+    // stack and had always been safe — that's why it wasn't caught before.
+    static uint8_t buffer[DaqifiOutMessage_size];
     size_t count = Nanopb_Encode(
             pBoardData,
             (const NanopbFlagsArray *) &fields_info,


### PR DESCRIPTION
## Summary

Fixes #347 — USB CDC control endpoint hangs after a single TCP interaction on port 9760.

**Root cause**: `SCPI_SysInfoGet` allocates `uint8_t buffer[DaqifiOutMessage_size]` (2008 bytes) on the caller's stack. When invoked via the TCP path (`wifi_tcp_server_ProcessReceivedBuff` → microrl → libscpi → callback), it runs on **WifiTask** which has only a **1024-word (4 KB) stack**.

Measured via `uxTaskGetStackHighWaterMark(NULL)` at callback entry on the TCP path:

| Metric | Words | Bytes |
|---|---:|---:|
| WifiTask stack total | 1024 | 4096 |
| Used at `SCPI_SysInfoGet` entry (TCP path) | 808 | 3232 |
| Free at entry | 216 | 864 |
| `buffer[2008]` stack demand | 502 | 2008 |
| Nanopb_Encode frame overhead (~) | 50-100 | 200-400 |
| **Total peak needed** | **~1360** | **~5440** |
| **Overflow** | **~280+** | **~1120+** |

The overflow corrupts adjacent FreeRTOS state. Symptom: USB CDC control-endpoint class requests stop being dispatched (TIOCMBIC ETIMEDOUT ~6 s) and TCP SCPI stops responding on the same socket. Device requires power cycle to recover.

USB path uses `app_USBDeviceTask`'s 3072-word (12 KB) stack, so the stack-allocated buffer always fit there. That's why this wasn't caught pre-merge — nobody hit it via TCP at the right depth.

**Fix**: declare `buffer` as `static`, moving it from stack to BSS. Stack depth at entry drops to just library frame overhead. Additional static allocation: 2008 bytes (negligible vs ~83 KB RAM headroom per CLAUDE.md).

## Reproduction (pre-fix, FW 3.4.6b1+)

Device in STA mode on an external AP:
1. Open + close `/dev/ttyACM0` → OK
2. Configure + apply LAN settings via serial → OK  
3. Wait 10 s, open + close serial → OK
4. Over TCP port 9760: `socket.connect` + `sendall(b"SYSTem:SYSInfoPB?\r\n")` + `recv(0.5s timeout)` + `close` → returns 0 bytes
5. Try to open `/dev/ttyACM0` → **hangs ~5 s on TIOCMBIC ETIMEDOUT, device fully unresponsive**

## Verification

With the fix:
- 5 consecutive repros, step-5 serial open = **1 ms each** (no hang)
- TCP recv returns full **591-byte protobuf** response
- USB `SYSTem:SYSInfoPB?` returns correct **593-byte protobuf** (unchanged behavior)

## Test plan

- [x] Build clean (NQ1 default config)
- [x] Flash and reconfigure STA on external AP
- [x] Repro pre-fix: hang reproduces 1/1
- [x] Apply fix, rebuild, reflash
- [x] Repro post-fix: 5/5 clean, no hang
- [x] USB `SYSTem:SYSInfoPB?` still returns valid protobuf
- [ ] Optional defense-in-depth follow-up: audit other SCPI callbacks for large stack-allocated buffers that could be exposed via TCP (`SCPI_Help` has a 512-byte buffer — safer margin, but worth review)

## Not in this PR

Other SCPI callbacks with smaller stack buffers (≤512 bytes) were not touched. They have safer stack margins but deserve a follow-up audit. Consider also bumping WifiTask stack from 1024 to 2048 words as defense-in-depth for unknown similar cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)