### PR TITLE
fix(rtos): bump WifiTask stack 1024→2048 words for TCP SCPI depth (#347 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,7 +652,7 @@ The PIC32MZ2048**EF**M144 has a hardware 64-bit double-precision FPU (Coprocesso
 | 7 | `app_USBDeviceTask` | 3072 | 1290 | SCPI callbacks use 512-byte locals |
 | 6 | `streaming_Task` | 1392 | 692 | Encodes PB/CSV/JSON + outputs, FPU (CSV/JSON at precision>0) |
 | 5 | `app_SDCardTask` | 1024 | 468 | SD mount/write/read/list/delete |
-| 2 | `app_WifiTask` | 1024 | 360 | WiFi state machine + TCP |
+| 2 | `app_WifiTask` | 2048 | 808 (at TCP SCPI callback entry) | WiFi state machine + TCP; SCPI path consumes ~800 words on TCP, bumped from 1024 per #347 |
 | 2 | `lWDRV_WINC_Tasks` | 1024 | 290 | WINC1500 driver background |
 | 2 | `fwUpdateTask` | 128 | 62 | WiFi FW update (dynamic) |
 | 1 | `lAPP_FREERTOS_Tasks` | 1500 | 1156 | Boot init (77% used) |

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -701,7 +701,16 @@ static void app_TasksCreate() {
 
     errStatus = xTaskCreate((TaskFunction_t) app_WifiTask,
             "WifiTask",
-            1024,  // Profiled: 360 words peak. 3x margin for unknown WiFi driver depth. (was 3000)
+            2048,  // #347 defense-in-depth: was 1024 (profiled 360-word peak on WiFi
+                   // state machine alone). TCP SCPI path (wifi_tcp_server → microrl →
+                   // libscpi → callback) consumes ~808 words at callback entry.
+                   // Callbacks with large stack buffers (SCPI_Help 512 B, SCPI_SysInfoPB
+                   // 2008 B, benchmark 512 B) could push past the 1024 limit and
+                   // corrupt adjacent FreeRTOS state — observed on #347 with
+                   // SysInfoPB (which is also individually fixed with static buffer).
+                   // 2048 words gives ~1000-word headroom over the measured 808-word
+                   // TCP-SCPI entry depth, covering current callbacks and plausible
+                   // future ones without per-site static-buffer fixes.
             NULL,
             2,
             NULL);


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to PR #348 (which fixed the specific stack overflow in `SCPI_SysInfoGet`).

## Why

During #347 debug we instrumented `SCPI_SysInfoGet` and measured `uxTaskGetStackHighWaterMark(NULL)` at its entry on the TCP path:

> WifiTask stack: 1024 words total  
> Used at callback entry: 808 words (TCP handler → microrl → libscpi → callback)  
> Free at entry: 216 words (864 bytes) — all that's left for the callback body

That's an alarmingly small budget. Audit of all SCPI callbacks with stack buffers ≥256 bytes, called on the TCP path:

| Callback | Stack buffer | Peak stack use (TCP) | Free margin on 1024 |
|---|---:|---:|---:|
| `SCPI_Help` | 512 B | ~976 words | **48 words — dangerously close** |
| `SCPI_SysInfoTextGet` | 256 B | ~908 words | 116 words |
| `SCPI_GetCommandHistory` | 256 B | ~908 words | 116 words |
| `SCPIStorageSD` benchmark | 512 B + fs depth | ~948 words + | tight |
| `SCPI_SysInfoGet` | 2008 B | 1310 words | **overflow (fixed static in #348)** |

`SCPI_Help` especially is one frame allocation away from the same corruption `SCPI_SysInfoGet` caused.

## What changed

- `firmware/src/app_freertos.c`: `app_WifiTask` stack 1024 → 2048 words.
- `CLAUDE.md`: task priority map updated with new size + measured 808-word TCP-SCPI entry peak. (The old "360 peak" was the WiFi state machine alone, before TCP SCPI path was exercised at depth.)

## Why stack bump rather than per-site static

- One change covers every current **and future** SCPI callback. Any new callback added after this PR automatically benefits.
- No new mutex/statics per-callback — no per-site reentrancy logic.
- Cost: +4 KB BSS, well within ~83 KB RAM headroom (per CLAUDE.md memory budget).
- SysInfoGet's static+mutex fix in #348 stays in place — its 2008 B buffer is large enough to be worth keeping off the stack regardless.

## Verification

- Build clean on NQ1 default config.
- Flash NQ1 hardware, STA mode joined to Tesla WiFi.
- `SYST:MEM:STACk?` confirms: `WifiTask: prio=2, hwm=1708 words (6832 bytes free)` — massive headroom.
- #347 repro still 3/3 clean (`SYSTem:SYSInfoPB?` over TCP + serial reopen).

## Test plan

- [x] Build NQ1 default
- [x] Flash hardware, confirm stack size in `SYST:MEM:STACk?`
- [x] Repro #347 scenario — 3/3 clean, device stays responsive on both USB and TCP
- [ ] Build NQ3 config (does not regress)
- [ ] Stress test: rapid `HELP` over TCP, mixed with USB SCPI — not run

🤖 Generated with [Claude Code](https://claude.com/claude-code)