### PR TITLE
fix(scpi): shared SCPI response buffer + static FreeRTOS alloc (#347 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -649,7 +649,7 @@ The PIC32MZ2048**EF**M144 has a hardware 64-bit double-precision FPU (Coprocesso
 | 9 | `MC12bADC_EosInterruptTask` | 160 | 80 | ADC end-of-scan deferred interrupt |
 | 9 | `AD7609_DeferredInterruptTask` | 160 | 76 | AD7609 BSY pin handler |
 | 7 | `app_PowerAndUITask` | 512 | 226 | UI + BQ24297 power, FPU |
-| 7 | `app_USBDeviceTask` | 3072 | 1290 | SCPI callbacks use 512-byte locals |
+| 7 | `app_USBDeviceTask` | 3072 | 1290 | SCPI callbacks use shared response buffer (see below) |
 | 6 | `streaming_Task` | 1392 | 692 | Encodes PB/CSV/JSON + outputs, FPU (CSV/JSON at precision>0) |
 | 5 | `app_SDCardTask` | 1024 | 468 | SD mount/write/read/list/delete |
 | 2 | `app_WifiTask` | 1024 | 360 | WiFi state machine + TCP |
@@ -662,6 +662,8 @@ The PIC32MZ2048**EF**M144 has a hardware 64-bit double-precision FPU (Coprocesso
 Stack sizes profiled under stress: 16ch@5kHz PB/CSV/JSON + SD file ops + WiFi TCP + power cycles. Sized at 2-3x measured peak. Query at runtime: `SYST:MEM:STACk?`
 
 **WARNING**: If recursive SD directory listing is enabled, `app_SDCardTask` needs 10KB+ (~550 bytes per nesting level).
+
+**SCPI shared response buffer**: Any SCPI callback needing ≥256 B of scratch MUST use `SCPI_ResponseBuf_Take()` / `SCPI_ResponseBuf_Give()` rather than a stack local. The shared buffer is a single 2048-byte static in BSS guarded by a statically-allocated mutex (`configSUPPORT_STATIC_ALLOCATION=1`). Rationale: WifiTask's stack is only 1024 words; the TCP → microrl → libscpi path consumes ~808 words before the callback runs, so a large stack-local buffer inside a SCPI callback can overflow (issue #347). Callers that use the shared pattern keep SCPI stack depth below the measured 372-word WifiTask peak. Current users: `SCPI_SysInfoGet`, `SCPI_SysInfoTextGet`, `SCPI_GetCommandHistory`, `SCPI_Help`, `SCPI_StorageSDBenchmark`.
 
 **Scheduling implications**: Capture tasks at priority 9 preempt everything to guarantee deterministic sample timing. The encoder at priority 6 preempts WiFi/WINC/background (priority 2) and SD (priority 5), but stays below USB (7) so SCPI commands remain responsive during streaming. SD task at priority 5 sits above background transports but below encoder — prevents encoder from starving SD writes when USB+SD both active. Encoder's `Streaming_WriteWithRetry` uses `vTaskDelay(1)` (not `taskYIELD()`) in its retry loop so lower-priority SD actually gets CPU to drain circular buffer (#312). See `docs/PIPELINE_TIMING.md` for measurements (PR #308, Sessions 7-17).
 

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -109,6 +109,7 @@ bool SPI0_Mutex_Initialize(void);  // No-op function when coordination disabled
 #include "HAL/ADC.h"
 #include "services/streaming.h"
 #include "HAL/UI/UI.h"
+#include "services/SCPI/SCPIInterface.h"
 // *****************************************************************************
 // *****************************************************************************
 // Section: Global Data Definitions
@@ -426,6 +427,10 @@ void app_PowerAndUITask(void) {
 }
 
 void app_SystemInit() {
+    // #347 / #350: init the shared SCPI response-buffer mutex before any
+    // transport creates its SCPI context or dispatches a callback.
+    SCPI_ResponseBuf_Init();
+
     // Initialize SPI coordination framework (currently disabled)
     // Note: Coordination disabled (SPI0_COORDINATION_ENABLED=0) - no runtime overhead
     // To enable frequency benchmarking: Set SPI0_COORDINATION_ENABLED=1 and rebuild

--- a/firmware/src/config/default/FreeRTOSConfig.h
+++ b/firmware/src/config/default/FreeRTOSConfig.h
@@ -245,7 +245,7 @@
  * memory in the build.  Set to 0 to exclude the ability to create statically
  * allocated objects from the build.  Defaults to 0 if left undefined.  See
  * https://www.freertos.org/Static_Vs_Dynamic_Memory_Allocation.html. */
-#define configSUPPORT_STATIC_ALLOCATION         0
+#define configSUPPORT_STATIC_ALLOCATION         1
 
 /* Set configSUPPORT_DYNAMIC_ALLOCATION to 1 to include FreeRTOS API functions
  * that create FreeRTOS objects (tasks, queues, etc.) using dynamically allocated

--- a/firmware/src/config/default/freertos_hooks.c
+++ b/firmware/src/config/default/freertos_hooks.c
@@ -123,6 +123,21 @@ void vApplicationMallocFailedHook( void )
 }
 /*-----------------------------------------------------------*/
 
+/* Required when configSUPPORT_STATIC_ALLOCATION == 1. FreeRTOS calls this to
+ * obtain storage for the Idle task TCB + stack. Only vApplicationGetIdleTaskMemory
+ * is mandatory in this firmware (configUSE_TIMERS == 0, so no timer hook needed). */
+void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
+                                    StackType_t **ppxIdleTaskStackBuffer,
+                                    configSTACK_DEPTH_TYPE *puxIdleTaskStackSize )
+{
+    static StaticTask_t xIdleTaskTCB;
+    static StackType_t uxIdleTaskStack[configMINIMAL_STACK_SIZE];
+    *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+    *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+    *puxIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
+/*-----------------------------------------------------------*/
+
 void vApplicationIdleHook( void )
 {
     /* vApplicationIdleHook() will only be called if configUSE_IDLE_HOOK is set

--- a/firmware/src/config/default/freertos_hooks.c
+++ b/firmware/src/config/default/freertos_hooks.c
@@ -123,9 +123,10 @@ void vApplicationMallocFailedHook( void )
 }
 /*-----------------------------------------------------------*/
 
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+
 /* Required when configSUPPORT_STATIC_ALLOCATION == 1. FreeRTOS calls this to
- * obtain storage for the Idle task TCB + stack. Only vApplicationGetIdleTaskMemory
- * is mandatory in this firmware (configUSE_TIMERS == 0, so no timer hook needed). */
+ * obtain storage for the Idle task TCB + stack. */
 void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
                                     StackType_t **ppxIdleTaskStackBuffer,
                                     configSTACK_DEPTH_TYPE *puxIdleTaskStackSize )
@@ -136,6 +137,24 @@ void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
     *ppxIdleTaskStackBuffer = uxIdleTaskStack;
     *puxIdleTaskStackSize = configMINIMAL_STACK_SIZE;
 }
+
+#if ( configUSE_TIMERS == 1 )
+/* Required only when configUSE_TIMERS == 1 (not currently — this firmware
+ * has configUSE_TIMERS == 0). Provided for future-proofing: if software
+ * timers are later enabled, this hook will already be in place. */
+void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
+                                     StackType_t **ppxTimerTaskStackBuffer,
+                                     configSTACK_DEPTH_TYPE *puxTimerTaskStackSize )
+{
+    static StaticTask_t xTimerTaskTCB;
+    static StackType_t uxTimerTaskStack[configTIMER_TASK_STACK_DEPTH];
+    *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
+    *ppxTimerTaskStackBuffer = uxTimerTaskStack;
+    *puxTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
+}
+#endif /* configUSE_TIMERS */
+
+#endif /* configSUPPORT_STATIC_ALLOCATION */
 /*-----------------------------------------------------------*/
 
 void vApplicationIdleHook( void )

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -408,12 +408,21 @@ static StaticSemaphore_t gScpiRespMutexStorage;
 static SemaphoreHandle_t gScpiRespMutex = NULL;
 
 void SCPI_ResponseBuf_Init(void) {
-    // Idempotent: if SCPI_Init is called more than once (e.g. directly from
-    // app boot AND implicitly from the first CreateSCPIContext), the second
-    // call is a no-op.
+    // Idempotent: if SCPI_ResponseBuf_Init is called more than once (e.g.
+    // directly from app boot AND implicitly from the first CreateSCPIContext),
+    // the second call is a no-op.
+    //
+    // The check-and-create pair is guarded by a critical section. The
+    // intended caller is single-threaded (app_SystemInit runs pre-scheduler,
+    // then CreateSCPIContext runs during serial boot-time transport init)
+    // and taskENTER_CRITICAL is a no-op before the scheduler starts, so this
+    // is cost-free in practice. The guard catches any future misuse where
+    // SCPI_ResponseBuf_Init is invoked concurrently.
+    taskENTER_CRITICAL();
     if (gScpiRespMutex == NULL) {
         gScpiRespMutex = xSemaphoreCreateMutexStatic(&gScpiRespMutexStorage);
     }
+    taskEXIT_CRITICAL();
 }
 
 uint8_t* SCPI_ResponseBuf_Take(void) {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -407,7 +407,20 @@ static uint8_t gScpiRespBuf[SCPI_RESPONSE_BUF_SIZE];
 static StaticSemaphore_t gScpiRespMutexStorage;
 static SemaphoreHandle_t gScpiRespMutex = NULL;
 
+void SCPI_ResponseBuf_Init(void) {
+    // Idempotent: if SCPI_Init is called more than once (e.g. directly from
+    // app boot AND implicitly from the first CreateSCPIContext), the second
+    // call is a no-op.
+    if (gScpiRespMutex == NULL) {
+        gScpiRespMutex = xSemaphoreCreateMutexStatic(&gScpiRespMutexStorage);
+    }
+}
+
 uint8_t* SCPI_ResponseBuf_Take(void) {
+    // gScpiRespMutex is NULL only if SCPI_ResponseBuf_Init() was not called
+    // before any SCPI dispatch — that would be a programming error. Defensive
+    // NULL return keeps the device alive (caller returns SCPI_RES_ERR) rather
+    // than dereferencing a NULL handle.
     if (gScpiRespMutex == NULL) {
         return NULL;
     }
@@ -2813,9 +2826,14 @@ static scpi_result_t SCPI_GetCommandHistory(scpi_t * context) {
     // Calculate starting position in circular buffer
     int startIdx = (usbSettings->cmdHistoryHead - usbSettings->cmdHistoryCount + SCPI_CMD_HISTORY_SIZE) % SCPI_CMD_HISTORY_SIZE;
 
-    // Send header
+    // Send header — guard against snprintf encoding errors (< 0) and
+    // clamp to buffer size if the output would otherwise be truncated.
     int len = snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "Last %d commands:\r\n", usbSettings->cmdHistoryCount);
-    context->interface->write(context, buffer, len);
+    if (len > 0) {
+        size_t wlen = ((size_t)len < SCPI_RESPONSE_BUF_SIZE)
+                      ? (size_t)len : (SCPI_RESPONSE_BUF_SIZE - 1);
+        context->interface->write(context, buffer, wlen);
+    }
 
     // Send command history
     for (int i = 0; i < usbSettings->cmdHistoryCount; i++) {
@@ -2823,7 +2841,11 @@ static scpi_result_t SCPI_GetCommandHistory(scpi_t * context) {
         len = snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "%d: %s\r\n",
                       usbSettings->cmdHistoryCount - i,
                       usbSettings->cmdHistory[idx]);
-        context->interface->write(context, buffer, len);
+        if (len > 0) {
+            size_t wlen = ((size_t)len < SCPI_RESPONSE_BUF_SIZE)
+                          ? (size_t)len : (SCPI_RESPONSE_BUF_SIZE - 1);
+            context->interface->write(context, buffer, wlen);
+        }
     }
 
     SCPI_ResponseBuf_Give();
@@ -3521,6 +3543,29 @@ static const scpi_command_t scpi_commands[] = {
 char scpi_input_buffer[SCPI_INPUT_BUFFER_LENGTH];
 scpi_error_t scpi_error_queue_data[SCPI_ERROR_QUEUE_SIZE];
 
+// Append formatted text to `buffer` at offset `count`, flushing via
+// `context->interface->write` when the next chunk would overflow. Returns
+// the updated count. snprintf negative returns (encoding errors) are
+// treated as empty append — safer than storing -1 into size_t.
+static size_t scpi_help_append(scpi_t* context, char* buffer, size_t count,
+                               const char* pattern) {
+    size_t cmdSize = strlen(pattern) + 5;  // "  " + pattern + "\r\n"
+    if (count + cmdSize >= SCPI_RESPONSE_BUF_SIZE) {
+        buffer[count] = '\0';
+        context->interface->write(context, buffer, count);
+        count = 0;
+    }
+    int n = snprintf(buffer + count, SCPI_RESPONSE_BUF_SIZE - count,
+                     "  %s\r\n", pattern);
+    if (n > 0) {
+        size_t added = (size_t)n < (SCPI_RESPONSE_BUF_SIZE - count)
+                       ? (size_t)n
+                       : (SCPI_RESPONSE_BUF_SIZE - count - 1);
+        count += added;
+    }
+    return count;
+}
+
 scpi_result_t SCPI_Help(scpi_t* context) {
     // #347: shared SCPI response scratch buffer (was stack-local char[512]).
     char* buffer = (char*)SCPI_ResponseBuf_Take();
@@ -3530,20 +3575,14 @@ scpi_result_t SCPI_Help(scpi_t* context) {
     size_t numCommands = sizeof (scpi_commands) / sizeof (scpi_command_t);
     size_t i = 0;
 
-    size_t count = snprintf(buffer, SCPI_RESPONSE_BUF_SIZE,
-                            "%s", "\r\nImplemented:\r\n");
+    int hdr = snprintf(buffer, SCPI_RESPONSE_BUF_SIZE,
+                       "%s", "\r\nImplemented:\r\n");
+    size_t count = (hdr > 0) ? (size_t)hdr : 0;
     for (i = 0; i < numCommands; ++i) {
         if (scpi_commands[i].callback != SCPI_NotImplemented &&
                 scpi_commands[i].pattern != NULL) {
-            size_t cmdSize = strlen(scpi_commands[i].pattern) + 5;
-            if (count + cmdSize >= SCPI_RESPONSE_BUF_SIZE) {
-                buffer[count] = '\0';
-                context->interface->write(context, buffer, count);
-                count = 0;
-            }
-
-            count += snprintf(buffer + count, SCPI_RESPONSE_BUF_SIZE - count,
-                              "  %s\r\n", scpi_commands[i].pattern);
+            count = scpi_help_append(context, buffer, count,
+                                     scpi_commands[i].pattern);
         }
     }
 
@@ -3551,20 +3590,14 @@ scpi_result_t SCPI_Help(scpi_t* context) {
         context->interface->write(context, buffer, count);
     }
 
-    count = snprintf(buffer, SCPI_RESPONSE_BUF_SIZE,
-                     "%s", "\r\nNot Implemented:\r\n");
+    hdr = snprintf(buffer, SCPI_RESPONSE_BUF_SIZE,
+                   "%s", "\r\nNot Implemented:\r\n");
+    count = (hdr > 0) ? (size_t)hdr : 0;
     for (i = 0; i < numCommands; ++i) {
         if (scpi_commands[i].callback == SCPI_NotImplemented &&
                 scpi_commands[i].pattern != NULL) {
-            size_t cmdSize = strlen(scpi_commands[i].pattern) + 5;
-            if (count + cmdSize >= SCPI_RESPONSE_BUF_SIZE) {
-                buffer[count] = '\0';
-                context->interface->write(context, buffer, count);
-                count = 0;
-            }
-
-            count += snprintf(buffer + count, SCPI_RESPONSE_BUF_SIZE - count,
-                              "  %s\r\n", scpi_commands[i].pattern);
+            count = scpi_help_append(context, buffer, count,
+                                     scpi_commands[i].pattern);
         }
     }
 
@@ -3594,14 +3627,11 @@ size_t SCPI_WriteWithRetry(ScpiTransportWriteFn writeFn,
 }
 
 scpi_t CreateSCPIContext(scpi_interface_t* interface, void* user_context) {
-    // #347: init the shared SCPI response-buffer mutex once, using static
-    // storage so it cannot fail (unlike xSemaphoreCreateMutex which can
-    // return NULL under heap pressure and would leave the buffer
-    // unserialized). Both USB and WiFi init call CreateSCPIContext during
-    // boot, which is single-threaded — no race on the NULL check.
-    if (gScpiRespMutex == NULL) {
-        gScpiRespMutex = xSemaphoreCreateMutexStatic(&gScpiRespMutexStorage);
-    }
+    // Defense in depth: SCPI_ResponseBuf_Init() is supposed to have been
+    // called during app boot before any transport creates its SCPI context.
+    // Call it again here — it's idempotent — so the shared response-buffer
+    // mutex is guaranteed to exist before any callback could dispatch.
+    SCPI_ResponseBuf_Init();
 
     // Construct model string from BoardConfig.BoardVariant (e.g., "Nq3")
     static char modelString[8] = {0};  // Initialize to prevent garbage data

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -401,8 +401,8 @@ scpi_result_t SCPI_Help(scpi_t* context);
 // docs and issue #347 for the underlying stack-overflow story).
 // Statically allocated mutex (configSUPPORT_STATIC_ALLOCATION=1) so there's
 // no heap-allocation failure path.
-static_assert(SCPI_RESPONSE_BUF_SIZE >= DaqifiOutMessage_size,
-              "SCPI_RESPONSE_BUF_SIZE must hold the largest SCPI response");
+_Static_assert(SCPI_RESPONSE_BUF_SIZE >= DaqifiOutMessage_size,
+               "SCPI_RESPONSE_BUF_SIZE must hold the largest SCPI response");
 static uint8_t gScpiRespBuf[SCPI_RESPONSE_BUF_SIZE];
 static StaticSemaphore_t gScpiRespMutexStorage;
 static SemaphoreHandle_t gScpiRespMutex = NULL;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -395,18 +395,33 @@ scpi_result_t SCPI_Help(scpi_t* context);
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error
  */
 
-// #347: mutex guarding gSysInfoBuffer. Created once in CreateSCPIContext().
-// USB and TCP SCPI run on separate tasks at different priorities; both may
-// call SCPI_SysInfoGet concurrently, so the shared buffer must be serialized.
-static SemaphoreHandle_t gSysInfoMutex = NULL;
+// #347: Shared SCPI response scratch buffer. Any SCPI callback needing
+// ≥256 B of scratch should use this instead of a stack local — keeps
+// WifiTask's 1024-word stack safe on the TCP path (see SCPI_ResponseBuf_Take
+// docs and issue #347 for the underlying stack-overflow story).
+// Statically allocated mutex (configSUPPORT_STATIC_ALLOCATION=1) so there's
+// no heap-allocation failure path.
+static_assert(SCPI_RESPONSE_BUF_SIZE >= DaqifiOutMessage_size,
+              "SCPI_RESPONSE_BUF_SIZE must hold the largest SCPI response");
+static uint8_t gScpiRespBuf[SCPI_RESPONSE_BUF_SIZE];
+static StaticSemaphore_t gScpiRespMutexStorage;
+static SemaphoreHandle_t gScpiRespMutex = NULL;
 
-// #347: moved from stack to BSS to avoid WifiTask stack overflow. WifiTask
-// has a 1024-word stack; TCP → microrl → libscpi already consumes ~808
-// words on entry, leaving only ~216 free. A 2008-byte stack-local buffer
-// plus Nanopb frame overhead would push total demand past the stack end,
-// corrupting adjacent FreeRTOS state (observed: USB CDC + TCP both hang
-// until power cycle). USB CDC path has a 3 KB+ stack so it was safe there.
-static uint8_t gSysInfoBuffer[DaqifiOutMessage_size];
+uint8_t* SCPI_ResponseBuf_Take(void) {
+    if (gScpiRespMutex == NULL) {
+        return NULL;
+    }
+    if (xSemaphoreTake(gScpiRespMutex, portMAX_DELAY) != pdTRUE) {
+        return NULL;
+    }
+    return gScpiRespBuf;
+}
+
+void SCPI_ResponseBuf_Give(void) {
+    if (gScpiRespMutex != NULL) {
+        xSemaphoreGive(gScpiRespMutex);
+    }
+}
 
 static scpi_result_t SCPI_SysInfoGet(scpi_t * context) {
     int param1;
@@ -416,25 +431,23 @@ static scpi_result_t SCPI_SysInfoGet(scpi_t * context) {
         param1 = 0;
     }
 
-    if (gSysInfoMutex != NULL &&
-        xSemaphoreTake(gSysInfoMutex, portMAX_DELAY) != pdTRUE) {
+    uint8_t* buf = SCPI_ResponseBuf_Take();
+    if (buf == NULL) {
         return SCPI_RES_ERR;
     }
 
     size_t count = Nanopb_Encode(
             pBoardData,
             (const NanopbFlagsArray *) &fields_info,
-            gSysInfoBuffer, DaqifiOutMessage_size);
+            buf, DaqifiOutMessage_size);
     scpi_result_t result = SCPI_RES_OK;
     if (count < 1) {
         result = SCPI_RES_ERR;
     } else {
-        context->interface->write(context, (char*) gSysInfoBuffer, count);
+        context->interface->write(context, (char*) buf, count);
     }
 
-    if (gSysInfoMutex != NULL) {
-        xSemaphoreGive(gSysInfoMutex);
-    }
+    SCPI_ResponseBuf_Give();
     return result;
 }
 
@@ -444,14 +457,14 @@ static scpi_result_t SCPI_SysInfoGet(scpi_t * context) {
  * @return SCPI_RES_OK on success
  */
 static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
-    char buffer[256];
     const tBoardConfig* pBoardConfig = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
     tBoardData * pBoardData = BoardData_Get(BOARDDATA_ALL_DATA, 0);
     wifi_manager_settings_t * pWifiSettings = BoardData_Get(BOARDDATA_WIFI_SETTINGS, 0);
     AInRuntimeArray * pAInConfig = BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_AIN_CHANNELS);
     DIORuntimeArray * pDIOConfig = BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_DIO_CHANNELS);
 
-    // Check for NULL pointers to prevent crashes
+    // Check for NULL pointers to prevent crashes (before taking the shared
+    // buffer so we don't need to release it on this early return).
     if (!pBoardData || !pBoardConfig) {
         const char* err = !pBoardData ? "ERROR: BoardData not available\r\n"
                                       : "ERROR: BoardConfig not available\r\n";
@@ -459,8 +472,14 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
+    // #347: use shared SCPI response scratch buffer (was stack-local char[256]).
+    char* buffer = (char*)SCPI_ResponseBuf_Take();
+    if (buffer == NULL) {
+        return SCPI_RES_ERR;
+    }
+
     // Header with device identification
-    snprintf(buffer, sizeof(buffer), "=== DAQiFi Nyquist%d | HW:%s FW:%s ===\r\n",
+    snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "=== DAQiFi Nyquist%d | HW:%s FW:%s ===\r\n",
         pBoardConfig->BoardVariant, pBoardConfig->boardHardwareRev, pBoardConfig->boardFirmwareRev);
     context->interface->write(context, buffer, strlen(buffer));
     
@@ -480,12 +499,12 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
             (uint8_t)((pWifiSettings->ipAddr.Val >> 16) & 0xFF),
             (uint8_t)((pWifiSettings->ipAddr.Val >> 24) & 0xFF));
         
-        snprintf(buffer, sizeof(buffer), "  2.4GHz: On | Mode: %s | SSID: %s\r\n", 
+        snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  2.4GHz: On | Mode: %s | SSID: %s\r\n", 
             pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_AP ? "AP" : "STA",
             pWifiSettings->ssid);
         context->interface->write(context, buffer, strlen(buffer));
         
-        snprintf(buffer, sizeof(buffer), "  IP: %s | Port: %d | Security: %s\r\n", 
+        snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  IP: %s | Port: %d | Security: %s\r\n", 
             ipStr, pWifiSettings->tcpPort,
             pWifiSettings->securityMode == WIFI_MANAGER_SECURITY_MODE_OPEN ? "Open" : "WPA");
         context->interface->write(context, buffer, strlen(buffer));
@@ -510,7 +529,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
         case USBHS_VBUS_VALID: vbusLevelStr = "Valid"; break;
         default: break;
     }
-    snprintf(buffer, sizeof(buffer), "  USB: %s | WiFi: %s | Ext power: %s | VBUS: %s (HW: %s)\r\n",
+    snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  USB: %s | WiFi: %s | Ext power: %s | VBUS: %s (HW: %s)\r\n",
         hasUSBPower ? "Connected" : "Disconnected",
         wifiStatus == WIFI_STATUS_CONNECTED ? "Connected" :
         (wifiStatus == WIFI_STATUS_DISCONNECTED ? "Disconnected" : "Disabled"),
@@ -536,7 +555,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
         shutdownStatus = pBoardData->PowerData.shutdownNotified ? " | Shutdown: Ready" : " | Shutdown: Pending";
     }
     
-    snprintf(buffer, sizeof(buffer), "  State: %s (%d) | USB: %s%s\r\n", 
+    snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  State: %s (%d) | USB: %s%s\r\n", 
         powerState,
         pBoardData->PowerData.powerState,
         pBoardData->PowerData.USBSleep ? "Sleep" : "Active",
@@ -559,7 +578,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
                 default: chargeStatus = "?"; break;
             }
         }
-        snprintf(buffer, sizeof(buffer), "  Battery: -- (--) [--] | Charging: %s\r\n", chargeStatus);
+        snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  Battery: -- (--) [--] | Charging: %s\r\n", chargeStatus);
     } else {
         // Battery monitoring active - show actual values
         const char* chargeStatus = "Off";
@@ -575,7 +594,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
                 default: chargeStatus = "?"; break;
             }
         }
-        snprintf(buffer, sizeof(buffer), "  Battery: %.2fV (%d%%) %s | Charging: %s\r\n", 
+        snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  Battery: %.2fV (%d%%) %s | Charging: %s\r\n", 
             pBoardData->PowerData.battVoltage, 
             pBoardData->PowerData.chargePct,
             pBoardData->PowerData.battLow ? "[Low]" : "[Ok]",
@@ -626,7 +645,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
     }
     
     // Display separated ADC counts
-    snprintf(buffer, sizeof(buffer), "  User ADC: %d/%d | Internal ADC: %d/%d | DIO: %d/%d inputs\r\n", 
+    snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  User ADC: %d/%d | Internal ADC: %d/%d | DIO: %d/%d inputs\r\n", 
         userAdcEnabled, userAdcTotal,
         internalAdcEnabled, internalAdcTotal,
         dioInputs, pDIOConfig ? pDIOConfig->Size : 0);
@@ -641,7 +660,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
             // Only show user channels (ID < 248, not internal monitoring)
             if (channelId < ADC_CHANNEL_3_3V && pAInConfig->Data[i].IsEnabled) {
                 if (!first) context->interface->write(context, ",", 1);
-                snprintf(buffer, sizeof(buffer), "%d", channelId);
+                snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "%d", channelId);
                 context->interface->write(context, buffer, strlen(buffer));
                 first = false;
             }
@@ -657,7 +676,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
         
         if (DIO_ReadSampleByMask(&sample, channelMask)) {
             // Debug: show raw value
-            snprintf(buffer, sizeof(buffer), "  DIO raw: %u (0x%04X)\r\n", sample.Values, sample.Values);
+            snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  DIO raw: %u (0x%04X)\r\n", sample.Values, sample.Values);
             context->interface->write(context, buffer, strlen(buffer));
             
             context->interface->write(context, "  DIO state: ", 13);
@@ -678,7 +697,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
     
     // Streaming and sampling - cannot be active in STANDBY
     bool canStream = (pBoardData->PowerData.powerState != STANDBY);
-    snprintf(buffer, sizeof(buffer), "  Streaming: %s\r\n",
+    snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  Streaming: %s\r\n",
         (canStream && pRunTimeStreamConfig && pRunTimeStreamConfig->IsEnabled) ? "Active" : 
         (!canStream ? "Disabled" : "Idle"));
     context->interface->write(context, buffer, strlen(buffer));
@@ -693,7 +712,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
         const char* adcInactive = "  ADC: -- | --\r\n";
         context->interface->write(context, adcInactive, strlen(adcInactive));
     } else {
-        snprintf(buffer, sizeof(buffer), "  ADC: %d%% | %.2fV\r\n",
+        snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  ADC: %d%% | %.2fV\r\n",
             pBoardData->PowerData.chargePct,
             pBoardData->PowerData.battVoltage);
         context->interface->write(context, buffer, strlen(buffer));
@@ -706,13 +725,13 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
         
         // Battery detection and charging
         const char* chgStatStr[] = {"Not Charging", "Pre-charge", "Fast Charge", "Charge Done"};
-        snprintf(buffer, sizeof(buffer), "  BQ24297: Battery %s | Charging: %s\r\n",
+        snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  BQ24297: Battery %s | Charging: %s\r\n",
             pBQ24297Data->status.batPresent ? "Present" : "Not Present",
             (pBQ24297Data->status.chgStat < 4) ? chgStatStr[pBQ24297Data->status.chgStat] : "Unknown");
         context->interface->write(context, buffer, strlen(buffer));
         
         // Power conditions with clear explanations
-        snprintf(buffer, sizeof(buffer), "  vsysStat: %d (Battery >3.0V: %s) | pgStat: %d (Ext power: %s)\r\n",
+        snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  vsysStat: %d (Battery >3.0V: %s) | pgStat: %d (Ext power: %s)\r\n",
             pBQ24297Data->status.vsysStat,
             pBQ24297Data->status.vsysStat ? "No" : "Yes",
             pBQ24297Data->status.pgStat,
@@ -726,7 +745,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
         // Read OTG GPIO pin state for debugging
         bool otgGpioState = BATT_MAN_OTG_Get();
         
-        snprintf(buffer, sizeof(buffer), "  NTC: %s | Current limit: %s | OTG: %s (GPIO: %s)\r\n",
+        snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  NTC: %s | Current limit: %s | OTG: %s (GPIO: %s)\r\n",
             (pBQ24297Data->status.ntcFault < 4) ? ntcStr[pBQ24297Data->status.ntcFault] : "Fault",
             (pBQ24297Data->status.inLim < 8) ? iLimStr[pBQ24297Data->status.inLim] : "Unknown",
             pBQ24297Data->status.otg ? "On" : "Off",
@@ -743,14 +762,14 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
 
         // REG01 breakdown: [7:6]=watchdog, [5]=OTG, [4]=CHG_CONFIG, [3:1]=SYS_MIN, [0]=reserved
         if (reg01Ok && reg07Ok) {
-            snprintf(buffer, sizeof(buffer), "  BATFET: %s | REG01: 0x%02X (OTG=%d, CHG=%d) | REG07: 0x%02X\r\n",
+            snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  BATFET: %s | REG01: 0x%02X (OTG=%d, CHG=%d) | REG07: 0x%02X\r\n",
                 batfetEnabled ? "Enabled" : "Disabled!",
                 reg01,
                 (reg01 >> 5) & 1,  // OTG bit
                 (reg01 >> 4) & 1,  // Charge enable bit
                 reg07);
         } else {
-            snprintf(buffer, sizeof(buffer), "  BATFET: %s | REG01: %s | REG07: %s\r\n",
+            snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  BATFET: %s | REG01: %s | REG07: %s\r\n",
                 reg07Ok ? (batfetEnabled ? "Enabled" : "Disabled!") : "ERR",
                 reg01Ok ? "OK" : "ERR",
                 reg07Ok ? "OK" : "ERR");
@@ -759,7 +778,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
         
         // Power-up readiness - the key diagnostic info
         bool canPowerUp = (!pBQ24297Data->status.vsysStat || pBQ24297Data->status.pgStat);
-        snprintf(buffer, sizeof(buffer), "  >>> Power-up ready: %s %s\r\n",
+        snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  >>> Power-up ready: %s %s\r\n",
             canPowerUp ? "Yes" : "No",
             canPowerUp ? "" : "(Battery <3.0V and no external power)");
         context->interface->write(context, buffer, strlen(buffer));
@@ -871,16 +890,16 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
             }
 
             // Display power rails
-            snprintf(buffer, sizeof(buffer), "  +3.3V: %s | +5V: %s | +10V: %s\r\n",
+            snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  +3.3V: %s | +5V: %s | +10V: %s\r\n",
                 str3_3, str5, str10);
             context->interface->write(context, buffer, strlen(buffer));
 
-            snprintf(buffer, sizeof(buffer), "  VSYS: %s | VBATT: %s\r\n",
+            snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  VSYS: %s | VBATT: %s\r\n",
                 strSys, strBatt);
             context->interface->write(context, buffer, strlen(buffer));
 
             // Display reference voltages
-            snprintf(buffer, sizeof(buffer), "  2.5V Ref: %s | 5V Ref: %s\r\n",
+            snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "  2.5V Ref: %s | 5V Ref: %s\r\n",
                 str2_5Ref, str5Ref);
             context->interface->write(context, buffer, strlen(buffer));
 
@@ -895,7 +914,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
                     StreamingRuntimeConfig *pStrmCfg = BoardRunTimeConfig_Get(
                             BOARDRUNTIME_STREAMING_CONFIGURATION);
                     bool diagOff = pStrmCfg->Running && !pStrmCfg->OnboardDiagEnabled;
-                    snprintf(buffer, sizeof(buffer),
+                    snprintf(buffer, SCPI_RESPONSE_BUF_SIZE,
                              "  * Stale: last update %lus ago%s\r\n",
                              (unsigned long)ageSec,
                              diagOff ? " (diag scanning disabled)" : "");
@@ -907,6 +926,7 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
         }
     }
 
+    SCPI_ResponseBuf_Give();
     return SCPI_RES_OK;
 }
 
@@ -2778,29 +2798,35 @@ scpi_result_t SCPI_Force5v5PowerStateSet(scpi_t * context) {
 
 static scpi_result_t SCPI_GetCommandHistory(scpi_t * context) {
     UsbCdcData_t* usbSettings = UsbCdc_GetSettings();
-    char buffer[256];
-    
+
     if (usbSettings->cmdHistoryCount == 0) {
         SCPI_ResultCharacters(context, "No command history", 18);
         return SCPI_RES_OK;
     }
-    
+
+    // #347: shared SCPI response scratch buffer (was stack-local char[256]).
+    char* buffer = (char*)SCPI_ResponseBuf_Take();
+    if (buffer == NULL) {
+        return SCPI_RES_ERR;
+    }
+
     // Calculate starting position in circular buffer
     int startIdx = (usbSettings->cmdHistoryHead - usbSettings->cmdHistoryCount + SCPI_CMD_HISTORY_SIZE) % SCPI_CMD_HISTORY_SIZE;
-    
+
     // Send header
-    int len = snprintf(buffer, sizeof(buffer), "Last %d commands:\r\n", usbSettings->cmdHistoryCount);
+    int len = snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "Last %d commands:\r\n", usbSettings->cmdHistoryCount);
     context->interface->write(context, buffer, len);
-    
+
     // Send command history
     for (int i = 0; i < usbSettings->cmdHistoryCount; i++) {
         int idx = (startIdx + i) % SCPI_CMD_HISTORY_SIZE;
-        len = snprintf(buffer, sizeof(buffer), "%d: %s\r\n", 
-                      usbSettings->cmdHistoryCount - i, 
+        len = snprintf(buffer, SCPI_RESPONSE_BUF_SIZE, "%d: %s\r\n",
+                      usbSettings->cmdHistoryCount - i,
                       usbSettings->cmdHistory[idx]);
         context->interface->write(context, buffer, len);
     }
-    
+
+    SCPI_ResponseBuf_Give();
     return SCPI_RES_OK;
 }
 
@@ -3496,22 +3522,28 @@ char scpi_input_buffer[SCPI_INPUT_BUFFER_LENGTH];
 scpi_error_t scpi_error_queue_data[SCPI_ERROR_QUEUE_SIZE];
 
 scpi_result_t SCPI_Help(scpi_t* context) {
-    char buffer[512];
+    // #347: shared SCPI response scratch buffer (was stack-local char[512]).
+    char* buffer = (char*)SCPI_ResponseBuf_Take();
+    if (buffer == NULL) {
+        return SCPI_RES_ERR;
+    }
     size_t numCommands = sizeof (scpi_commands) / sizeof (scpi_command_t);
     size_t i = 0;
 
-    size_t count = snprintf(buffer, 512, "%s", "\r\nImplemented:\r\n");
+    size_t count = snprintf(buffer, SCPI_RESPONSE_BUF_SIZE,
+                            "%s", "\r\nImplemented:\r\n");
     for (i = 0; i < numCommands; ++i) {
         if (scpi_commands[i].callback != SCPI_NotImplemented &&
                 scpi_commands[i].pattern != NULL) {
             size_t cmdSize = strlen(scpi_commands[i].pattern) + 5;
-            if (count + cmdSize >= 512) {
+            if (count + cmdSize >= SCPI_RESPONSE_BUF_SIZE) {
                 buffer[count] = '\0';
                 context->interface->write(context, buffer, count);
                 count = 0;
             }
 
-            count += snprintf(buffer + count, 512 - count, "  %s\r\n", scpi_commands[i].pattern);
+            count += snprintf(buffer + count, SCPI_RESPONSE_BUF_SIZE - count,
+                              "  %s\r\n", scpi_commands[i].pattern);
         }
     }
 
@@ -3519,18 +3551,20 @@ scpi_result_t SCPI_Help(scpi_t* context) {
         context->interface->write(context, buffer, count);
     }
 
-    count = snprintf(buffer, 512, "%s", "\r\nNot Implemented:\r\n");
+    count = snprintf(buffer, SCPI_RESPONSE_BUF_SIZE,
+                     "%s", "\r\nNot Implemented:\r\n");
     for (i = 0; i < numCommands; ++i) {
         if (scpi_commands[i].callback == SCPI_NotImplemented &&
                 scpi_commands[i].pattern != NULL) {
             size_t cmdSize = strlen(scpi_commands[i].pattern) + 5;
-            if (count + cmdSize >= 512) {
+            if (count + cmdSize >= SCPI_RESPONSE_BUF_SIZE) {
                 buffer[count] = '\0';
                 context->interface->write(context, buffer, count);
                 count = 0;
             }
 
-            count += snprintf(buffer + count, 512 - count, "  %s\r\n", scpi_commands[i].pattern);
+            count += snprintf(buffer + count, SCPI_RESPONSE_BUF_SIZE - count,
+                              "  %s\r\n", scpi_commands[i].pattern);
         }
     }
 
@@ -3538,6 +3572,7 @@ scpi_result_t SCPI_Help(scpi_t* context) {
         context->interface->write(context, buffer, count);
     }
 
+    SCPI_ResponseBuf_Give();
     return SCPI_RES_OK;
 }
 
@@ -3559,17 +3594,13 @@ size_t SCPI_WriteWithRetry(ScpiTransportWriteFn writeFn,
 }
 
 scpi_t CreateSCPIContext(scpi_interface_t* interface, void* user_context) {
-    // #347: init the SysInfoGet buffer mutex once (both USB and WiFi init
-    // call this during boot; boot is single-threaded so no race here).
-    // If creation fails (OOM at boot — extremely unlikely since heap is
-    // fresh), SCPI_SysInfoGet falls through without serialization. This
-    // LOG_E surfaces the degraded state so operators can notice.
-    if (gSysInfoMutex == NULL) {
-        gSysInfoMutex = xSemaphoreCreateMutex();
-        if (gSysInfoMutex == NULL) {
-            LOG_E("SCPI: failed to create SysInfoGet mutex — concurrent "
-                  "USB+TCP SysInfoPB may corrupt responses");
-        }
+    // #347: init the shared SCPI response-buffer mutex once, using static
+    // storage so it cannot fail (unlike xSemaphoreCreateMutex which can
+    // return NULL under heap pressure and would leave the buffer
+    // unserialized). Both USB and WiFi init call CreateSCPIContext during
+    // boot, which is single-threaded — no race on the NULL check.
+    if (gScpiRespMutex == NULL) {
+        gScpiRespMutex = xSemaphoreCreateMutexStatic(&gScpiRespMutexStorage);
     }
 
     // Construct model string from BoardConfig.BoardVariant (e.g., "Nq3")

--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -22,6 +22,33 @@ extern "C" {
      */
     scpi_t CreateSCPIContext(scpi_interface_t* interface, void* user_context);
 
+    /**
+     * Size of the shared SCPI response scratch buffer. Sized to hold the
+     * largest known SCPI response (DaqifiOutMessage protobuf, currently
+     * 2008 bytes). All callers that need ≥256 B of scratch should use this
+     * buffer rather than stack-allocating, especially those reachable on
+     * the TCP path where WifiTask stack is tight (see #347).
+     */
+    #define SCPI_RESPONSE_BUF_SIZE 2048U
+
+    /**
+     * Acquire the shared SCPI response scratch buffer.
+     * Blocks until the buffer mutex is available (portMAX_DELAY). Caller
+     * MUST pair every successful Take with exactly one Give.
+     * Returns NULL only if the mutex hasn't been created yet (shouldn't
+     * happen after CreateSCPIContext has run); callers should treat NULL
+     * as an internal error and return SCPI_RES_ERR.
+     * @return Pointer to the shared buffer (SCPI_RESPONSE_BUF_SIZE bytes)
+     *         or NULL on internal error.
+     */
+    uint8_t* SCPI_ResponseBuf_Take(void);
+
+    /**
+     * Release the shared SCPI response scratch buffer.
+     * Must only be called after a successful SCPI_ResponseBuf_Take.
+     */
+    void SCPI_ResponseBuf_Give(void);
+
     /*! Function pointer type for transport-level write (no SCPI context) */
     typedef size_t (*ScpiTransportWriteFn)(const char* data, size_t len);
 

--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -14,6 +14,17 @@ extern "C" {
 #endif
 
     /**
+     * One-time init for the shared SCPI response buffer mutex (statically
+     * allocated, so this cannot fail). MUST be called exactly once during
+     * app boot, before any transport creates its SCPI context and before
+     * any SCPI command can be dispatched. Idempotent — safe to call more
+     * than once, subsequent calls are no-ops.
+     * Separate name from libscpi's `SCPI_Init(context)` which initializes
+     * a per-transport context object.
+     */
+    void SCPI_ResponseBuf_Init(void);
+
+    /**
      * Creates a new SCPI context object.
      * This allows us to have multiple independent consoles.
      * @param interface Defines the SCPI callback functions

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -403,16 +403,27 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
 
     // Start benchmark timing
     uint32_t startTime = xTaskGetTickCount();
-    
-    // Generate and write test data
-    uint8_t testBuffer[512]; // Write in 512-byte blocks
+
+    // #347: use shared SCPI response scratch buffer (was stack-local 512 B).
+    // Benchmark writes are chunked, so any slice of the shared buffer works.
+    uint8_t* testBuffer = (uint8_t*)SCPI_ResponseBuf_Take();
+    if (testBuffer == NULL) {
+        LOG_E("SD:BENCH - Could not acquire SCPI response buffer\r\n");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        gSDBenchmarkResults.testInProgress = false;
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
+        sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
+        result = SCPI_RES_ERR;
+        goto __exit_point;  // no Give needed — Take failed
+    }
+    const uint32_t kTestBufferChunk = 512;  // benchmark writes in 512 B blocks
     uint32_t bytesToWrite = testSizeKB * 1024;
     uint32_t bytesWritten = 0;
     
     while (bytesWritten < bytesToWrite) {
-        uint32_t chunkSize = (bytesToWrite - bytesWritten > sizeof(testBuffer)) ? 
-                            sizeof(testBuffer) : (bytesToWrite - bytesWritten);
-        
+        uint32_t chunkSize = (bytesToWrite - bytesWritten > kTestBufferChunk) ?
+                            kTestBufferChunk : (bytesToWrite - bytesWritten);
+
         // Fill buffer based on pattern
         switch (pattern) {
             case 0: // All zeros
@@ -429,7 +440,7 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
                 }
                 break;
         }
-        
+
         // Write to SD card (WriteToBuffer has timeout protection)
         size_t written = sd_card_manager_WriteToBuffer((const char*)testBuffer, chunkSize);
         if (written != chunkSize) {
@@ -439,11 +450,14 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
             pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
             sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
             result = SCPI_RES_ERR;
+            SCPI_ResponseBuf_Give();
             goto __exit_point;
         }
-        
+
         bytesWritten += written;
     }
+    // Loop exited successfully — release shared buffer before post-flush phase.
+    SCPI_ResponseBuf_Give();
 
     // Trigger flush: set mode to NONE so SD task drains buffer and closes file
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -404,18 +404,13 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
     // Start benchmark timing
     uint32_t startTime = xTaskGetTickCount();
 
-    // #347: use shared SCPI response scratch buffer (was stack-local 512 B).
-    // Benchmark writes are chunked, so any slice of the shared buffer works.
-    uint8_t* testBuffer = (uint8_t*)SCPI_ResponseBuf_Take();
-    if (testBuffer == NULL) {
-        LOG_E("SD:BENCH - Could not acquire SCPI response buffer\r\n");
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        gSDBenchmarkResults.testInProgress = false;
-        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
-        sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
-        result = SCPI_RES_ERR;
-        goto __exit_point;  // no Give needed — Take failed
-    }
+    // #347 / #350: take and release the shared SCPI response buffer PER
+    // CHUNK. A large benchmark can run for many seconds; holding the shared
+    // mutex across the whole loop would make every other SCPI command
+    // (on either transport) wait for the benchmark to finish. Per-chunk
+    // take/give lets other SCPI callbacks interleave between 512-byte
+    // SD writes without losing the stack-safety properties of the shared
+    // buffer pattern.
     const uint32_t kTestBufferChunk = 512;  // benchmark writes in 512 B blocks
     uint32_t bytesToWrite = testSizeKB * 1024;
     uint32_t bytesWritten = 0;
@@ -423,6 +418,17 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
     while (bytesWritten < bytesToWrite) {
         uint32_t chunkSize = (bytesToWrite - bytesWritten > kTestBufferChunk) ?
                             kTestBufferChunk : (bytesToWrite - bytesWritten);
+
+        uint8_t* testBuffer = (uint8_t*)SCPI_ResponseBuf_Take();
+        if (testBuffer == NULL) {
+            LOG_E("SD:BENCH - Could not acquire SCPI response buffer\r\n");
+            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+            gSDBenchmarkResults.testInProgress = false;
+            pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
+            sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
+            result = SCPI_RES_ERR;
+            goto __exit_point;  // Take failed — nothing to Give
+        }
 
         // Fill buffer based on pattern
         switch (pattern) {
@@ -441,8 +447,12 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
                 break;
         }
 
-        // Write to SD card (WriteToBuffer has timeout protection)
+        // Write to SD card (WriteToBuffer has timeout protection). Release
+        // the shared mutex before checking the result so the error path
+        // doesn't need to remember to give it back.
         size_t written = sd_card_manager_WriteToBuffer((const char*)testBuffer, chunkSize);
+        SCPI_ResponseBuf_Give();
+
         if (written != chunkSize) {
             LOG_E("SD:BENCH - Write failed at %u/%u bytes\r\n", bytesWritten, bytesToWrite);
             SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
@@ -450,14 +460,11 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
             pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
             sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
             result = SCPI_RES_ERR;
-            SCPI_ResponseBuf_Give();
             goto __exit_point;
         }
 
         bytesWritten += written;
     }
-    // Loop exited successfully — release shared buffer before post-flush phase.
-    SCPI_ResponseBuf_Give();
 
     // Trigger flush: set mode to NONE so SD task drains buffer and closes file
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #348 (SysInfoGet static+mutex) and an alternative to the withdrawn #349 (stack bump). Unifies the SCPI big-buffer story into one architectural pattern.

## The pattern

One 2048-byte static buffer (`gScpiRespBuf`) guarded by a **statically allocated** FreeRTOS mutex (`gScpiRespMutex`, no heap pressure, no NULL-return failure mode). Any SCPI callback needing ≥256 B of scratch calls `SCPI_ResponseBuf_Take()` / `_Give()` instead of allocating on the stack.

### Migrated callbacks

- `SCPI_SysInfoGet` (2008 B protobuf) — was per-site static+mutex from #348
- `SCPI_SysInfoTextGet` (256 B chunked snprintf, ~24 uses)
- `SCPI_GetCommandHistory` (256 B chunked snprintf)
- `SCPI_Help` (512 B chunked command list)
- `SCPI_StorageSDBenchmark` (512 B test pattern chunks)

## Why this shape

| Criterion | Per-site static (#348) | Stack bump (#349) | **Shared buffer (this PR)** |
|---|---|---|---|
| BSS cost | 2 KB + N×mutex state | +4 KB (stack growth) | 2 KB + 1 mutex |
| Covers future callbacks | No — per-site decision | Yes, transparently | Yes via `_Take/Give` |
| Reentrancy between transports | Yes (per-site mutex) | **No** | Yes (one mutex) |
| Heap failure mode | Possible (dynamic mutex) | N/A | **None** (static mutex) |
| Invariants to remember | Which callbacks have statics | Just a bigger number | One pattern for all |

## Static FreeRTOS allocation

Also flips `configSUPPORT_STATIC_ALLOCATION = 1` and adds the mandatory `vApplicationGetIdleTaskMemory` hook (only one required — `configUSE_TIMERS = 0`, no timer hook needed). This is what makes `xSemaphoreCreateMutexStatic` available, which is what makes the shared-buffer mutex have zero failure mode. Dynamic allocation (`configSUPPORT_DYNAMIC_ALLOCATION = 1`) stays on, so no existing `xSemaphoreCreateMutex` / `xQueueCreate` / `xTaskCreate` calls need to change.

## Files changed

- `firmware/src/config/default/FreeRTOSConfig.h` — enable static allocation
- `firmware/src/config/default/freertos_hooks.c` — idle-task memory hook
- `firmware/src/services/SCPI/SCPIInterface.h` — `SCPI_ResponseBuf_Take/Give` + `SCPI_RESPONSE_BUF_SIZE`
- `firmware/src/services/SCPI/SCPIInterface.c` — buffer/mutex + migrate 4 callbacks
- `firmware/src/services/SCPI/SCPIStorageSD.c` — migrate benchmark
- `CLAUDE.md` — document the pattern

## Verification

- Build clean on NQ1 default config
- Flash NQ1 hardware, STA mode on Tesla WiFi
- **#347 repro 3/3 clean** — `SYSTem:SYSInfoPB?` over TCP + step-5 serial reopen: 1 ms each
- Exercised via TCP: `HELP` (1400 B response), `SYSTem:INFo?`, `SYSTem:LOG:CMDHistory?` — all responsive
- `SYST:MEM:STACk?` after exercising all callbacks: `WifiTask hwm=652 words free` — unchanged from pre-callback baseline, confirms shared buffer is keeping SCPI callback stack depth below the WifiTask peak (372 words)

## Post-merge cleanup

- #349 (stack bump) already closed as superseded by this approach. WifiTask stack stays at 1024 words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)