### PR TITLE
fix(wifi,scpi,adc): #353 Option 2 (decouple SCPI from WINC stack) + #355 hygiene

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,8 +652,8 @@ The PIC32MZ2048**EF**M144 has a hardware 64-bit double-precision FPU (Coprocesso
 | 7 | `app_USBDeviceTask` | 3072 | 1290 | SCPI callbacks use shared response buffer (see below) |
 | 6 | `streaming_Task` | 1392 | 692 | Encodes PB/CSV/JSON + outputs, FPU (CSV/JSON at precision>0) |
 | 5 | `app_SDCardTask` | 1024 | 468 | SD mount/write/read/list/delete |
-| 2 | `app_WifiTask` | 1024 | 360 | WiFi state machine + TCP |
-| 2 | `lWDRV_WINC_Tasks` | 1500 | 778 | WINC1500 driver + SCPI-over-TCP dispatch context. Peak rose from 290 pre-#353 fix — SCPI callbacks now actually run to completion on this stack (previously overflowed) |
+| 2 | `app_WifiTask` | 1500 | 780 | WiFi state machine + TCP + SCPI-over-TCP dispatch (post-#353 Opt 2: microrl + libscpi + handlers all run here instead of on WDRV_WINC_Tasks) |
+| 2 | `lWDRV_WINC_Tasks` | 1024 | 320 | WINC1500 driver only. SCPI dispatch moved to app_WifiTask per #353 Option 2 |
 | 2 | `fwUpdateTask` | 128 | 62 | WiFi FW update (dynamic) |
 | 1 | `lAPP_FREERTOS_Tasks` | 1500 | 1156 | Boot init (77% used) |
 | 1 | `F_USB_DEVICE_Tasks` | 144 | 72 | USB device stack |

--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -236,7 +236,7 @@ bool ADC_WriteChannelStateAll(void) {
         bool isPowered = (powerState == POWERED_UP ||
                           powerState == POWERED_UP_EXT_DOWN);
         if (isPowered) {
-            result &= AD7609_WriteStateAll(pChannels, pRuntime);
+            result &= AD7609_WriteStateAll();
         }
     }
 

--- a/firmware/src/HAL/ADC/AD7609.c
+++ b/firmware/src/HAL/ADC/AD7609.c
@@ -314,18 +314,11 @@ bool AD7609_WriteStateSingle(
     return true;
 }
 
-bool AD7609_WriteStateAll(
-                        const AInArray* channelConfig,
-                        AInRuntimeArray* channelRuntimeConfig)
-{
-    UNUSED(channelConfig);
-    UNUSED(channelRuntimeConfig);
-
+bool AD7609_WriteStateAll(void) {
     if (pModuleConfigAD7609 == NULL) {
         LOG_E("AD7609_WriteStateAll: AD7609 not initialized");
         return false;
     }
-
     return true;
 }
 

--- a/firmware/src/HAL/ADC/AD7609.h
+++ b/firmware/src/HAL/ADC/AD7609.h
@@ -45,13 +45,13 @@ bool AD7609_WriteStateSingle(                                               \
 
 
 /*!
- * Sets the state for all ADC channels
- * @param[in] channelConfig Channel configuration
- * @param[in] channelRuntimeConfig Channel configuration in runtime
+ * Verifies AD7609 is initialized. AD7609 has no per-channel hardware enable
+ * (it's a simultaneous 8-ch ADC), so this doesn't apply any per-channel
+ * state — the "enabled" flag is a software concept the streaming engine
+ * uses to filter samples. Returns false if the module isn't initialized
+ * (i.e. 10 V rail wasn't powered when ADC_InitHardware last ran).
  */
-bool AD7609_WriteStateAll(                                                  \
-                        const AInArray* channelConfig,                      \
-                        AInRuntimeArray* channelRuntimeConfig);
+bool AD7609_WriteStateAll(void);
     
 
     

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -706,7 +706,10 @@ static void app_TasksCreate() {
 
     errStatus = xTaskCreate((TaskFunction_t) app_WifiTask,
             "WifiTask",
-            1024,  // Profiled: 360 words peak. 3x margin for unknown WiFi driver depth. (was 3000)
+            1500,  // Post-#353 Option 2: SCPI dispatch via TCP now runs on this
+                   // task's stack (microrl + libscpi + handler chain). Pre-change
+                   // profile: 360 peak. Sized to match WDRV_WINC_Tasks'
+                   // post-#354 budget (1500 words, ~800 SCPI-over-TCP peak).
             NULL,
             2,
             NULL);

--- a/firmware/src/config/default/tasks.c
+++ b/firmware/src/config/default/tasks.c
@@ -263,11 +263,11 @@ void SYS_Tasks ( void )
     // conservative — driver internals have unknown stack depth.
     BaseType_t wifiResult = xTaskCreate( lWDRV_WINC_Tasks,
         "WDRV_WINC_Tasks",
-        1500,   // Post-#353 profile: 778 words peak during SCPI-over-TCP dispatch
-                // (SOCKET_MSG_RECV → ProcessReceivedBuff → microrl → SCPI_Input →
-                // handler). Earlier 290-word figure was pre-#347-v2 — SCPI never
-                // completed on this stack because it overflowed first.
-                // 1500 gives ~50% margin over real workload.
+        1024,   // Post-#353 Option 2: SCPI dispatch deferred to WifiTask, so
+                // this task only hosts WDRV_WINC_Tasks itself. Post-decouple
+                // peak: ~320 words (WINC driver + socket-callback overhead).
+                // 1024 restores the original #353 acceptance target with
+                // comfortable 3x margin.
         (void*)NULL,
         DRV_WIFI_WINC_RTOS_TASK_PRIORITY,
         (TaskHandle_t*)NULL

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -133,7 +133,13 @@ static size_t SCPI_SafeParamString(scpi_t * context, char* value, const size_t m
     const char* buffer;
     size_t len;
     if (!SCPI_ParamCharacters(context, &buffer, &len, mandatory)) {
-        return SCPI_RES_ERR;
+        // Return 0 on parse failure, not SCPI_RES_ERR (= -1). This function
+        // returns size_t, and (size_t)-1 is a huge positive number that
+        // bypasses `if (len < 1)` checks in callers. 0 makes "failure" and
+        // "empty" indistinguishable at the type level, but every caller
+        // treats both the same way ("nothing usable was parsed") and the
+        // parser separately raises an SCPI error for the client.
+        return 0;
     }
 
     if (len > 0) {

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -120,8 +120,17 @@ static scpi_result_t SCPI_LANStringGetImpl(scpi_t * context, const char* string)
 
 static scpi_result_t SCPI_LANStringSetImpl(scpi_t * context, char* string, size_t maxLen) {
     // Parse straight into the caller's buffer — no intermediate 128 B stack
-    // local. SCPI_SafeParamString null-terminates on success and returns 0
-    // (via the maxLength check) for too-long input. (#355)
+    // local. (#355)
+    //
+    // API contract shared with the other SCPI_SafeParamString callers in
+    // this file: `maxLen` is the max PAYLOAD length. Callers allocate
+    // `maxLen + 1` bytes so SafeParamString's `value[len] = '\0'` write at
+    // index `len == maxLen` lands inside the buffer. Current outer caller
+    // `SCPI_LANSsidSet` passes `pRunTimeWifiSettings->ssid` (char[33]) with
+    // maxLen = WDRV_WINC_MAX_SSID_LEN (= 32), matching the convention also
+    // used by SCPI_LANAddrSetImpl, SCPI_LANPasskeySet, and
+    // SCPI_LANPasskeyGet (all of which declare `char value[FOO_LEN + 1]`
+    // and pass maxLength = FOO_LEN).
     size_t len = SCPI_SafeParamString(context, string, maxLen, TRUE);
     if (len < 1) {
         return SCPI_RES_ERR;

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -119,21 +119,13 @@ static scpi_result_t SCPI_LANStringGetImpl(scpi_t * context, const char* string)
 }
 
 static scpi_result_t SCPI_LANStringSetImpl(scpi_t * context, char* string, size_t maxLen) {
-    char value[128];
-    size_t len = SCPI_SafeParamString(context, value, 127, TRUE);
+    // Parse straight into the caller's buffer — no intermediate 128 B stack
+    // local. SCPI_SafeParamString null-terminates on success and returns 0
+    // (via the maxLength check) for too-long input. (#355)
+    size_t len = SCPI_SafeParamString(context, string, maxLen, TRUE);
     if (len < 1) {
         return SCPI_RES_ERR;
     }
-
-    if (len > maxLen) {
-        return SCPI_RES_ERR;
-    } else if (len < 1) {
-        string[0] = '\0';
-    } else {
-        memcpy(string, value, len);
-        string[len] = '\0';
-    }
-
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -99,6 +99,20 @@ static wifi_tcp_server_context_t gTcpServerContext;
 
 // Volatile flags for on-demand RSSI queries
 static volatile bool gRssiUpdatePending = false;
+
+// #353 Option 2: decouple SCPI dispatch from WINC callback context.
+// SOCKET_MSG_RECV fires on WDRV_WINC_Tasks (the WINC driver's task). Prior
+// to this change, the handler ran the whole microrl + libscpi + SCPI handler
+// chain inline on that task's stack — which caused #347 v2 (stack overflow
+// on SCPI handlers with large locals). PR #354 fixed the specific overflow;
+// this decouples the dispatch path entirely so the next SCPI handler with a
+// fat stack frame can't cause a similar crash.
+//
+// Flow: SOCKET_MSG_RECV stores size + sets flag + returns (no ProcessRx,
+// no recv re-arm). WifiTask's wifi_manager_ProcessState() picks up the flag,
+// runs wifi_tcp_server_ProcessReceivedBuff on WifiTask's stack, then re-arms
+// recv. WINC buffers inbound TCP while we process (per WINC docs).
+static volatile bool gTcpRxPending = false;
 static volatile bool gRssiUpdateComplete = false;
 static volatile uint8_t gLastRssiPercentage = 0;
 
@@ -276,9 +290,13 @@ static void SocketEventCallback(SOCKET socket, uint8_t messageType, void *pMessa
             tstrSocketRecvMsg *pRecvMessage = (tstrSocketRecvMsg*) pMessage;
 
             if ((NULL != pRecvMessage) && (pRecvMessage->s16BufferSize > 0)) {
+                // #353 Option 2: defer ProcessReceivedBuff + recv re-arm to
+                // WifiTask context. See gTcpRxPending comment above. The
+                // WINC driver buffers subsequent TCP data internally until
+                // we call recv() again, so missing this tick's re-arm is
+                // safe.
                 gStateMachineContext.pTcpServerContext->client.readBufferLength = pRecvMessage->s16BufferSize;
-                wifi_tcp_server_ProcessReceivedBuff();
-                recv(gStateMachineContext.pTcpServerContext->client.clientSocket, gStateMachineContext.pTcpServerContext->client.readBuffer, WIFI_RBUFFER_SIZE, 0);
+                gTcpRxPending = true;
 
             } else {
                 LOG_E("[%s:%d]Error Socket MSG Recv", __FILE__, __LINE__);
@@ -1370,7 +1388,27 @@ void wifi_manager_ProcessState() {
         return;
     }
     wifi_tcp_server_TransmitBufferedData();
-    
+
+    // #353 Option 2: drain any deferred TCP rx data on this task's stack.
+    // SOCKET_MSG_RECV (WDRV_WINC_Tasks context) stored length + set the flag
+    // but did NOT call ProcessReceivedBuff or re-arm recv — so all of that
+    // runs here, on WifiTask's stack, with ~4 KB of headroom for the
+    // microrl + libscpi + handler chain.
+    //
+    // Always clear the flag under the socket-valid guard, so a RECV that
+    // arrived just before the client disconnected doesn't leave stale data
+    // queued for the next client.
+    if (gTcpRxPending) {
+        gTcpRxPending = false;
+        if (gStateMachineContext.pTcpServerContext != NULL &&
+            gStateMachineContext.pTcpServerContext->client.clientSocket >= 0) {
+            wifi_tcp_server_ProcessReceivedBuff();
+            recv(gStateMachineContext.pTcpServerContext->client.clientSocket,
+                 gStateMachineContext.pTcpServerContext->client.readBuffer,
+                 WIFI_RBUFFER_SIZE, 0);
+        }
+    }
+
     if (xQueueReceive(gEventQH, &event, 1) != pdPASS) {
         return;
     }


### PR DESCRIPTION
## Summary

Two follow-ups to PR #354:

- **#355 hygiene** (commit 1): drop unused param in `SCPI_LANStringSetImpl` intermediate buffer; drop UNUSED params from `AD7609_WriteStateAll`.
- **#353 Option 2** (commit 2): structurally decouple SCPI dispatch from the WINC driver callback stack so the next SCPI handler with a fat stack frame can't repeat #347 v2's overflow.

## Option 2 — the structural fix

Before: `SOCKET_MSG_RECV → ProcessReceivedBuff → microrl → SCPI_Input → handler` ran inline on \`WDRV_WINC_Tasks\`. PR #354 fixed the specific 5 KB overflow; this fixes the class bug.

After: \`SOCKET_MSG_RECV\` stores the length and sets \`gTcpRxPending\`. \`wifi_manager_ProcessState\` (on \`app_WifiTask\`) polls the flag and runs \`ProcessReceivedBuff\` + re-arms \`recv()\` on its own stack. WINC buffers inbound TCP data internally while we wait (per its docs).

Net stack shift (measured on bench under TCP SCPI load):

| Task | Before #354 | After #354 | After this PR |
|------|------------:|-----------:|--------------:|
| WDRV_WINC_Tasks size | 1024 | 1500 | **1024** |
| WDRV_WINC_Tasks peak | (OF) | 802 | **316** |
| app_WifiTask size | 1024 | 1024 | **1500** |
| app_WifiTask peak | 360 | 360 | **782** |
| Net heap delta | — | +2 KB | **0** |

SCPI dispatch cost moved to the right task. WDRV_WINC_Tasks restored to the original #353 acceptance criterion of 1024. Both tasks at ~50% stack utilization.

## Thread safety

\`gTcpRxPending\` is \`volatile bool\` (atomic RMW on PIC32MZ for single bytes, though we only use plain writes). WDRV_WINC_Tasks and app_WifiTask are both priority 2 → FreeRTOS time-slices them, no preemption. WINC serializes \`SOCKET_MSG_RECV\` events per its own API (no re-arm = no more data delivered), so single-producer / single-consumer with strict alternation. Flag is cleared before the socket-validity check in the drain path, so a RECV racing a disconnect can't leave stale state for the next client.

## Test plan

- [x] \`/code-review\` — clean
- [x] Clean build on \`default\` config (\`-Werror\`, no new warnings)
- [x] Device boots, \`*IDN?\` / \`SYST:POW:STAT 1\` / \`ENAble:VOLTage:DC N\` respond over USB
- [x] \`SYST:COMM:LAN:SSID \"X\"\` + \`SYST:COMM:LAN:SSID?\` round-trip (exercises #355 LAN handler fix)
- [x] TCP repro from WiFi-host Python to device AP — reporter trigger sequence completes cleanly, \`SYSInfoPB?\` returns full 568 B
- [x] \`SYST:MEM:STACk?\` peaks match table above (WINC 316, WifiTask 782)
- [x] USB streaming 1 kHz × 16ch for ~3s — 124068 samples, 0 drops

## Ticket compliance

- **#355**: both items addressed, closes #355.
- **#353 Option 2**: structural decouple implemented; WDRV_WINC_Tasks restored to 1024 per original acceptance criterion.

## References

- PR #354 (merged) — #347 v2 Option 1 fix (remove fat ADC stack locals)
- #347 — original USB CDC hang report
- #353 — class-bug structural fix (this PR completes Option 2)
- #355 — minor hygiene (this PR closes)