### PR TITLE
perf(wifi): bump active WiFi auto-balance circular buffer 32 → 64 KB

### DIFF
--- a/firmware/src/Util/StreamingBufferPool.h
+++ b/firmware/src/Util/StreamingBufferPool.h
@@ -34,6 +34,10 @@ extern "C" {
 #define ENCODER_BUFFER_DEFAULT      8192   /* Optimal for USB; SD benefits from 16384 */
 #define STREAMING_SD_CIRCULAR_MIN   512    /* Min valid circular buffer (unused when inactive) */
 
+/** Active-interface defaults used by Streaming_ComputeAutoBuffers */
+#define STREAMING_USB_DEFAULT       (64U * 1024U)  /* USB circular when active */
+#define STREAMING_WIFI_DEFAULT      (64U * 1024U)  /* WiFi circular when active (#362/#363) */
+
 /**
  * Initialize the pool and set default partition.
  * Call once at boot before USB/WiFi/sample pool init.

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -723,8 +723,8 @@ void Streaming_ComputeAutoBuffers(uint32_t* outUsbSize, uint32_t* outWifiSize,
     // WINC's per-packet callback-paced drain catches up. Sample-pool
     // floor with USB+WiFi active is ~520 samples (well above
     // MIN_AIN_SAMPLE_COUNT=100).
-    *outWifiSize = hasWifi ? (64U * 1024U) : STREAMING_WIFI_MIN;
-    *outUsbSize  = hasUsb  ? (64U * 1024U) : STREAMING_USB_MIN;
+    *outWifiSize = hasWifi ? STREAMING_WIFI_DEFAULT : STREAMING_WIFI_MIN;
+    *outUsbSize  = hasUsb  ? STREAMING_USB_DEFAULT  : STREAMING_USB_MIN;
 }
 
 /*!

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -719,9 +719,17 @@ void Streaming_ComputeAutoBuffers(uint32_t* outUsbSize, uint32_t* outWifiSize,
 
     // Circular buffers: larger buffers reduce retry frequency for
     // all-or-nothing writes, but must leave enough pool for samples.
-    // 64KB USB (85ms at 3kHz×250B) and 32KB WiFi (23ms at 1kHz×1400B)
-    // balance retry avoidance with sample pool depth (~500+ samples).
-    *outWifiSize = hasWifi ? (32U * 1024U) : STREAMING_WIFI_MIN;
+    // 64KB USB (85ms at 3kHz×250B) balances retry avoidance with sample
+    // pool depth.
+    //
+    // #363 / #362 v2: bumped WiFi 32KB → 64KB. Bigger circular buffer
+    // gives the encoder more headroom while WINC drains via callback,
+    // and the WriteBuffer→TransmitBufferedData "bail when 30% full"
+    // path triggers less frequently (more bytes per drain). Audited
+    // sample-pool fallout: USB+WiFi auto-balance now ~520 samples
+    // (was ~436); WiFi-only ~970 (was ~738). All cases stay well
+    // above MIN_AIN_SAMPLE_COUNT (100).
+    *outWifiSize = hasWifi ? (64U * 1024U) : STREAMING_WIFI_MIN;
     *outUsbSize  = hasUsb  ? (64U * 1024U) : STREAMING_USB_MIN;
 }
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -719,16 +719,10 @@ void Streaming_ComputeAutoBuffers(uint32_t* outUsbSize, uint32_t* outWifiSize,
 
     // Circular buffers: larger buffers reduce retry frequency for
     // all-or-nothing writes, but must leave enough pool for samples.
-    // 64KB USB (85ms at 3kHz×250B) balances retry avoidance with sample
-    // pool depth.
-    //
-    // #363 / #362 v2: bumped WiFi 32KB → 64KB. Bigger circular buffer
-    // gives the encoder more headroom while WINC drains via callback,
-    // and the WriteBuffer→TransmitBufferedData "bail when 30% full"
-    // path triggers less frequently (more bytes per drain). Audited
-    // sample-pool fallout: USB+WiFi auto-balance now ~520 samples
-    // (was ~436); WiFi-only ~970 (was ~738). All cases stay well
-    // above MIN_AIN_SAMPLE_COUNT (100).
+    // WiFi at 64KB absorbs ~44ms of encoder lead at 1kHz×1400B before
+    // WINC's per-packet callback-paced drain catches up. Sample-pool
+    // floor with USB+WiFi active is ~520 samples (well above
+    // MIN_AIN_SAMPLE_COUNT=100).
     *outWifiSize = hasWifi ? (64U * 1024U) : STREAMING_WIFI_MIN;
     *outUsbSize  = hasUsb  ? (64U * 1024U) : STREAMING_USB_MIN;
 }


### PR DESCRIPTION
## Summary

- Doubles the active-WiFi circular buffer in `Streaming_ComputeAutoBuffers` from 32 KB to 64 KB.
- One-line size change in `firmware/src/services/streaming.c:725` plus a docs cleanup (drops in-flight task references + one inaccurate comment about WriteBuffer's 30 % threshold being relative to the circular buffer; the threshold is `WIFI_WBUFFER_SIZE * 3 / 10` i.e. 420 B, independent of this knob).
- The 64 KB buffer absorbs ~44 ms of encoder lead at 1 kHz×1400 B before WINC's per-packet callback-paced drain catches up. Mechanism: the wire rate per WINC TCP packet is unchanged (still bounded by SPI + WINC TX cycle), but the bigger buffer absorbs transient encoder bursts that previously caused brief overflow → leak. Reflected in the LEAK-detection ceiling.
- Sample pool fallout audited: USB+WiFi auto-balance ~520 samples (was ~436); WiFi-only ~970 (was ~738). All scenarios stay well above `MIN_AIN_SAMPLE_COUNT` (100). #229 streaming pool 194 KB budget unchanged.

Refs #362, #363.

## Bench results vs Session 23 baseline

NQ1, fullscale test pattern, WiFi STA, 6 s ceiling sweep, `--skip-endurance`. Tesla AP, RSSI ~85.

### PB highlights (full table 16/16 in benchmarks CSV)

| Config | Sess23 Hz | This PR Hz | Δ Hz | Sess23 KB/s | This PR KB/s | Δ KB/s |
|--------|---:|---:|---:|---:|---:|---:|
| 1×T1 OBD=OFF | 8k | **10k** | **+2k** | 107 | 123 | +16 |
| 5×T1 OBD=ON | 3k | **5k** | **+2k** | 104 | 170 | **+66** |
| 8×T2 | 2k | **4k** | **+2k** | 102 | 183 | **+81** |
| 5T1+3T2 (8ch) | 2k | **4k** | **+2k** | 98 | 192 | **+94** |
| 5×T1 OBD=OFF | 4k | **5k** | **+1k** | 139 | 167 | +28 |
| 11×T2 | 2k | **3k** | **+1k** | 135 | 192 | **+57** |
| 5T1+5T2 (10ch) | 2k | **3k** | **+1k** | 125 | 174 | **+49** |
| 5T1+11T2 (16ch) | 1k | **2k** | **+1k** | 89 | 156 | **+67** |
| 5T1+11T2 OBD=OFF (16ch) | 1k | **2k** | **+1k** | 85 | 170 | **+85** |
| 3×T1 | 5k | **4k** | **-1k** | 113 | 81 | -32 (only ceiling regression — see test plan, suspect run-to-run) |

9/16 PB configs gain ceiling, 6 unchanged, 1 regression.

### CSV highlights (full table 16/16 in benchmarks CSV)

| Config | Sess23 Hz | This PR Hz | Δ Hz | Sess23 KB/s | This PR KB/s | Δ KB/s |
|--------|---:|---:|---:|---:|---:|---:|
| 5T1+11T2 OBD=OFF (16ch) | 300* | **1k** | **+700** | 102 | 345 | **+243** |
| 5×T1 OBD=OFF (5ch) | 1k | **2k** | **+1k** | 93 | 201 | **+108** |
| 5×T2 (5ch) | 1k | **2k** | **+1k** | 108 | 213 | **+105** |
| 5×T1 (5ch) | 700* | **2k** | **+1.3k** | 65 | 163 | **+98** |
| 5×T1 OBD=ON (5ch) | 1k | **2k** | **+1k** | 103 | 195 | **+92** |
| 5T1+3T2 (8ch) | 500* | **1k** | **+500** | 87 | 174 | **+87** |
| 3×T1 (3ch) | 3k | 3k | 0 | 116 | 186 | **+70** |
| 1×T2 (1ch) | 6k | **7k** | **+1k** | 103 | 148 | **+45** |
| 1×T1 OBD=OFF (1ch) | 8k | 7k | -1k | 183 | 156 | -27 (suspect run-to-run; 6 s vs Sess23's 10 s sweep windows) |

*Session 23 numbers below 1 kHz come from the lowrate (sub-1k) sweep, not the main sweep.

## Test plan

- [x] Build clean (`bash ~/.claude/skills/build/build.sh`)
- [x] Flash via PICkit 4 (`bash ~/.claude/skills/flash/flash.sh`)
- [x] STA-mode association (Tesla SSID, 192.168.1.160, RSSI ~85)
- [x] PB sweep 16 configs × ~9 rates × 6 s — see table above
- [x] CSV sweep 16 configs × ~9 rates × 6 s — see table above
- [ ] Sub-1k sweep for the 3 CSV configs that show 0 in the main sweep (8ch+ that need <1 kHz: 11×T2, 5T1+5T2, 5T1+11T2)
- [ ] Multi-trial verification on 3×T1 PB (5k → 4k -32 KB/s) and 1×T1 OBD=OFF CSV (8k → 7k -27 KB/s) — these are the only ceiling regressions; suspect run-to-run variance on the shorter 6 s window
- [ ] 60 s endurance at each new ceiling (re-run with `--endurance 60`)
- [ ] Qodo `/review` + `/improve` cycle
- [ ] Update CLAUDE.md WiFi STA characterization tables once endurance confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)