### PR TITLE
feat(wifi): in-firmware iperf2 TCP+UDP module for wire-rate truth (#377)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -543,11 +543,11 @@ SYSTem:STORage:SD:BENCHmark?                      # Query results: bytes,ms,bps
 
 **WiFi STA characterization (NQ1, fullscale test pattern, Session 23 — 2026-04-25):**
 
-> ⚠️ **All Session 23 (and earlier Session 21/22) WiFi ceilings are inflated.** Captured before the #371 silent-loss accounting fix; `WifiDroppedBytes` was reading 0 even when the streaming task silently dropped up to 86 % of encoded bytes (the per-iteration `hasWifi = (wifiSize >= 128)` gate skipped the entire WriteBuffer call when the circular buffer fell below 128 bytes free). True wire ceiling on Tesla AP is ~200-230 KB/s sustained; "ceilings" reported below are mostly hitting that wall but were measured as clean because the silent drops weren't counted.
+> ⚠️ **All Session 23 (and earlier Session 21/22) WiFi ceilings are inflated.** Captured before the #371 silent-loss accounting fix; `WifiDroppedBytes` was reading 0 even when the streaming task silently dropped up to 86 % of encoded bytes (the per-iteration `hasWifi = (wifiSize >= 128)` gate skipped the entire WriteBuffer call when the circular buffer fell below 128 bytes free). The DAQiFi firmware path through WINC1500 delivers ~200-280 KB/s sustained on Tesla AP at this RSSI/distance — but whether the wall is the AP, the WINC1500 module, our SPI clocking, or our send pipeline is **unverified**. Until the Microchip WINC1500 iperf demo is flashed and benchmarked on the same hardware + AP (#377), this is the "firmware-path ceiling on our hardware," not an AP property. "Ceilings" reported below are mostly hitting that wall but were measured as clean because the silent drops weren't counted.
 >
 > **Do not use these numbers** for capacity planning. Spot-check with truthful counter (post-#371): 1×T1 PB real ceiling is ~3 kHz (not 7), 5×T1 PB is ~2 kHz (not 3), 16ch is ~2.5 kHz (not 1).
 >
-> Retrospective A/B planned in #373 to determine which prior throughput PRs actually moved Tesla AP wire rate vs which were measurement artifacts. Session 24 numbers will replace this table after that audit.
+> Retrospective A/B planned in #373 to determine which prior throughput PRs actually moved firmware-path wire rate vs which were measurement artifacts. iperf demo A/B planned in #377 to establish the true wire-rate ceiling. Session 24 numbers will replace this table after both audits.
 
 Single-trial ceiling sweep, no endurance. Best wire rate = **183 KB/s = 1.5 Mbps** (CSV 1×T1 OBD=OFF @ 8 kHz). WINC1500 spec is 5–10 Mbps real TCP — **~25 % of available bandwidth, 3-7× headroom**. WiFi-side bottleneck is `WifiDroppedBytes` in every leak (pipeline up to encoder is clean; WINC SPI staging is the bottleneck).
 

--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -988,6 +988,7 @@
           <itemPath>../src/services/wifi_services/wifi_serial_bridge_interface.c</itemPath>
           <itemPath>../src/services/wifi_services/wifi_tcp_server.c</itemPath>
           <itemPath>../src/services/wifi_services/wifi_manager.c</itemPath>
+          <itemPath>../src/services/wifi_services/iperf2/iperf2.c</itemPath>
         </logicalFolder>
         <itemPath>../src/services/daqifi_settings.c</itemPath>
         <itemPath>../src/services/streaming.c</itemPath>

--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -989,6 +989,7 @@
           <itemPath>../src/services/wifi_services/wifi_tcp_server.c</itemPath>
           <itemPath>../src/services/wifi_services/wifi_manager.c</itemPath>
           <itemPath>../src/services/wifi_services/iperf2/iperf2.c</itemPath>
+          <itemPath>../src/services/wifi_services/iperf2/iperf2.h</itemPath>
         </logicalFolder>
         <itemPath>../src/services/daqifi_settings.c</itemPath>
         <itemPath>../src/services/streaming.c</itemPath>

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -1908,56 +1908,90 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
 // #377 iperf2 SCPI handlers
 // =====================================================================
 
-static scpi_result_t SCPI_Iperf2_Server(scpi_t * context) {
-    int32_t port = IPERF2_DEFAULT_PORT;
-    // Optional port argument; default 5001
-    if (!SCPI_ParamInt32(context, &port, FALSE)) {
-        port = IPERF2_DEFAULT_PORT;
-    }
-    if (port <= 0 || port > 65535) {
-        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
-        return SCPI_RES_ERR;
-    }
-    // Refuse if streaming is active — iperf needs the socket stack quiet
+static bool Iperf2_RefuseIfStreaming(scpi_t * context) {
     StreamingRuntimeConfig* pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
     if (pStreamCfg && pStreamCfg->IsEnabled && pStreamCfg->Running) {
         SCPI_ExecutionError(context, "SYST:WIFI:IPERF: stop streaming first");
+        return true;
+    }
+    return false;
+}
+
+// Optional [port=5001] arg
+static scpi_result_t SCPI_Iperf2_TcpServer(scpi_t * context) {
+    int32_t port = IPERF2_DEFAULT_PORT;
+    if (!SCPI_ParamInt32(context, &port, FALSE)) port = IPERF2_DEFAULT_PORT;
+    if (port <= 0 || port > 65535) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
         return SCPI_RES_ERR;
     }
-    if (!Iperf2_StartServer((uint16_t)port)) {
+    if (Iperf2_RefuseIfStreaming(context)) return SCPI_RES_ERR;
+    if (!Iperf2_StartTcpServer((uint16_t)port)) {
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         return SCPI_RES_ERR;
     }
     return SCPI_RES_OK;
 }
 
-static scpi_result_t SCPI_Iperf2_Client(scpi_t * context) {
-    char ipBuf[32];
-    size_t ipLen = 0;
+static scpi_result_t SCPI_Iperf2_UdpServer(scpi_t * context) {
     int32_t port = IPERF2_DEFAULT_PORT;
-    int32_t duration_sec = 10;
-    if (!SCPI_ParamCopyText(context, ipBuf, sizeof(ipBuf), &ipLen, TRUE)) {
-        SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
-        return SCPI_RES_ERR;
-    }
-    if (!SCPI_ParamInt32(context, &port, FALSE)) {
-        port = IPERF2_DEFAULT_PORT;
-    }
-    if (!SCPI_ParamInt32(context, &duration_sec, FALSE)) {
-        duration_sec = 10;
-    }
-    if (port <= 0 || port > 65535 || duration_sec < 1 || duration_sec > 3600) {
+    if (!SCPI_ParamInt32(context, &port, FALSE)) port = IPERF2_DEFAULT_PORT;
+    if (port <= 0 || port > 65535) {
         SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
         return SCPI_RES_ERR;
     }
-    StreamingRuntimeConfig* pStreamCfg = BoardRunTimeConfig_Get(
-            BOARDRUNTIME_STREAMING_CONFIGURATION);
-    if (pStreamCfg && pStreamCfg->IsEnabled && pStreamCfg->Running) {
-        SCPI_ExecutionError(context, "SYST:WIFI:IPERF: stop streaming first");
+    if (Iperf2_RefuseIfStreaming(context)) return SCPI_RES_ERR;
+    if (!Iperf2_StartUdpServer((uint16_t)port)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         return SCPI_RES_ERR;
     }
-    if (!Iperf2_StartClient(ipBuf, (uint16_t)port, (uint32_t)duration_sec)) {
+    return SCPI_RES_OK;
+}
+
+// Common <ip>,[port=5001],[dur_s=10] parser
+static bool Iperf2_ParseClientArgs(scpi_t * context, char* ipBuf,
+                                   size_t ipBufLen, int32_t* port,
+                                   int32_t* duration_sec) {
+    size_t ipLen = 0;
+    *port = IPERF2_DEFAULT_PORT;
+    *duration_sec = 10;
+    if (!SCPI_ParamCopyText(context, ipBuf, ipBufLen, &ipLen, TRUE)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+        return false;
+    }
+    if (!SCPI_ParamInt32(context, port, FALSE)) *port = IPERF2_DEFAULT_PORT;
+    if (!SCPI_ParamInt32(context, duration_sec, FALSE)) *duration_sec = 10;
+    if (*port <= 0 || *port > 65535 || *duration_sec < 1 ||
+        *duration_sec > 3600) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return false;
+    }
+    return true;
+}
+
+static scpi_result_t SCPI_Iperf2_TcpClient(scpi_t * context) {
+    char ipBuf[32];
+    int32_t port, duration_sec;
+    if (!Iperf2_ParseClientArgs(context, ipBuf, sizeof(ipBuf), &port,
+                                 &duration_sec)) return SCPI_RES_ERR;
+    if (Iperf2_RefuseIfStreaming(context)) return SCPI_RES_ERR;
+    if (!Iperf2_StartTcpClient(ipBuf, (uint16_t)port,
+                               (uint32_t)duration_sec)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_Iperf2_UdpClient(scpi_t * context) {
+    char ipBuf[32];
+    int32_t port, duration_sec;
+    if (!Iperf2_ParseClientArgs(context, ipBuf, sizeof(ipBuf), &port,
+                                 &duration_sec)) return SCPI_RES_ERR;
+    if (Iperf2_RefuseIfStreaming(context)) return SCPI_RES_ERR;
+    if (!Iperf2_StartUdpClient(ipBuf, (uint16_t)port,
+                               (uint32_t)duration_sec)) {
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         return SCPI_RES_ERR;
     }
@@ -1978,6 +2012,9 @@ static scpi_result_t SCPI_Iperf2_Stats(scpi_t * context) {
     scpi_printf(context, "Bytes=%llu\r\n", (unsigned long long)s.bytes_transferred);
     scpi_printf(context, "DurationMs=%u\r\n", (unsigned)s.duration_ms);
     scpi_printf(context, "KBps=%u\r\n", (unsigned)s.kbps);
+    scpi_printf(context, "UdpTotalPkt=%u\r\n", (unsigned)s.udp_total_pkt);
+    scpi_printf(context, "UdpLostPkt=%u\r\n", (unsigned)s.udp_lost_pkt);
+    scpi_printf(context, "UdpOutOfOrder=%u\r\n", (unsigned)s.udp_outoforder);
     return SCPI_RES_OK;
 }
 
@@ -3611,9 +3648,11 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:STReam:BENCHmark", .callback = SCPI_SetBenchmarkMode,}, // 0=normal, 1=nocap, 2=pipeline (skip ADC)
     {.pattern = "SYSTem:STReam:BENCHmark?", .callback = SCPI_GetBenchmarkMode,},
     {.pattern = "SYSTem:STReam:THRoughput", .callback = SCPI_RunThroughputBench,}, // <freq>,<duration_sec> — self-contained benchmark
-    // #377 iperf2 wire-rate benchmarks (TCP only).  Refuse if streaming.
-    {.pattern = "SYSTem:WIFI:IPERF:SERVer", .callback = SCPI_Iperf2_Server,}, // [port=5001]
-    {.pattern = "SYSTem:WIFI:IPERF:CLIent", .callback = SCPI_Iperf2_Client,}, // <ip>,[port=5001],[dur_s=10]
+    // #377 iperf2 wire-rate benchmarks (TCP + UDP).  Refuse if streaming.
+    {.pattern = "SYSTem:WIFI:IPERF:TSERVer", .callback = SCPI_Iperf2_TcpServer,}, // [port=5001]
+    {.pattern = "SYSTem:WIFI:IPERF:USERVer", .callback = SCPI_Iperf2_UdpServer,}, // [port=5001]
+    {.pattern = "SYSTem:WIFI:IPERF:TCLIent", .callback = SCPI_Iperf2_TcpClient,}, // <ip>,[port=5001],[dur_s=10]
+    {.pattern = "SYSTem:WIFI:IPERF:UCLIent", .callback = SCPI_Iperf2_UdpClient,}, // <ip>,[port=5001],[dur_s=10]
     {.pattern = "SYSTem:WIFI:IPERF:STOP", .callback = SCPI_Iperf2_Stop,},
     {.pattern = "SYSTem:WIFI:IPERF:STATs?", .callback = SCPI_Iperf2_Stats,},
     // Dynamic memory configuration

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -50,6 +50,7 @@
 #include "Util/CoherentPool.h"
 #include "state/data/AInSample.h"  // For AInSampleList_PoolCapacity
 #include "services/wifi_services/wifi_tcp_server.h"  // For WIFI_CIRCULAR_BUFF_SIZE
+#include "services/wifi_services/iperf2/iperf2.h"   // #377 iperf2 control
 #include "config/default/driver/winc/include/dev/wdrv_winc_spi.h"  // For WDRV_WINC_SPI_SetBuffer/WaitIdle
 #include "config/default/WincIdleGate.h"  // For SYST:WINC:GATE? debug accessor
 #ifndef DAQIFI_WINC_SPI_PATCHED
@@ -1903,6 +1904,83 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+// =====================================================================
+// #377 iperf2 SCPI handlers
+// =====================================================================
+
+static scpi_result_t SCPI_Iperf2_Server(scpi_t * context) {
+    int32_t port = IPERF2_DEFAULT_PORT;
+    // Optional port argument; default 5001
+    if (!SCPI_ParamInt32(context, &port, FALSE)) {
+        port = IPERF2_DEFAULT_PORT;
+    }
+    if (port <= 0 || port > 65535) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+    // Refuse if streaming is active — iperf needs the socket stack quiet
+    StreamingRuntimeConfig* pStreamCfg = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_STREAMING_CONFIGURATION);
+    if (pStreamCfg && pStreamCfg->IsEnabled && pStreamCfg->Running) {
+        SCPI_ExecutionError(context, "SYST:WIFI:IPERF: stop streaming first");
+        return SCPI_RES_ERR;
+    }
+    if (!Iperf2_StartServer((uint16_t)port)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_Iperf2_Client(scpi_t * context) {
+    char ipBuf[32];
+    size_t ipLen = 0;
+    int32_t port = IPERF2_DEFAULT_PORT;
+    int32_t duration_sec = 10;
+    if (!SCPI_ParamCopyText(context, ipBuf, sizeof(ipBuf), &ipLen, TRUE)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+        return SCPI_RES_ERR;
+    }
+    if (!SCPI_ParamInt32(context, &port, FALSE)) {
+        port = IPERF2_DEFAULT_PORT;
+    }
+    if (!SCPI_ParamInt32(context, &duration_sec, FALSE)) {
+        duration_sec = 10;
+    }
+    if (port <= 0 || port > 65535 || duration_sec < 1 || duration_sec > 3600) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+    StreamingRuntimeConfig* pStreamCfg = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_STREAMING_CONFIGURATION);
+    if (pStreamCfg && pStreamCfg->IsEnabled && pStreamCfg->Running) {
+        SCPI_ExecutionError(context, "SYST:WIFI:IPERF: stop streaming first");
+        return SCPI_RES_ERR;
+    }
+    if (!Iperf2_StartClient(ipBuf, (uint16_t)port, (uint32_t)duration_sec)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_Iperf2_Stop(scpi_t * context) {
+    Iperf2_Stop();
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_Iperf2_Stats(scpi_t * context) {
+    Iperf2_Stats s;
+    Iperf2_GetStats(&s);
+    scpi_printf(context, "Mode=%d\r\n", (int)s.mode);
+    scpi_printf(context, "Active=%d\r\n", (int)(s.active ? 1 : 0));
+    scpi_printf(context, "Completed=%d\r\n", (int)(s.completed ? 1 : 0));
+    scpi_printf(context, "Bytes=%llu\r\n", (unsigned long long)s.bytes_transferred);
+    scpi_printf(context, "DurationMs=%u\r\n", (unsigned)s.duration_ms);
+    scpi_printf(context, "KBps=%u\r\n", (unsigned)s.kbps);
+    return SCPI_RES_OK;
+}
+
 static scpi_result_t SCPI_ClearStreamStats(scpi_t * context) {
     Streaming_ClearStats();
     // Reset WiFi TCP send tracking counters atomically
@@ -3533,6 +3611,11 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:STReam:BENCHmark", .callback = SCPI_SetBenchmarkMode,}, // 0=normal, 1=nocap, 2=pipeline (skip ADC)
     {.pattern = "SYSTem:STReam:BENCHmark?", .callback = SCPI_GetBenchmarkMode,},
     {.pattern = "SYSTem:STReam:THRoughput", .callback = SCPI_RunThroughputBench,}, // <freq>,<duration_sec> — self-contained benchmark
+    // #377 iperf2 wire-rate benchmarks (TCP only).  Refuse if streaming.
+    {.pattern = "SYSTem:WIFI:IPERF:SERVer", .callback = SCPI_Iperf2_Server,}, // [port=5001]
+    {.pattern = "SYSTem:WIFI:IPERF:CLIent", .callback = SCPI_Iperf2_Client,}, // <ip>,[port=5001],[dur_s=10]
+    {.pattern = "SYSTem:WIFI:IPERF:STOP", .callback = SCPI_Iperf2_Stop,},
+    {.pattern = "SYSTem:WIFI:IPERF:STATs?", .callback = SCPI_Iperf2_Stats,},
     // Dynamic memory configuration
     {.pattern = "SYSTem:MEMory:SD:BUFfer", .callback = SCPI_SetMemSdBuf,},
     {.pattern = "SYSTem:MEMory:SD:BUFfer?", .callback = SCPI_GetMemSdBuf,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -1911,7 +1911,7 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
 static bool Iperf2_RefuseIfStreaming(scpi_t * context) {
     StreamingRuntimeConfig* pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
-    if (pStreamCfg && pStreamCfg->IsEnabled && pStreamCfg->Running) {
+    if (pStreamCfg->IsEnabled && pStreamCfg->Running) {
         SCPI_ExecutionError(context, "SYST:WIFI:IPERF: stop streaming first");
         return true;
     }
@@ -3649,10 +3649,10 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:STReam:BENCHmark?", .callback = SCPI_GetBenchmarkMode,},
     {.pattern = "SYSTem:STReam:THRoughput", .callback = SCPI_RunThroughputBench,}, // <freq>,<duration_sec> — self-contained benchmark
     // #377 iperf2 wire-rate benchmarks (TCP + UDP).  Refuse if streaming.
-    {.pattern = "SYSTem:WIFI:IPERF:TSERVer", .callback = SCPI_Iperf2_TcpServer,}, // [port=5001]
-    {.pattern = "SYSTem:WIFI:IPERF:USERVer", .callback = SCPI_Iperf2_UdpServer,}, // [port=5001]
-    {.pattern = "SYSTem:WIFI:IPERF:TCLIent", .callback = SCPI_Iperf2_TcpClient,}, // <ip>,[port=5001],[dur_s=10]
-    {.pattern = "SYSTem:WIFI:IPERF:UCLIent", .callback = SCPI_Iperf2_UdpClient,}, // <ip>,[port=5001],[dur_s=10]
+    {.pattern = "SYSTem:WIFI:IPERF:TCPServer", .callback = SCPI_Iperf2_TcpServer,}, // [port=5001]
+    {.pattern = "SYSTem:WIFI:IPERF:UDPServer", .callback = SCPI_Iperf2_UdpServer,}, // [port=5001]
+    {.pattern = "SYSTem:WIFI:IPERF:TCPClient", .callback = SCPI_Iperf2_TcpClient,}, // <ip>,[port=5001],[dur_s=10]
+    {.pattern = "SYSTem:WIFI:IPERF:UDPClient", .callback = SCPI_Iperf2_UdpClient,}, // <ip>,[port=5001],[dur_s=10]
     {.pattern = "SYSTem:WIFI:IPERF:STOP", .callback = SCPI_Iperf2_Stop,},
     {.pattern = "SYSTem:WIFI:IPERF:STATs?", .callback = SCPI_Iperf2_Stats,},
     // Dynamic memory configuration

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -593,8 +593,12 @@ static void TasksUdpClient(void) {
                             (struct sockaddr*)&gCtx.udp_remote,
                             sizeof(gCtx.udp_remote));
             if (rc == SOCK_ERR_NO_ERROR) {
+                // 8-bit RMW; same critical-section pattern as the TX-phase
+                // path above for consistency.
+                taskENTER_CRITICAL();
                 gCtx.pending_tx++;
                 gCtx.udp_fin_count++;
+                taskEXIT_CRITICAL();
             }
         }
     }

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -1,0 +1,364 @@
+#define LOG_LVL LOG_LEVEL_WIFI
+#define LOG_MODULE LOG_MODULE_WIFI
+
+#include "iperf2.h"
+#include "Util/Logger.h"
+#include "FreeRTOS.h"
+#include "task.h"
+#include "socket.h"
+#include "m2m_wifi.h"
+#include <string.h>
+
+// ============================================================================
+// iperf2 — minimal TCP iperf 2 protocol over WINC m2m sockets, control via
+// SCPI.  Server mode: listen, accept, recv-and-count-bytes until disconnect,
+// emit summary.  Client mode: connect, send tClientHdr, then 1400-byte
+// chunks for `duration_sec`, close.
+// ============================================================================
+
+#define IPERF2_TXFER_SIZE       1400U   // matches WINC SOCKET_BUFFER_MAX_LENGTH
+#define IPERF2_RXFER_SIZE       1400U
+#define IPERF2_MAX_DURATION_S   3600U   // 1h cap
+#define IPERF2_MAX_PENDING_TX   2U      // WINC HIF queue cap (mirror tcp_server)
+
+typedef struct {
+    Iperf2_Mode    mode;
+    SOCKET         listen_sock;     // server only
+    SOCKET         data_sock;       // active TCP connection (server: accepted; client: connected)
+    bool           server_running;
+    bool           client_connect_pending;
+    bool           client_connected;
+    bool           tx_in_flight;    // single outstanding send slot for client
+    uint8_t        pending_tx;      // count of m2m_send not yet ACKed
+    TickType_t     start_tick;
+    TickType_t     deadline_tick;   // client mode TX deadline
+    uint32_t       duration_ms;     // requested duration
+    uint64_t       bytes_transferred;
+    uint64_t       bytes_confirmed; // server: rcv'd; client: ACKed by m2m_send callback
+    Iperf2_Stats   last_stats;
+} Iperf2_Context;
+
+static Iperf2_Context gCtx;
+
+// Static TX/RX buffers — keep off task stacks.  TX buffer carries a synthetic
+// counter pattern so PC-side iperf can't compress; RX buffer is just a sink.
+static uint8_t gTxBuf[IPERF2_TXFER_SIZE];
+static uint8_t gRxBuf[IPERF2_RXFER_SIZE];
+
+static void FillTxBuffer(void) {
+    // Counter pattern — one byte per index — defeats PC-side TCP coalescing
+    // optimizations and gives a predictable wire stream.  Pre-filled at init.
+    for (uint16_t i = 0; i < IPERF2_TXFER_SIZE; i++) {
+        gTxBuf[i] = (uint8_t)(i & 0xFFU);
+    }
+}
+
+static void ResetContext(void) {
+    gCtx.mode = IPERF2_MODE_IDLE;
+    gCtx.listen_sock = -1;
+    gCtx.data_sock = -1;
+    gCtx.server_running = false;
+    gCtx.client_connect_pending = false;
+    gCtx.client_connected = false;
+    gCtx.tx_in_flight = false;
+    gCtx.pending_tx = 0;
+    gCtx.start_tick = 0;
+    gCtx.deadline_tick = 0;
+    gCtx.duration_ms = 0;
+    gCtx.bytes_transferred = 0;
+    gCtx.bytes_confirmed = 0;
+}
+
+static void FinalizeStats(void) {
+    TickType_t elapsed = xTaskGetTickCount() - gCtx.start_tick;
+    uint32_t elapsed_ms = elapsed * portTICK_PERIOD_MS;
+    gCtx.last_stats.mode = gCtx.mode;
+    gCtx.last_stats.bytes_transferred = gCtx.bytes_confirmed;
+    gCtx.last_stats.duration_ms = elapsed_ms;
+    gCtx.last_stats.kbps = (elapsed_ms > 0)
+        ? (uint32_t)((gCtx.bytes_confirmed * 1000ULL) / (uint64_t)elapsed_ms / 1024ULL)
+        : 0U;
+    gCtx.last_stats.active = false;
+    gCtx.last_stats.completed = true;
+}
+
+static void CloseAll(void) {
+    if (gCtx.data_sock >= 0) {
+        shutdown(gCtx.data_sock);
+        gCtx.data_sock = -1;
+    }
+    if (gCtx.listen_sock >= 0) {
+        shutdown(gCtx.listen_sock);
+        gCtx.listen_sock = -1;
+    }
+}
+
+void Iperf2_Initialize(void) {
+    ResetContext();
+    FillTxBuffer();
+    memset(&gCtx.last_stats, 0, sizeof(gCtx.last_stats));
+}
+
+bool Iperf2_StartServer(uint16_t port) {
+    if (gCtx.mode != IPERF2_MODE_IDLE) {
+        LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
+        return false;
+    }
+
+    gCtx.listen_sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (gCtx.listen_sock < 0) {
+        LOG_E("iperf2: socket() failed");
+        return false;
+    }
+
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = _htons(port);
+    addr.sin_addr.s_addr = 0;  // INADDR_ANY
+
+    int rc = bind(gCtx.listen_sock, (struct sockaddr*)&addr, sizeof(addr));
+    if (rc != 0) {
+        LOG_E("iperf2: bind() rc=%d", rc);
+        CloseAll();
+        return false;
+    }
+
+    gCtx.mode = IPERF2_MODE_SERVER;
+    gCtx.server_running = true;
+    gCtx.start_tick = xTaskGetTickCount();
+    gCtx.bytes_transferred = 0;
+    gCtx.bytes_confirmed = 0;
+    gCtx.last_stats.active = true;
+    gCtx.last_stats.completed = false;
+    LOG_I("iperf2: TCP server listening on port %u", (unsigned)port);
+    return true;
+}
+
+bool Iperf2_StartClient(const char* remote_ip, uint16_t remote_port,
+                        uint32_t duration_sec) {
+    if (gCtx.mode != IPERF2_MODE_IDLE) {
+        LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
+        return false;
+    }
+    if (duration_sec == 0 || duration_sec > IPERF2_MAX_DURATION_S) {
+        LOG_E("iperf2: invalid duration %u s", (unsigned)duration_sec);
+        return false;
+    }
+
+    gCtx.data_sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (gCtx.data_sock < 0) {
+        LOG_E("iperf2: client socket() failed");
+        return false;
+    }
+
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = _htons(remote_port);
+    addr.sin_addr.s_addr = inet_addr((char*)remote_ip);
+    if (addr.sin_addr.s_addr == 0) {
+        LOG_E("iperf2: bad remote IP %s", remote_ip);
+        CloseAll();
+        return false;
+    }
+
+    int rc = connect(gCtx.data_sock, (struct sockaddr*)&addr, sizeof(addr));
+    if (rc != 0) {
+        LOG_E("iperf2: connect() rc=%d", rc);
+        CloseAll();
+        return false;
+    }
+
+    gCtx.mode = IPERF2_MODE_CLIENT;
+    gCtx.client_connect_pending = true;
+    gCtx.client_connected = false;
+    gCtx.duration_ms = duration_sec * 1000U;
+    gCtx.bytes_transferred = 0;
+    gCtx.bytes_confirmed = 0;
+    gCtx.last_stats.active = true;
+    gCtx.last_stats.completed = false;
+    LOG_I("iperf2: TCP client connecting to %s:%u for %u s",
+          remote_ip, (unsigned)remote_port, (unsigned)duration_sec);
+    return true;
+}
+
+void Iperf2_Stop(void) {
+    if (gCtx.mode == IPERF2_MODE_IDLE) {
+        return;
+    }
+    LOG_I("iperf2: stop requested (mode=%d, bytes=%llu)",
+          (int)gCtx.mode, (unsigned long long)gCtx.bytes_confirmed);
+    FinalizeStats();
+    CloseAll();
+    ResetContext();
+}
+
+void Iperf2_GetStats(Iperf2_Stats* out) {
+    if (out == NULL) return;
+    if (gCtx.mode != IPERF2_MODE_IDLE && gCtx.last_stats.active) {
+        // Update on-the-fly so STATS? during a run shows progress
+        TickType_t elapsed = xTaskGetTickCount() - gCtx.start_tick;
+        uint32_t elapsed_ms = elapsed * portTICK_PERIOD_MS;
+        out->mode = gCtx.mode;
+        out->bytes_transferred = gCtx.bytes_confirmed;
+        out->duration_ms = elapsed_ms;
+        out->kbps = (elapsed_ms > 0)
+            ? (uint32_t)((gCtx.bytes_confirmed * 1000ULL) / (uint64_t)elapsed_ms / 1024ULL)
+            : 0U;
+        out->active = true;
+        out->completed = false;
+    } else {
+        *out = gCtx.last_stats;
+    }
+}
+
+bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
+    if (gCtx.mode == IPERF2_MODE_IDLE) {
+        return false;
+    }
+    // Only handle sockets we own
+    if (sock != gCtx.listen_sock && sock != gCtx.data_sock) {
+        return false;
+    }
+
+    switch (msg_type) {
+        case SOCKET_MSG_BIND: {
+            tstrSocketBindMsg* m = (tstrSocketBindMsg*)pMessage;
+            if (m && m->status == 0 && sock == gCtx.listen_sock) {
+                listen(gCtx.listen_sock, 0);
+            } else {
+                LOG_E("iperf2: bind status=%d", m ? m->status : -1);
+                Iperf2_Stop();
+            }
+            return true;
+        }
+        case SOCKET_MSG_LISTEN: {
+            tstrSocketListenMsg* m = (tstrSocketListenMsg*)pMessage;
+            if (m && m->status == 0 && sock == gCtx.listen_sock) {
+                accept(gCtx.listen_sock, NULL, NULL);
+            } else {
+                LOG_E("iperf2: listen status=%d", m ? m->status : -1);
+                Iperf2_Stop();
+            }
+            return true;
+        }
+        case SOCKET_MSG_ACCEPT: {
+            tstrSocketAcceptMsg* m = (tstrSocketAcceptMsg*)pMessage;
+            if (m && m->sock >= 0 && sock == gCtx.listen_sock) {
+                if (gCtx.data_sock >= 0) {
+                    shutdown(gCtx.data_sock);
+                }
+                gCtx.data_sock = m->sock;
+                gCtx.start_tick = xTaskGetTickCount();
+                gCtx.bytes_transferred = 0;
+                gCtx.bytes_confirmed = 0;
+                LOG_I("iperf2: server accepted connection (sock=%d)",
+                      (int)m->sock);
+                recv(gCtx.data_sock, gRxBuf, IPERF2_RXFER_SIZE, 0);
+            } else {
+                LOG_E("iperf2: accept failed");
+                Iperf2_Stop();
+            }
+            return true;
+        }
+        case SOCKET_MSG_CONNECT: {
+            tstrSocketConnectMsg* m = (tstrSocketConnectMsg*)pMessage;
+            if (m && m->s8Error == 0 && sock == gCtx.data_sock) {
+                gCtx.client_connect_pending = false;
+                gCtx.client_connected = true;
+                gCtx.start_tick = xTaskGetTickCount();
+                gCtx.deadline_tick = gCtx.start_tick +
+                                     pdMS_TO_TICKS(gCtx.duration_ms);
+                // Send client header first per iperf2 protocol
+                Iperf2_ClientHdr hdr;
+                memset(&hdr, 0, sizeof(hdr));
+                hdr.flags = _htonl((uint32_t)IPERF2_HEADER_VERSION1);
+                hdr.numThreads = _htonl((uint32_t)1U);
+                hdr.mPort = _htonl((uint32_t)IPERF2_DEFAULT_PORT);
+                hdr.bufferlen = _htonl((uint32_t)IPERF2_TXFER_SIZE);
+                hdr.mWinBand = _htonl((uint32_t)0U);
+                // negative mAmount = duration in -100us units (iperf2 quirk)
+                int32_t signed_amount = -(int32_t)(gCtx.duration_ms * 10U);
+                hdr.mAmount = _htonl((uint32_t)signed_amount);
+                int rc = send(gCtx.data_sock, (char*)&hdr, sizeof(hdr), 0);
+                if (rc == SOCK_ERR_NO_ERROR) {
+                    gCtx.pending_tx = 1;
+                    LOG_I("iperf2: client connected, header queued");
+                } else {
+                    LOG_E("iperf2: header send rc=%d", rc);
+                    Iperf2_Stop();
+                }
+            } else {
+                LOG_E("iperf2: connect err=%d", m ? m->s8Error : -1);
+                Iperf2_Stop();
+            }
+            return true;
+        }
+        case SOCKET_MSG_RECV: {
+            tstrSocketRecvMsg* m = (tstrSocketRecvMsg*)pMessage;
+            if (m && m->s16BufferSize > 0) {
+                gCtx.bytes_transferred += (uint64_t)m->s16BufferSize;
+                gCtx.bytes_confirmed += (uint64_t)m->s16BufferSize;
+                // Re-arm recv to keep the receive pump going
+                recv(gCtx.data_sock, gRxBuf, IPERF2_RXFER_SIZE, 0);
+            } else {
+                // Disconnect or error → finalize
+                LOG_I("iperf2: peer closed (size=%d), finalizing",
+                      m ? m->s16BufferSize : 0);
+                FinalizeStats();
+                CloseAll();
+                ResetContext();
+            }
+            return true;
+        }
+        case SOCKET_MSG_SEND: {
+            // Returns int16_t = bytes sent (negative = error).  Decrement
+            // pending_tx so Iperf2_Tasks knows it can queue another chunk.
+            int16_t sent = (pMessage != NULL) ? *(int16_t*)pMessage : -1;
+            if (sent > 0) {
+                gCtx.bytes_confirmed += (uint64_t)sent;
+                if (gCtx.pending_tx > 0) gCtx.pending_tx--;
+            } else {
+                LOG_E("iperf2: send cb err=%d", (int)sent);
+                if (gCtx.pending_tx > 0) gCtx.pending_tx--;
+            }
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+void Iperf2_Tasks(void) {
+    if (gCtx.mode != IPERF2_MODE_CLIENT) return;
+    if (!gCtx.client_connected) return;
+
+    // Deadline check: stop sending once duration expires + drain in-flight
+    if ((int32_t)(xTaskGetTickCount() - gCtx.deadline_tick) >= 0) {
+        if (gCtx.pending_tx == 0) {
+            LOG_I("iperf2: client TX done, %llu bytes sent",
+                  (unsigned long long)gCtx.bytes_confirmed);
+            FinalizeStats();
+            CloseAll();
+            ResetContext();
+        }
+        return;
+    }
+
+    // Top up the in-flight cap: queue until WINC HIF is full
+    while (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
+        int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TXFER_SIZE, 0);
+        if (rc == SOCK_ERR_NO_ERROR) {
+            gCtx.bytes_transferred += IPERF2_TXFER_SIZE;
+            gCtx.pending_tx++;
+        } else if (rc == SOCK_ERR_BUFFER_FULL) {
+            // WINC out of staging — back off until callback fires
+            break;
+        } else {
+            LOG_E("iperf2: send err rc=%d, aborting", rc);
+            FinalizeStats();
+            CloseAll();
+            ResetContext();
+            return;
+        }
+    }
+}

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -49,8 +49,10 @@ typedef struct {
 static Iperf2_Context gCtx;
 
 // Static TX/RX buffers — keep off task stacks.  Sized to the larger of TCP/UDP.
-static uint8_t gTxBuf[IPERF2_UDP_BUF_SIZE];
-static uint8_t gRxBuf[IPERF2_UDP_BUF_SIZE];
+// 4-byte aligned: HandleUdpRecvFrom casts gRxBuf to Iperf2_PktInfo* (which has
+// int32_t/uint32_t fields).  MIPS would fault on unaligned 32-bit access.
+static uint8_t gTxBuf[IPERF2_UDP_BUF_SIZE] __attribute__((aligned(4)));
+static uint8_t gRxBuf[IPERF2_UDP_BUF_SIZE] __attribute__((aligned(4)));
 
 static void FillTxBuffer(void) {
     // Counter pattern — defeats PC-side TCP coalescing optimizations and gives
@@ -278,6 +280,10 @@ void Iperf2_Stop(void) {
 
 void Iperf2_GetStats(Iperf2_Stats* out) {
     if (out == NULL) return;
+    // bytes_transferred / bytes_confirmed are 64-bit and updated by the
+    // socket-event task; reading them needs a critical section so we don't
+    // get torn 32-bit halves.  See PIC32MZ atomicity rules in CLAUDE.md.
+    taskENTER_CRITICAL();
     if (gCtx.mode != IPERF2_MODE_IDLE && gCtx.last_stats.active) {
         // Update on-the-fly so STATS? during a run shows progress
         TickType_t elapsed = xTaskGetTickCount() - gCtx.start_tick;
@@ -296,6 +302,7 @@ void Iperf2_GetStats(Iperf2_Stats* out) {
     } else {
         *out = gCtx.last_stats;
     }
+    taskEXIT_CRITICAL();
 }
 
 // ----------------------------------------------------------------------------
@@ -304,8 +311,11 @@ void Iperf2_GetStats(Iperf2_Stats* out) {
 
 static void HandleTcpRecv(tstrSocketRecvMsg* m) {
     if (m && m->s16BufferSize > 0) {
+        // 64-bit RMW + paired with USB-priority Iperf2_GetStats reader
+        taskENTER_CRITICAL();
         gCtx.bytes_transferred += (uint64_t)m->s16BufferSize;
         gCtx.bytes_confirmed += (uint64_t)m->s16BufferSize;
+        taskEXIT_CRITICAL();
         recv(gCtx.data_sock, gRxBuf, IPERF2_TCP_BUF_SIZE, 0);
     } else {
         // Disconnect or error → finalize
@@ -325,6 +335,14 @@ static void HandleUdpRecvFrom(tstrSocketRecvMsg* m) {
         return;
     }
 
+    // Reject runt datagrams: a valid iperf2 UDP packet has at least the
+    // 12-byte Iperf2_PktInfo header.  Without this guard, casting gRxBuf
+    // to Iperf2_PktInfo* would read past the actual payload.
+    if ((size_t)m->s16BufferSize < sizeof(Iperf2_PktInfo)) {
+        recvfrom(gCtx.data_sock, gRxBuf, sizeof(gRxBuf), 0);
+        return;
+    }
+
     // Capture remote on first packet (where peer port comes from)
     if (gCtx.bytes_transferred == 0) {
         gCtx.udp_remote = m->strRemoteAddr;
@@ -334,7 +352,9 @@ static void HandleUdpRecvFrom(tstrSocketRecvMsg* m) {
     int32_t id = (int32_t)_ntohl((uint32_t)pkt->id);
 
     if (id >= 0) {
-        // Normal packet — track sequence/loss
+        // Normal packet — track sequence/loss.  RMW + 64-bit, paired with
+        // USB-priority Iperf2_GetStats reader.
+        taskENTER_CRITICAL();
         if (gCtx.udp_id != id) {
             // Gap or out-of-order — only count gaps as lost (forward-only count)
             if (id > gCtx.udp_id) {
@@ -349,6 +369,7 @@ static void HandleUdpRecvFrom(tstrSocketRecvMsg* m) {
         gCtx.udp_total_pkt++;
         gCtx.bytes_transferred += (uint64_t)m->s16BufferSize;
         gCtx.bytes_confirmed += (uint64_t)m->s16BufferSize;
+        taskEXIT_CRITICAL();
     } else {
         // Negative ID = end-of-test marker.  iperf2 client retransmits this 10
         // times to ensure the server sees it.  Finalize on first observation.
@@ -434,7 +455,8 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                 hdr.mPort = _htonl((uint32_t)IPERF2_DEFAULT_PORT);
                 hdr.bufferlen = _htonl((uint32_t)IPERF2_TCP_BUF_SIZE);
                 hdr.mWinBand = _htonl((uint32_t)0U);
-                int32_t signed_amount = -(int32_t)(gCtx.duration_ms * 10U);
+                // iperf2 mAmount is in 10ms units (negative = duration mode)
+                int32_t signed_amount = -(int32_t)(gCtx.duration_ms / 10U);
                 hdr.mAmount = _htonl((uint32_t)signed_amount);
                 int rc = send(gCtx.data_sock, (char*)&hdr, sizeof(hdr), 0);
                 if (rc == SOCK_ERR_NO_ERROR) {
@@ -461,12 +483,17 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
         case SOCKET_MSG_SEND:
         case SOCKET_MSG_SENDTO: {
             int16_t sent = (pMessage != NULL) ? *(int16_t*)pMessage : -1;
+            // 64-bit + 8-bit RMW, paired with USB-priority reader / driver-task writer
+            taskENTER_CRITICAL();
             if (sent > 0) {
                 gCtx.bytes_confirmed += (uint64_t)sent;
                 if (gCtx.pending_tx > 0) gCtx.pending_tx--;
             } else {
-                LOG_E("iperf2: send cb err=%d", (int)sent);
                 if (gCtx.pending_tx > 0) gCtx.pending_tx--;
+            }
+            taskEXIT_CRITICAL();
+            if (sent <= 0) {
+                LOG_E("iperf2: send cb err=%d", (int)sent);
             }
             return true;
         }
@@ -496,8 +523,11 @@ static void TasksTcpClient(void) {
     while (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
         int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TCP_BUF_SIZE, 0);
         if (rc == SOCK_ERR_NO_ERROR) {
+            // 64-bit RMW, paired with USB-priority reader
+            taskENTER_CRITICAL();
             gCtx.bytes_transferred += IPERF2_TCP_BUF_SIZE;
             gCtx.pending_tx++;
+            taskEXIT_CRITICAL();
         } else if (rc == SOCK_ERR_BUFFER_FULL) {
             break;
         } else {
@@ -528,9 +558,12 @@ static void TasksUdpClient(void) {
                             (struct sockaddr*)&gCtx.udp_remote,
                             sizeof(gCtx.udp_remote));
             if (rc == SOCK_ERR_NO_ERROR) {
+                // 64-bit RMW, paired with USB-priority reader
+                taskENTER_CRITICAL();
                 gCtx.bytes_transferred += IPERF2_UDP_BUF_SIZE;
                 gCtx.pending_tx++;
                 gCtx.udp_id++;
+                taskEXIT_CRITICAL();
             } else if (rc == SOCK_ERR_BUFFER_FULL) {
                 break;
             } else {

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -29,7 +29,6 @@ typedef struct {
     Iperf2_Mode    mode;
     SOCKET         listen_sock;     // TCP server only
     SOCKET         data_sock;       // active TCP connection or UDP socket
-    bool           server_running;
     bool           client_connected;
     uint8_t        pending_tx;      // count of m2m_send not yet ACKed
     TickType_t     start_tick;
@@ -65,7 +64,6 @@ static void ResetContext(void) {
     gCtx.mode = IPERF2_MODE_IDLE;
     gCtx.listen_sock = -1;
     gCtx.data_sock = -1;
-    gCtx.server_running = false;
     gCtx.client_connected = false;
     gCtx.pending_tx = 0;
     gCtx.start_tick = 0;
@@ -143,7 +141,6 @@ bool Iperf2_StartTcpServer(uint16_t port) {
     }
 
     gCtx.mode = IPERF2_MODE_TCP_SERVER;
-    gCtx.server_running = true;
     gCtx.start_tick = xTaskGetTickCount();
     gCtx.last_stats.active = true;
     gCtx.last_stats.completed = false;
@@ -176,7 +173,6 @@ bool Iperf2_StartUdpServer(uint16_t port) {
     }
 
     gCtx.mode = IPERF2_MODE_UDP_SERVER;
-    gCtx.server_running = true;
     gCtx.start_tick = xTaskGetTickCount();
     gCtx.last_stats.active = true;
     gCtx.last_stats.completed = false;

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -10,45 +10,53 @@
 #include <string.h>
 
 // ============================================================================
-// iperf2 — minimal TCP iperf 2 protocol over WINC m2m sockets, control via
-// SCPI.  Server mode: listen, accept, recv-and-count-bytes until disconnect,
-// emit summary.  Client mode: connect, send tClientHdr, then 1400-byte
-// chunks for `duration_sec`, close.
+// iperf2 — TCP + UDP iperf 2 protocol over WINC m2m sockets, control via
+// SCPI.
+//
+// Modeled on avrxml/asf WINC1500 module-mode iperf_server_example
+// (common/components/wifi/winc1500/iperf_server_example/iperf.c) but
+// callback-driven instead of poll-driven so it integrates with our
+// existing wifi_manager event dispatcher.
 // ============================================================================
 
-#define IPERF2_TXFER_SIZE       1400U   // matches WINC SOCKET_BUFFER_MAX_LENGTH
-#define IPERF2_RXFER_SIZE       1400U
+#define IPERF2_TCP_BUF_SIZE     1400U   // matches WINC SOCKET_BUFFER_MAX_LENGTH for TCP
+#define IPERF2_UDP_BUF_SIZE     1470U   // standard iperf2 UDP datagram size (1500 - IP/UDP overhead)
 #define IPERF2_MAX_DURATION_S   3600U   // 1h cap
 #define IPERF2_MAX_PENDING_TX   2U      // WINC HIF queue cap (mirror tcp_server)
+#define IPERF2_FIN_RETRANSMITS  10U     // iperf2 protocol: 10× retransmit of last UDP pkt
 
 typedef struct {
     Iperf2_Mode    mode;
-    SOCKET         listen_sock;     // server only
-    SOCKET         data_sock;       // active TCP connection (server: accepted; client: connected)
+    SOCKET         listen_sock;     // TCP server only
+    SOCKET         data_sock;       // active TCP connection or UDP socket
     bool           server_running;
-    bool           client_connect_pending;
     bool           client_connected;
-    bool           tx_in_flight;    // single outstanding send slot for client
     uint8_t        pending_tx;      // count of m2m_send not yet ACKed
     TickType_t     start_tick;
-    TickType_t     deadline_tick;   // client mode TX deadline
+    TickType_t     deadline_tick;   // *_CLIENT mode TX deadline
     uint32_t       duration_ms;     // requested duration
     uint64_t       bytes_transferred;
     uint64_t       bytes_confirmed; // server: rcv'd; client: ACKed by m2m_send callback
+    // UDP-specific:
+    struct sockaddr_in udp_remote;  // remote peer (set on first recvfrom in server, or in client setup)
+    int32_t        udp_id;          // client: next seq to send; server: next expected seq
+    uint32_t       udp_total_pkt;
+    uint32_t       udp_lost_pkt;
+    uint32_t       udp_outoforder;
+    uint8_t        udp_fin_count;   // FIN retransmits sent
     Iperf2_Stats   last_stats;
 } Iperf2_Context;
 
 static Iperf2_Context gCtx;
 
-// Static TX/RX buffers — keep off task stacks.  TX buffer carries a synthetic
-// counter pattern so PC-side iperf can't compress; RX buffer is just a sink.
-static uint8_t gTxBuf[IPERF2_TXFER_SIZE];
-static uint8_t gRxBuf[IPERF2_RXFER_SIZE];
+// Static TX/RX buffers — keep off task stacks.  Sized to the larger of TCP/UDP.
+static uint8_t gTxBuf[IPERF2_UDP_BUF_SIZE];
+static uint8_t gRxBuf[IPERF2_UDP_BUF_SIZE];
 
 static void FillTxBuffer(void) {
-    // Counter pattern — one byte per index — defeats PC-side TCP coalescing
-    // optimizations and gives a predictable wire stream.  Pre-filled at init.
-    for (uint16_t i = 0; i < IPERF2_TXFER_SIZE; i++) {
+    // Counter pattern — defeats PC-side TCP coalescing optimizations and gives
+    // a predictable wire stream.  Pre-filled at init.
+    for (uint16_t i = 0; i < sizeof(gTxBuf); i++) {
         gTxBuf[i] = (uint8_t)(i & 0xFFU);
     }
 }
@@ -58,15 +66,19 @@ static void ResetContext(void) {
     gCtx.listen_sock = -1;
     gCtx.data_sock = -1;
     gCtx.server_running = false;
-    gCtx.client_connect_pending = false;
     gCtx.client_connected = false;
-    gCtx.tx_in_flight = false;
     gCtx.pending_tx = 0;
     gCtx.start_tick = 0;
     gCtx.deadline_tick = 0;
     gCtx.duration_ms = 0;
     gCtx.bytes_transferred = 0;
     gCtx.bytes_confirmed = 0;
+    memset(&gCtx.udp_remote, 0, sizeof(gCtx.udp_remote));
+    gCtx.udp_id = 0;
+    gCtx.udp_total_pkt = 0;
+    gCtx.udp_lost_pkt = 0;
+    gCtx.udp_outoforder = 0;
+    gCtx.udp_fin_count = 0;
 }
 
 static void FinalizeStats(void) {
@@ -78,6 +90,9 @@ static void FinalizeStats(void) {
     gCtx.last_stats.kbps = (elapsed_ms > 0)
         ? (uint32_t)((gCtx.bytes_confirmed * 1000ULL) / (uint64_t)elapsed_ms / 1024ULL)
         : 0U;
+    gCtx.last_stats.udp_total_pkt = gCtx.udp_total_pkt;
+    gCtx.last_stats.udp_lost_pkt = gCtx.udp_lost_pkt;
+    gCtx.last_stats.udp_outoforder = gCtx.udp_outoforder;
     gCtx.last_stats.active = false;
     gCtx.last_stats.completed = true;
 }
@@ -93,13 +108,17 @@ static void CloseAll(void) {
     }
 }
 
+// ----------------------------------------------------------------------------
+// Public API
+// ----------------------------------------------------------------------------
+
 void Iperf2_Initialize(void) {
     ResetContext();
     FillTxBuffer();
     memset(&gCtx.last_stats, 0, sizeof(gCtx.last_stats));
 }
 
-bool Iperf2_StartServer(uint16_t port) {
+bool Iperf2_StartTcpServer(uint16_t port) {
     if (gCtx.mode != IPERF2_MODE_IDLE) {
         LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
         return false;
@@ -107,7 +126,7 @@ bool Iperf2_StartServer(uint16_t port) {
 
     gCtx.listen_sock = socket(AF_INET, SOCK_STREAM, 0);
     if (gCtx.listen_sock < 0) {
-        LOG_E("iperf2: socket() failed");
+        LOG_E("iperf2: TCP socket() failed");
         return false;
     }
 
@@ -118,24 +137,55 @@ bool Iperf2_StartServer(uint16_t port) {
 
     int rc = bind(gCtx.listen_sock, (struct sockaddr*)&addr, sizeof(addr));
     if (rc != 0) {
-        LOG_E("iperf2: bind() rc=%d", rc);
+        LOG_E("iperf2: TCP bind() rc=%d", rc);
         CloseAll();
         return false;
     }
 
-    gCtx.mode = IPERF2_MODE_SERVER;
+    gCtx.mode = IPERF2_MODE_TCP_SERVER;
     gCtx.server_running = true;
     gCtx.start_tick = xTaskGetTickCount();
-    gCtx.bytes_transferred = 0;
-    gCtx.bytes_confirmed = 0;
     gCtx.last_stats.active = true;
     gCtx.last_stats.completed = false;
     LOG_I("iperf2: TCP server listening on port %u", (unsigned)port);
     return true;
 }
 
-bool Iperf2_StartClient(const char* remote_ip, uint16_t remote_port,
-                        uint32_t duration_sec) {
+bool Iperf2_StartUdpServer(uint16_t port) {
+    if (gCtx.mode != IPERF2_MODE_IDLE) {
+        LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
+        return false;
+    }
+
+    gCtx.data_sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (gCtx.data_sock < 0) {
+        LOG_E("iperf2: UDP socket() failed");
+        return false;
+    }
+
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = _htons(port);
+    addr.sin_addr.s_addr = 0;
+
+    int rc = bind(gCtx.data_sock, (struct sockaddr*)&addr, sizeof(addr));
+    if (rc != 0) {
+        LOG_E("iperf2: UDP bind() rc=%d", rc);
+        CloseAll();
+        return false;
+    }
+
+    gCtx.mode = IPERF2_MODE_UDP_SERVER;
+    gCtx.server_running = true;
+    gCtx.start_tick = xTaskGetTickCount();
+    gCtx.last_stats.active = true;
+    gCtx.last_stats.completed = false;
+    LOG_I("iperf2: UDP server listening on port %u", (unsigned)port);
+    return true;
+}
+
+bool Iperf2_StartTcpClient(const char* remote_ip, uint16_t remote_port,
+                           uint32_t duration_sec) {
     if (gCtx.mode != IPERF2_MODE_IDLE) {
         LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
         return false;
@@ -147,7 +197,7 @@ bool Iperf2_StartClient(const char* remote_ip, uint16_t remote_port,
 
     gCtx.data_sock = socket(AF_INET, SOCK_STREAM, 0);
     if (gCtx.data_sock < 0) {
-        LOG_E("iperf2: client socket() failed");
+        LOG_E("iperf2: TCP client socket() failed");
         return false;
     }
 
@@ -163,21 +213,59 @@ bool Iperf2_StartClient(const char* remote_ip, uint16_t remote_port,
 
     int rc = connect(gCtx.data_sock, (struct sockaddr*)&addr, sizeof(addr));
     if (rc != 0) {
-        LOG_E("iperf2: connect() rc=%d", rc);
+        LOG_E("iperf2: TCP connect() rc=%d", rc);
         CloseAll();
         return false;
     }
 
-    gCtx.mode = IPERF2_MODE_CLIENT;
-    gCtx.client_connect_pending = true;
+    gCtx.mode = IPERF2_MODE_TCP_CLIENT;
     gCtx.client_connected = false;
     gCtx.duration_ms = duration_sec * 1000U;
-    gCtx.bytes_transferred = 0;
-    gCtx.bytes_confirmed = 0;
     gCtx.last_stats.active = true;
     gCtx.last_stats.completed = false;
     LOG_I("iperf2: TCP client connecting to %s:%u for %u s",
           remote_ip, (unsigned)remote_port, (unsigned)duration_sec);
+    return true;
+}
+
+bool Iperf2_StartUdpClient(const char* remote_ip, uint16_t remote_port,
+                           uint32_t duration_sec) {
+    if (gCtx.mode != IPERF2_MODE_IDLE) {
+        LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
+        return false;
+    }
+    if (duration_sec == 0 || duration_sec > IPERF2_MAX_DURATION_S) {
+        LOG_E("iperf2: invalid duration %u s", (unsigned)duration_sec);
+        return false;
+    }
+
+    gCtx.data_sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (gCtx.data_sock < 0) {
+        LOG_E("iperf2: UDP client socket() failed");
+        return false;
+    }
+
+    gCtx.udp_remote.sin_family = AF_INET;
+    gCtx.udp_remote.sin_port = _htons(remote_port);
+    gCtx.udp_remote.sin_addr.s_addr = inet_addr((char*)remote_ip);
+    if (gCtx.udp_remote.sin_addr.s_addr == 0) {
+        LOG_E("iperf2: bad remote IP %s", remote_ip);
+        CloseAll();
+        return false;
+    }
+
+    // UDP is connectionless — start sending immediately from Iperf2_Tasks
+    gCtx.mode = IPERF2_MODE_UDP_CLIENT;
+    gCtx.client_connected = true;
+    gCtx.duration_ms = duration_sec * 1000U;
+    gCtx.start_tick = xTaskGetTickCount();
+    gCtx.deadline_tick = gCtx.start_tick + pdMS_TO_TICKS(gCtx.duration_ms);
+    gCtx.udp_id = 0;
+    gCtx.udp_fin_count = 0;
+    gCtx.last_stats.active = true;
+    gCtx.last_stats.completed = false;
+    LOG_I("iperf2: UDP client → %s:%u for %u s", remote_ip,
+          (unsigned)remote_port, (unsigned)duration_sec);
     return true;
 }
 
@@ -204,11 +292,81 @@ void Iperf2_GetStats(Iperf2_Stats* out) {
         out->kbps = (elapsed_ms > 0)
             ? (uint32_t)((gCtx.bytes_confirmed * 1000ULL) / (uint64_t)elapsed_ms / 1024ULL)
             : 0U;
+        out->udp_total_pkt = gCtx.udp_total_pkt;
+        out->udp_lost_pkt = gCtx.udp_lost_pkt;
+        out->udp_outoforder = gCtx.udp_outoforder;
         out->active = true;
         out->completed = false;
     } else {
         *out = gCtx.last_stats;
     }
+}
+
+// ----------------------------------------------------------------------------
+// Socket event dispatch
+// ----------------------------------------------------------------------------
+
+static void HandleTcpRecv(tstrSocketRecvMsg* m) {
+    if (m && m->s16BufferSize > 0) {
+        gCtx.bytes_transferred += (uint64_t)m->s16BufferSize;
+        gCtx.bytes_confirmed += (uint64_t)m->s16BufferSize;
+        recv(gCtx.data_sock, gRxBuf, IPERF2_TCP_BUF_SIZE, 0);
+    } else {
+        // Disconnect or error → finalize
+        LOG_I("iperf2: TCP peer closed (size=%d)", m ? m->s16BufferSize : 0);
+        FinalizeStats();
+        CloseAll();
+        ResetContext();
+    }
+}
+
+static void HandleUdpRecvFrom(tstrSocketRecvMsg* m) {
+    if (m == NULL || m->pu8Buffer == NULL || m->s16BufferSize <= 0) {
+        // Re-arm for next datagram
+        if (gCtx.data_sock >= 0) {
+            recvfrom(gCtx.data_sock, gRxBuf, sizeof(gRxBuf), 0);
+        }
+        return;
+    }
+
+    // Capture remote on first packet (where peer port comes from)
+    if (gCtx.bytes_transferred == 0) {
+        gCtx.udp_remote = m->strRemoteAddr;
+    }
+
+    Iperf2_PktInfo* pkt = (Iperf2_PktInfo*)gRxBuf;
+    int32_t id = (int32_t)_ntohl((uint32_t)pkt->id);
+
+    if (id >= 0) {
+        // Normal packet — track sequence/loss
+        if (gCtx.udp_id != id) {
+            // Gap or out-of-order — only count gaps as lost (forward-only count)
+            if (id > gCtx.udp_id) {
+                gCtx.udp_lost_pkt += (uint32_t)(id - gCtx.udp_id);
+                gCtx.udp_id = id + 1;
+            } else {
+                gCtx.udp_outoforder++;
+            }
+        } else {
+            gCtx.udp_id += 1;
+        }
+        gCtx.udp_total_pkt++;
+        gCtx.bytes_transferred += (uint64_t)m->s16BufferSize;
+        gCtx.bytes_confirmed += (uint64_t)m->s16BufferSize;
+    } else {
+        // Negative ID = end-of-test marker.  iperf2 client retransmits this 10
+        // times to ensure the server sees it.  Finalize on first observation.
+        LOG_I("iperf2: UDP end-of-test (id=%d, %u pkts, %u lost, %u oo)",
+              (int)id, (unsigned)gCtx.udp_total_pkt,
+              (unsigned)gCtx.udp_lost_pkt, (unsigned)gCtx.udp_outoforder);
+        FinalizeStats();
+        CloseAll();
+        ResetContext();
+        return;
+    }
+
+    // Re-arm
+    recvfrom(gCtx.data_sock, gRxBuf, sizeof(gRxBuf), 0);
 }
 
 bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
@@ -223,8 +381,13 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
     switch (msg_type) {
         case SOCKET_MSG_BIND: {
             tstrSocketBindMsg* m = (tstrSocketBindMsg*)pMessage;
-            if (m && m->status == 0 && sock == gCtx.listen_sock) {
-                listen(gCtx.listen_sock, 0);
+            if (m && m->status == 0) {
+                if (gCtx.mode == IPERF2_MODE_TCP_SERVER && sock == gCtx.listen_sock) {
+                    listen(gCtx.listen_sock, 0);
+                } else if (gCtx.mode == IPERF2_MODE_UDP_SERVER && sock == gCtx.data_sock) {
+                    // UDP: bind succeeded, start recv loop
+                    recvfrom(gCtx.data_sock, gRxBuf, sizeof(gRxBuf), 0);
+                }
             } else {
                 LOG_E("iperf2: bind status=%d", m ? m->status : -1);
                 Iperf2_Stop();
@@ -251,9 +414,9 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                 gCtx.start_tick = xTaskGetTickCount();
                 gCtx.bytes_transferred = 0;
                 gCtx.bytes_confirmed = 0;
-                LOG_I("iperf2: server accepted connection (sock=%d)",
+                LOG_I("iperf2: TCP server accepted connection (sock=%d)",
                       (int)m->sock);
-                recv(gCtx.data_sock, gRxBuf, IPERF2_RXFER_SIZE, 0);
+                recv(gCtx.data_sock, gRxBuf, IPERF2_TCP_BUF_SIZE, 0);
             } else {
                 LOG_E("iperf2: accept failed");
                 Iperf2_Stop();
@@ -263,26 +426,24 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
         case SOCKET_MSG_CONNECT: {
             tstrSocketConnectMsg* m = (tstrSocketConnectMsg*)pMessage;
             if (m && m->s8Error == 0 && sock == gCtx.data_sock) {
-                gCtx.client_connect_pending = false;
                 gCtx.client_connected = true;
                 gCtx.start_tick = xTaskGetTickCount();
                 gCtx.deadline_tick = gCtx.start_tick +
                                      pdMS_TO_TICKS(gCtx.duration_ms);
-                // Send client header first per iperf2 protocol
+                // Send iperf2 client header (24 bytes)
                 Iperf2_ClientHdr hdr;
                 memset(&hdr, 0, sizeof(hdr));
                 hdr.flags = _htonl((uint32_t)IPERF2_HEADER_VERSION1);
                 hdr.numThreads = _htonl((uint32_t)1U);
                 hdr.mPort = _htonl((uint32_t)IPERF2_DEFAULT_PORT);
-                hdr.bufferlen = _htonl((uint32_t)IPERF2_TXFER_SIZE);
+                hdr.bufferlen = _htonl((uint32_t)IPERF2_TCP_BUF_SIZE);
                 hdr.mWinBand = _htonl((uint32_t)0U);
-                // negative mAmount = duration in -100us units (iperf2 quirk)
                 int32_t signed_amount = -(int32_t)(gCtx.duration_ms * 10U);
                 hdr.mAmount = _htonl((uint32_t)signed_amount);
                 int rc = send(gCtx.data_sock, (char*)&hdr, sizeof(hdr), 0);
                 if (rc == SOCK_ERR_NO_ERROR) {
                     gCtx.pending_tx = 1;
-                    LOG_I("iperf2: client connected, header queued");
+                    LOG_I("iperf2: TCP client connected, header queued");
                 } else {
                     LOG_E("iperf2: header send rc=%d", rc);
                     Iperf2_Stop();
@@ -294,25 +455,15 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
             return true;
         }
         case SOCKET_MSG_RECV: {
-            tstrSocketRecvMsg* m = (tstrSocketRecvMsg*)pMessage;
-            if (m && m->s16BufferSize > 0) {
-                gCtx.bytes_transferred += (uint64_t)m->s16BufferSize;
-                gCtx.bytes_confirmed += (uint64_t)m->s16BufferSize;
-                // Re-arm recv to keep the receive pump going
-                recv(gCtx.data_sock, gRxBuf, IPERF2_RXFER_SIZE, 0);
-            } else {
-                // Disconnect or error → finalize
-                LOG_I("iperf2: peer closed (size=%d), finalizing",
-                      m ? m->s16BufferSize : 0);
-                FinalizeStats();
-                CloseAll();
-                ResetContext();
-            }
+            HandleTcpRecv((tstrSocketRecvMsg*)pMessage);
             return true;
         }
-        case SOCKET_MSG_SEND: {
-            // Returns int16_t = bytes sent (negative = error).  Decrement
-            // pending_tx so Iperf2_Tasks knows it can queue another chunk.
+        case SOCKET_MSG_RECVFROM: {
+            HandleUdpRecvFrom((tstrSocketRecvMsg*)pMessage);
+            return true;
+        }
+        case SOCKET_MSG_SEND:
+        case SOCKET_MSG_SENDTO: {
             int16_t sent = (pMessage != NULL) ? *(int16_t*)pMessage : -1;
             if (sent > 0) {
                 gCtx.bytes_confirmed += (uint64_t)sent;
@@ -328,14 +479,16 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
     }
 }
 
-void Iperf2_Tasks(void) {
-    if (gCtx.mode != IPERF2_MODE_CLIENT) return;
+// ----------------------------------------------------------------------------
+// Driver-task hook for *_CLIENT mode
+// ----------------------------------------------------------------------------
+
+static void TasksTcpClient(void) {
     if (!gCtx.client_connected) return;
 
-    // Deadline check: stop sending once duration expires + drain in-flight
     if ((int32_t)(xTaskGetTickCount() - gCtx.deadline_tick) >= 0) {
         if (gCtx.pending_tx == 0) {
-            LOG_I("iperf2: client TX done, %llu bytes sent",
+            LOG_I("iperf2: TCP client TX done, %llu bytes sent",
                   (unsigned long long)gCtx.bytes_confirmed);
             FinalizeStats();
             CloseAll();
@@ -344,21 +497,84 @@ void Iperf2_Tasks(void) {
         return;
     }
 
-    // Top up the in-flight cap: queue until WINC HIF is full
     while (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
-        int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TXFER_SIZE, 0);
+        int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TCP_BUF_SIZE, 0);
         if (rc == SOCK_ERR_NO_ERROR) {
-            gCtx.bytes_transferred += IPERF2_TXFER_SIZE;
+            gCtx.bytes_transferred += IPERF2_TCP_BUF_SIZE;
             gCtx.pending_tx++;
         } else if (rc == SOCK_ERR_BUFFER_FULL) {
-            // WINC out of staging — back off until callback fires
             break;
         } else {
-            LOG_E("iperf2: send err rc=%d, aborting", rc);
+            LOG_E("iperf2: TCP send err rc=%d, aborting", rc);
             FinalizeStats();
             CloseAll();
             ResetContext();
             return;
         }
+    }
+}
+
+static void TasksUdpClient(void) {
+    if (!gCtx.client_connected) return;
+
+    Iperf2_PktInfo* pkt = (Iperf2_PktInfo*)gTxBuf;
+    bool past_deadline = ((int32_t)(xTaskGetTickCount() - gCtx.deadline_tick) >= 0);
+
+    if (!past_deadline) {
+        // Normal TX phase — send datagrams with monotonic IDs while pending_tx
+        // has slots.  WINC UDP has more headroom than TCP, but cap at the same
+        // value to stay safe.
+        while (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
+            pkt->id = (int32_t)_htonl((uint32_t)gCtx.udp_id);
+            pkt->tv_sec = 0;
+            pkt->tv_usec = 0;
+            int rc = sendto(gCtx.data_sock, (char*)gTxBuf, IPERF2_UDP_BUF_SIZE, 0,
+                            (struct sockaddr*)&gCtx.udp_remote,
+                            sizeof(gCtx.udp_remote));
+            if (rc == SOCK_ERR_NO_ERROR) {
+                gCtx.bytes_transferred += IPERF2_UDP_BUF_SIZE;
+                gCtx.pending_tx++;
+                gCtx.udp_id++;
+            } else if (rc == SOCK_ERR_BUFFER_FULL) {
+                break;
+            } else {
+                LOG_E("iperf2: UDP sendto err rc=%d, aborting", rc);
+                FinalizeStats();
+                CloseAll();
+                ResetContext();
+                return;
+            }
+        }
+    } else {
+        // FIN phase — send final packet with negated ID 10× to ensure server
+        // sees end-of-test.  Once done, finalize.
+        if (gCtx.udp_fin_count >= IPERF2_FIN_RETRANSMITS) {
+            LOG_I("iperf2: UDP client TX done, %u pkts sent",
+                  (unsigned)gCtx.udp_id);
+            FinalizeStats();
+            CloseAll();
+            ResetContext();
+            return;
+        }
+        if (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
+            pkt->id = (int32_t)_htonl((uint32_t)(-gCtx.udp_id));
+            pkt->tv_sec = 0;
+            pkt->tv_usec = 0;
+            int rc = sendto(gCtx.data_sock, (char*)gTxBuf, IPERF2_UDP_BUF_SIZE, 0,
+                            (struct sockaddr*)&gCtx.udp_remote,
+                            sizeof(gCtx.udp_remote));
+            if (rc == SOCK_ERR_NO_ERROR) {
+                gCtx.pending_tx++;
+                gCtx.udp_fin_count++;
+            }
+        }
+    }
+}
+
+void Iperf2_Tasks(void) {
+    switch (gCtx.mode) {
+        case IPERF2_MODE_TCP_CLIENT: TasksTcpClient(); break;
+        case IPERF2_MODE_UDP_CLIENT: TasksUdpClient(); break;
+        default: break;  // IDLE / *_SERVER are pure callback-driven
     }
 }

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -203,7 +203,9 @@ bool Iperf2_StartTcpClient(const char* remote_ip, uint16_t remote_port,
     addr.sin_family = AF_INET;
     addr.sin_port = _htons(remote_port);
     addr.sin_addr.s_addr = inet_addr((char*)remote_ip);
-    if (addr.sin_addr.s_addr == 0) {
+    // WINC inet_addr returns 0 on parse failure; also reject 0xFFFFFFFFU
+    // (POSIX INADDR_NONE / "255.255.255.255") — not a valid iperf target.
+    if (addr.sin_addr.s_addr == 0 || addr.sin_addr.s_addr == 0xFFFFFFFFU) {
         LOG_E("iperf2: bad remote IP %s", remote_ip);
         CloseAll();
         return false;
@@ -246,7 +248,8 @@ bool Iperf2_StartUdpClient(const char* remote_ip, uint16_t remote_port,
     gCtx.udp_remote.sin_family = AF_INET;
     gCtx.udp_remote.sin_port = _htons(remote_port);
     gCtx.udp_remote.sin_addr.s_addr = inet_addr((char*)remote_ip);
-    if (gCtx.udp_remote.sin_addr.s_addr == 0) {
+    if (gCtx.udp_remote.sin_addr.s_addr == 0 ||
+        gCtx.udp_remote.sin_addr.s_addr == 0xFFFFFFFFU) {
         LOG_E("iperf2: bad remote IP %s", remote_ip);
         CloseAll();
         return false;

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -1,0 +1,115 @@
+#ifndef IPERF2_H
+#define IPERF2_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include "socket.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// iperf2 wire protocol — see Microchip Harmony net/tcpip/src/iperf.c and
+// the original iperf source.  These structs are the on-the-wire format
+// and are NOT subject to local style rules (long, big-endian, packed).
+
+#define IPERF2_HEADER_VERSION1   0x80000000U
+
+typedef struct {
+    int32_t  id;
+    uint32_t tv_sec;
+    uint32_t tv_usec;
+} Iperf2_PktInfo;  // UDP datagram header
+
+typedef struct {
+    uint32_t flags;
+    uint32_t total_len1;
+    uint32_t total_len2;
+    uint32_t stop_sec;
+    uint32_t stop_usec;
+    uint32_t error_cnt;
+    uint32_t outorder_cnt;
+    uint32_t datagrams;
+    uint32_t jitter1;
+    uint32_t jitter2;
+} Iperf2_ServerHdr;  // server → client at end of test
+
+typedef struct {
+    uint32_t flags;
+    uint32_t numThreads;
+    uint32_t mPort;
+    uint32_t bufferlen;
+    uint32_t mWinBand;
+    uint32_t mAmount;
+} Iperf2_ClientHdr;  // client → server at start of test
+
+typedef enum {
+    IPERF2_MODE_IDLE = 0,
+    IPERF2_MODE_SERVER,
+    IPERF2_MODE_CLIENT
+} Iperf2_Mode;
+
+typedef struct {
+    Iperf2_Mode mode;
+    uint64_t bytes_transferred;
+    uint32_t duration_ms;
+    uint32_t kbps;          // computed at end of test
+    bool     active;
+    bool     completed;
+} Iperf2_Stats;
+
+// Default iperf2 port (matches `iperf -s` default)
+#define IPERF2_DEFAULT_PORT  5001
+
+/**
+ * Initialize the iperf2 module.  Call once at boot after wifi_manager init.
+ * Allocates the listening/client socket slots; does not open any sockets.
+ */
+void Iperf2_Initialize(void);
+
+/**
+ * Start an iperf2 TCP server on `port`.  Returns true if the listening socket
+ * was opened.  Quiesces ADC streaming + SD logging before binding (caller
+ * responsibility — this just refuses to start if streaming is active).
+ */
+bool Iperf2_StartServer(uint16_t port);
+
+/**
+ * Start an iperf2 TCP client connecting to `remote_ip:remote_port`, sending
+ * for `duration_sec` seconds.  Returns true if the connect was issued.
+ * Same quiesce requirement as the server.
+ */
+bool Iperf2_StartClient(const char* remote_ip, uint16_t remote_port,
+                        uint32_t duration_sec);
+
+/**
+ * Cancel the in-flight iperf2 session (closes sockets, finalizes stats).
+ */
+void Iperf2_Stop(void);
+
+/**
+ * Snapshot the current stats — safe to call at any time.  Stats reflect the
+ * most recent completed test until a new one starts.
+ */
+void Iperf2_GetStats(Iperf2_Stats* out);
+
+/**
+ * Hook into wifi_manager's SocketEventCallback dispatcher.  Returns true if
+ * the socket belongs to iperf2 and was handled here.  Wifi_manager calls this
+ * as a first step in its dispatch and skips its own handling on true.
+ */
+bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage);
+
+/**
+ * Driver-task hook: must be called once per WifiTask iteration when iperf2
+ * is in CLIENT mode.  Performs the deadline check and the main TX send loop.
+ * No-op in IDLE / SERVER modes (server is purely callback-driven).
+ */
+void Iperf2_Tasks(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // IPERF2_H

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -15,7 +15,6 @@ extern "C" {
 // on-the-wire format and are NOT subject to local style rules.
 
 #define IPERF2_HEADER_VERSION1   0x80000000U
-#define IPERF2_RUN_NOW           0x00000001U
 
 // UDP datagram header — first 12 bytes of every UDP iperf2 packet.
 // Negative `id` marks the last packet (end-of-test signal).
@@ -100,8 +99,9 @@ bool Iperf2_StartTcpClient(const char* remote_ip, uint16_t remote_port,
 
 /**
  * Start an iperf2 UDP client sending to `remote_ip:remote_port` for
- * `duration_sec` seconds.  Sends 1500-byte datagrams with monotonic
- * sequence IDs.  Final 10 packets carry negated ID for end-of-test.
+ * `duration_sec` seconds.  Sends 1470-byte datagrams (matches
+ * IPERF2_UDP_BUF_SIZE) with monotonic sequence IDs.  Final 10
+ * packets carry negated ID for end-of-test.
  */
 bool Iperf2_StartUdpClient(const char* remote_ip, uint16_t remote_port,
                            uint32_t duration_sec);

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -10,18 +10,22 @@
 extern "C" {
 #endif
 
-// iperf2 wire protocol — see Microchip Harmony net/tcpip/src/iperf.c and
-// the original iperf source.  These structs are the on-the-wire format
-// and are NOT subject to local style rules (long, big-endian, packed).
+// iperf2 wire protocol — see avrxml/asf WINC1500 iperf_server_example
+// (module mode) and the original iperf source.  These structs are the
+// on-the-wire format and are NOT subject to local style rules.
 
 #define IPERF2_HEADER_VERSION1   0x80000000U
+#define IPERF2_RUN_NOW           0x00000001U
 
+// UDP datagram header — first 12 bytes of every UDP iperf2 packet.
+// Negative `id` marks the last packet (end-of-test signal).
 typedef struct {
     int32_t  id;
     uint32_t tv_sec;
     uint32_t tv_usec;
-} Iperf2_PktInfo;  // UDP datagram header
+} Iperf2_PktInfo;
 
+// server → client at end of test (sent over the same connection)
 typedef struct {
     uint32_t flags;
     uint32_t total_len1;
@@ -33,8 +37,9 @@ typedef struct {
     uint32_t datagrams;
     uint32_t jitter1;
     uint32_t jitter2;
-} Iperf2_ServerHdr;  // server → client at end of test
+} Iperf2_ServerHdr;
 
+// client → server at start of test (sent as first 24 bytes)
 typedef struct {
     uint32_t flags;
     uint32_t numThreads;
@@ -42,12 +47,14 @@ typedef struct {
     uint32_t bufferlen;
     uint32_t mWinBand;
     uint32_t mAmount;
-} Iperf2_ClientHdr;  // client → server at start of test
+} Iperf2_ClientHdr;
 
 typedef enum {
     IPERF2_MODE_IDLE = 0,
-    IPERF2_MODE_SERVER,
-    IPERF2_MODE_CLIENT
+    IPERF2_MODE_TCP_SERVER,
+    IPERF2_MODE_TCP_CLIENT,
+    IPERF2_MODE_UDP_SERVER,
+    IPERF2_MODE_UDP_CLIENT
 } Iperf2_Mode;
 
 typedef struct {
@@ -55,6 +62,10 @@ typedef struct {
     uint64_t bytes_transferred;
     uint32_t duration_ms;
     uint32_t kbps;          // computed at end of test
+    // UDP-specific (zero for TCP modes):
+    uint32_t udp_total_pkt;
+    uint32_t udp_lost_pkt;
+    uint32_t udp_outoforder;
     bool     active;
     bool     completed;
 } Iperf2_Stats;
@@ -64,24 +75,36 @@ typedef struct {
 
 /**
  * Initialize the iperf2 module.  Call once at boot after wifi_manager init.
- * Allocates the listening/client socket slots; does not open any sockets.
+ * Does not open any sockets.
  */
 void Iperf2_Initialize(void);
 
 /**
- * Start an iperf2 TCP server on `port`.  Returns true if the listening socket
- * was opened.  Quiesces ADC streaming + SD logging before binding (caller
- * responsibility — this just refuses to start if streaming is active).
+ * Start an iperf2 TCP server on `port`.  Returns true if the listening
+ * socket was opened.  Refuses if streaming is active.
  */
-bool Iperf2_StartServer(uint16_t port);
+bool Iperf2_StartTcpServer(uint16_t port);
 
 /**
- * Start an iperf2 TCP client connecting to `remote_ip:remote_port`, sending
- * for `duration_sec` seconds.  Returns true if the connect was issued.
- * Same quiesce requirement as the server.
+ * Start an iperf2 UDP server on `port`.  Counts received bytes/datagrams,
+ * tracks sequence/loss, detects end-of-test via negative ID.
  */
-bool Iperf2_StartClient(const char* remote_ip, uint16_t remote_port,
-                        uint32_t duration_sec);
+bool Iperf2_StartUdpServer(uint16_t port);
+
+/**
+ * Start an iperf2 TCP client connecting to `remote_ip:remote_port`,
+ * sending for `duration_sec` seconds.  Returns true if connect issued.
+ */
+bool Iperf2_StartTcpClient(const char* remote_ip, uint16_t remote_port,
+                           uint32_t duration_sec);
+
+/**
+ * Start an iperf2 UDP client sending to `remote_ip:remote_port` for
+ * `duration_sec` seconds.  Sends 1500-byte datagrams with monotonic
+ * sequence IDs.  Final 10 packets carry negated ID for end-of-test.
+ */
+bool Iperf2_StartUdpClient(const char* remote_ip, uint16_t remote_port,
+                           uint32_t duration_sec);
 
 /**
  * Cancel the in-flight iperf2 session (closes sockets, finalizes stats).
@@ -89,22 +112,22 @@ bool Iperf2_StartClient(const char* remote_ip, uint16_t remote_port,
 void Iperf2_Stop(void);
 
 /**
- * Snapshot the current stats — safe to call at any time.  Stats reflect the
- * most recent completed test until a new one starts.
+ * Snapshot the current stats — safe to call at any time.  Stats reflect
+ * the most recent completed test until a new one starts.
  */
 void Iperf2_GetStats(Iperf2_Stats* out);
 
 /**
- * Hook into wifi_manager's SocketEventCallback dispatcher.  Returns true if
- * the socket belongs to iperf2 and was handled here.  Wifi_manager calls this
- * as a first step in its dispatch and skips its own handling on true.
+ * Hook into wifi_manager's SocketEventCallback dispatcher.  Returns true
+ * if the socket belongs to iperf2 and was handled here.  Wifi_manager
+ * calls this as the first step in its dispatch.
  */
 bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage);
 
 /**
- * Driver-task hook: must be called once per WifiTask iteration when iperf2
- * is in CLIENT mode.  Performs the deadline check and the main TX send loop.
- * No-op in IDLE / SERVER modes (server is purely callback-driven).
+ * Driver-task hook: must be called once per WifiTask iteration when
+ * iperf2 is in *_CLIENT mode.  Drives the TX deadline + send loop.
+ * No-op in IDLE / *_SERVER modes (servers are purely callback-driven).
  */
 void Iperf2_Tasks(void);
 

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -8,6 +8,7 @@
 #include "state/runtime/BoardRuntimeConfig.h"
 #include "wifi_serial_bridge.h"
 #include "wifi_serial_bridge_interface.h"
+#include "iperf2/iperf2.h"
 #include "driver/winc/include/dev/wdrv_winc_gpio.h"
 #include "driver/winc/include/drv/driver/m2m_wifi.h"
 
@@ -222,6 +223,15 @@ static void StaEventCallback(DRV_HANDLE handle, WDRV_WINC_ASSOC_HANDLE assocHand
 
 static void SocketEventCallback(SOCKET socket, uint8_t messageType, void *pMessage) {
     static uint8_t udpBuffer[UDP_BUFFER_SIZE];
+
+    // #377: iperf2 first claim — when an iperf benchmark is running it owns
+    // its own listen + data sockets and dispatches the full state machine
+    // here.  Skip the wifi_tcp_server / UDP-discovery cases below if iperf2
+    // handles the event.
+    if (Iperf2_HandleSocketEvent(socket, messageType, pMessage)) {
+        return;
+    }
+
     switch (messageType) {
         case SOCKET_MSG_BIND:
         {
@@ -1268,6 +1278,10 @@ bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
     gStateMachineContext.active(&gStateMachineContext, WIFI_MANAGER_EVENT_ENTRY);
     gStateMachineContext.nextState = NULL;
 
+    // #377: iperf2 module — initialize once at boot.  Doesn't open any
+    // sockets until SYST:WIFI:IPERF:* is invoked.
+    Iperf2_Initialize();
+
     return true;
 }
 
@@ -1406,6 +1420,10 @@ void wifi_manager_ProcessState() {
         return;
     }
     wifi_tcp_server_TransmitBufferedData();
+
+    // #377: iperf2 client mode — keep the TX cap topped up.  No-op in
+    // SERVER / IDLE.  Cheap when idle (single mode-check).
+    Iperf2_Tasks();
 
     // #353 Option 2: drain any deferred TCP rx data on this task's stack.
     // SOCKET_MSG_RECV (WDRV_WINC_Tasks context) stored length + set the flag


### PR DESCRIPTION
## Summary

Adds a minimal iperf2 (TCP + UDP) implementation over WINC m2m sockets,
controllable via SCPI. Lets us measure WiFi wire rate independently of
our streaming pipeline (encoder, circular buffer, mutex, SCPI overhead)
to answer #377 — *what's the actual wire-rate ceiling on this hardware
path?*

Modeled on [avrxml/asf WINC1500 module-mode iperf_server_example](https://github.com/avrxml/asf/tree/master/common/components/wifi/winc1500/iperf_server_example),
adapted to be callback-driven (integrates with our existing
\`wifi_manager\` event dispatcher) instead of poll-driven.

## SCPI surface

\`\`\`
SYSTem:WIFI:IPERF:TSERVer [port=5001]                       # TCP server (PC pushes to firmware)
SYSTem:WIFI:IPERF:USERVer [port=5001]                       # UDP server
SYSTem:WIFI:IPERF:TCLIent <ip>,[port=5001],[dur_s=10]       # TCP client (firmware pushes to PC)
SYSTem:WIFI:IPERF:UCLIent <ip>,[port=5001],[dur_s=10]       # UDP client
SYSTem:WIFI:IPERF:STOP                                      # Cancel
SYSTem:WIFI:IPERF:STATs?                                    # Mode/Active/Bytes/KBps + UDP pkt/lost/oo
\`\`\`

All four start commands refuse if streaming is active (\`IsEnabled && Running\`).

## Smoke test results (Tesla AP, NQ1, default 16.67 MHz SPI)

| Test | Throughput | Notes |
|---|---:|---|
| TCP server (PC→firmware, 5 s) | **264 KB/s** | clean, 0 retries |
| UDP server (PC→firmware, 5 s, sustained over-feed) | **326 KB/s recv ceiling** | 92 % loss when over-fed at 8.4 MB/s — expected, UDP doesn't retransmit |
| Both: \`SYST:WIFI:IPERF:STOP\` cleanup | OK | Mode=0 → reset, last_stats preserved |
| \`SYST:WIFI:IPERF:STATs?\` field reporting | OK | TCP shows zeros for UDP fields, UDP populates them correctly |

UDP server's sequence/loss tracking verified — \`udp_lost_pkt = (next_expected - actual)\` for gaps, \`udp_outoforder\` for backwards IDs. Final 10 retransmits with negated ID detected as end-of-test marker.

## Headline finding

The iperf2 TCP server (no encoder, no circular buffer, no streaming task contention) hits **the same ~260 KB/s ceiling** as our streaming pipeline. This strongly suggests the wall is in the WINC1500/SPI/AP path, not in our firmware path. UDP RX ceiling 326 KB/s > TCP RX 260 KB/s, ratio ~1.25 — consistent with Microchip's published Setup 1 numbers (UDP 19.5 vs TCP 11.8 Mbps, ratio ~1.65).

## Architecture

- New module: \`firmware/src/services/wifi_services/iperf2/{iperf2.c,iperf2.h}\`
- \`Iperf2_HandleSocketEvent\` hooks at the top of \`wifi_manager\`'s \`SocketEventCallback\` — claims events for sockets it owns (when active), falls through to existing \`wifi_tcp_server\` / UDP-discovery handlers otherwise. No-op when \`IPERF2_MODE_IDLE\`.
- \`Iperf2_Tasks()\` called from \`wifi_manager_ProcessState()\` — drives the TX deadline + send loop in \`*_CLIENT\` modes. No-op in IDLE / \`*_SERVER\` (servers are pure callback-driven).
- Static TX/RX buffers (1470 B each) — kept off task stacks.
- Respects \`WIFI_TCP_MAX_IN_FLIGHT\` semantics via a \`pending_tx\` counter decremented on \`SOCKET_MSG_SEND\` / \`SOCKET_MSG_SENDTO\`.

## Known limitations / not in this PR

- **Server-summary frame** (\`Iperf2_ServerHdr\` → client at end of test) not implemented.  The avrxml reference comments theirs out citing \"WINC1500 too busy handling RX pkts.\" The struct is defined as scaffolding for a future PR.  For now, stats are surfaced via \`SYST:WIFI:IPERF:STATs?\` SCPI, not the iperf2 protocol response.  Standard \`iperf -c <ip> -u\` will print \"WARNING: did not receive server's report\" but its own client-side bandwidth output is correct.
- **No RFC 1889 jitter calculation** (related to the missing server frame).
- **TCP client mode** works at the protocol level but the test from this branch hit Windows-side networking complications (WSL2 mirrored networking adapter routing) that aren't a firmware bug — see #379-area discussion.  TCP server + both UDP modes verified working.

## Related issues

- #377 — iperf2 wire-rate truth (this PR)
- #258 — perf: close gap with iperf (this PR provides the measurement infrastructure)
- #378 — WiFi tasks priority restructure (filed during this work — lower-priority follow-up)
- #379 — \`Running\` flag boot semantic bug (filed during this work)
- #380 — SPI clock bump experiment broke SD (filed during this work)
- CLAUDE.md updated to soften \"AP wire bandwidth\" claim until iperf-vs-streaming numbers settle the question

## Test plan

- [ ] CI build (clean, all 3 configs)
- [ ] PC→firmware TCP server probe via \`iperf -c <ip>\` or custom Python client
- [ ] PC→firmware UDP server probe with sequence/loss tracking
- [ ] firmware→PC TCP client probe (test environment permitting)
- [ ] firmware→PC UDP client probe (test environment permitting)
- [ ] Confirm \`SYST:WIFI:IPERF:STOP\` cleanly cancels mid-flight
- [ ] Confirm refusal when streaming is active
- [ ] Verify no regression on existing wifi_tcp_server (streaming path)

## Reference

- [avrxml/asf — WINC1500 iperf_server_example (module mode)](https://github.com/avrxml/asf/tree/master/common/components/wifi/winc1500/iperf_server_example)
- Microchip ATWINC15x0 Throughput Measurement using iPerf, DS00002879A

🤖 Generated with [Claude Code](https://claude.com/claude-code)