### PR TITLE
feat(iperf2): in-firmware iperf2 client + WINC HardReset + A/B verdict (#383, #385)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,10 +76,21 @@ The XC32 linker script (`p32MZ2048EFM144.ld`) uses a "best-fit allocator" for `.
 
 Command options:
 - `-TPPK4`: Use PICkit 4 as programmer
-- `-P32MZ2048EFM144`: Target device
+- `-TS<serial>`: Pick a specific PICkit when multiple are connected
+- `-P32MZ2048EFM144`: Target device (no `PIC` prefix)
 - `-M`: Program mode
-- `-F`: Hex file to program
+- `-F`: Hex file to program (must be Windows-style path; `/mnt/c/...` fails silently)
 - `-OL`: Use loaded memories only
+
+### Bench tool inventory (this dev station)
+| Item | Identifier | Notes |
+|------|-----------|-------|
+| Primary PICkit 4 (this board) | `BUR184882598` | Pass `-TSBUR184882598` to ipecmd when multiple PICkits are attached |
+| Secondary PICkit 4 | `BUR202272588` | On other board(s) — ignore unless re-targeting |
+| MCU device target | `PIC32MZ2048EFM144` | Pass to ipecmd as `-P32MZ2048EFM144` (no `PIC` prefix; with the prefix you get exit 36 / "Unable to locate DFP") |
+| Serial port (USB CDC) | `/dev/ttyACM0` (WSL) / `COM3` (Windows) | usbipd busid `2-4`; reattach via `powershell.exe -Command "usbipd attach --wsl --busid 2-4"` after each reboot/flash |
+| Bench WiFi AP | SSID `Tesla` | Credentials in `~/.daqifi.env` (chmod 600) — never commit |
+| Bench PC iperf2 | `C:\Users\User\Downloads\iperf-2.2.1-win64.exe` | Run `-s -p 5002 -i 1`; redirect stdout to `C:\temp\iperf2.log` for log-side correlation |
 
 ### Bootloader Entry
 - Hold the user button for ~20 seconds until board resets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,21 @@ Services Layer
      - `SYST:COMM:LAN:NETMode` can be abbreviated as `SYST:COMM:LAN:NETM`
      - `SYST:COMM:LAN:APPLy` can be abbreviated as `SYST:COMM:LAN:APPL`
 
+#### Quiescence Rule — No SCPI queries during a benchmarked test
+
+Send no SCPI to the device while a streaming or iperf2 run is in
+progress — every query preempts the data path being measured (USB
+SCPI = priority 7; TCP SCPI runs on the WifiTask itself).
+
+The firmware preserves end-of-test stats in IDLE: `IPERF:STATs?`
+returns `gCtx.last_stats` (frozen by `FinalizeStats`); `STR:STATS?`
+survives across `StopStreamData` until the next start or
+`STATS:CLEar`.
+
+**Pattern:** `start → time.sleep(duration + margin) → single STATS query`.
+Out-of-band visibility (Saleae, PC-side iperf2.log) for long runs;
+never poll the device under test. Mirrored in the SCPI wiki.
+
 #### SCPI Command Verification Protocol
 
 **⚠️ CRITICAL: NEVER guess SCPI command syntax. ALWAYS verify first.**

--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -445,15 +445,7 @@
       <logicalFolder name="Util" displayName="Util" projectFiles="true">
         <itemPath>../src/Util/ArrayWrapper.h</itemPath>
         <itemPath>../src/Util/CircularBuffer.h</itemPath>
-        <itemPath>../src/Util/Delay.h</itemPath>
-        <itemPath>../src/Util/FreeRTOSLockContext.h</itemPath>
-        <itemPath>../src/Util/FreeRTOSLockProvider.h</itemPath>
-        <itemPath>../src/Util/HeapList.h</itemPath>
-        <itemPath>../src/Util/LinkedList.h</itemPath>
-        <itemPath>../src/Util/LockProvider.h</itemPath>
         <itemPath>../src/Util/Logger.h</itemPath>
-        <itemPath>../src/Util/NullLockProvider.h</itemPath>
-        <itemPath>../src/Util/StackList.h</itemPath>
         <itemPath>../src/Util/StringFormatters.h</itemPath>
       </logicalFolder>
       <logicalFolder name="wolfcrypt" displayName="wolfcrypt" projectFiles="true">
@@ -1489,102 +1481,6 @@
         <C32Global>
         </C32Global>
       </item>
-      <item path="../src/Util/Delay.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/FreeRTOSLockContext.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/FreeRTOSLockProvider.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/HeapList.h" ex="false" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/LinkedList.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/LockProvider.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
       <item path="../src/Util/Logger.c" ex="false" overriding="false">
         <C32>
         </C32>
@@ -1602,38 +1498,6 @@
         </C32Global>
       </item>
       <item path="../src/Util/Logger.h" ex="false" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/NullLockProvider.h" ex="false" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/StackList.h" ex="false" overriding="false">
         <C32>
         </C32>
         <C32-AR>
@@ -4468,102 +4332,6 @@
         <C32Global>
         </C32Global>
       </item>
-      <item path="../src/Util/Delay.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/FreeRTOSLockContext.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/FreeRTOSLockProvider.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/HeapList.h" ex="false" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/LinkedList.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/LockProvider.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
       <item path="../src/Util/Logger.c" ex="false" overriding="false">
         <C32>
         </C32>
@@ -4581,38 +4349,6 @@
         </C32Global>
       </item>
       <item path="../src/Util/Logger.h" ex="false" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/NullLockProvider.h" ex="false" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/StackList.h" ex="false" overriding="false">
         <C32>
         </C32>
         <C32-AR>
@@ -7084,102 +6820,6 @@
         <C32Global>
         </C32Global>
       </item>
-      <item path="../src/Util/Delay.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/FreeRTOSLockContext.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/FreeRTOSLockProvider.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/HeapList.h" ex="false" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/LinkedList.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/LockProvider.h" ex="true" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
       <item path="../src/Util/Logger.c" ex="false" overriding="false">
         <C32>
         </C32>
@@ -7197,38 +6837,6 @@
         </C32Global>
       </item>
       <item path="../src/Util/Logger.h" ex="false" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/NullLockProvider.h" ex="false" overriding="false">
-        <C32>
-        </C32>
-        <C32-AR>
-        </C32-AR>
-        <C32-AS>
-        </C32-AS>
-        <C32-CO>
-        </C32-CO>
-        <C32-LD>
-        </C32-LD>
-        <C32CPP>
-        </C32CPP>
-        <C32Global>
-        </C32Global>
-      </item>
-      <item path="../src/Util/StackList.h" ex="false" overriding="false">
         <C32>
         </C32>
         <C32-AR>

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -16,6 +16,7 @@
 #include "state/data/AInSample.h"
 #include "services/UsbCdc/UsbCdc.h"
 #include "services/wifi_services/wifi_tcp_server.h"
+#include "services/wifi_services/iperf2/iperf2.h"
 
 /*
  * SPI Coordination Framework for Future Extensibility
@@ -258,7 +259,7 @@ static void app_WifiTask(void* p_arg) {
             }
                 break;
         }
-        vTaskDelay(5 / portTICK_PERIOD_MS);  
+        vTaskDelay(5 / portTICK_PERIOD_MS);
     }
 }
 
@@ -729,6 +730,11 @@ static void app_TasksCreate() {
         LOG_E("FATAL: Failed to create SDCardTask\r\n");
         while (1);
     }
+
+    // Dedicated iperf2 task for tight client-mode pacing (#377).  Runs at
+    // pri 5 with adaptive 1 ms (active) / 50 ms (idle) cadence.  WifiTask
+    // (pri 2) keeps its 5 ms cadence for streaming + SCPI dispatch paths.
+    Iperf2_StartTask();
 }
 
 void APP_FREERTOS_Initialize(void) {

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -732,7 +732,7 @@ static void app_TasksCreate() {
     }
 
     // Dedicated iperf2 task for tight client-mode pacing (#377).  Runs at
-    // pri 5 with adaptive 1 ms (active) / 50 ms (idle) cadence.  WifiTask
+    // pri 5 with adaptive 2 ms (active) / 50 ms (idle) cadence.  WifiTask
     // (pri 2) keeps its 5 ms cadence for streaming + SCPI dispatch paths.
     Iperf2_StartTask();
 }

--- a/firmware/src/config/default/FreeRTOSConfig.h
+++ b/firmware/src/config/default/FreeRTOSConfig.h
@@ -399,7 +399,7 @@
  * the build, or 0 to exclude the named feature from the build. */
 #define configUSE_TASK_NOTIFICATIONS            1
 #define configUSE_MUTEXES                       1
-#define configUSE_RECURSIVE_MUTEXES             0
+#define configUSE_RECURSIVE_MUTEXES             1
 #define configUSE_COUNTING_SEMAPHORES           1
 #define configUSE_QUEUE_SETS                    0
 #define configUSE_APPLICATION_TASK_TAG          0

--- a/firmware/src/config/default/FreeRTOSConfig.h
+++ b/firmware/src/config/default/FreeRTOSConfig.h
@@ -428,7 +428,7 @@
 #define INCLUDE_xTaskAbortDelay                 0
 #define INCLUDE_xTaskGetHandle                  0
 #define INCLUDE_xQueueGetMutexHolder            0
-#define INCLUDE_xSemaphoreGetMutexHolder        0
+#define INCLUDE_xSemaphoreGetMutexHolder        1
 #define INCLUDE_uxTaskGetStackHighWaterMark2    0
 #define INCLUDE_xTaskResumeFromISR              0
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -365,12 +365,22 @@ static scpi_result_t SCPI_Reset(scpi_t * context) {
     // Reset the WINC chip via GPIO toggle BEFORE the PIC32 soft reset.
     // RCON_SoftwareReset() only resets the PIC32 — the WINC keeps running
     // with stale state and ends up out-of-sync with the freshly-booted
-    // driver (#383). Firing DEINIT here drives WDRV_WINC_Deinitialize +
-    // wifi_manager_FixWincResetState (CHIP_EN/RESET_N GPIO toggle), so
-    // both halves reboot together and the user gets the expected
-    // "device is fresh" state after *RST.
+    // driver (#383). Firing DEINIT drives WDRV_WINC_Deinitialize +
+    // wifi_manager_FixWincResetState (CHIP_EN/RESET_N GPIO toggle).
     wifi_manager_Deinit();
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+
+    // Actively pump wifi_manager_ProcessState() during the 500 ms settle —
+    // not just sleep.  Reason: TCP-SCPI dispatch runs on app_WifiTask
+    // (post-#353), the same task that drains the WiFi event queue.  A
+    // passive vTaskDelay there blocks the queue and DEINIT never gets
+    // processed before RCON_SoftwareReset() reboots the chip.
+    {
+        TickType_t start = xTaskGetTickCount();
+        while ((xTaskGetTickCount() - start) < pdMS_TO_TICKS(500)) {
+            wifi_manager_ProcessState();
+            vTaskDelay(pdMS_TO_TICKS(5));
+        }
+    }
 
     // Allow time for message transmission and any pending operations
     vTaskDelay(100 / portTICK_PERIOD_MS);

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2003,21 +2003,6 @@ static scpi_result_t SCPI_Iperf2_Stop(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
-static scpi_result_t SCPI_Iperf2_Delay(scpi_t * context) {
-    int32_t ms = 0;
-    if (!SCPI_ParamInt32(context, &ms, TRUE) || ms < 0 || ms > 100) {
-        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
-        return SCPI_RES_ERR;
-    }
-    Iperf2_SetActiveDelayMs((uint8_t)ms);
-    return SCPI_RES_OK;
-}
-
-static scpi_result_t SCPI_Iperf2_DelayGet(scpi_t * context) {
-    SCPI_ResultUInt32(context, (uint32_t)Iperf2_GetActiveDelayMs());
-    return SCPI_RES_OK;
-}
-
 static scpi_result_t SCPI_Iperf2_Stats(scpi_t * context) {
     Iperf2_Stats s;
     Iperf2_GetStats(&s);
@@ -3670,8 +3655,6 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:WIFI:IPERF:UDPClient", .callback = SCPI_Iperf2_UdpClient,}, // <ip>,[port=5001],[dur_s=10]
     {.pattern = "SYSTem:WIFI:IPERF:STOP", .callback = SCPI_Iperf2_Stop,},
     {.pattern = "SYSTem:WIFI:IPERF:STATs?", .callback = SCPI_Iperf2_Stats,},
-    {.pattern = "SYSTem:WIFI:IPERF:DELay", .callback = SCPI_Iperf2_Delay,},   // active-mode task delay (ms, 0-100)
-    {.pattern = "SYSTem:WIFI:IPERF:DELay?", .callback = SCPI_Iperf2_DelayGet,},
     // Dynamic memory configuration
     {.pattern = "SYSTem:MEMory:SD:BUFfer", .callback = SCPI_SetMemSdBuf,},
     {.pattern = "SYSTem:MEMory:SD:BUFfer?", .callback = SCPI_GetMemSdBuf,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2003,6 +2003,21 @@ static scpi_result_t SCPI_Iperf2_Stop(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+static scpi_result_t SCPI_Iperf2_Delay(scpi_t * context) {
+    int32_t ms = 0;
+    if (!SCPI_ParamInt32(context, &ms, TRUE) || ms < 0 || ms > 100) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+    Iperf2_SetActiveDelayMs((uint8_t)ms);
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_Iperf2_DelayGet(scpi_t * context) {
+    SCPI_ResultUInt32(context, (uint32_t)Iperf2_GetActiveDelayMs());
+    return SCPI_RES_OK;
+}
+
 static scpi_result_t SCPI_Iperf2_Stats(scpi_t * context) {
     Iperf2_Stats s;
     Iperf2_GetStats(&s);
@@ -3655,6 +3670,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:WIFI:IPERF:UDPClient", .callback = SCPI_Iperf2_UdpClient,}, // <ip>,[port=5001],[dur_s=10]
     {.pattern = "SYSTem:WIFI:IPERF:STOP", .callback = SCPI_Iperf2_Stop,},
     {.pattern = "SYSTem:WIFI:IPERF:STATs?", .callback = SCPI_Iperf2_Stats,},
+    {.pattern = "SYSTem:WIFI:IPERF:DELay", .callback = SCPI_Iperf2_Delay,},   // active-mode task delay (ms, 0-100)
+    {.pattern = "SYSTem:WIFI:IPERF:DELay?", .callback = SCPI_Iperf2_DelayGet,},
     // Dynamic memory configuration
     {.pattern = "SYSTem:MEMory:SD:BUFfer", .callback = SCPI_SetMemSdBuf,},
     {.pattern = "SYSTem:MEMory:SD:BUFfer?", .callback = SCPI_GetMemSdBuf,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -362,12 +362,22 @@ static scpi_result_t SCPI_Reset(scpi_t * context) {
         context->interface->flush(context);
     }
     
+    // Reset the WINC chip via GPIO toggle BEFORE the PIC32 soft reset.
+    // RCON_SoftwareReset() only resets the PIC32 — the WINC keeps running
+    // with stale state and ends up out-of-sync with the freshly-booted
+    // driver (#383). Firing DEINIT here drives WDRV_WINC_Deinitialize +
+    // wifi_manager_FixWincResetState (CHIP_EN/RESET_N GPIO toggle), so
+    // both halves reboot together and the user gets the expected
+    // "device is fresh" state after *RST.
+    wifi_manager_Deinit();
+    vTaskDelay(500 / portTICK_PERIOD_MS);
+
     // Allow time for message transmission and any pending operations
     vTaskDelay(100 / portTICK_PERIOD_MS);
-    
+
     // Perform the software reset
     RCON_SoftwareReset();
-    
+
     // If we get here, the reset didn't work
     SCPI_ErrorPush(context, SCPI_ERROR_SYSTEM_ERROR);
     return SCPI_RES_ERR;
@@ -3573,6 +3583,7 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:COMMunicate:LAN:PASSCHECK?", .callback = SCPI_LANPasskeyGet,},
     {.pattern = "SYSTem:COMMunicate:LAN:DISPlay", .callback = SCPI_NotImplemented,},
     {.pattern = "SYSTem:COMMunicate:LAN:APPLY", .callback = SCPI_LANSettingsApply,},
+    {.pattern = "SYSTem:COMMunicate:LAN:HRESet", .callback = SCPI_LANHardReset,},   // hard reset WINC (#383 recovery)
     {.pattern = "SYSTem:COMMunicate:LAN:LOAD", .callback = SCPI_LANSettingsLoad,},
     {.pattern = "SYSTem:COMMunicate:LAN:SAVE", .callback = SCPI_LANSettingsSave,},
     {.pattern = "SYSTem:COMMunicate:LAN:FACRESET", .callback = SCPI_LANSettingsFactoryLoad,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -367,7 +367,15 @@ static scpi_result_t SCPI_Reset(scpi_t * context) {
     // with stale state and ends up out-of-sync with the freshly-booted
     // driver (#383). Firing DEINIT drives WDRV_WINC_Deinitialize +
     // wifi_manager_FixWincResetState (CHIP_EN/RESET_N GPIO toggle).
-    wifi_manager_Deinit();
+    //
+    // Surface failure: if the event queue is uninitialized or saturated,
+    // we'll proceed with the PIC32 reset even though the WINC won't have
+    // been reset.  Better than wedging — the user's reboot still
+    // happens, and the LOG_E gives them a breadcrumb.
+    if (!wifi_manager_Deinit()) {
+        LOG_E("SYST:REboot: wifi_manager_Deinit failed, WINC may not "
+              "be reset before PIC32 reboot");
+    }
 
     // Actively pump wifi_manager_ProcessState() during the 500 ms settle —
     // not just sleep.  Reason: TCP-SCPI dispatch runs on app_WifiTask

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -560,7 +560,6 @@ scpi_result_t SCPI_LANSettingsApply(scpi_t * context) {
 }
 
 scpi_result_t SCPI_LANHardReset(scpi_t * context) {
-    (void)context;
     if (!wifi_manager_HardReset()) {
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         return SCPI_RES_ERR;

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -559,6 +559,15 @@ scpi_result_t SCPI_LANSettingsApply(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+scpi_result_t SCPI_LANHardReset(scpi_t * context) {
+    (void)context;
+    if (!wifi_manager_HardReset()) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
 scpi_result_t SCPI_LANFwUpdate(scpi_t * context) {
     // Block if SD card is actively logging (shared SPI bus)
     if (sd_card_manager_IsBusy()) {

--- a/firmware/src/services/SCPI/SCPILAN.h
+++ b/firmware/src/services/SCPI/SCPILAN.h
@@ -141,6 +141,13 @@ scpi_result_t SCPI_LANPasskeyGet(scpi_t * context);
  */
 scpi_result_t SCPI_LANSettingsApply(scpi_t * context);
 /**
+ * SCPI Callback: Hardware-reset the WINC chip (toggles GPIO reset).
+ * Use to recover a wedged outbound TCP stack (#383). Returns
+ * immediately; full recovery takes ~20 s — poll ADDR? to confirm.
+ * @return SCPI_RES_OK on success SCPI_RES_ERR on error
+ */
+scpi_result_t SCPI_LANHardReset(scpi_t * context);
+/**
  * @brief
  * @param context
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -552,8 +552,8 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
             // when WINC frees a HIF slot, immediately refill it from here
             // instead of waiting for the next Iperf2 task tick.  Pacing is
             // then naturally rate-limited by WINC's actual completion rate,
-            // not our task delay.  The 5 ms task tick is just a backup /
-            // initial trigger.
+            // not our task delay.  The task tick is just a backup / initial
+            // trigger (see IPERF2_ACTIVE_DELAY_MS).
             if (sent > 0 && !gCtx.abort_pending) {
                 if (gCtx.mode == IPERF2_MODE_TCP_CLIENT) {
                     TasksTcpClient();
@@ -699,16 +699,11 @@ static void TasksUdpClient(void) {
     }
 }
 
-// Task body — runs continuously at modest cadence as a backup/initial
-// trigger.  The hot path is event-driven via SOCKET_MSG_SEND callback
-// chaining (see HandleSocketEvent) — this loop just kicks off the first
-// send and catches any missed callbacks.  5 ms cadence is enough for
-// bring-up; the actual send rate is set by WINC HIF completion timing.
-//
-// Empirically (this session): 1 ms cadence was less stable than 5 ms —
-// over-aggressive polling caught WINC mid-state and triggered more
-// BUFFER_FULL churn / TCP cwnd issues.  5 ms paces well with the
-// callback-chain doing the heavy lifting.
+// Task body — backup/initial trigger only.  The hot path is event-driven
+// via SOCKET_MSG_SEND callback chaining (see HandleSocketEvent); this
+// loop kicks off the first send and catches any missed callbacks.
+// Active-mode cadence comes from IPERF2_ACTIVE_DELAY_MS — see the
+// define for the empirical sweep that picked 2 ms.
 static void Iperf2TaskMain(void* arg) {
     (void)arg;
     for (;;) {

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -50,12 +50,11 @@ typedef struct {
 
 static Iperf2_Context gCtx;
 
-// Active-mode task delay (ms).  Runtime-tunable via SCPI for sweep tests.
-// Default 2 ms — empirical sweep with cross-verified PC iperf2 +
-// firmware-side counters (2026-04-28): delay=2ms yields ~454 KB/s
-// (3.70 Mbps), which is the peak.  delay=1ms is over-aggressive and
-// drops to ~334 KB/s; delay=3-5ms tie at ~415 KB/s.
-static volatile uint8_t gActiveDelayMs = 2;
+// Active-mode task delay (ms).  Locked at 2 ms — empirical sweep with
+// cross-verified PC iperf2 + firmware-side counters (2026-04-28):
+// delay=2ms yields ~454 KB/s (3.70 Mbps) which is the peak; delay=1ms
+// is over-aggressive (334 KB/s); delay=3-5ms tie at ~415 KB/s.
+#define IPERF2_ACTIVE_DELAY_MS  2U
 
 // Static TX/RX buffers — keep off task stacks.  Sized to the larger of TCP/UDP.
 // 4-byte aligned: HandleUdpRecvFrom casts gRxBuf to Iperf2_PktInfo* (which has
@@ -694,22 +693,8 @@ static void Iperf2TaskMain(void* arg) {
         Iperf2_Tasks();
         bool active = (gCtx.mode == IPERF2_MODE_TCP_CLIENT) ||
                       (gCtx.mode == IPERF2_MODE_UDP_CLIENT);
-        uint32_t ms = active ? gActiveDelayMs : 50U;
-        if (ms == 0U) {
-            taskYIELD();
-        } else {
-            vTaskDelay(pdMS_TO_TICKS(ms));
-        }
+        vTaskDelay(pdMS_TO_TICKS(active ? IPERF2_ACTIVE_DELAY_MS : 50U));
     }
-}
-
-void Iperf2_SetActiveDelayMs(uint8_t ms) {
-    if (ms > 100U) ms = 100U;  // sanity cap
-    gActiveDelayMs = ms;
-}
-
-uint8_t Iperf2_GetActiveDelayMs(void) {
-    return gActiveDelayMs;
 }
 
 void Iperf2_StartTask(void) {

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -51,9 +51,11 @@ typedef struct {
 static Iperf2_Context gCtx;
 
 // Active-mode task delay (ms).  Runtime-tunable via SCPI for sweep tests.
-// 5 ms default per empirical observation that 5 ms paces well with the
-// callback chain (over-aggressive 1 ms polling caught WINC mid-state).
-static volatile uint8_t gActiveDelayMs = 5;
+// Default 2 ms — empirical sweep with cross-verified PC iperf2 +
+// firmware-side counters (2026-04-28): delay=2ms yields ~454 KB/s
+// (3.70 Mbps), which is the peak.  delay=1ms is over-aggressive and
+// drops to ~334 KB/s; delay=3-5ms tie at ~415 KB/s.
+static volatile uint8_t gActiveDelayMs = 2;
 
 // Static TX/RX buffers — keep off task stacks.  Sized to the larger of TCP/UDP.
 // 4-byte aligned: HandleUdpRecvFrom casts gRxBuf to Iperf2_PktInfo* (which has

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -440,8 +440,9 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                     recvfrom(gCtx.data_sock, gRxBuf, sizeof(gRxBuf), 0);
                 }
             } else {
-                LOG_E("iperf2: bind status=%d", m ? m->status : -1);
-                Iperf2_Stop();
+                // Defer teardown — see #383 / SEND-callback note below.
+                LOG_E("iperf2: bind status=%d, scheduling abort", m ? m->status : -1);
+                gCtx.abort_pending = true;
             }
             return true;
         }
@@ -450,8 +451,8 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
             if (m && m->status == 0 && sock == gCtx.listen_sock) {
                 accept(gCtx.listen_sock, NULL, NULL);
             } else {
-                LOG_E("iperf2: listen status=%d", m ? m->status : -1);
-                Iperf2_Stop();
+                LOG_E("iperf2: listen status=%d, scheduling abort", m ? m->status : -1);
+                gCtx.abort_pending = true;
             }
             return true;
         }
@@ -469,8 +470,8 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                       (int)m->sock);
                 recv(gCtx.data_sock, gRxBuf, IPERF2_TCP_BUF_SIZE, 0);
             } else {
-                LOG_E("iperf2: accept failed");
-                Iperf2_Stop();
+                LOG_E("iperf2: accept failed, scheduling abort");
+                gCtx.abort_pending = true;
             }
             return true;
         }
@@ -497,12 +498,12 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                     gCtx.pending_tx = 1;
                     LOG_I("iperf2: TCP client connected, header queued");
                 } else {
-                    LOG_E("iperf2: header send rc=%d", rc);
-                    Iperf2_Stop();
+                    LOG_E("iperf2: header send rc=%d, scheduling abort", rc);
+                    gCtx.abort_pending = true;
                 }
             } else {
-                LOG_E("iperf2: connect err=%d", m ? m->s8Error : -1);
-                Iperf2_Stop();
+                LOG_E("iperf2: connect err=%d, scheduling abort", m ? m->s8Error : -1);
+                gCtx.abort_pending = true;
             }
             return true;
         }

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -22,7 +22,7 @@
 #define IPERF2_TCP_BUF_SIZE     1400U   // matches WINC SOCKET_BUFFER_MAX_LENGTH for TCP
 #define IPERF2_UDP_BUF_SIZE     1470U   // standard iperf2 UDP datagram size (1500 - IP/UDP overhead)
 #define IPERF2_MAX_DURATION_S   3600U   // 1h cap
-#define IPERF2_MAX_PENDING_TX   1U      // single-shot send-per-tick (Microchip pattern)
+#define IPERF2_MAX_PENDING_TX   4U      // matches WINC HIF queue depth (mirrors wifi_tcp_server)
 #define IPERF2_FIN_RETRANSMITS  10U     // iperf2 protocol: 10× retransmit of last UDP pkt
 
 typedef struct {
@@ -555,19 +555,17 @@ static void TasksTcpClient(void) {
         return;
     }
 
-    // Drain the WINC HIF queue: keep sending until WINC reports
-    // SOCK_ERR_BUFFER_FULL.  This is what wifi_tcp_server does internally
-    // and lets us saturate the chip without per-callback gating.
-    //
-    // Cap iterations per call so we don't starve the WifiTask state
-    // machine.  On WINC HIF (~4 in-flight slots) one Tasks() pass typically
-    // fills 1-4 slots before BUFFER_FULL.
-    for (int i = 0; i < 16; i++) {
+    // Drain WINC HIF up to IPERF2_MAX_PENDING_TX (4, matching WINC chip's
+    // internal HIF queue depth — same cap as wifi_tcp_server's
+    // WIFI_TCP_MAX_IN_FLIGHT). Going over this risks pushing past WINC's
+    // accept-without-error threshold even before BUFFER_FULL fires, which
+    // can corrupt internal state.
+    while (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
         int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TCP_BUF_SIZE, 0);
         if (rc == SOCK_ERR_NO_ERROR) {
             taskENTER_CRITICAL();
             gCtx.bytes_transferred += IPERF2_TCP_BUF_SIZE;
-            if (gCtx.pending_tx < UINT8_MAX) gCtx.pending_tx++;
+            gCtx.pending_tx++;
             taskEXIT_CRITICAL();
         } else if (rc == SOCK_ERR_BUFFER_FULL) {
             break;  // WINC HIF full — let WINC drain, retry next tick.
@@ -586,9 +584,8 @@ static void TasksUdpClient(void) {
     bool past_deadline = ((int32_t)(xTaskGetTickCount() - gCtx.deadline_tick) >= 0);
 
     if (!past_deadline) {
-        // Drain the WINC HIF queue with sendto until BUFFER_FULL.  Same
-        // pattern as TCP path — saturate WINC's HIF without per-send gating.
-        for (int i = 0; i < 16; i++) {
+        // Drain UDP up to IPERF2_MAX_PENDING_TX (matches WINC HIF depth).
+        while (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
             pkt->id = (int32_t)_htonl((uint32_t)gCtx.udp_id);
             pkt->tv_sec = 0;
             pkt->tv_usec = 0;
@@ -598,7 +595,7 @@ static void TasksUdpClient(void) {
             if (rc == SOCK_ERR_NO_ERROR) {
                 taskENTER_CRITICAL();
                 gCtx.bytes_transferred += IPERF2_UDP_BUF_SIZE;
-                if (gCtx.pending_tx < UINT8_MAX) gCtx.pending_tx++;
+                gCtx.pending_tx++;
                 gCtx.udp_id++;
                 taskEXIT_CRITICAL();
             } else if (rc == SOCK_ERR_BUFFER_FULL) {

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -495,7 +495,14 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                 memset(&hdr, 0, sizeof(hdr));
                 hdr.flags = _htonl((uint32_t)IPERF2_HEADER_VERSION1);
                 hdr.numThreads = _htonl((uint32_t)1U);
-                hdr.mPort = _htonl((uint32_t)IPERF2_DEFAULT_PORT);
+                // mPort = 0 → tell iperf2 server to NOT attempt dual-mode
+                // reverse connection back to us. We don't service the
+                // reverse direction (port 5001 server). Setting mPort=5001
+                // (default) caused the server to connect back, fail to
+                // reach us at 5001, time out at 10 s, and abort the inbound
+                // session — which capped all our tests at 10 s and
+                // triggered SOCK_ERR_CONN_ABORTED. See #385.
+                hdr.mPort = _htonl((uint32_t)0U);
                 hdr.bufferlen = _htonl((uint32_t)IPERF2_TCP_BUF_SIZE);
                 hdr.mWinBand = _htonl((uint32_t)0U);
                 // iperf2 mAmount is in 10ms units (negative = duration mode)

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -22,7 +22,7 @@
 #define IPERF2_TCP_BUF_SIZE     1400U   // matches WINC SOCKET_BUFFER_MAX_LENGTH for TCP
 #define IPERF2_UDP_BUF_SIZE     1470U   // standard iperf2 UDP datagram size (1500 - IP/UDP overhead)
 #define IPERF2_MAX_DURATION_S   3600U   // 1h cap
-#define IPERF2_MAX_PENDING_TX   2U      // WINC HIF queue cap (mirror tcp_server)
+#define IPERF2_MAX_PENDING_TX   1U      // single-shot send-per-tick (Microchip pattern)
 #define IPERF2_FIN_RETRANSMITS  10U     // iperf2 protocol: 10× retransmit of last UDP pkt
 
 typedef struct {
@@ -43,6 +43,7 @@ typedef struct {
     uint32_t       udp_lost_pkt;
     uint32_t       udp_outoforder;
     uint8_t        udp_fin_count;   // FIN retransmits sent
+    bool           abort_pending;   // set in callback context, processed in Iperf2_Tasks
     Iperf2_Stats   last_stats;
 } Iperf2_Context;
 
@@ -79,6 +80,7 @@ static void ResetContext(void) {
     gCtx.udp_lost_pkt = 0;
     gCtx.udp_outoforder = 0;
     gCtx.udp_fin_count = 0;
+    gCtx.abort_pending = false;
 }
 
 static void FinalizeStats(void) {
@@ -495,8 +497,18 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                 if (gCtx.pending_tx > 0) gCtx.pending_tx--;
             }
             taskEXIT_CRITICAL();
+            // For TCP, a negative send callback (e.g. SOCK_ERR_INVALID = -9)
+            // means the underlying connection is dead.  Don't tear down the
+            // socket from inside its own callback — WINC's HIF event loop may
+            // still be referencing it and shutdown() here can wedge USB CDC
+            // (observed: serial write hangs after iperf2 test completes).
+            // Set a flag instead and let Iperf2_Tasks() do the cleanup
+            // outside the callback context.
             if (sent <= 0) {
-                LOG_E("iperf2: send cb err=%d", (int)sent);
+                LOG_E("iperf2: send cb err=%d, scheduling abort", (int)sent);
+                if (gCtx.mode == IPERF2_MODE_TCP_CLIENT) {
+                    gCtx.abort_pending = true;
+                }
             }
             return true;
         }
@@ -513,32 +525,38 @@ static void TasksTcpClient(void) {
     if (!gCtx.client_connected) return;
 
     if ((int32_t)(xTaskGetTickCount() - gCtx.deadline_tick) >= 0) {
-        if (gCtx.pending_tx == 0) {
-            LOG_I("iperf2: TCP client TX done, %llu bytes sent",
-                  (unsigned long long)gCtx.bytes_confirmed);
-            FinalizeStats();
-            CloseAll();
-            ResetContext();
-        }
+        // Deadline reached — finalize unconditionally.  Don't gate on
+        // pending_tx==0 because the previous design could deadlock if a
+        // send-callback was lost.
+        LOG_I("iperf2: TCP client TX done, %llu bytes sent",
+              (unsigned long long)gCtx.bytes_confirmed);
+        FinalizeStats();
+        CloseAll();
+        ResetContext();
         return;
     }
 
-    while (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
+    // ONE send per Iperf2_Tasks() invocation — matches Microchip's reference
+    // iperf example (avrxml/asf .../iperf_server_example/iperf.c TCP TX
+    // loop).  Filling a deeper send pipeline (while pending_tx < N) hammers
+    // the WINC HIF queue, never lets it drain via WINC events between calls,
+    // and produces exactly the SOCK_ERR_INVALID flood we saw at 233 packets.
+    // Single-shot sends with WifiTask's natural cadence as the rate limiter
+    // is the model that works.
+    if (gCtx.pending_tx == 0) {
         int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TCP_BUF_SIZE, 0);
         if (rc == SOCK_ERR_NO_ERROR) {
-            // 64-bit RMW, paired with USB-priority reader
             taskENTER_CRITICAL();
             gCtx.bytes_transferred += IPERF2_TCP_BUF_SIZE;
-            gCtx.pending_tx++;
+            gCtx.pending_tx = 1;
             taskEXIT_CRITICAL();
         } else if (rc == SOCK_ERR_BUFFER_FULL) {
-            break;
+            // WINC HIF full — try again next tick.
         } else {
             LOG_E("iperf2: TCP send err rc=%d, aborting", rc);
             FinalizeStats();
             CloseAll();
             ResetContext();
-            return;
         }
     }
 }
@@ -550,10 +568,10 @@ static void TasksUdpClient(void) {
     bool past_deadline = ((int32_t)(xTaskGetTickCount() - gCtx.deadline_tick) >= 0);
 
     if (!past_deadline) {
-        // Normal TX phase — send datagrams with monotonic IDs while pending_tx
-        // has slots.  WINC UDP has more headroom than TCP, but cap at the same
-        // value to stay safe.
-        while (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
+        // ONE sendto per Iperf2_Tasks() — same single-shot model as the TCP
+        // path. Microchip's reference iperf example uses one send per main
+        // loop iteration (avrxml/asf .../iperf_server_example/iperf.c).
+        if (gCtx.pending_tx == 0) {
             pkt->id = (int32_t)_htonl((uint32_t)gCtx.udp_id);
             pkt->tv_sec = 0;
             pkt->tv_usec = 0;
@@ -561,14 +579,13 @@ static void TasksUdpClient(void) {
                             (struct sockaddr*)&gCtx.udp_remote,
                             sizeof(gCtx.udp_remote));
             if (rc == SOCK_ERR_NO_ERROR) {
-                // 64-bit RMW, paired with USB-priority reader
                 taskENTER_CRITICAL();
                 gCtx.bytes_transferred += IPERF2_UDP_BUF_SIZE;
-                gCtx.pending_tx++;
+                gCtx.pending_tx = 1;
                 gCtx.udp_id++;
                 taskEXIT_CRITICAL();
             } else if (rc == SOCK_ERR_BUFFER_FULL) {
-                break;
+                // WINC HIF full — try again next tick.
             } else {
                 LOG_E("iperf2: UDP sendto err rc=%d, aborting", rc);
                 FinalizeStats();
@@ -608,6 +625,18 @@ static void TasksUdpClient(void) {
 }
 
 void Iperf2_Tasks(void) {
+    // Process any deferred abort from a SOCKET_MSG_SEND callback first.  We
+    // can't tear down the socket from inside the WINC's event handler — do
+    // it here from app_WifiTask context, after the event loop returns.
+    if (gCtx.abort_pending) {
+        LOG_I("iperf2: deferred abort (mode=%d, %llu bytes)",
+              (int)gCtx.mode, (unsigned long long)gCtx.bytes_confirmed);
+        FinalizeStats();
+        CloseAll();
+        ResetContext();
+        return;
+    }
+
     switch (gCtx.mode) {
         case IPERF2_MODE_TCP_CLIENT: TasksTcpClient(); break;
         case IPERF2_MODE_UDP_CLIENT: TasksUdpClient(); break;

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -88,6 +88,14 @@ static void ResetContext(void) {
     gCtx.udp_outoforder = 0;
     gCtx.udp_fin_count = 0;
     gCtx.abort_pending = false;
+    // Stale-cache cleanup: STAT? returns last_stats when gCtx.mode==IDLE.
+    // last_stats.mode was set by the previous FinalizeStats to whatever
+    // mode was running, which is misleading after we ResetContext —
+    // user sees "Mode=2" and thinks a TCP client is still active.
+    // Other last_stats fields (bytes, kbps) stay valid — they describe
+    // what the last test transferred — but Mode should reflect "no
+    // current operation".
+    gCtx.last_stats.mode = IPERF2_MODE_IDLE;
 }
 
 static void FinalizeStats(void) {

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -223,6 +223,7 @@ bool Iperf2_StartTcpClient(const char* remote_ip, uint16_t remote_port,
     gCtx.mode = IPERF2_MODE_TCP_CLIENT;
     gCtx.client_connected = false;
     gCtx.duration_ms = duration_sec * 1000U;
+    gCtx.start_tick = xTaskGetTickCount();  // baseline for connect timeout
     gCtx.last_stats.active = true;
     gCtx.last_stats.completed = false;
     LOG_I("iperf2: TCP client connecting to %s:%u for %u s",
@@ -521,8 +522,26 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
 // Driver-task hook for *_CLIENT mode
 // ----------------------------------------------------------------------------
 
+// Time we'll wait for the WINC SOCKET_MSG_CONNECT callback before bailing.
+// Connect attempts to a closed/firewalled host normally hang forever
+// because TasksTcpClient early-returns until client_connected is set.
+#define IPERF2_CONNECT_TIMEOUT_MS  10000U
+
 static void TasksTcpClient(void) {
-    if (!gCtx.client_connected) return;
+    if (!gCtx.client_connected) {
+        // Bail if connect has been pending too long.  start_tick is set in
+        // Iperf2_StartTcpClient() before connect(), updated again in the
+        // CONNECT callback if it succeeds.
+        TickType_t elapsed = xTaskGetTickCount() - gCtx.start_tick;
+        if (elapsed > pdMS_TO_TICKS(IPERF2_CONNECT_TIMEOUT_MS)) {
+            LOG_E("iperf2: TCP connect timeout (%u ms), aborting",
+                  (unsigned)(elapsed * portTICK_PERIOD_MS));
+            FinalizeStats();
+            CloseAll();
+            ResetContext();
+        }
+        return;
+    }
 
     if ((int32_t)(xTaskGetTickCount() - gCtx.deadline_tick) >= 0) {
         // Deadline reached — finalize unconditionally.  Don't gate on
@@ -617,6 +636,31 @@ static void TasksUdpClient(void) {
                 taskEXIT_CRITICAL();
             }
         }
+    }
+}
+
+// Task body — runs continuously, adapting delay to active state.  Lives in
+// its own FreeRTOS task at priority above WifiTask so client-mode TX gets
+// tight pacing (1 ms tick) without affecting other WiFi paths' 5 ms cadence.
+// When iperf2 is idle/server-only, sleeps 50 ms between ticks (cheap).
+static void Iperf2TaskMain(void* arg) {
+    (void)arg;
+    for (;;) {
+        Iperf2_Tasks();
+        bool active = (gCtx.mode == IPERF2_MODE_TCP_CLIENT) ||
+                      (gCtx.mode == IPERF2_MODE_UDP_CLIENT);
+        vTaskDelay(active ? pdMS_TO_TICKS(1) : pdMS_TO_TICKS(50));
+    }
+}
+
+void Iperf2_StartTask(void) {
+    static StaticTask_t taskTcb;
+    static StackType_t  taskStack[512];
+    TaskHandle_t h = xTaskCreateStatic(Iperf2TaskMain, "Iperf2",
+                                       (uint32_t)(sizeof(taskStack) / sizeof(taskStack[0])),
+                                       NULL, 5, taskStack, &taskTcb);
+    if (h == NULL) {
+        LOG_E("iperf2: failed to create dedicated task");
     }
 }
 

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -536,24 +536,27 @@ static void TasksTcpClient(void) {
         return;
     }
 
-    // ONE send per Iperf2_Tasks() invocation — matches Microchip's reference
-    // iperf example (avrxml/asf .../iperf_server_example/iperf.c TCP TX
-    // loop).  Note: the reference has NO pending-count gate — it just calls
-    // send() each iteration and lets SOCK_ERR_BUFFER_FULL be the rate
-    // limiter (WINC's HIF queue drains via the WINC driver's event task
-    // between our Iperf2_Tasks ticks). With no gate, throughput rises by
-    // ~10x vs the gated single-shot pattern.
-    int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TCP_BUF_SIZE, 0);
-    if (rc == SOCK_ERR_NO_ERROR) {
-        taskENTER_CRITICAL();
-        gCtx.bytes_transferred += IPERF2_TCP_BUF_SIZE;
-        if (gCtx.pending_tx < UINT8_MAX) gCtx.pending_tx++;
-        taskEXIT_CRITICAL();
-    } else if (rc == SOCK_ERR_BUFFER_FULL) {
-        // WINC HIF full — try again next tick.
-    } else {
-        LOG_E("iperf2: TCP send err rc=%d, aborting", rc);
-        gCtx.abort_pending = true;
+    // Drain the WINC HIF queue: keep sending until WINC reports
+    // SOCK_ERR_BUFFER_FULL.  This is what wifi_tcp_server does internally
+    // and lets us saturate the chip without per-callback gating.
+    //
+    // Cap iterations per call so we don't starve the WifiTask state
+    // machine.  On WINC HIF (~4 in-flight slots) one Tasks() pass typically
+    // fills 1-4 slots before BUFFER_FULL.
+    for (int i = 0; i < 16; i++) {
+        int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TCP_BUF_SIZE, 0);
+        if (rc == SOCK_ERR_NO_ERROR) {
+            taskENTER_CRITICAL();
+            gCtx.bytes_transferred += IPERF2_TCP_BUF_SIZE;
+            if (gCtx.pending_tx < UINT8_MAX) gCtx.pending_tx++;
+            taskEXIT_CRITICAL();
+        } else if (rc == SOCK_ERR_BUFFER_FULL) {
+            break;  // WINC HIF full — let WINC drain, retry next tick.
+        } else {
+            LOG_E("iperf2: TCP send err rc=%d, aborting", rc);
+            gCtx.abort_pending = true;
+            break;
+        }
     }
 }
 
@@ -564,26 +567,28 @@ static void TasksUdpClient(void) {
     bool past_deadline = ((int32_t)(xTaskGetTickCount() - gCtx.deadline_tick) >= 0);
 
     if (!past_deadline) {
-        // ONE sendto per iteration, no gate — same pattern as TCP path.
-        // SOCK_ERR_BUFFER_FULL is the natural rate limiter via WINC's HIF.
-        pkt->id = (int32_t)_htonl((uint32_t)gCtx.udp_id);
-        pkt->tv_sec = 0;
-        pkt->tv_usec = 0;
-        int rc = sendto(gCtx.data_sock, (char*)gTxBuf, IPERF2_UDP_BUF_SIZE, 0,
-                        (struct sockaddr*)&gCtx.udp_remote,
-                        sizeof(gCtx.udp_remote));
-        if (rc == SOCK_ERR_NO_ERROR) {
-            taskENTER_CRITICAL();
-            gCtx.bytes_transferred += IPERF2_UDP_BUF_SIZE;
-            if (gCtx.pending_tx < UINT8_MAX) gCtx.pending_tx++;
-            gCtx.udp_id++;
-            taskEXIT_CRITICAL();
-        } else if (rc == SOCK_ERR_BUFFER_FULL) {
-            // WINC HIF full — try again next tick.
-        } else {
-            LOG_E("iperf2: UDP sendto err rc=%d, aborting", rc);
-            gCtx.abort_pending = true;
-            return;
+        // Drain the WINC HIF queue with sendto until BUFFER_FULL.  Same
+        // pattern as TCP path — saturate WINC's HIF without per-send gating.
+        for (int i = 0; i < 16; i++) {
+            pkt->id = (int32_t)_htonl((uint32_t)gCtx.udp_id);
+            pkt->tv_sec = 0;
+            pkt->tv_usec = 0;
+            int rc = sendto(gCtx.data_sock, (char*)gTxBuf, IPERF2_UDP_BUF_SIZE, 0,
+                            (struct sockaddr*)&gCtx.udp_remote,
+                            sizeof(gCtx.udp_remote));
+            if (rc == SOCK_ERR_NO_ERROR) {
+                taskENTER_CRITICAL();
+                gCtx.bytes_transferred += IPERF2_UDP_BUF_SIZE;
+                if (gCtx.pending_tx < UINT8_MAX) gCtx.pending_tx++;
+                gCtx.udp_id++;
+                taskEXIT_CRITICAL();
+            } else if (rc == SOCK_ERR_BUFFER_FULL) {
+                break;
+            } else {
+                LOG_E("iperf2: UDP sendto err rc=%d, aborting", rc);
+                gCtx.abort_pending = true;
+                return;
+            }
         }
     } else {
         // FIN phase — send final packet with negated ID 10× to ensure server

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -27,13 +27,13 @@
 #define IPERF2_FIN_RETRANSMITS  10U     // iperf2 protocol: 10× retransmit of last UDP pkt
 
 typedef struct {
-    Iperf2_Mode    mode;
+    volatile Iperf2_Mode    mode;
     SOCKET         listen_sock;     // TCP server only
     SOCKET         data_sock;       // active TCP connection or UDP socket
     volatile bool  client_connected;
     volatile uint8_t pending_tx;    // count of m2m_send not yet ACKed
-    TickType_t     start_tick;
-    TickType_t     deadline_tick;   // *_CLIENT mode TX deadline
+    volatile TickType_t start_tick;
+    volatile TickType_t deadline_tick;   // *_CLIENT mode TX deadline
     uint32_t       duration_ms;     // requested duration
     uint64_t       bytes_transferred;
     uint64_t       bytes_confirmed; // server: rcv'd; client: ACKed by m2m_send callback

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -448,9 +448,15 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                     recvfrom(gCtx.data_sock, gRxBuf, sizeof(gRxBuf), 0);
                 }
             } else {
-                // Defer teardown — see #383 / SEND-callback note below.
-                LOG_E("iperf2: bind status=%d, scheduling abort", m ? m->status : -1);
-                gCtx.abort_pending = true;
+                // A/B verified 2026-04-28 (issue #385): in-callback Iperf2_Stop
+                // gives 5/5 stable trials and 0 FinWait2 leaks; deferred-abort
+                // gave 3/5 stable + 8 FinWait2 leaks across 5 trials. Stay
+                // synchronous on the listener-error / connect-error paths.
+                // The SEND-callback path (line 542 below) keeps deferred
+                // teardown — that's still required to avoid USB CDC wedge
+                // when the data socket is being torn down mid-send.
+                LOG_E("iperf2: bind status=%d", m ? m->status : -1);
+                Iperf2_Stop();
             }
             return true;
         }
@@ -459,8 +465,8 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
             if (m && m->status == 0 && sock == gCtx.listen_sock) {
                 accept(gCtx.listen_sock, NULL, NULL);
             } else {
-                LOG_E("iperf2: listen status=%d, scheduling abort", m ? m->status : -1);
-                gCtx.abort_pending = true;
+                LOG_E("iperf2: listen status=%d", m ? m->status : -1);
+                Iperf2_Stop();
             }
             return true;
         }
@@ -478,8 +484,8 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                       (int)m->sock);
                 recv(gCtx.data_sock, gRxBuf, IPERF2_TCP_BUF_SIZE, 0);
             } else {
-                LOG_E("iperf2: accept failed, scheduling abort");
-                gCtx.abort_pending = true;
+                LOG_E("iperf2: accept failed");
+                Iperf2_Stop();
             }
             return true;
         }
@@ -513,12 +519,12 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                     gCtx.pending_tx = 1;
                     LOG_I("iperf2: TCP client connected, header queued");
                 } else {
-                    LOG_E("iperf2: header send rc=%d, scheduling abort", rc);
-                    gCtx.abort_pending = true;
+                    LOG_E("iperf2: header send rc=%d", rc);
+                    Iperf2_Stop();
                 }
             } else {
-                LOG_E("iperf2: connect err=%d, scheduling abort", m ? m->s8Error : -1);
-                gCtx.abort_pending = true;
+                LOG_E("iperf2: connect err=%d", m ? m->s8Error : -1);
+                Iperf2_Stop();
             }
             return true;
         }

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -538,26 +538,22 @@ static void TasksTcpClient(void) {
 
     // ONE send per Iperf2_Tasks() invocation — matches Microchip's reference
     // iperf example (avrxml/asf .../iperf_server_example/iperf.c TCP TX
-    // loop).  Filling a deeper send pipeline (while pending_tx < N) hammers
-    // the WINC HIF queue, never lets it drain via WINC events between calls,
-    // and produces exactly the SOCK_ERR_INVALID flood we saw at 233 packets.
-    // Single-shot sends with WifiTask's natural cadence as the rate limiter
-    // is the model that works.
-    if (gCtx.pending_tx == 0) {
-        int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TCP_BUF_SIZE, 0);
-        if (rc == SOCK_ERR_NO_ERROR) {
-            taskENTER_CRITICAL();
-            gCtx.bytes_transferred += IPERF2_TCP_BUF_SIZE;
-            gCtx.pending_tx = 1;
-            taskEXIT_CRITICAL();
-        } else if (rc == SOCK_ERR_BUFFER_FULL) {
-            // WINC HIF full — try again next tick.
-        } else {
-            LOG_E("iperf2: TCP send err rc=%d, aborting", rc);
-            FinalizeStats();
-            CloseAll();
-            ResetContext();
-        }
+    // loop).  Note: the reference has NO pending-count gate — it just calls
+    // send() each iteration and lets SOCK_ERR_BUFFER_FULL be the rate
+    // limiter (WINC's HIF queue drains via the WINC driver's event task
+    // between our Iperf2_Tasks ticks). With no gate, throughput rises by
+    // ~10x vs the gated single-shot pattern.
+    int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TCP_BUF_SIZE, 0);
+    if (rc == SOCK_ERR_NO_ERROR) {
+        taskENTER_CRITICAL();
+        gCtx.bytes_transferred += IPERF2_TCP_BUF_SIZE;
+        if (gCtx.pending_tx < UINT8_MAX) gCtx.pending_tx++;
+        taskEXIT_CRITICAL();
+    } else if (rc == SOCK_ERR_BUFFER_FULL) {
+        // WINC HIF full — try again next tick.
+    } else {
+        LOG_E("iperf2: TCP send err rc=%d, aborting", rc);
+        gCtx.abort_pending = true;
     }
 }
 
@@ -568,31 +564,26 @@ static void TasksUdpClient(void) {
     bool past_deadline = ((int32_t)(xTaskGetTickCount() - gCtx.deadline_tick) >= 0);
 
     if (!past_deadline) {
-        // ONE sendto per Iperf2_Tasks() — same single-shot model as the TCP
-        // path. Microchip's reference iperf example uses one send per main
-        // loop iteration (avrxml/asf .../iperf_server_example/iperf.c).
-        if (gCtx.pending_tx == 0) {
-            pkt->id = (int32_t)_htonl((uint32_t)gCtx.udp_id);
-            pkt->tv_sec = 0;
-            pkt->tv_usec = 0;
-            int rc = sendto(gCtx.data_sock, (char*)gTxBuf, IPERF2_UDP_BUF_SIZE, 0,
-                            (struct sockaddr*)&gCtx.udp_remote,
-                            sizeof(gCtx.udp_remote));
-            if (rc == SOCK_ERR_NO_ERROR) {
-                taskENTER_CRITICAL();
-                gCtx.bytes_transferred += IPERF2_UDP_BUF_SIZE;
-                gCtx.pending_tx = 1;
-                gCtx.udp_id++;
-                taskEXIT_CRITICAL();
-            } else if (rc == SOCK_ERR_BUFFER_FULL) {
-                // WINC HIF full — try again next tick.
-            } else {
-                LOG_E("iperf2: UDP sendto err rc=%d, aborting", rc);
-                FinalizeStats();
-                CloseAll();
-                ResetContext();
-                return;
-            }
+        // ONE sendto per iteration, no gate — same pattern as TCP path.
+        // SOCK_ERR_BUFFER_FULL is the natural rate limiter via WINC's HIF.
+        pkt->id = (int32_t)_htonl((uint32_t)gCtx.udp_id);
+        pkt->tv_sec = 0;
+        pkt->tv_usec = 0;
+        int rc = sendto(gCtx.data_sock, (char*)gTxBuf, IPERF2_UDP_BUF_SIZE, 0,
+                        (struct sockaddr*)&gCtx.udp_remote,
+                        sizeof(gCtx.udp_remote));
+        if (rc == SOCK_ERR_NO_ERROR) {
+            taskENTER_CRITICAL();
+            gCtx.bytes_transferred += IPERF2_UDP_BUF_SIZE;
+            if (gCtx.pending_tx < UINT8_MAX) gCtx.pending_tx++;
+            gCtx.udp_id++;
+            taskEXIT_CRITICAL();
+        } else if (rc == SOCK_ERR_BUFFER_FULL) {
+            // WINC HIF full — try again next tick.
+        } else {
+            LOG_E("iperf2: UDP sendto err rc=%d, aborting", rc);
+            gCtx.abort_pending = true;
+            return;
         }
     } else {
         // FIN phase — send final packet with negated ID 10× to ensure server

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -592,7 +592,8 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
             // outside the callback context.
             if (sent <= 0) {
                 LOG_E("iperf2: send cb err=%d, scheduling abort", (int)sent);
-                if (gCtx.mode == IPERF2_MODE_TCP_CLIENT) {
+                if (gCtx.mode == IPERF2_MODE_TCP_CLIENT ||
+                    gCtx.mode == IPERF2_MODE_UDP_CLIENT) {
                     gCtx.abort_pending = true;
                 }
             }

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -737,6 +737,9 @@ static void Iperf2TaskMain(void* arg) {
 }
 
 void Iperf2_StartTask(void) {
+    if (gIperf2TaskHandle != NULL) {
+        return;  // already created — re-using static taskTcb/taskStack would corrupt
+    }
     static StaticTask_t taskTcb;
     static StackType_t  taskStack[512];
     gIperf2TaskHandle = xTaskCreateStatic(Iperf2TaskMain, "Iperf2",

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -755,8 +755,15 @@ void Iperf2_Tasks(void) {
     // can't tear down the socket from inside the WINC's event handler — do
     // it here from app_WifiTask context, after the event loop returns.
     if (gCtx.abort_pending) {
+        // Copy bytes_confirmed under critical section — 64-bit reads are
+        // not atomic on PIC32MZ, and bytes_confirmed is updated from
+        // the WINC callback context.  Without this, the LOG_I could
+        // print a torn 32-bit-half value.
+        taskENTER_CRITICAL();
+        uint64_t snap_bytes = gCtx.bytes_confirmed;
+        taskEXIT_CRITICAL();
         LOG_I("iperf2: deferred abort (mode=%d, %llu bytes)",
-              (int)gCtx.mode, (unsigned long long)gCtx.bytes_confirmed);
+              (int)gCtx.mode, (unsigned long long)snap_bytes);
         FinalizeStats();
         CloseAll();
         ResetContext();

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -30,8 +30,8 @@ typedef struct {
     Iperf2_Mode    mode;
     SOCKET         listen_sock;     // TCP server only
     SOCKET         data_sock;       // active TCP connection or UDP socket
-    bool           client_connected;
-    uint8_t        pending_tx;      // count of m2m_send not yet ACKed
+    volatile bool  client_connected;
+    volatile uint8_t pending_tx;    // count of m2m_send not yet ACKed
     TickType_t     start_tick;
     TickType_t     deadline_tick;   // *_CLIENT mode TX deadline
     uint32_t       duration_ms;     // requested duration
@@ -44,7 +44,7 @@ typedef struct {
     uint32_t       udp_lost_pkt;
     uint32_t       udp_outoforder;
     uint8_t        udp_fin_count;   // FIN retransmits sent
-    bool           abort_pending;   // set in callback context, processed in Iperf2_Tasks
+    volatile bool  abort_pending;   // set in callback context, processed in Iperf2_Tasks
     Iperf2_Stats   last_stats;
 } Iperf2_Context;
 

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -7,6 +7,7 @@
 #include "task.h"
 #include "socket.h"
 #include "m2m_wifi.h"
+#include "services/wifi_services/wifi_manager.h"
 #include <string.h>
 
 // ============================================================================
@@ -48,6 +49,11 @@ typedef struct {
 } Iperf2_Context;
 
 static Iperf2_Context gCtx;
+
+// Active-mode task delay (ms).  Runtime-tunable via SCPI for sweep tests.
+// 5 ms default per empirical observation that 5 ms paces well with the
+// callback chain (over-aggressive 1 ms polling caught WINC mid-state).
+static volatile uint8_t gActiveDelayMs = 5;
 
 // Static TX/RX buffers — keep off task stacks.  Sized to the larger of TCP/UDP.
 // 4-byte aligned: HandleUdpRecvFrom casts gRxBuf to Iperf2_PktInfo* (which has
@@ -99,6 +105,17 @@ static void FinalizeStats(void) {
     gCtx.last_stats.completed = true;
 }
 
+// Refuse to call socket()/connect()/bind() unless WiFi is fully associated and
+// has an IP. Calling sockets against an un-ready WINC leaves stuck state on
+// the PIC32 side that survives WDRV_WINC_Deinitialize/Init cycles (#383).
+static bool RequireWifiConnected(const char* where) {
+    if (wifi_manager_GetWiFiStatus() != WIFI_STATUS_CONNECTED) {
+        LOG_E("iperf2: %s refused — WiFi not CONNECTED", where);
+        return false;
+    }
+    return true;
+}
+
 static void CloseAll(void) {
     if (gCtx.data_sock >= 0) {
         shutdown(gCtx.data_sock);
@@ -121,6 +138,7 @@ void Iperf2_Initialize(void) {
 }
 
 bool Iperf2_StartTcpServer(uint16_t port) {
+    if (!RequireWifiConnected("TCP server")) return false;
     if (gCtx.mode != IPERF2_MODE_IDLE) {
         LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
         return false;
@@ -153,6 +171,7 @@ bool Iperf2_StartTcpServer(uint16_t port) {
 }
 
 bool Iperf2_StartUdpServer(uint16_t port) {
+    if (!RequireWifiConnected("UDP server")) return false;
     if (gCtx.mode != IPERF2_MODE_IDLE) {
         LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
         return false;
@@ -186,6 +205,7 @@ bool Iperf2_StartUdpServer(uint16_t port) {
 
 bool Iperf2_StartTcpClient(const char* remote_ip, uint16_t remote_port,
                            uint32_t duration_sec) {
+    if (!RequireWifiConnected("TCP client")) return false;
     if (gCtx.mode != IPERF2_MODE_IDLE) {
         LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
         return false;
@@ -233,6 +253,7 @@ bool Iperf2_StartTcpClient(const char* remote_ip, uint16_t remote_port,
 
 bool Iperf2_StartUdpClient(const char* remote_ip, uint16_t remote_port,
                            uint32_t duration_sec) {
+    if (!RequireWifiConnected("UDP client")) return false;
     if (gCtx.mode != IPERF2_MODE_IDLE) {
         LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
         return false;
@@ -671,8 +692,22 @@ static void Iperf2TaskMain(void* arg) {
         Iperf2_Tasks();
         bool active = (gCtx.mode == IPERF2_MODE_TCP_CLIENT) ||
                       (gCtx.mode == IPERF2_MODE_UDP_CLIENT);
-        vTaskDelay(active ? pdMS_TO_TICKS(5) : pdMS_TO_TICKS(50));
+        uint32_t ms = active ? gActiveDelayMs : 50U;
+        if (ms == 0U) {
+            taskYIELD();
+        } else {
+            vTaskDelay(pdMS_TO_TICKS(ms));
+        }
     }
+}
+
+void Iperf2_SetActiveDelayMs(uint8_t ms) {
+    if (ms > 100U) ms = 100U;  // sanity cap
+    gActiveDelayMs = ms;
+}
+
+uint8_t Iperf2_GetActiveDelayMs(void) {
+    return gActiveDelayMs;
 }
 
 void Iperf2_StartTask(void) {

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -62,6 +62,11 @@ static Iperf2_Context gCtx;
 static uint8_t gTxBuf[IPERF2_UDP_BUF_SIZE] __attribute__((aligned(4)));
 static uint8_t gRxBuf[IPERF2_UDP_BUF_SIZE] __attribute__((aligned(4)));
 
+// Handle for the dedicated Iperf2 task — used by the SOCKET_MSG_SEND
+// callback to wake the task immediately on slot completion.  Set in
+// Iperf2_StartTask, NULL until then.
+static TaskHandle_t gIperf2TaskHandle = NULL;
+
 static void FillTxBuffer(void) {
     // Counter pattern — defeats PC-side TCP coalescing optimizations and gives
     // a predictable wire stream.  Pre-filled at init.
@@ -345,12 +350,6 @@ void Iperf2_GetStats(Iperf2_Stats* out) {
 // Socket event dispatch
 // ----------------------------------------------------------------------------
 
-// Forward declarations — TasksTcpClient/TasksUdpClient are defined later in
-// the file but called from SOCKET_MSG_SEND/SENDTO callbacks for event-driven
-// send chaining (mirrors wifi_tcp_server's pattern).
-static void TasksTcpClient(void);
-static void TasksUdpClient(void);
-
 static void HandleTcpRecv(tstrSocketRecvMsg* m) {
     if (m && m->s16BufferSize > 0) {
         // 64-bit RMW + paired with USB-priority Iperf2_GetStats reader
@@ -548,18 +547,16 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                 if (gCtx.pending_tx > 0) gCtx.pending_tx--;
             }
             taskEXIT_CRITICAL();
-            // Event-driven send chaining (mirrors wifi_tcp_server pattern):
-            // when WINC frees a HIF slot, immediately refill it from here
-            // instead of waiting for the next Iperf2 task tick.  Pacing is
-            // then naturally rate-limited by WINC's actual completion rate,
-            // not our task delay.  The task tick is just a backup / initial
-            // trigger (see IPERF2_ACTIVE_DELAY_MS).
-            if (sent > 0 && !gCtx.abort_pending) {
-                if (gCtx.mode == IPERF2_MODE_TCP_CLIENT) {
-                    TasksTcpClient();
-                } else if (gCtx.mode == IPERF2_MODE_UDP_CLIENT) {
-                    TasksUdpClient();
-                }
+            // Event-driven wake: when WINC frees a HIF slot, kick the
+            // dedicated Iperf2 task so it refills immediately instead of
+            // waiting for the next IPERF2_ACTIVE_DELAY_MS tick. Calling
+            // TasksTcpClient() directly here would be unsafe — TasksTcpClient
+            // calls FinalizeStats/CloseAll/ResetContext on deadline-reached,
+            // and synchronous teardown from inside a WINC callback is what
+            // the deferred-abort design is meant to avoid (see SEND-error
+            // path comment below + #385 A/B verdict).
+            if (sent > 0 && !gCtx.abort_pending && gIperf2TaskHandle != NULL) {
+                xTaskNotifyGive(gIperf2TaskHandle);
             }
             // For TCP, a negative send callback (e.g. SOCK_ERR_INVALID = -9)
             // means the underlying connection is dead.  Don't tear down the
@@ -699,28 +696,28 @@ static void TasksUdpClient(void) {
     }
 }
 
-// Task body — backup/initial trigger only.  The hot path is event-driven
-// via SOCKET_MSG_SEND callback chaining (see HandleSocketEvent); this
-// loop kicks off the first send and catches any missed callbacks.
-// Active-mode cadence comes from IPERF2_ACTIVE_DELAY_MS — see the
-// define for the empirical sweep that picked 2 ms.
+// Task body — runs Iperf2_Tasks then sleeps until either notified by a
+// SOCKET_MSG_SEND callback (instant wake on HIF slot completion) or the
+// fallback timeout fires (IPERF2_ACTIVE_DELAY_MS in client mode, 50 ms
+// idle).  See the define for the empirical sweep that picked 2 ms.
 static void Iperf2TaskMain(void* arg) {
     (void)arg;
     for (;;) {
         Iperf2_Tasks();
         bool active = (gCtx.mode == IPERF2_MODE_TCP_CLIENT) ||
                       (gCtx.mode == IPERF2_MODE_UDP_CLIENT);
-        vTaskDelay(pdMS_TO_TICKS(active ? IPERF2_ACTIVE_DELAY_MS : 50U));
+        ulTaskNotifyTake(pdTRUE,
+                         pdMS_TO_TICKS(active ? IPERF2_ACTIVE_DELAY_MS : 50U));
     }
 }
 
 void Iperf2_StartTask(void) {
     static StaticTask_t taskTcb;
     static StackType_t  taskStack[512];
-    TaskHandle_t h = xTaskCreateStatic(Iperf2TaskMain, "Iperf2",
-                                       (uint32_t)(sizeof(taskStack) / sizeof(taskStack[0])),
-                                       NULL, 5, taskStack, &taskTcb);
-    if (h == NULL) {
+    gIperf2TaskHandle = xTaskCreateStatic(Iperf2TaskMain, "Iperf2",
+                                          (uint32_t)(sizeof(taskStack) / sizeof(taskStack[0])),
+                                          NULL, 5, taskStack, &taskTcb);
+    if (gIperf2TaskHandle == NULL) {
         LOG_E("iperf2: failed to create dedicated task");
     }
 }

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -323,11 +323,13 @@ static void HandleTcpRecv(tstrSocketRecvMsg* m) {
         taskEXIT_CRITICAL();
         recv(gCtx.data_sock, gRxBuf, IPERF2_TCP_BUF_SIZE, 0);
     } else {
-        // Disconnect or error → finalize
-        LOG_I("iperf2: TCP peer closed (size=%d)", m ? m->s16BufferSize : 0);
-        FinalizeStats();
-        CloseAll();
-        ResetContext();
+        // Disconnect or error.  Defer cleanup to Iperf2_Tasks() — calling
+        // shutdown(sock) from inside the socket's own callback corrupts
+        // shared SPI4/DMA state with USB CDC (same wedge we hit on the
+        // SEND callback abort path).
+        LOG_I("iperf2: TCP peer closed (size=%d), scheduling abort",
+              m ? m->s16BufferSize : 0);
+        gCtx.abort_pending = true;
     }
 }
 
@@ -376,14 +378,12 @@ static void HandleUdpRecvFrom(tstrSocketRecvMsg* m) {
         gCtx.bytes_confirmed += (uint64_t)m->s16BufferSize;
         taskEXIT_CRITICAL();
     } else {
-        // Negative ID = end-of-test marker.  iperf2 client retransmits this 10
-        // times to ensure the server sees it.  Finalize on first observation.
-        LOG_I("iperf2: UDP end-of-test (id=%d, %u pkts, %u lost, %u oo)",
+        // Negative ID = end-of-test marker.  Defer cleanup to Iperf2_Tasks()
+        // — same in-callback teardown safety as TCP RECV/SEND.
+        LOG_I("iperf2: UDP end-of-test (id=%d, %u pkts, %u lost, %u oo), scheduling abort",
               (int)id, (unsigned)gCtx.udp_total_pkt,
               (unsigned)gCtx.udp_lost_pkt, (unsigned)gCtx.udp_outoforder);
-        FinalizeStats();
-        CloseAll();
-        ResetContext();
+        gCtx.abort_pending = true;
         return;
     }
 

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -119,16 +119,25 @@ static void FinalizeStats(void) {
     gCtx.last_stats.completed = true;
 }
 
-// Refuse to call socket()/connect()/bind() unless WiFi is fully associated and
-// has an IP. Calling sockets against an un-ready WINC leaves stuck state on
-// the PIC32 side that survives WDRV_WINC_Deinitialize/Init cycles (#383).
+// Refuse to call socket()/connect()/bind() unless the WINC driver is fully
+// started.  Calling sockets against a chip in WIFI_STATE_INIT (transitional)
+// leaves stuck state on the PIC32 side that survives
+// WDRV_WINC_Deinitialize/Init cycles (#383).
 //
 // RequireWifiConnected — strict check for client modes (we need to send out).
 // RequireWifiReadyForSockets — looser check for server modes; SoftAP with no
 // connected station is still a valid configuration to listen on.
+//
+// Both also gate on m2m_wifi_get_state() == WIFI_STATE_START so we don't even
+// start the socket stack mid-init (where GetWiFiStatus may briefly return
+// DISCONNECTED but the WINC isn't actually up yet).
 static bool RequireWifiConnected(const char* where) {
     if (wifi_manager_GetWiFiStatus() != WIFI_STATUS_CONNECTED) {
         LOG_E("iperf2: %s refused — WiFi not CONNECTED", where);
+        return false;
+    }
+    if (m2m_wifi_get_state() != WIFI_STATE_START) {
+        LOG_E("iperf2: %s refused — WINC not started", where);
         return false;
     }
     return true;
@@ -137,6 +146,10 @@ static bool RequireWifiConnected(const char* where) {
 static bool RequireWifiReadyForSockets(const char* where) {
     if (wifi_manager_GetWiFiStatus() == WIFI_STATUS_DISABLED) {
         LOG_E("iperf2: %s refused — WiFi DISABLED", where);
+        return false;
+    }
+    if (m2m_wifi_get_state() != WIFI_STATE_START) {
+        LOG_E("iperf2: %s refused — WINC not started", where);
         return false;
     }
     return true;

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -122,9 +122,21 @@ static void FinalizeStats(void) {
 // Refuse to call socket()/connect()/bind() unless WiFi is fully associated and
 // has an IP. Calling sockets against an un-ready WINC leaves stuck state on
 // the PIC32 side that survives WDRV_WINC_Deinitialize/Init cycles (#383).
+//
+// RequireWifiConnected — strict check for client modes (we need to send out).
+// RequireWifiReadyForSockets — looser check for server modes; SoftAP with no
+// connected station is still a valid configuration to listen on.
 static bool RequireWifiConnected(const char* where) {
     if (wifi_manager_GetWiFiStatus() != WIFI_STATUS_CONNECTED) {
         LOG_E("iperf2: %s refused — WiFi not CONNECTED", where);
+        return false;
+    }
+    return true;
+}
+
+static bool RequireWifiReadyForSockets(const char* where) {
+    if (wifi_manager_GetWiFiStatus() == WIFI_STATUS_DISABLED) {
+        LOG_E("iperf2: %s refused — WiFi DISABLED", where);
         return false;
     }
     return true;
@@ -152,7 +164,7 @@ void Iperf2_Initialize(void) {
 }
 
 bool Iperf2_StartTcpServer(uint16_t port) {
-    if (!RequireWifiConnected("TCP server")) return false;
+    if (!RequireWifiReadyForSockets("TCP server")) return false;
     if (gCtx.mode != IPERF2_MODE_IDLE) {
         LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
         return false;
@@ -185,7 +197,7 @@ bool Iperf2_StartTcpServer(uint16_t port) {
 }
 
 bool Iperf2_StartUdpServer(uint16_t port) {
-    if (!RequireWifiConnected("UDP server")) return false;
+    if (!RequireWifiReadyForSockets("UDP server")) return false;
     if (gCtx.mode != IPERF2_MODE_IDLE) {
         LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
         return false;

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -315,6 +315,12 @@ void Iperf2_GetStats(Iperf2_Stats* out) {
 // Socket event dispatch
 // ----------------------------------------------------------------------------
 
+// Forward declarations — TasksTcpClient/TasksUdpClient are defined later in
+// the file but called from SOCKET_MSG_SEND/SENDTO callbacks for event-driven
+// send chaining (mirrors wifi_tcp_server's pattern).
+static void TasksTcpClient(void);
+static void TasksUdpClient(void);
+
 static void HandleTcpRecv(tstrSocketRecvMsg* m) {
     if (m && m->s16BufferSize > 0) {
         // 64-bit RMW + paired with USB-priority Iperf2_GetStats reader
@@ -498,6 +504,19 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                 if (gCtx.pending_tx > 0) gCtx.pending_tx--;
             }
             taskEXIT_CRITICAL();
+            // Event-driven send chaining (mirrors wifi_tcp_server pattern):
+            // when WINC frees a HIF slot, immediately refill it from here
+            // instead of waiting for the next Iperf2 task tick.  Pacing is
+            // then naturally rate-limited by WINC's actual completion rate,
+            // not our task delay.  The 5 ms task tick is just a backup /
+            // initial trigger.
+            if (sent > 0 && !gCtx.abort_pending) {
+                if (gCtx.mode == IPERF2_MODE_TCP_CLIENT) {
+                    TasksTcpClient();
+                } else if (gCtx.mode == IPERF2_MODE_UDP_CLIENT) {
+                    TasksUdpClient();
+                }
+            }
             // For TCP, a negative send callback (e.g. SOCK_ERR_INVALID = -9)
             // means the underlying connection is dead.  Don't tear down the
             // socket from inside its own callback — WINC's HIF event loop may
@@ -636,17 +655,23 @@ static void TasksUdpClient(void) {
     }
 }
 
-// Task body — runs continuously, adapting delay to active state.  Lives in
-// its own FreeRTOS task at priority above WifiTask so client-mode TX gets
-// tight pacing (1 ms tick) without affecting other WiFi paths' 5 ms cadence.
-// When iperf2 is idle/server-only, sleeps 50 ms between ticks (cheap).
+// Task body — runs continuously at modest cadence as a backup/initial
+// trigger.  The hot path is event-driven via SOCKET_MSG_SEND callback
+// chaining (see HandleSocketEvent) — this loop just kicks off the first
+// send and catches any missed callbacks.  5 ms cadence is enough for
+// bring-up; the actual send rate is set by WINC HIF completion timing.
+//
+// Empirically (this session): 1 ms cadence was less stable than 5 ms —
+// over-aggressive polling caught WINC mid-state and triggered more
+// BUFFER_FULL churn / TCP cwnd issues.  5 ms paces well with the
+// callback-chain doing the heavy lifting.
 static void Iperf2TaskMain(void* arg) {
     (void)arg;
     for (;;) {
         Iperf2_Tasks();
         bool active = (gCtx.mode == IPERF2_MODE_TCP_CLIENT) ||
                       (gCtx.mode == IPERF2_MODE_UDP_CLIENT);
-        vTaskDelay(active ? pdMS_TO_TICKS(1) : pdMS_TO_TICKS(50));
+        vTaskDelay(active ? pdMS_TO_TICKS(5) : pdMS_TO_TICKS(50));
     }
 }
 

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -143,15 +143,6 @@ void Iperf2_Tasks(void);
  */
 void Iperf2_StartTask(void);
 
-/**
- * Active-mode task delay tunable for sweep testing.  ms range 0..100;
- * 0 means taskYIELD() (no explicit delay, just give other priorities a
- * chance).  Default 2 ms (empirical peak — see iperf2.c).  Idle
- * (server/IDLE) uses fixed 50 ms.
- */
-void Iperf2_SetActiveDelayMs(uint8_t ms);
-uint8_t Iperf2_GetActiveDelayMs(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -146,7 +146,8 @@ void Iperf2_StartTask(void);
 /**
  * Active-mode task delay tunable for sweep testing.  ms range 0..100;
  * 0 means taskYIELD() (no explicit delay, just give other priorities a
- * chance).  Default 5 ms.  Idle (server/IDLE) uses fixed 50 ms.
+ * chance).  Default 2 ms (empirical peak — see iperf2.c).  Idle
+ * (server/IDLE) uses fixed 50 ms.
  */
 void Iperf2_SetActiveDelayMs(uint8_t ms);
 uint8_t Iperf2_GetActiveDelayMs(void);

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -143,6 +143,14 @@ void Iperf2_Tasks(void);
  */
 void Iperf2_StartTask(void);
 
+/**
+ * Active-mode task delay tunable for sweep testing.  ms range 0..100;
+ * 0 means taskYIELD() (no explicit delay, just give other priorities a
+ * chance).  Default 5 ms.  Idle (server/IDLE) uses fixed 50 ms.
+ */
+void Iperf2_SetActiveDelayMs(uint8_t ms);
+uint8_t Iperf2_GetActiveDelayMs(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -129,14 +129,14 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage);
  * mode.  Drives the TX deadline + send loop.  No-op in IDLE / *_SERVER
  * modes (servers are purely callback-driven).
  *
- * Called from the dedicated Iperf2 task at adaptive cadence (1 ms when
+ * Called from the dedicated Iperf2 task at adaptive cadence (2 ms when
  * active, 50 ms idle).
  */
 void Iperf2_Tasks(void);
 
 /**
  * Create the dedicated iperf2 FreeRTOS task.  Call once at boot, after
- * Iperf2_Initialize().  Task self-paces: 1 ms tick during active client
+ * Iperf2_Initialize().  Task self-paces: 2 ms tick during active client
  * mode, 50 ms tick when idle/server (cheap).
  *
  * Task priority is 5 (above WifiTask 2, SD 5; below encoder 6, USB SCPI 7).

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -125,11 +125,23 @@ void Iperf2_GetStats(Iperf2_Stats* out);
 bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage);
 
 /**
- * Driver-task hook: must be called once per WifiTask iteration when
- * iperf2 is in *_CLIENT mode.  Drives the TX deadline + send loop.
- * No-op in IDLE / *_SERVER modes (servers are purely callback-driven).
+ * Driver-task hook: must be called periodically when iperf2 is in *_CLIENT
+ * mode.  Drives the TX deadline + send loop.  No-op in IDLE / *_SERVER
+ * modes (servers are purely callback-driven).
+ *
+ * Called from the dedicated Iperf2 task at adaptive cadence (1 ms when
+ * active, 50 ms idle).
  */
 void Iperf2_Tasks(void);
+
+/**
+ * Create the dedicated iperf2 FreeRTOS task.  Call once at boot, after
+ * Iperf2_Initialize().  Task self-paces: 1 ms tick during active client
+ * mode, 50 ms tick when idle/server (cheap).
+ *
+ * Task priority is 5 (above WifiTask 2, SD 5; below encoder 6, USB SCPI 7).
+ */
+void Iperf2_StartTask(void);
 
 #ifdef __cplusplus
 }

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -10,6 +10,7 @@
 #include "wifi_serial_bridge_interface.h"
 #include "iperf2/iperf2.h"
 #include "driver/winc/include/dev/wdrv_winc_gpio.h"
+#include "semphr.h"
 #include "driver/winc/include/drv/driver/m2m_wifi.h"
 
 #define UNUSED(x) (void)(x)
@@ -121,6 +122,15 @@ static volatile bool gTcpRxPending = false;
 // concurrency rules).  Marked volatile because it's set from any task
 // calling HardReset/Deinit and read every tick from app_WifiTask.
 static volatile TickType_t gWifiReinitDeadlineTick = 0;
+
+// Mutex serializing wifi_manager_ProcessState across callers.  Today
+// app_WifiTask is the primary owner; SCPI_Reset's active pump
+// (SYSTem:REboot path) also enters from the SCPI dispatch task.  Without
+// the mutex, the body's xQueueReceive + state-machine update on shared
+// gStateMachineContext could corrupt under any future priority change
+// that lets the two callers interleave.  Created in wifi_manager_Init.
+static StaticSemaphore_t gProcessStateMutexBuf;
+static SemaphoreHandle_t gProcessStateMutex = NULL;
 static volatile bool gRssiUpdateComplete = false;
 static volatile uint8_t gLastRssiPercentage = 0;
 
@@ -1272,6 +1282,9 @@ bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
     if (gEventQH == NULL)
         gEventQH = xQueueCreate(20, sizeof (wifi_manager_event_t));
     else return true;
+    if (gProcessStateMutex == NULL) {
+        gProcessStateMutex = xSemaphoreCreateMutexStatic(&gProcessStateMutexBuf);
+    }
     if (pSettings != NULL)
         gStateMachineContext.pWifiSettings = pSettings;
     if (gStateMachineContext.fwUpdateTaskHandle == NULL) {
@@ -1455,6 +1468,16 @@ void wifi_manager_ProcessState() {
         return;
     }
 
+    // Serialize re-entrant callers (app_WifiTask + SCPI_Reset active pump,
+    // and any future call site).  portMAX_DELAY blocks until owner releases;
+    // priority inheritance keeps the holder unblocked.  See gProcessStateMutex
+    // declaration for the rationale.
+    if (gProcessStateMutex != NULL) {
+        if (xSemaphoreTake(gProcessStateMutex, portMAX_DELAY) != pdTRUE) {
+            return;
+        }
+    }
+
     // Deferred-INIT after wifi_manager_HardReset(): once the 2 s settle
     // window has elapsed, re-enable WiFi and queue INIT.  See HardReset
     // for why we can't just vTaskDelay(2000) — the calling task may be
@@ -1496,18 +1519,21 @@ void wifi_manager_ProcessState() {
         }
     }
 
-    if (xQueueReceive(gEventQH, &event, 1) != pdPASS) {
-        return;
-    }
-    ret = gStateMachineContext.active(&gStateMachineContext, event);
-    if (ret == WIFI_MANAGER_STATE_MACHINE_RETURN_STATUS_TRAN) {
-        gStateMachineContext.active(&gStateMachineContext, WIFI_MANAGER_EVENT_EXIT);
-        if (gStateMachineContext.nextState != NULL) {
-            gStateMachineContext.active = gStateMachineContext.nextState;
-            gStateMachineContext.active(&gStateMachineContext, WIFI_MANAGER_EVENT_ENTRY);
-        } else {
-            LOG_E("%s : %d : State Change Requested, but NextSate is NULL", __func__, __LINE__);
+    if (xQueueReceive(gEventQH, &event, 1) == pdPASS) {
+        ret = gStateMachineContext.active(&gStateMachineContext, event);
+        if (ret == WIFI_MANAGER_STATE_MACHINE_RETURN_STATUS_TRAN) {
+            gStateMachineContext.active(&gStateMachineContext, WIFI_MANAGER_EVENT_EXIT);
+            if (gStateMachineContext.nextState != NULL) {
+                gStateMachineContext.active = gStateMachineContext.nextState;
+                gStateMachineContext.active(&gStateMachineContext, WIFI_MANAGER_EVENT_ENTRY);
+            } else {
+                LOG_E("%s : %d : State Change Requested, but NextSate is NULL", __func__, __LINE__);
+            }
         }
+    }
+
+    if (gProcessStateMutex != NULL) {
+        xSemaphoreGive(gProcessStateMutex);
     }
 }
 

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -563,6 +563,21 @@ static bool SendEvent(wifi_manager_event_t event) {
         if (xQueueSend(gEventQH, &event, timeout) == pdPASS) {
             return true;
         }
+
+        // DEINIT/INIT are lifecycle-critical: the manager can wedge if these
+        // are dropped.  If the queue is full enough that we couldn't even
+        // wait 20 ms, something has already gone wrong; reset the queue
+        // and force the event in.  Pending stale events would have been
+        // invalidated by the lifecycle transition anyway.
+        if (event == WIFI_MANAGER_EVENT_DEINIT ||
+            event == WIFI_MANAGER_EVENT_INIT) {
+            LOG_E("WiFi SendEvent: queue full, force-flushing for lifecycle event=%u",
+                  (unsigned)event);
+            xQueueReset(gEventQH);
+            if (xQueueSend(gEventQH, &event, 0) == pdPASS) {
+                return true;
+            }
+        }
         LOG_E("WiFi SendEvent: queue full (event=%u)", (unsigned)event);
         return false;
     }

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -594,7 +594,8 @@ static bool SendEvent(wifi_manager_event_t event) {
     // which doesn't block long, but the drain-loop approach is
     // safer-by-construction.
     if (event == WIFI_MANAGER_EVENT_DEINIT ||
-        event == WIFI_MANAGER_EVENT_INIT) {
+        event == WIFI_MANAGER_EVENT_INIT ||
+        event == WIFI_MANAGER_EVENT_REINIT) {
         LOG_E("WiFi SendEvent: queue full, draining for lifecycle event=%u",
               (unsigned)event);
         wifi_manager_event_t drop;

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1379,6 +1379,10 @@ bool wifi_manager_IsWiFiConnected(void) {
 
 bool wifi_manager_Deinit() {
     if (gStateMachineContext.pWifiSettings == NULL) return false;
+    // Tear down iperf2 sockets before the WINC GPIO toggle — otherwise
+    // the dedicated Iperf2 task could call send() against an
+    // already-deinitialized chip and wedge the HIF queue.
+    Iperf2_Stop();
     // Cancel any pending deferred-INIT — without this, a Deinit shortly
     // after HardReset would still see WiFi come back up after 2 s.
     gWifiReinitDeadlineTick = 0;
@@ -1404,6 +1408,9 @@ bool wifi_manager_Deinit() {
 // typically takes ~20 s; poll SYST:COMM:LAN:ADDR? to confirm.
 bool wifi_manager_HardReset(void) {
     if (gStateMachineContext.pWifiSettings == NULL) return false;
+    // Tear down iperf2 sockets before the WINC GPIO toggle (same reason
+    // as wifi_manager_Deinit).
+    Iperf2_Stop();
     LOG_I("WiFi: hard reset (DEINIT -> REINIT in 2 s)");
     gStateMachineContext.pWifiSettings->isEnabled = 0;
     SendEvent(WIFI_MANAGER_EVENT_DEINIT);

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -114,6 +114,13 @@ static volatile bool gRssiUpdatePending = false;
 // runs wifi_tcp_server_ProcessReceivedBuff on WifiTask's stack, then re-arms
 // recv. WINC buffers inbound TCP while we process (per WINC docs).
 static volatile bool gTcpRxPending = false;
+
+// Deadline (in ticks) at which wifi_manager_ProcessState should queue
+// the deferred WIFI_MANAGER_EVENT_INIT after a HardReset.  0 = none
+// pending.  32-bit reads/writes are atomic on PIC32MZ (see CLAUDE.md
+// concurrency rules).  Marked volatile because it's set from any task
+// calling HardReset/Deinit and read every tick from app_WifiTask.
+static volatile TickType_t gWifiReinitDeadlineTick = 0;
 static volatile bool gRssiUpdateComplete = false;
 static volatile uint8_t gLastRssiPercentage = 0;
 
@@ -1358,17 +1365,14 @@ bool wifi_manager_IsWiFiConnected(void) {
 }
 
 bool wifi_manager_Deinit() {
+    if (gStateMachineContext.pWifiSettings == NULL) return false;
+    // Cancel any pending deferred-INIT — without this, a Deinit shortly
+    // after HardReset would still see WiFi come back up after 2 s.
+    gWifiReinitDeadlineTick = 0;
     gStateMachineContext.pWifiSettings->isEnabled = 0;
     SendEvent(WIFI_MANAGER_EVENT_DEINIT);
     return true;
 }
-
-// Deadline (in ticks) at which wifi_manager_ProcessState should queue
-// the deferred WIFI_MANAGER_EVENT_INIT after a HardReset.  0 = none
-// pending.  32-bit reads/writes are atomic on PIC32MZ (see CLAUDE.md
-// concurrency rules).  Marked volatile because it's set from any task
-// calling HardReset and read every tick from app_WifiTask.
-static volatile TickType_t gWifiReinitDeadlineTick = 0;
 
 // True hardware reset of the WINC chip: disable -> DEINIT (toggles
 // CHIP_EN/RESET_N GPIOs via wifi_manager_FixWincResetState) -> after

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1363,34 +1363,34 @@ bool wifi_manager_Deinit() {
     return true;
 }
 
+// Deadline (in ticks) at which wifi_manager_ProcessState should queue
+// the deferred WIFI_MANAGER_EVENT_INIT after a HardReset.  0 = none
+// pending.  32-bit reads/writes are atomic on PIC32MZ (see CLAUDE.md
+// concurrency rules).  Marked volatile because it's set from any task
+// calling HardReset and read every tick from app_WifiTask.
+static volatile TickType_t gWifiReinitDeadlineTick = 0;
+
 // True hardware reset of the WINC chip: disable -> DEINIT (toggles
-// CHIP_EN/RESET_N GPIOs via wifi_manager_FixWincResetState) -> wait
-// for the state machine to process -> re-enable -> REINIT to bring
-// the chip back up.
+// CHIP_EN/RESET_N GPIOs via wifi_manager_FixWincResetState) -> after
+// 2 s settle, re-enable -> REINIT to bring the chip back up.
 //
 // This is the only path that recovers a wedged outbound TCP stack
 // (#383). APPLY's REINIT path explicitly skips Deinitialize because
 // of a Microchip driver bug (see comment near line 867), so APPLY
 // alone never drives the WINC reset GPIOs.
 //
-// Caller note: this fires events asynchronously and returns
-// immediately. The full recovery (DEINIT settle + STA reassoc +
-// DHCP) typically takes ~20 s; poll SYST:COMM:LAN:ADDR? to confirm
-// the WiFi is back up.
+// Returns immediately — the deferred-INIT runs from
+// wifi_manager_ProcessState's deadline check, so this works
+// correctly whether HardReset is called from app_WifiTask itself
+// (TCP SCPI dispatch path, post-#353) or from another task (USB
+// CDC).  Full recovery (DEINIT settle + STA reassoc + DHCP)
+// typically takes ~20 s; poll SYST:COMM:LAN:ADDR? to confirm.
 bool wifi_manager_HardReset(void) {
     if (gStateMachineContext.pWifiSettings == NULL) return false;
-    LOG_I("WiFi: hard reset (DEINIT -> REINIT)");
-    // Phase 1: disable + DEINIT (drives WINC GPIO reset)
+    LOG_I("WiFi: hard reset (DEINIT -> REINIT in 2 s)");
     gStateMachineContext.pWifiSettings->isEnabled = 0;
     SendEvent(WIFI_MANAGER_EVENT_DEINIT);
-    // Phase 2: brief block so the state machine can process DEINIT
-    // before we flip isEnabled back. Without this, the REINIT we
-    // queue below could be processed before DEINIT fully completes.
-    vTaskDelay(pdMS_TO_TICKS(2000));
-    // Phase 3: re-enable + INIT (full re-init — REINIT assumes the
-    // driver handle is still valid, which it isn't after DEINIT).
-    gStateMachineContext.pWifiSettings->isEnabled = 1;
-    SendEvent(WIFI_MANAGER_EVENT_INIT);
+    gWifiReinitDeadlineTick = xTaskGetTickCount() + pdMS_TO_TICKS(2000);
     return true;
 }
 
@@ -1450,6 +1450,21 @@ void wifi_manager_ProcessState() {
     while (gEventQH == NULL) {
         return;
     }
+
+    // Deferred-INIT after wifi_manager_HardReset(): once the 2 s settle
+    // window has elapsed, re-enable WiFi and queue INIT.  See HardReset
+    // for why we can't just vTaskDelay(2000) — the calling task may be
+    // app_WifiTask itself (TCP SCPI dispatch path post-#353), and that
+    // task is what drains gEventQH.
+    if (gWifiReinitDeadlineTick != 0 &&
+        (int32_t)(xTaskGetTickCount() - gWifiReinitDeadlineTick) >= 0) {
+        gWifiReinitDeadlineTick = 0;
+        if (gStateMachineContext.pWifiSettings != NULL) {
+            gStateMachineContext.pWifiSettings->isEnabled = 1;
+            SendEvent(WIFI_MANAGER_EVENT_INIT);
+        }
+    }
+
     wifi_tcp_server_TransmitBufferedData();
 
     // #377 iperf2 now runs in its own dedicated task with adaptive 2 ms

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1363,6 +1363,37 @@ bool wifi_manager_Deinit() {
     return true;
 }
 
+// True hardware reset of the WINC chip: disable -> DEINIT (toggles
+// CHIP_EN/RESET_N GPIOs via wifi_manager_FixWincResetState) -> wait
+// for the state machine to process -> re-enable -> REINIT to bring
+// the chip back up.
+//
+// This is the only path that recovers a wedged outbound TCP stack
+// (#383). APPLY's REINIT path explicitly skips Deinitialize because
+// of a Microchip driver bug (see comment near line 867), so APPLY
+// alone never drives the WINC reset GPIOs.
+//
+// Caller note: this fires events asynchronously and returns
+// immediately. The full recovery (DEINIT settle + STA reassoc +
+// DHCP) typically takes ~20 s; poll SYST:COMM:LAN:ADDR? to confirm
+// the WiFi is back up.
+bool wifi_manager_HardReset(void) {
+    if (gStateMachineContext.pWifiSettings == NULL) return false;
+    LOG_I("WiFi: hard reset (DEINIT -> REINIT)");
+    // Phase 1: disable + DEINIT (drives WINC GPIO reset)
+    gStateMachineContext.pWifiSettings->isEnabled = 0;
+    SendEvent(WIFI_MANAGER_EVENT_DEINIT);
+    // Phase 2: brief block so the state machine can process DEINIT
+    // before we flip isEnabled back. Without this, the REINIT we
+    // queue below could be processed before DEINIT fully completes.
+    vTaskDelay(pdMS_TO_TICKS(2000));
+    // Phase 3: re-enable + INIT (full re-init — REINIT assumes the
+    // driver handle is still valid, which it isn't after DEINIT).
+    gStateMachineContext.pWifiSettings->isEnabled = 1;
+    SendEvent(WIFI_MANAGER_EVENT_INIT);
+    return true;
+}
+
 bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t * pSettings) {
 
     // Always allow settings to be updated regardless of power state

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -552,13 +552,19 @@ static void ApplyDefaultSuffixAndDeviceName(stateMachineInst_t *pInstance) {
 
 static bool SendEvent(wifi_manager_event_t event) {
     if (gEventQH != NULL) {
-        if (xQueueSend(gEventQH, &event, portMAX_DELAY) == pdPASS) {
+        // Bounded timeout: SendEvent can be called from inside
+        // wifi_manager_ProcessState (state-machine handlers, deferred-INIT
+        // path).  ProcessState holds gProcessStateMutex, and it's also
+        // the queue-drainer.  A blocking portMAX_DELAY send on a full
+        // queue would deadlock — the same task can't drain.  20 ms is
+        // long enough for a higher-priority drainer (USB SCPI pump path)
+        // to clear room, short enough not to wedge the calling task.
+        const TickType_t timeout = pdMS_TO_TICKS(20);
+        if (xQueueSend(gEventQH, &event, timeout) == pdPASS) {
             return true;
-        } else {
-            LOG_E("WiFi SendEvent: queue send failed");
-            return false;
         }
-
+        LOG_E("WiFi SendEvent: queue full (event=%u)", (unsigned)event);
+        return false;
     }
     return true;
 }

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1421,9 +1421,10 @@ void wifi_manager_ProcessState() {
     }
     wifi_tcp_server_TransmitBufferedData();
 
-    // #377: iperf2 client mode — keep the TX cap topped up.  No-op in
-    // SERVER / IDLE.  Cheap when idle (single mode-check).
-    Iperf2_Tasks();
+    // #377 iperf2 now runs in its own dedicated task with adaptive 1 ms
+    // (active) / 50 ms (idle) cadence — see Iperf2_StartTask() in iperf2.c.
+    // Removed from this task's loop so streaming + SCPI dispatch keep their
+    // 5 ms cadence undisturbed.
 
     // #353 Option 2: drain any deferred TCP rx data on this task's stack.
     // SOCKET_MSG_RECV (WDRV_WINC_Tasks context) stored length + set the flag

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1452,7 +1452,7 @@ void wifi_manager_ProcessState() {
     }
     wifi_tcp_server_TransmitBufferedData();
 
-    // #377 iperf2 now runs in its own dedicated task with adaptive 1 ms
+    // #377 iperf2 now runs in its own dedicated task with adaptive 2 ms
     // (active) / 50 ms (idle) cadence — see Iperf2_StartTask() in iperf2.c.
     // Removed from this task's loop so streaming + SCPI dispatch keep their
     // 5 ms cadence undisturbed.

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1279,11 +1279,21 @@ void fwUpdateTask(void *pvParameters) {
 
 bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
 
-    if (gEventQH == NULL)
-        gEventQH = xQueueCreate(20, sizeof (wifi_manager_event_t));
-    else return true;
+    // Init order matters: mutex first (so ProcessState calls before queue
+    // creation are still safe), then queue.  If queue already exists, we
+    // were already initialized — bail.
     if (gProcessStateMutex == NULL) {
         gProcessStateMutex = xSemaphoreCreateMutexStatic(&gProcessStateMutexBuf);
+    }
+
+    if (gEventQH == NULL) {
+        gEventQH = xQueueCreate(20, sizeof (wifi_manager_event_t));
+        if (gEventQH == NULL) {
+            LOG_E("WiFi Init: failed to create event queue");
+            return false;
+        }
+    } else {
+        return true;
     }
     if (pSettings != NULL)
         gStateMachineContext.pWifiSettings = pSettings;

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1532,12 +1532,21 @@ void wifi_manager_ProcessState() {
     }
 
     // Serialize re-entrant callers (app_WifiTask + SCPI_Reset active pump,
-    // and any future call site).  portMAX_DELAY blocks until owner releases;
-    // priority inheritance keeps the holder unblocked.  Recursive — same
-    // task can re-enter (TCP SCPI nests ProcessState inside ProcessState);
-    // see gProcessStateMutex declaration for the rationale.
+    // and any future call site).  Recursive — same task can re-enter
+    // (TCP SCPI nests ProcessState inside ProcessState); see
+    // gProcessStateMutex declaration for the rationale.
+    //
+    // Bounded 100 ms timeout (instead of portMAX_DELAY): if the holder
+    // is genuinely wedged, the caller must be able to bail and return
+    // — otherwise the SCPI_Reset active pump would hang and the device
+    // could never reboot.  Normal ProcessState body completes in <10 ms,
+    // so 100 ms gives generous headroom for healthy operation while
+    // failing fast on actual stalls.  Skipped iterations recover
+    // naturally on the next invocation.
     if (gProcessStateMutex != NULL) {
-        if (xSemaphoreTakeRecursive(gProcessStateMutex, portMAX_DELAY) != pdTRUE) {
+        if (xSemaphoreTakeRecursive(gProcessStateMutex,
+                                    pdMS_TO_TICKS(100)) != pdTRUE) {
+            LOG_E("WiFi ProcessState: mutex timeout — skipping iteration");
             return;
         }
     }

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1420,10 +1420,14 @@ bool wifi_manager_Deinit() {
     // the dedicated Iperf2 task could call send() against an
     // already-deinitialized chip and wedge the HIF queue.
     Iperf2_Stop();
-    // Cancel any pending deferred-INIT — without this, a Deinit shortly
-    // after HardReset would still see WiFi come back up after 2 s.
+    // Cancel any pending deferred-INIT and clear isEnabled atomically —
+    // without the critical section, a higher-priority caller of Deinit
+    // could race ProcessState's deferred-INIT branch and end up with
+    // isEnabled=1 even though the user requested Deinit.
+    taskENTER_CRITICAL();
     gWifiReinitDeadlineTick = 0;
     gStateMachineContext.pWifiSettings->isEnabled = 0;
+    taskEXIT_CRITICAL();
     SendEvent(WIFI_MANAGER_EVENT_DEINIT);
     return true;
 }
@@ -1449,9 +1453,14 @@ bool wifi_manager_HardReset(void) {
     // as wifi_manager_Deinit).
     Iperf2_Stop();
     LOG_I("WiFi: hard reset (DEINIT -> REINIT in 2 s)");
+    // Set isEnabled=0 + arm deadline atomically so a concurrent Deinit
+    // can't race the (deadline, isEnabled) pair into an inconsistent
+    // state.
+    taskENTER_CRITICAL();
     gStateMachineContext.pWifiSettings->isEnabled = 0;
-    SendEvent(WIFI_MANAGER_EVENT_DEINIT);
     gWifiReinitDeadlineTick = xTaskGetTickCount() + pdMS_TO_TICKS(2000);
+    taskEXIT_CRITICAL();
+    SendEvent(WIFI_MANAGER_EVENT_DEINIT);
     return true;
 }
 
@@ -1528,13 +1537,29 @@ void wifi_manager_ProcessState() {
     // for why we can't just vTaskDelay(2000) — the calling task may be
     // app_WifiTask itself (TCP SCPI dispatch path post-#353), and that
     // task is what drains gEventQH.
+    //
+    // Double-checked under a critical section: a concurrent Deinit could
+    // clear gWifiReinitDeadlineTick between the outer check and the
+    // isEnabled write, leaving us with isEnabled=1 even though the user
+    // called Deinit.  Re-check while holding the lock so only one of
+    // (Deinit, deferred-INIT) wins atomically.  SendEvent runs outside
+    // the critical section because it can take a queue mutex.
+    bool doInit = false;
     if (gWifiReinitDeadlineTick != 0 &&
         (int32_t)(xTaskGetTickCount() - gWifiReinitDeadlineTick) >= 0) {
-        gWifiReinitDeadlineTick = 0;
-        if (gStateMachineContext.pWifiSettings != NULL) {
-            gStateMachineContext.pWifiSettings->isEnabled = 1;
-            SendEvent(WIFI_MANAGER_EVENT_INIT);
+        taskENTER_CRITICAL();
+        if (gWifiReinitDeadlineTick != 0 &&
+            (int32_t)(xTaskGetTickCount() - gWifiReinitDeadlineTick) >= 0) {
+            gWifiReinitDeadlineTick = 0;
+            if (gStateMachineContext.pWifiSettings != NULL) {
+                gStateMachineContext.pWifiSettings->isEnabled = 1;
+                doInit = true;
+            }
         }
+        taskEXIT_CRITICAL();
+    }
+    if (doInit) {
+        SendEvent(WIFI_MANAGER_EVENT_INIT);
     }
 
     wifi_tcp_server_TransmitBufferedData();

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -561,12 +561,22 @@ static bool SendEvent(wifi_manager_event_t event) {
 
     // Bounded timeout: SendEvent can be called from inside
     // wifi_manager_ProcessState (state-machine handlers, deferred-INIT
-    // path).  ProcessState holds gProcessStateMutex, and it's also
-    // the queue-drainer.  A blocking portMAX_DELAY send on a full
-    // queue would deadlock — the same task can't drain.  20 ms is
-    // long enough for a higher-priority drainer (USB SCPI pump path)
-    // to clear room, short enough not to wedge the calling task.
-    const TickType_t timeout = pdMS_TO_TICKS(20);
+    // path).  ProcessState holds gProcessStateMutex AND is the
+    // queue-drainer.  A blocking portMAX_DELAY send on a full queue
+    // would deadlock — the same task can't drain.
+    //
+    // Detect "I'm already the holder" via xSemaphoreGetMutexHolder and
+    // use timeout=0 in that case: waiting can't possibly help when
+    // we're the only drainer.  Otherwise 20 ms — long enough for a
+    // higher-priority drainer (USB SCPI pump path) to clear room,
+    // short enough not to wedge the calling task.
+    TickType_t timeout = pdMS_TO_TICKS(20);
+    if (gProcessStateMutex != NULL) {
+        if (xSemaphoreGetMutexHolder(gProcessStateMutex) ==
+            xTaskGetCurrentTaskHandle()) {
+            timeout = 0;
+        }
+    }
     if (xQueueSend(gEventQH, &event, timeout) == pdPASS) {
         return true;
     }

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -551,47 +551,52 @@ static void ApplyDefaultSuffixAndDeviceName(stateMachineInst_t *pInstance) {
 }
 
 static bool SendEvent(wifi_manager_event_t event) {
-    if (gEventQH != NULL) {
-        // Bounded timeout: SendEvent can be called from inside
-        // wifi_manager_ProcessState (state-machine handlers, deferred-INIT
-        // path).  ProcessState holds gProcessStateMutex, and it's also
-        // the queue-drainer.  A blocking portMAX_DELAY send on a full
-        // queue would deadlock — the same task can't drain.  20 ms is
-        // long enough for a higher-priority drainer (USB SCPI pump path)
-        // to clear room, short enough not to wedge the calling task.
-        const TickType_t timeout = pdMS_TO_TICKS(20);
-        if (xQueueSend(gEventQH, &event, timeout) == pdPASS) {
-            return true;
-        }
-
-        // DEINIT/INIT are lifecycle-critical: the manager can wedge if these
-        // are dropped.  If the queue is full enough that we couldn't even
-        // wait 20 ms, something has already gone wrong; drain the queue
-        // and force the event in.  Pending stale events would have been
-        // invalidated by the lifecycle transition anyway.
-        //
-        // Use xQueueReceive(timeout=0) drain instead of xQueueReset:
-        // FreeRTOS docs warn xQueueReset is unsafe if any task is blocked
-        // on the queue (would leave it in inconsistent state).  In our
-        // case the only drainer is ProcessState's xQueueReceive(timeout=1)
-        // which doesn't block long, but the drain-loop approach is
-        // safer-by-construction.
-        if (event == WIFI_MANAGER_EVENT_DEINIT ||
-            event == WIFI_MANAGER_EVENT_INIT) {
-            LOG_E("WiFi SendEvent: queue full, draining for lifecycle event=%u",
-                  (unsigned)event);
-            wifi_manager_event_t drop;
-            while (xQueueReceive(gEventQH, &drop, 0) == pdPASS) {
-                /* drop stale events */
-            }
-            if (xQueueSend(gEventQH, &event, 0) == pdPASS) {
-                return true;
-            }
-        }
-        LOG_E("WiFi SendEvent: queue full (event=%u)", (unsigned)event);
+    if (gEventQH == NULL) {
+        // Init hasn't run yet — caller is misusing the API.  Surface as
+        // an error rather than silently succeeding.
+        LOG_E("WiFi SendEvent: queue not initialized (event=%u)",
+              (unsigned)event);
         return false;
     }
-    return true;
+
+    // Bounded timeout: SendEvent can be called from inside
+    // wifi_manager_ProcessState (state-machine handlers, deferred-INIT
+    // path).  ProcessState holds gProcessStateMutex, and it's also
+    // the queue-drainer.  A blocking portMAX_DELAY send on a full
+    // queue would deadlock — the same task can't drain.  20 ms is
+    // long enough for a higher-priority drainer (USB SCPI pump path)
+    // to clear room, short enough not to wedge the calling task.
+    const TickType_t timeout = pdMS_TO_TICKS(20);
+    if (xQueueSend(gEventQH, &event, timeout) == pdPASS) {
+        return true;
+    }
+
+    // DEINIT/INIT are lifecycle-critical: the manager can wedge if these
+    // are dropped.  If the queue is full enough that we couldn't even
+    // wait 20 ms, something has already gone wrong; drain the queue
+    // and force the event in.  Pending stale events would have been
+    // invalidated by the lifecycle transition anyway.
+    //
+    // Use xQueueReceive(timeout=0) drain instead of xQueueReset:
+    // FreeRTOS docs warn xQueueReset is unsafe if any task is blocked
+    // on the queue (would leave it in inconsistent state).  In our
+    // case the only drainer is ProcessState's xQueueReceive(timeout=1)
+    // which doesn't block long, but the drain-loop approach is
+    // safer-by-construction.
+    if (event == WIFI_MANAGER_EVENT_DEINIT ||
+        event == WIFI_MANAGER_EVENT_INIT) {
+        LOG_E("WiFi SendEvent: queue full, draining for lifecycle event=%u",
+              (unsigned)event);
+        wifi_manager_event_t drop;
+        while (xQueueReceive(gEventQH, &drop, 0) == pdPASS) {
+            /* drop stale events */
+        }
+        if (xQueueSend(gEventQH, &event, 0) == pdPASS) {
+            return true;
+        }
+    }
+    LOG_E("WiFi SendEvent: queue full (event=%u)", (unsigned)event);
+    return false;
 }
 
 static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * const pInstance, uint16_t event) {
@@ -1438,8 +1443,7 @@ bool wifi_manager_Deinit() {
     gWifiReinitDeadlineTick = 0;
     gStateMachineContext.pWifiSettings->isEnabled = 0;
     taskEXIT_CRITICAL();
-    SendEvent(WIFI_MANAGER_EVENT_DEINIT);
-    return true;
+    return SendEvent(WIFI_MANAGER_EVENT_DEINIT);
 }
 
 // True hardware reset of the WINC chip: disable -> DEINIT (toggles
@@ -1470,8 +1474,7 @@ bool wifi_manager_HardReset(void) {
     gStateMachineContext.pWifiSettings->isEnabled = 0;
     gWifiReinitDeadlineTick = xTaskGetTickCount() + pdMS_TO_TICKS(2000);
     taskEXIT_CRITICAL();
-    SendEvent(WIFI_MANAGER_EVENT_DEINIT);
-    return true;
+    return SendEvent(WIFI_MANAGER_EVENT_DEINIT);
 }
 
 bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t * pSettings) {

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -566,14 +566,24 @@ static bool SendEvent(wifi_manager_event_t event) {
 
         // DEINIT/INIT are lifecycle-critical: the manager can wedge if these
         // are dropped.  If the queue is full enough that we couldn't even
-        // wait 20 ms, something has already gone wrong; reset the queue
+        // wait 20 ms, something has already gone wrong; drain the queue
         // and force the event in.  Pending stale events would have been
         // invalidated by the lifecycle transition anyway.
+        //
+        // Use xQueueReceive(timeout=0) drain instead of xQueueReset:
+        // FreeRTOS docs warn xQueueReset is unsafe if any task is blocked
+        // on the queue (would leave it in inconsistent state).  In our
+        // case the only drainer is ProcessState's xQueueReceive(timeout=1)
+        // which doesn't block long, but the drain-loop approach is
+        // safer-by-construction.
         if (event == WIFI_MANAGER_EVENT_DEINIT ||
             event == WIFI_MANAGER_EVENT_INIT) {
-            LOG_E("WiFi SendEvent: queue full, force-flushing for lifecycle event=%u",
+            LOG_E("WiFi SendEvent: queue full, draining for lifecycle event=%u",
                   (unsigned)event);
-            xQueueReset(gEventQH);
+            wifi_manager_event_t drop;
+            while (xQueueReceive(gEventQH, &drop, 0) == pdPASS) {
+                /* drop stale events */
+            }
             if (xQueueSend(gEventQH, &event, 0) == pdPASS) {
                 return true;
             }

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -123,12 +123,18 @@ static volatile bool gTcpRxPending = false;
 // calling HardReset/Deinit and read every tick from app_WifiTask.
 static volatile TickType_t gWifiReinitDeadlineTick = 0;
 
-// Mutex serializing wifi_manager_ProcessState across callers.  Today
-// app_WifiTask is the primary owner; SCPI_Reset's active pump
+// Recursive mutex serializing wifi_manager_ProcessState across callers.
+// Today app_WifiTask is the primary owner; SCPI_Reset's active pump
 // (SYSTem:REboot path) also enters from the SCPI dispatch task.  Without
 // the mutex, the body's xQueueReceive + state-machine update on shared
 // gStateMachineContext could corrupt under any future priority change
-// that lets the two callers interleave.  Created in wifi_manager_Init.
+// that lets the two callers interleave.
+//
+// Recursive: TCP-SCPI dispatch nests ProcessState → wifi_tcp_server callback
+// → SCPI_Reset → active pump → ProcessState.  Same task takes the mutex
+// twice on that path; recursive avoids self-deadlock.  Requires
+// configUSE_RECURSIVE_MUTEXES=1 in FreeRTOSConfig.h.  Created in
+// wifi_manager_Init.
 static StaticSemaphore_t gProcessStateMutexBuf;
 static SemaphoreHandle_t gProcessStateMutex = NULL;
 static volatile bool gRssiUpdateComplete = false;
@@ -1283,7 +1289,7 @@ bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
     // creation are still safe), then queue.  If queue already exists, we
     // were already initialized — bail.
     if (gProcessStateMutex == NULL) {
-        gProcessStateMutex = xSemaphoreCreateMutexStatic(&gProcessStateMutexBuf);
+        gProcessStateMutex = xSemaphoreCreateRecursiveMutexStatic(&gProcessStateMutexBuf);
     }
 
     if (gEventQH == NULL) {
@@ -1487,10 +1493,11 @@ void wifi_manager_ProcessState() {
 
     // Serialize re-entrant callers (app_WifiTask + SCPI_Reset active pump,
     // and any future call site).  portMAX_DELAY blocks until owner releases;
-    // priority inheritance keeps the holder unblocked.  See gProcessStateMutex
-    // declaration for the rationale.
+    // priority inheritance keeps the holder unblocked.  Recursive — same
+    // task can re-enter (TCP SCPI nests ProcessState inside ProcessState);
+    // see gProcessStateMutex declaration for the rationale.
     if (gProcessStateMutex != NULL) {
-        if (xSemaphoreTake(gProcessStateMutex, portMAX_DELAY) != pdTRUE) {
+        if (xSemaphoreTakeRecursive(gProcessStateMutex, portMAX_DELAY) != pdTRUE) {
             return;
         }
     }
@@ -1550,7 +1557,7 @@ void wifi_manager_ProcessState() {
     }
 
     if (gProcessStateMutex != NULL) {
-        xSemaphoreGive(gProcessStateMutex);
+        xSemaphoreGiveRecursive(gProcessStateMutex);
     }
 }
 

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -201,10 +201,13 @@ extern "C" {
     /**
      * @brief Hardware reset the WINC chip (true GPIO reset).
      *
-     * Disables WiFi (fires DEINIT event which toggles CHIP_EN/RESET_N
-     * GPIOs via wifi_manager_FixWincResetState), waits ~2 s for the
-     * state machine to process, then re-enables (REINIT) to bring the
-     * chip back up.
+     * Disables WiFi and queues the DEINIT event (toggles CHIP_EN /
+     * RESET_N GPIOs via wifi_manager_FixWincResetState).  After 2 s
+     * settle, wifi_manager_ProcessState re-enables and queues INIT —
+     * see gWifiReinitDeadlineTick.
+     *
+     * Non-blocking — works whether called from app_WifiTask itself
+     * (TCP SCPI dispatch path post-#353) or from another task.
      *
      * This is the only software path that drives a real WINC hardware
      * reset. APPLY's REINIT path is a soft restart only (see comment
@@ -213,9 +216,9 @@ extern "C" {
      * Use to recover a wedged outbound TCP stack (#383): symptoms are
      * ICMP ping still works but TCP connect() from MCU times out.
      *
-     * Returns immediately after queueing events. Full recovery
-     * (DEINIT + reassoc + DHCP) takes ~20 s — poll
-     * SYST:COMM:LAN:ADDR? to confirm.
+     * Returns immediately. Full recovery (DEINIT + 2 s settle +
+     * reassoc + DHCP) takes ~20 s — poll SYST:COMM:LAN:ADDR? to
+     * confirm.
      *
      * @return True on success, false if WiFi settings not initialized.
      */

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -199,6 +199,29 @@ extern "C" {
     bool wifi_manager_Deinit();
 
     /**
+     * @brief Hardware reset the WINC chip (true GPIO reset).
+     *
+     * Disables WiFi (fires DEINIT event which toggles CHIP_EN/RESET_N
+     * GPIOs via wifi_manager_FixWincResetState), waits ~2 s for the
+     * state machine to process, then re-enables (REINIT) to bring the
+     * chip back up.
+     *
+     * This is the only software path that drives a real WINC hardware
+     * reset. APPLY's REINIT path is a soft restart only (see comment
+     * near wifi_manager.c:867 explaining the Microchip driver bug).
+     *
+     * Use to recover a wedged outbound TCP stack (#383): symptoms are
+     * ICMP ping still works but TCP connect() from MCU times out.
+     *
+     * Returns immediately after queueing events. Full recovery
+     * (DEINIT + reassoc + DHCP) takes ~20 s — poll
+     * SYST:COMM:LAN:ADDR? to confirm.
+     *
+     * @return True on success, false if WiFi settings not initialized.
+     */
+    bool wifi_manager_HardReset(void);
+
+    /**
      * @brief Updates the WiFi network settings.
      * 
      * Changes the current WiFi configuration and reinitializes the WiFi manager with the updated settings.


### PR DESCRIPTION
## Summary

Bundles three threads of iperf2 hardening + WiFi recovery work that
landed on \`debug/iperf2-pacing\` after the initial port (#377/#381).

- **iperf2 client stability** (#383) — dedicated FreeRTOS task at
  pri 5 with adaptive 2 ms / 50 ms cadence, event-driven send
  chaining via SOCKET_MSG_SEND callback, 4-slot HIF drain (matches
  WINC chip queue depth + \`wifi_tcp_server\` pattern), connect
  timeout, deferred-abort on UDP FIN / TCP RECV EOF. \`mPort=0\` in
  the iperf2 client header to disable PC dual-mode reverse probe
  (was capping all runs at 10 s).
- **WiFi hard reset** — new \`SYSTem:COMMunicate:LAN:HRESet\` SCPI
  command + \`wifi_manager_HardReset()\` API. \`*RST\` now drives
  WINC DEINIT + 500 ms settle before \`RCON_SoftwareReset()\` so
  PIC32 and WINC come up together. Recovers a wedged outbound TCP
  stack (#383) — APPLY's REINIT path skips Deinitialize (Microchip
  driver bug), so this was the only missing recovery primitive.
- **A/B verdict on deferred-abort** (#385) — 5×12 s × 3 variants on
  Tesla AP. Synchronous \`Iperf2_Stop()\` on the 5 callback error
  paths (BIND/LISTEN/ACCEPT/CONNECT-success-header-fail/CONNECT)
  beats deferred-abort 5/5 vs 3/5, with 0 vs 8 PC-side FinWait2
  leaks. Reverted the in-callback defer that cc66690a introduced.
  SEND-callback path (line ~542) keeps deferred teardown — that's
  the original USB-CDC-wedge concern and unrelated.
- **Docs** — quiescence rule in CLAUDE.md + SCPI wiki (no SCPI
  during a benchmarked test; post-test STAT? is the supported
  pattern). Bench tool inventory (PICkit serial, MCU target,
  Tesla AP, PC iperf2 path).

## A/B table (#385)

| Metric                | A (revert) | B (deferred)         | C (sync shutdown + defer) |
|-----------------------|-----------:|---------------------:|--------------------------:|
| CLEAN reaches 10 s    | 5/5        | 3/5                  | 3/5                       |
| Early aborts          | 0/5        | 2/5                  | 2/5                       |
| FinWait2 leaks (PC)   | 0          | 8                    | 0                         |
| KB/s range            | 409–439    | 363–407              | 367–415                   |

## What's preserved from cc66690a

The two orthogonal halves of cc66690a survive: \`LAN:HRESet\` SCPI
command + WiFi reset bundled into \`SYSTem:REboot\`. Only the
deferred-abort half (the regression) was reverted.

## Out of scope / tracked separately

- 10 s session wall on 12 s requested runs (every variant; PC-side
  TCP keepalive or iperf2 reverse-path probe). Not blocking #385
  closure.
- \`*RST\` is currently a libscpi no-op stub for both USB and TCP
  interfaces — filed #386. \`SYSTem:REboot\` is the working path.
- WINC port attack-surface characterization — filed #387.

## Test plan

- [x] A/B battery 1 (5×12 s × 3 variants) — Variant A wins
- [x] FinWait2 leak count post-trial — 0 (was 8 on Variant B)
- [x] LAN:HRESet recovers wedged WINC after \`*RST\`
- [x] WiFi-CONNECTED guard refuses iperf start in disconnected state
- [x] Build clean — no compile warnings introduced
- [x] Code review pass — 3 stale comments fixed (1 ms / 5 ms task-cadence references, actual is 2 ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)