### PR TITLE
feat(iperf2): TXBlast + auto-HRESet + diagnostics SCPI for #399

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2046,6 +2046,33 @@ static scpi_result_t SCPI_Iperf2_Stats(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+// #399 diagnostic — visibility into WINC HIF state across iperf2 sessions.
+// Shows current/last gCtx state plus a free-socket probe (only when IDLE).
+static scpi_result_t SCPI_Iperf2_Diag(scpi_t * context) {
+    Iperf2_Diag d;
+    Iperf2_GetDiag(&d);
+    scpi_printf(context, "Mode=%d\r\n", (int)d.mode);
+    scpi_printf(context, "DataSock=%d\r\n", (int)d.data_sock);
+    scpi_printf(context, "ListenSock=%d\r\n", (int)d.listen_sock);
+    scpi_printf(context, "PendingTx=%u\r\n", (unsigned)d.pending_tx);
+    scpi_printf(context, "AbortPending=%d\r\n", (int)(d.abort_pending ? 1 : 0));
+    scpi_printf(context, "BytesConfirmed=%llu\r\n",
+                (unsigned long long)d.bytes_confirmed);
+    scpi_printf(context, "LastSendRc=%d\r\n", (int)d.last_send_rc);
+    scpi_printf(context, "SendErrCount=%u\r\n", (unsigned)d.send_err_count);
+    scpi_printf(context, "WincState=%u\r\n", (unsigned)d.winc_state);
+    if (d.free_tcp_sockets == 0xFF) {
+        scpi_printf(context, "FreeTcpSockets=skipped\r\n");
+        scpi_printf(context, "FreeUdpSockets=skipped\r\n");
+    } else {
+        scpi_printf(context, "FreeTcpSockets=%u\r\n",
+                    (unsigned)d.free_tcp_sockets);
+        scpi_printf(context, "FreeUdpSockets=%u\r\n",
+                    (unsigned)d.free_udp_sockets);
+    }
+    return SCPI_RES_OK;
+}
+
 static scpi_result_t SCPI_ClearStreamStats(scpi_t * context) {
     Streaming_ClearStats();
     // Reset WiFi TCP send tracking counters atomically
@@ -3684,6 +3711,7 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:WIFI:IPERF:UDPClient", .callback = SCPI_Iperf2_UdpClient,}, // <ip>,[port=5001],[dur_s=10]
     {.pattern = "SYSTem:WIFI:IPERF:STOP", .callback = SCPI_Iperf2_Stop,},
     {.pattern = "SYSTem:WIFI:IPERF:STATs?", .callback = SCPI_Iperf2_Stats,},
+    {.pattern = "SYSTem:WIFI:IPERF:DIAGnostics?", .callback = SCPI_Iperf2_Diag,}, // #399
     // Dynamic memory configuration
     {.pattern = "SYSTem:MEMory:SD:BUFfer", .callback = SCPI_SetMemSdBuf,},
     {.pattern = "SYSTem:MEMory:SD:BUFfer?", .callback = SCPI_GetMemSdBuf,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2026,6 +2026,27 @@ static scpi_result_t SCPI_Iperf2_UdpClient(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+// SYST:WIFI:IPERF:TXBLast <port>,<duration_s>
+// Listen+accept TX-blast for #399 — repeated-session-safe TX throughput.
+// Device listens on port; on accept, sends 1400-byte chunks for duration.
+// PC connects with any TCP client (iperf -c, nc, etc.) and measures bytes
+// received as device's TX throughput.
+static scpi_result_t SCPI_Iperf2_TxBlast(scpi_t * context) {
+    int32_t port, duration_sec;
+    if (!SCPI_ParamInt32(context, &port, TRUE)) return SCPI_RES_ERR;
+    if (!SCPI_ParamInt32(context, &duration_sec, TRUE)) return SCPI_RES_ERR;
+    if (port <= 0 || port > 65535 || duration_sec <= 0) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+    if (Iperf2_RefuseIfStreaming(context)) return SCPI_RES_ERR;
+    if (!Iperf2_StartTxBlast((uint16_t)port, (uint32_t)duration_sec)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
 static scpi_result_t SCPI_Iperf2_Stop(scpi_t * context) {
     Iperf2_Stop();
     return SCPI_RES_OK;
@@ -2061,6 +2082,19 @@ static scpi_result_t SCPI_Iperf2_SetMaxPending(scpi_t * context) {
 
 static scpi_result_t SCPI_Iperf2_GetMaxPending(scpi_t * context) {
     SCPI_ResultInt32(context, (int32_t)Iperf2_GetMaxPending());
+    return SCPI_RES_OK;
+}
+
+// #399 workaround toggle — auto-HRESet WiFi after every iperf2 session.
+static scpi_result_t SCPI_Iperf2_SetAutoReset(scpi_t * context) {
+    int32_t v;
+    if (!SCPI_ParamInt32(context, &v, TRUE)) return SCPI_RES_ERR;
+    Iperf2_SetAutoReset(v != 0);
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_Iperf2_GetAutoReset(scpi_t * context) {
+    SCPI_ResultInt32(context, Iperf2_GetAutoReset() ? 1 : 0);
     return SCPI_RES_OK;
 }
 
@@ -3724,6 +3758,7 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:STReam:THRoughput", .callback = SCPI_RunThroughputBench,}, // <freq>,<duration_sec> — self-contained benchmark
     // #377 iperf2 wire-rate benchmarks (TCP + UDP).  Refuse if streaming.
     {.pattern = "SYSTem:WIFI:IPERF:TCPServer", .callback = SCPI_Iperf2_TcpServer,}, // [port=5001]
+    {.pattern = "SYSTem:WIFI:IPERF:TXBLast", .callback = SCPI_Iperf2_TxBlast,}, // <port>,<duration_s>  #399 workaround
     {.pattern = "SYSTem:WIFI:IPERF:UDPServer", .callback = SCPI_Iperf2_UdpServer,}, // [port=5001]
     {.pattern = "SYSTem:WIFI:IPERF:TCPClient", .callback = SCPI_Iperf2_TcpClient,}, // <ip>,[port=5001],[dur_s=10]
     {.pattern = "SYSTem:WIFI:IPERF:UDPClient", .callback = SCPI_Iperf2_UdpClient,}, // <ip>,[port=5001],[dur_s=10]
@@ -3732,6 +3767,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:WIFI:IPERF:DIAGnostics?", .callback = SCPI_Iperf2_Diag,}, // #399
     {.pattern = "SYSTem:WIFI:IPERF:MAXPending", .callback = SCPI_Iperf2_SetMaxPending,}, // #399 throttle (0=default, 1-4)
     {.pattern = "SYSTem:WIFI:IPERF:MAXPending?", .callback = SCPI_Iperf2_GetMaxPending,},
+    {.pattern = "SYSTem:WIFI:IPERF:AUTOReset", .callback = SCPI_Iperf2_SetAutoReset,}, // #399 auto-HRESet on stop
+    {.pattern = "SYSTem:WIFI:IPERF:AUTOReset?", .callback = SCPI_Iperf2_GetAutoReset,},
     // Dynamic memory configuration
     {.pattern = "SYSTem:MEMory:SD:BUFfer", .callback = SCPI_SetMemSdBuf,},
     {.pattern = "SYSTem:MEMory:SD:BUFfer?", .callback = SCPI_GetMemSdBuf,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2046,6 +2046,24 @@ static scpi_result_t SCPI_Iperf2_Stats(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+// #399 workaround — limit MAX_PENDING_TX (= WINC HIF queue depth in flight).
+// 0 restores compile-time default (4), 1-4 throttle TX rate.
+static scpi_result_t SCPI_Iperf2_SetMaxPending(scpi_t * context) {
+    int32_t n;
+    if (!SCPI_ParamInt32(context, &n, TRUE)) return SCPI_RES_ERR;
+    if (n < 0 || n > 4) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    Iperf2_SetMaxPending((uint8_t)n);
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_Iperf2_GetMaxPending(scpi_t * context) {
+    SCPI_ResultInt32(context, (int32_t)Iperf2_GetMaxPending());
+    return SCPI_RES_OK;
+}
+
 // #399 diagnostic — visibility into WINC HIF state across iperf2 sessions.
 // Shows current/last gCtx state plus a free-socket probe (only when IDLE).
 static scpi_result_t SCPI_Iperf2_Diag(scpi_t * context) {
@@ -3712,6 +3730,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:WIFI:IPERF:STOP", .callback = SCPI_Iperf2_Stop,},
     {.pattern = "SYSTem:WIFI:IPERF:STATs?", .callback = SCPI_Iperf2_Stats,},
     {.pattern = "SYSTem:WIFI:IPERF:DIAGnostics?", .callback = SCPI_Iperf2_Diag,}, // #399
+    {.pattern = "SYSTem:WIFI:IPERF:MAXPending", .callback = SCPI_Iperf2_SetMaxPending,}, // #399 throttle (0=default, 1-4)
+    {.pattern = "SYSTem:WIFI:IPERF:MAXPending?", .callback = SCPI_Iperf2_GetMaxPending,},
     // Dynamic memory configuration
     {.pattern = "SYSTem:MEMory:SD:BUFfer", .callback = SCPI_SetMemSdBuf,},
     {.pattern = "SYSTem:MEMory:SD:BUFfer?", .callback = SCPI_GetMemSdBuf,},

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -24,6 +24,12 @@
 #define IPERF2_UDP_BUF_SIZE     1470U   // standard iperf2 UDP datagram size (1500 - IP/UDP overhead)
 #define IPERF2_MAX_DURATION_S   3600U   // 1h cap
 #define IPERF2_MAX_PENDING_TX   4U      // matches WINC HIF queue depth (mirrors wifi_tcp_server)
+
+// Runtime override of MAX_PENDING_TX (0 = use compile-time default).  Lets
+// us deliberately back off WINC HIF saturation as a workaround for #399 —
+// the CONN_ABORTED cascade may be triggered by hammering WINC at peak.  N=3
+// → ~75% rate; N=2 → ~50%.  Set via SYST:WIFI:IPERF:MAXPending.
+static volatile uint8_t gMaxPendingOverride = 0;
 #define IPERF2_FIN_RETRANSMITS  10U     // iperf2 protocol: 10× retransmit of last UDP pkt
 
 typedef struct {
@@ -376,6 +382,15 @@ void Iperf2_GetStats(Iperf2_Stats* out) {
     taskEXIT_CRITICAL();
 }
 
+void Iperf2_SetMaxPending(uint8_t n) {
+    if (n > IPERF2_MAX_PENDING_TX) n = IPERF2_MAX_PENDING_TX;
+    gMaxPendingOverride = n;
+}
+
+uint8_t Iperf2_GetMaxPending(void) {
+    return gMaxPendingOverride ? gMaxPendingOverride : IPERF2_MAX_PENDING_TX;
+}
+
 void Iperf2_GetDiag(Iperf2_Diag* out) {
     if (out == NULL) return;
     memset(out, 0, sizeof(*out));
@@ -699,7 +714,7 @@ static void TasksTcpClient(void) {
     // WIFI_TCP_MAX_IN_FLIGHT). Going over this risks pushing past WINC's
     // accept-without-error threshold even before BUFFER_FULL fires, which
     // can corrupt internal state.
-    while (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
+    while (gCtx.pending_tx < (gMaxPendingOverride ? gMaxPendingOverride : IPERF2_MAX_PENDING_TX)) {
         int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TCP_BUF_SIZE, 0);
         if (rc == SOCK_ERR_NO_ERROR) {
             taskENTER_CRITICAL();
@@ -724,7 +739,7 @@ static void TasksUdpClient(void) {
 
     if (!past_deadline) {
         // Drain UDP up to IPERF2_MAX_PENDING_TX (matches WINC HIF depth).
-        while (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
+        while (gCtx.pending_tx < (gMaxPendingOverride ? gMaxPendingOverride : IPERF2_MAX_PENDING_TX)) {
             pkt->id = (int32_t)_htonl((uint32_t)gCtx.udp_id);
             pkt->tv_sec = 0;
             pkt->tv_usec = 0;
@@ -756,7 +771,7 @@ static void TasksUdpClient(void) {
             ResetContext();
             return;
         }
-        if (gCtx.pending_tx < IPERF2_MAX_PENDING_TX) {
+        if (gCtx.pending_tx < (gMaxPendingOverride ? gMaxPendingOverride : IPERF2_MAX_PENDING_TX)) {
             pkt->id = (int32_t)_htonl((uint32_t)(-gCtx.udp_id));
             pkt->tv_sec = 0;
             pkt->tv_usec = 0;

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -45,6 +45,11 @@ typedef struct {
     uint32_t       udp_outoforder;
     uint8_t        udp_fin_count;   // FIN retransmits sent
     volatile bool  abort_pending;   // set in callback context, processed in Iperf2_Tasks
+    // Diagnostic / sticky tracking for #399 investigation.  Not zeroed by
+    // ResetContext — these survive across sessions so GetDiag can show
+    // accumulating evidence of HIF leak.  Cleared explicitly by Initialize.
+    volatile int16_t last_send_rc;
+    volatile uint8_t send_err_count;
     Iperf2_Stats   last_stats;
 } Iperf2_Context;
 
@@ -371,6 +376,52 @@ void Iperf2_GetStats(Iperf2_Stats* out) {
     taskEXIT_CRITICAL();
 }
 
+void Iperf2_GetDiag(Iperf2_Diag* out) {
+    if (out == NULL) return;
+    memset(out, 0, sizeof(*out));
+
+    taskENTER_CRITICAL();
+    out->mode = gCtx.mode;
+    out->data_sock = gCtx.data_sock;
+    out->listen_sock = gCtx.listen_sock;
+    out->pending_tx = gCtx.pending_tx;
+    out->abort_pending = gCtx.abort_pending;
+    out->bytes_confirmed = gCtx.bytes_confirmed;
+    out->last_send_rc = gCtx.last_send_rc;
+    out->send_err_count = gCtx.send_err_count;
+    taskEXIT_CRITICAL();
+
+    out->winc_state = (uint8_t)m2m_wifi_get_state();
+
+    // Free-socket probe — only safe when iperf2 is IDLE.  Open up to
+    // TCP_SOCK_MAX TCP sockets and UDP_SOCK_MAX UDP sockets, count
+    // successes, then shutdown each.  Reveals whether prior iperf2
+    // sessions left WINC slots stuck (#399).
+    if (out->mode != IPERF2_MODE_IDLE) {
+        out->free_tcp_sockets = 0xFF;  // sentinel "not probed"
+        out->free_udp_sockets = 0xFF;
+        return;
+    }
+
+    SOCKET tcp_probes[TCP_SOCK_MAX];
+    SOCKET udp_probes[UDP_SOCK_MAX];
+
+    for (int i = 0; i < TCP_SOCK_MAX; i++) {
+        tcp_probes[i] = socket(AF_INET, SOCK_STREAM, 0);
+        if (tcp_probes[i] >= 0) out->free_tcp_sockets++;
+    }
+    for (int i = 0; i < UDP_SOCK_MAX; i++) {
+        udp_probes[i] = socket(AF_INET, SOCK_DGRAM, 0);
+        if (udp_probes[i] >= 0) out->free_udp_sockets++;
+    }
+    for (int i = 0; i < TCP_SOCK_MAX; i++) {
+        if (tcp_probes[i] >= 0) shutdown(tcp_probes[i]);
+    }
+    for (int i = 0; i < UDP_SOCK_MAX; i++) {
+        if (udp_probes[i] >= 0) shutdown(udp_probes[i]);
+    }
+}
+
 // ----------------------------------------------------------------------------
 // Socket event dispatch
 // ----------------------------------------------------------------------------
@@ -565,11 +616,13 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
             int16_t sent = (pMessage != NULL) ? *(int16_t*)pMessage : -1;
             // 64-bit + 8-bit RMW, paired with USB-priority reader / driver-task writer
             taskENTER_CRITICAL();
+            gCtx.last_send_rc = sent;  // diag: record latest WINC return code
             if (sent > 0) {
                 gCtx.bytes_confirmed += (uint64_t)sent;
                 if (gCtx.pending_tx > 0) gCtx.pending_tx--;
             } else {
                 if (gCtx.pending_tx > 0) gCtx.pending_tx--;
+                if (gCtx.send_err_count < 0xFF) gCtx.send_err_count++;
             }
             taskEXIT_CRITICAL();
             // Event-driven wake: when WINC frees a HIF slot, kick the

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -521,11 +521,21 @@ void Iperf2_GetDiag(Iperf2_Diag* out) {
         udp_probes[i] = socket(AF_INET, SOCK_DGRAM, 0);
         if (udp_probes[i] >= 0) out->free_udp_sockets++;
     }
+    // Yield 1 ms between shutdowns so the WINC driver task can drain
+    // SOCKET_CMD_CLOSE before we queue the next one — same pattern as
+    // the encoder retry loop (#312).  Total adds ~11 ms to the SCPI
+    // response, which is acceptable on a diagnostic-only path.
     for (int i = 0; i < TCP_SOCK_MAX; i++) {
-        if (tcp_probes[i] >= 0) shutdown(tcp_probes[i]);
+        if (tcp_probes[i] >= 0) {
+            shutdown(tcp_probes[i]);
+            vTaskDelay(pdMS_TO_TICKS(1));
+        }
     }
     for (int i = 0; i < UDP_SOCK_MAX; i++) {
-        if (udp_probes[i] >= 0) shutdown(udp_probes[i]);
+        if (udp_probes[i] >= 0) {
+            shutdown(udp_probes[i]);
+            vTaskDelay(pdMS_TO_TICKS(1));
+        }
     }
 }
 

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -25,18 +25,39 @@
 #define IPERF2_MAX_DURATION_S   3600U   // 1h cap
 #define IPERF2_MAX_PENDING_TX   4U      // matches WINC HIF queue depth (mirrors wifi_tcp_server)
 
-// Runtime override of MAX_PENDING_TX (0 = use compile-time default).  Lets
-// us deliberately back off WINC HIF saturation as a workaround for #399 —
-// the CONN_ABORTED cascade may be triggered by hammering WINC at peak.  N=3
-// → ~75% rate; N=2 → ~50%.  Set via SYST:WIFI:IPERF:MAXPending.
+// DORMANT debug knob — gMaxPendingOverride defaults to 0 (use compile-time
+// IPERF2_MAX_PENDING_TX = 4).  Set via SYST:WIFI:IPERF:MAXPending 0..4 to
+// throttle the WINC HIF queue at runtime (N=3 ≈ 75% rate, N=2 ≈ 50%).
+//
+// Tested 2026-04-30 / 2026-05-01 against the #399 sustained-rate decay
+// hypothesis: hypothesis was that hammering WINC HIF at peak triggers the
+// CONN_ABORTED cascade, so backing off should improve stability.  Empirical
+// verdict (commit 85adddfd): didn't help.  Throttle is functional (verified
+// via getter and observed rate reduction) but did not reduce wedging or
+// improve sustained throughput.
+//
+// Kept available because the knob is benign (affects only iperf2's own send
+// loop) and re-enables the experiment cheaply if a future investigation
+// wants to revisit at a different SPI clock, AP, or workload.
 static volatile uint8_t gMaxPendingOverride = 0;
 
-// #399 workaround: auto-HRESet WiFi after every iperf2 session.  The bug
-// fires whenever WINC creates new TCP-state objects per session (proven
-// via TXBlast + iperf2 client both degrading multi-session).  Streaming
-// avoids it because its listen socket is created once at boot.  HRESet
-// is the only known reliable recovery — costs ~12 s WiFi reassoc per
-// session.  Default ON for iperf2 (debug tool); SCPI toggle to disable.
+// ACTIVE BY DEFAULT — auto-HRESet WiFi after every iperf2 session.
+// Toggle via SYST:WIFI:IPERF:AUTOReset 0|1.
+//
+// Why on by default: iperf2 is a debug tool, and across multiple
+// sessions WINC accumulates TCP-state per new socket (E: observed
+// 2026-04-30 multi-session sustained-rate decay matches per-session
+// socket creation pattern; see project_399_*).  HRESet is the only
+// known reliable recovery (E: tested 2026-04-30 / 2026-05-01).
+// Streaming avoids the symptom because its listen socket is created
+// once at boot.
+//
+// Cost: ~12 s WiFi reassociation per session.  Set AUTOReset 0 if you
+// need back-to-back fast trials where reassoc overhead dominates
+// measurement.  E: 2026-05-02 5×60s iperf2 + 5×TXBlast alternating
+// battery with default AUTOReset=1 produced 0 wedges across 10 trials,
+// median 354 KBps iperf2 / 346 KBps TXBlast — auto-HRESet between
+// trials is what kept WINC clean.
 static volatile bool gAutoResetOnStop = true;
 #define IPERF2_FIN_RETRANSMITS  10U     // iperf2 protocol: 10× retransmit of last UDP pkt
 

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -30,6 +30,14 @@
 // the CONN_ABORTED cascade may be triggered by hammering WINC at peak.  N=3
 // → ~75% rate; N=2 → ~50%.  Set via SYST:WIFI:IPERF:MAXPending.
 static volatile uint8_t gMaxPendingOverride = 0;
+
+// #399 workaround: auto-HRESet WiFi after every iperf2 session.  The bug
+// fires whenever WINC creates new TCP-state objects per session (proven
+// via TXBlast + iperf2 client both degrading multi-session).  Streaming
+// avoids it because its listen socket is created once at boot.  HRESet
+// is the only known reliable recovery — costs ~12 s WiFi reassoc per
+// session.  Default ON for iperf2 (debug tool); SCPI toggle to disable.
+static volatile bool gAutoResetOnStop = true;
 #define IPERF2_FIN_RETRANSMITS  10U     // iperf2 protocol: 10× retransmit of last UDP pkt
 
 typedef struct {
@@ -77,6 +85,9 @@ static uint8_t gRxBuf[IPERF2_UDP_BUF_SIZE] __attribute__((aligned(4)));
 // callback to wake the task immediately on slot completion.  Set in
 // Iperf2_StartTask, NULL until then.
 static TaskHandle_t gIperf2TaskHandle = NULL;
+
+// Forward decl — body lives below the public API setters/getters.
+static void MaybeAutoReset(void);
 
 static void FillTxBuffer(void) {
     // Counter pattern — defeats PC-side TCP coalescing optimizations and gives
@@ -220,6 +231,47 @@ bool Iperf2_StartTcpServer(uint16_t port) {
     return true;
 }
 
+bool Iperf2_StartTxBlast(uint16_t port, uint32_t duration_sec) {
+    if (!RequireWifiReadyForSockets("TX blast")) return false;
+    if (gCtx.mode != IPERF2_MODE_IDLE) {
+        LOG_E("iperf2: already running (mode=%d)", (int)gCtx.mode);
+        return false;
+    }
+    if (duration_sec == 0 || duration_sec > IPERF2_MAX_DURATION_S) {
+        LOG_E("iperf2: invalid duration %u s", (unsigned)duration_sec);
+        return false;
+    }
+
+    gCtx.listen_sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (gCtx.listen_sock < 0) {
+        LOG_E("iperf2: TX blast socket() failed");
+        return false;
+    }
+
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = _htons(port);
+    addr.sin_addr.s_addr = 0;  // INADDR_ANY
+
+    int rc = bind(gCtx.listen_sock, (struct sockaddr*)&addr, sizeof(addr));
+    if (rc != 0) {
+        LOG_E("iperf2: TX blast bind() rc=%d", rc);
+        CloseAll();
+        return false;
+    }
+
+    gCtx.mode = IPERF2_MODE_TX_BLAST;
+    gCtx.duration_ms = duration_sec * 1000U;
+    // start_tick / deadline_tick are set in SOCKET_MSG_ACCEPT once a peer
+    // arrives — duration is measured from accept, not bind, so the test
+    // doesn't time out while the user is starting their PC-side iperf.
+    gCtx.last_stats.active = true;
+    gCtx.last_stats.completed = false;
+    LOG_I("iperf2: TX blast listening on port %u for %u s",
+          (unsigned)port, (unsigned)duration_sec);
+    return true;
+}
+
 bool Iperf2_StartUdpServer(uint16_t port) {
     if (!RequireWifiReadyForSockets("UDP server")) return false;
     if (gCtx.mode != IPERF2_MODE_IDLE) {
@@ -353,6 +405,7 @@ void Iperf2_Stop(void) {
     FinalizeStats();
     CloseAll();
     ResetContext();
+    MaybeAutoReset();
 }
 
 void Iperf2_GetStats(Iperf2_Stats* out) {
@@ -389,6 +442,24 @@ void Iperf2_SetMaxPending(uint8_t n) {
 
 uint8_t Iperf2_GetMaxPending(void) {
     return gMaxPendingOverride ? gMaxPendingOverride : IPERF2_MAX_PENDING_TX;
+}
+
+void Iperf2_SetAutoReset(bool enable) {
+    gAutoResetOnStop = enable;
+}
+
+bool Iperf2_GetAutoReset(void) {
+    return gAutoResetOnStop;
+}
+
+// Called from every session-end path (Iperf2_Stop, deferred-abort,
+// natural completion).  If gAutoResetOnStop, fires HRESet so the next
+// session starts from clean WINC state (#399 workaround).
+static void MaybeAutoReset(void) {
+    if (!gAutoResetOnStop) return;
+    LOG_I("iperf2: auto-HRESet armed (~12 s WiFi reassoc); next session "
+          "will start from clean WINC state");
+    wifi_manager_HardReset();
 }
 
 void Iperf2_GetDiag(Iperf2_Diag* out) {
@@ -531,7 +602,9 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
         case SOCKET_MSG_BIND: {
             tstrSocketBindMsg* m = (tstrSocketBindMsg*)pMessage;
             if (m && m->status == 0) {
-                if (gCtx.mode == IPERF2_MODE_TCP_SERVER && sock == gCtx.listen_sock) {
+                if ((gCtx.mode == IPERF2_MODE_TCP_SERVER ||
+                     gCtx.mode == IPERF2_MODE_TX_BLAST) &&
+                    sock == gCtx.listen_sock) {
                     listen(gCtx.listen_sock, 0);
                 } else if (gCtx.mode == IPERF2_MODE_UDP_SERVER && sock == gCtx.data_sock) {
                     // UDP: bind succeeded, start recv loop
@@ -570,9 +643,21 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
                 gCtx.start_tick = xTaskGetTickCount();
                 gCtx.bytes_transferred = 0;
                 gCtx.bytes_confirmed = 0;
-                LOG_I("iperf2: TCP server accepted connection (sock=%d)",
-                      (int)m->sock);
-                recv(gCtx.data_sock, gRxBuf, IPERF2_TCP_BUF_SIZE, 0);
+                if (gCtx.mode == IPERF2_MODE_TX_BLAST) {
+                    // Set deadline relative to accept() — duration starts now,
+                    // not at bind().  TasksTxBlast() drives the send loop.
+                    gCtx.deadline_tick = gCtx.start_tick +
+                                         pdMS_TO_TICKS(gCtx.duration_ms);
+                    LOG_I("iperf2: TX blast accepted connection (sock=%d), "
+                          "blasting for %u ms",
+                          (int)m->sock, (unsigned)gCtx.duration_ms);
+                    // No recv() — we're transmit-only.  TasksTxBlast picks up
+                    // on next tick and starts pumping.
+                } else {
+                    LOG_I("iperf2: TCP server accepted connection (sock=%d)",
+                          (int)m->sock);
+                    recv(gCtx.data_sock, gRxBuf, IPERF2_TCP_BUF_SIZE, 0);
+                }
             } else {
                 LOG_E("iperf2: accept failed");
                 Iperf2_Stop();
@@ -661,7 +746,8 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
             if (sent <= 0) {
                 LOG_E("iperf2: send cb err=%d, scheduling abort", (int)sent);
                 if (gCtx.mode == IPERF2_MODE_TCP_CLIENT ||
-                    gCtx.mode == IPERF2_MODE_UDP_CLIENT) {
+                    gCtx.mode == IPERF2_MODE_UDP_CLIENT ||
+                    gCtx.mode == IPERF2_MODE_TX_BLAST) {
                     gCtx.abort_pending = true;
                 }
             }
@@ -681,6 +767,44 @@ bool Iperf2_HandleSocketEvent(SOCKET sock, uint8_t msg_type, void* pMessage) {
 // because TasksTcpClient early-returns until client_connected is set.
 #define IPERF2_CONNECT_TIMEOUT_MS  10000U
 
+static void TasksTxBlast(void) {
+    // Idle-listening — no peer connected yet.  Just wait.  No deadline at
+    // this stage; user can take their time starting the PC client.
+    if (gCtx.data_sock < 0) {
+        return;
+    }
+
+    // Connection accepted — check deadline.
+    if ((int32_t)(xTaskGetTickCount() - gCtx.deadline_tick) >= 0) {
+        LOG_I("iperf2: TX blast done, %llu bytes sent",
+              (unsigned long long)gCtx.bytes_confirmed);
+        FinalizeStats();
+        CloseAll();
+        ResetContext();
+        MaybeAutoReset();
+        return;
+    }
+
+    // Same drain pattern as TasksTcpClient — fill WINC HIF until BUFFER_FULL,
+    // pacing via IPERF2_MAX_PENDING_TX gate.  See TasksTcpClient comments.
+    while (gCtx.pending_tx <
+           (gMaxPendingOverride ? gMaxPendingOverride : IPERF2_MAX_PENDING_TX)) {
+        int rc = send(gCtx.data_sock, (char*)gTxBuf, IPERF2_TCP_BUF_SIZE, 0);
+        if (rc == SOCK_ERR_NO_ERROR) {
+            taskENTER_CRITICAL();
+            gCtx.bytes_transferred += IPERF2_TCP_BUF_SIZE;
+            gCtx.pending_tx++;
+            taskEXIT_CRITICAL();
+        } else if (rc == SOCK_ERR_BUFFER_FULL) {
+            break;
+        } else {
+            LOG_E("iperf2: TX blast send err rc=%d, aborting", rc);
+            gCtx.abort_pending = true;
+            break;
+        }
+    }
+}
+
 static void TasksTcpClient(void) {
     if (!gCtx.client_connected) {
         // Bail if connect has been pending too long.  start_tick is set in
@@ -693,6 +817,7 @@ static void TasksTcpClient(void) {
             FinalizeStats();
             CloseAll();
             ResetContext();
+            MaybeAutoReset();
         }
         return;
     }
@@ -706,6 +831,7 @@ static void TasksTcpClient(void) {
         FinalizeStats();
         CloseAll();
         ResetContext();
+        MaybeAutoReset();
         return;
     }
 
@@ -769,6 +895,7 @@ static void TasksUdpClient(void) {
             FinalizeStats();
             CloseAll();
             ResetContext();
+            MaybeAutoReset();
             return;
         }
         if (gCtx.pending_tx < (gMaxPendingOverride ? gMaxPendingOverride : IPERF2_MAX_PENDING_TX)) {
@@ -799,7 +926,9 @@ static void Iperf2TaskMain(void* arg) {
     for (;;) {
         Iperf2_Tasks();
         bool active = (gCtx.mode == IPERF2_MODE_TCP_CLIENT) ||
-                      (gCtx.mode == IPERF2_MODE_UDP_CLIENT);
+                      (gCtx.mode == IPERF2_MODE_UDP_CLIENT) ||
+                      (gCtx.mode == IPERF2_MODE_TX_BLAST &&
+                       gCtx.data_sock >= 0);  // accepted, blasting
         ulTaskNotifyTake(pdTRUE,
                          pdMS_TO_TICKS(active ? IPERF2_ACTIVE_DELAY_MS : 50U));
     }
@@ -836,12 +965,14 @@ void Iperf2_Tasks(void) {
         FinalizeStats();
         CloseAll();
         ResetContext();
+        MaybeAutoReset();
         return;
     }
 
     switch (gCtx.mode) {
         case IPERF2_MODE_TCP_CLIENT: TasksTcpClient(); break;
         case IPERF2_MODE_UDP_CLIENT: TasksUdpClient(); break;
+        case IPERF2_MODE_TX_BLAST:  TasksTxBlast();   break;
         default: break;  // IDLE / *_SERVER are pure callback-driven
     }
 }

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -134,6 +134,14 @@ void Iperf2_Stop(void);
 void Iperf2_GetStats(Iperf2_Stats* out);
 
 /**
+ * Override IPERF2_MAX_PENDING_TX at runtime (1-4, or 0 for compile-time
+ * default).  Lower values throttle TX rate as a workaround for #399 — N=3
+ * yields ~75% of peak, N=2 ~50%.  Takes effect on the next iperf2 run.
+ */
+void Iperf2_SetMaxPending(uint8_t n);
+uint8_t Iperf2_GetMaxPending(void);
+
+/**
  * Diagnostic snapshot for #399 investigation.  Probes WINC's free socket
  * slots (opens up to TCP_SOCK_MAX/UDP_SOCK_MAX, counts successes, closes
  * them) — refuses if iperf2 is currently running (would steal the running

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -69,6 +69,22 @@ typedef struct {
     bool     completed;
 } Iperf2_Stats;
 
+// Diagnostic snapshot for #399 investigation — visibility into WINC HIF
+// state across iperf2 sessions.  Populated by Iperf2_GetDiag().
+typedef struct {
+    Iperf2_Mode  mode;             // current mode
+    int16_t      data_sock;        // current/last data socket descriptor
+    int16_t      listen_sock;      // current/last listen socket descriptor
+    uint8_t      pending_tx;       // m2m_send calls not yet ACKed
+    bool         abort_pending;    // deferred-abort flag
+    uint64_t     bytes_confirmed;  // current/last session
+    int16_t      last_send_rc;     // most recent send() return value
+    uint8_t      send_err_count;   // sticky count of negative send rcs since last reset
+    uint8_t      winc_state;       // m2m_wifi_get_state()
+    uint8_t      free_tcp_sockets; // probed: socket()/shutdown() loop, max 7
+    uint8_t      free_udp_sockets; // probed: socket()/shutdown() loop, max 4
+} Iperf2_Diag;
+
 // Default iperf2 port (matches `iperf -s` default)
 #define IPERF2_DEFAULT_PORT  5001
 
@@ -116,6 +132,14 @@ void Iperf2_Stop(void);
  * the most recent completed test until a new one starts.
  */
 void Iperf2_GetStats(Iperf2_Stats* out);
+
+/**
+ * Diagnostic snapshot for #399 investigation.  Probes WINC's free socket
+ * slots (opens up to TCP_SOCK_MAX/UDP_SOCK_MAX, counts successes, closes
+ * them) — refuses if iperf2 is currently running (would steal the running
+ * session's resources).  Otherwise reads internal context state into out.
+ */
+void Iperf2_GetDiag(Iperf2_Diag* out);
 
 /**
  * Hook into wifi_manager's SocketEventCallback dispatcher.  Returns true

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -53,7 +53,8 @@ typedef enum {
     IPERF2_MODE_TCP_SERVER,
     IPERF2_MODE_TCP_CLIENT,
     IPERF2_MODE_UDP_SERVER,
-    IPERF2_MODE_UDP_CLIENT
+    IPERF2_MODE_UDP_CLIENT,
+    IPERF2_MODE_TX_BLAST       // listen+accept, blast TX for duration (#399 workaround)
 } Iperf2_Mode;
 
 typedef struct {
@@ -123,6 +124,17 @@ bool Iperf2_StartUdpClient(const char* remote_ip, uint16_t remote_port,
                            uint32_t duration_sec);
 
 /**
+ * TX-blast mode (#399 workaround for repeated throughput testing).
+ * Listen+accept on `port`, on first connection blast 1400-byte chunks
+ * for `duration_sec` then close.  Uses listen+accept (not connect)
+ * so it avoids WINC's outbound-TCP state bug — back-to-back sessions
+ * stay clean without HRESet between.  PC connects with any TCP client
+ * (e.g. `iperf -c <ip> -p <port>` or `nc <ip> <port> > /dev/null`)
+ * and measures bytes received as the device's TX throughput.
+ */
+bool Iperf2_StartTxBlast(uint16_t port, uint32_t duration_sec);
+
+/**
  * Cancel the in-flight iperf2 session (closes sockets, finalizes stats).
  */
 void Iperf2_Stop(void);
@@ -140,6 +152,16 @@ void Iperf2_GetStats(Iperf2_Stats* out);
  */
 void Iperf2_SetMaxPending(uint8_t n);
 uint8_t Iperf2_GetMaxPending(void);
+
+/**
+ * Auto-HRESet on iperf2 session end (#399 workaround).  When true,
+ * Iperf2 fires wifi_manager_HardReset() after FinalizeStats/CloseAll/
+ * ResetContext.  Costs ~12 s WiFi reassoc per session but ensures every
+ * subsequent iperf2 starts from clean WINC state (no multi-session
+ * degradation).  Default true for iperf2 since it's a debug tool.
+ */
+void Iperf2_SetAutoReset(bool enable);
+bool Iperf2_GetAutoReset(void);
 
 /**
  * Diagnostic snapshot for #399 investigation.  Probes WINC's free socket


### PR DESCRIPTION
## Summary

Adds 4 SCPI commands and one new iperf2 mode for #399 (WINC1500 stability/throughput investigation). Verified across two same-firmware test sessions on Tesla AP.

- `feat(iperf2): TXBlast mode + auto-HRESet on stop` — verified working (a33c7784)
- `debug(iperf2): runtime MAXPending throttle for #399 (didn't help)` — knob works, dormant by default (85adddfd)
- `debug(iperf2): add SYST:WIFI:IPERF:DIAGnostics?` — verified working for visibility (3aea190a)

## What ships

| SCPI | Default | Status |
|---|---|---|
| `SYST:WIFI:IPERF:TXBLast <port>,<dur_s>` | n/a | **Active.** Pure raw-byte TCP blasting from static buffer. PC connects with any TCP byte-counter. Useful for separating "iperf2 protocol cost" from "WINC SPI staging ceiling." |
| `SYST:WIFI:IPERF:AUTOReset 0\|1` | `1` (on) | **Active.** Runs `wifi_manager_HardReset()` after every iperf2 session. ~12 s WiFi reassoc per session. Disable for back-to-back fast trials. |
| `SYST:WIFI:IPERF:DIAGnostics?` | n/a | **Active.** Mode/socket/HIF state dump for #399 investigations. |
| `SYST:WIFI:IPERF:MAXPending 0..4` | `0` (use compile-time default 4) | **Dormant.** Throttles WINC HIF queue depth at runtime. Tested across multiple workloads, did not deliver. Kept available for future debug. |

Wiki updated: https://github.com/daqifi/daqifi-nyquist-firmware/wiki/01-SCPI-Interface — full command + response field reference.

## Test sessions

### 2026-05-01 single-trial baseline (debug/399 alone)

| Test | Bytes | Dur | KBps | Notes |
|---|---:|---:|---:|---|
| iperf2 TCPClient 60s | 14.13 MB | 40.78 s | 338 | Peer-closed early at 40s |
| TXBlast 60s | 20.72 MB | 60.00 s | 337 | Full duration; PC and device counts agreed to 0.03% |

iperf2 ≈ TXBlast tie at 337 KBps confirmed on first take that the iperf2 protocol layer is **not** the throughput bottleneck. The gap to MCHP's prior `wifi_socket_demos` "4.38 Mbps baseline" lives below the iperf2 layer.

### 2026-05-02 5×iperf2 + 5×TXBlast alternating battery (debug/399 + main merged)

Same firmware (a33c7784 + main merge for the Capabilities #343 trees), same Tesla AP @ SSIDSTR=100, 13 minutes back-to-back. PC iperf2 server kill+restart once at start; auto-HRESet ON between trials.

| # | Type | FW bytes | FW KBps | PC KBps | Dur s | Notes |
|---|---|---:|---:|---:|---:|---|
| 1 | iperf2 | 12.59 MB | 384 | – | 31.9 | early-close at 32s |
| 1 | TXBlast | 17.99 MB | 324 | 340 | 54.2 | clean |
| 2 | iperf2 | 23.14 MB | 376 | – | 60.0 | clean full 60s |
| 2 | TXBlast | 22.63 MB | 368 | 368 | 60.0 | clean full 60s |
| 3 | iperf2 | 7.01 MB | **114** | – | 60.0 | full 60s but Class B sustained-rate collapse |
| 3 | TXBlast | 20.97 MB | 361 | 379 | 56.7 | clean |
| 4 | iperf2 | 5.91 MB | 354 | – | 16.3 | early-close at 16s |
| 4 | TXBlast | 19.60 MB | 318 | 319 | 60.0 | clean |
| 5 | iperf2 | 16.45 MB | 267 | – | 60.0 | full 60s, mid-band |
| 5 | TXBlast | 21.28 MB | 346 | 347 | 60.0 | clean |

**Aggregates:**

| Metric | iperf2 (n=5) | TXBlast (n=5) |
|---|---:|---:|
| Median KBps | 354 | **346** |
| Range KBps | 114 – 384 | 318 – 368 |
| Range spread | 3.4× | 1.16× (15%) |
| Full-duration runs | 3/5 | 5/5 (≥54s) |
| WINC wedges | 0 | 0 |
| HRESet recoveries needed | 0 | 0 |

## Conclusions (V/E/I tagged per CLAUDE.md debugging discipline)

1. **E: Stability is causal-fixed by Variant A (PR #393).** Zero WINC wedges across 10 back-to-back trials, all sessions ended cleanly via the standard FinalizeStats path. No regression on this branch.
2. **E: TXBlast is the better characterization tool.** 15% spread vs iperf2's 3.4×. PC and FW byte counts agree to ≤2% — the firmware accounting is honest post-#371 silent-loss fix.
3. **E: iperf2 ceiling ≈ TXBlast ceiling.** When both run full duration, they agree within ~10%. The iperf2 protocol/encoder layer is not the throughput bottleneck. (Reaffirms 2026-05-01 single-trial finding with N=5.)
4. **E: Class B sustained-rate decay reproduces.** Trial 3 iperf2 ran the full 60s without error, wedge, or socket failure but at 3.3× below median. Same fingerprint as `project_class_b_round_trip_2026_05_01.md`. Methodology-resistant — this is a real residual phenomenon, not a measurement artifact.
5. **I: MAXPending throttle didn't deliver across both test sessions.** Empirical, not proof — kept as dormant debug knob in case a future investigation at a different SPI clock, AP, or workload finds value.
6. **E: Auto-HRESet held up across 10 successive sessions** with ~12 s reassociation cost. No firmware-side breakage observed.

## Why ship now

- TXBlast is genuinely useful for any future WiFi pipeline characterization work.
- DIAGnostics has already been used during #399 investigations to inspect WINC state without firmware reflashing.
- Auto-HRESet is the documented #399 workaround and provided clean WINC state across the entire battery.
- MAXPending stays as a dormant, well-documented knob — zero cost to ship, available for re-activation if a future hypothesis warrants.
- Variant A causality is preserved (no callback shutdown changes on this branch).

## Files touched

- `firmware/src/services/wifi_services/iperf2/iperf2.c` (+`.h`) — feature implementation + comments tightened (V/E/I tagging, dormancy explicit)
- `firmware/src/services/SCPI/SCPIInterface.c` — 4 new command registrations + callbacks
- Wiki: `01-SCPI-Interface.md` — full command reference + DIAGnostics response fields + Mode 5 TX-blast notes

No changes outside the iperf2 module + its SCPI registration. Variant A behavior on the 5 connection-setup error paths is preserved.

## Test plan

- [x] **2026-05-01 baseline:** TXBlast 337 KBps, iperf2 338 KBps (`project_399_txblast_vs_iperf2.md`)
- [x] **2026-05-02 5×60s alternating battery (this PR's verification):** 0 wedges, TXBlast median 346, iperf2 median 354 — see table above
- [x] **DIAGnostics? exercised** during multi-session investigation
- [x] **MAXPending getter+setter** verified functional
- [x] **AUTOReset** verified by the 10-trial battery completing cleanly with default ON

Memory: `session_2026_05_01_iperf2_summary.md` has the original investigation; today's battery results saved to `project_403_pr_battery_2026_05_02.md`.

Related: #401 (audit), #393 (Variant A merge), #383 / #385 (prior A/B), #371 (silent loss), #399 (root cause).
