### PR TITLE
fix(scpi): wire *RST to SCPI_Reset (was silent no-op) (#386)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3966,7 +3966,10 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "*IDN?", .callback = SCPI_CoreIdnQ,},
     {.pattern = "*OPC", .callback = SCPI_CoreOpc,},
     {.pattern = "*OPC?", .callback = SCPI_CoreOpcQ,},
-    {.pattern = "*RST", .callback = SCPI_CoreRst,},
+    // *RST → SCPI_Reset directly. libscpi's SCPI_CoreRst dispatches to
+    // interface->reset, which is NULL on both USB CDC and TCP server
+    // scpi_interface_t structs — going through CoreRst would no-op.
+    {.pattern = "*RST", .callback = SCPI_Reset,},
     {.pattern = "*SRE", .callback = SCPI_CoreSre,},
     {.pattern = "*SRE?", .callback = SCPI_CoreSreQ,},
     {.pattern = "*STB?", .callback = SCPI_CoreStbQ,},


### PR DESCRIPTION
## Summary

`*RST` was wired through libscpi's default `SCPI_CoreRst` dispatch, which delegates to `context->interface->reset`. But both the USB CDC and TCP server `scpi_interface_t` structs have `.reset = NULL`, so the IEEE 488.2 mandatory reset command was silently a no-op.

This 1-line table change routes `*RST` directly to `SCPI_Reset` — the same callback `SYSTem:REboot` uses (added in PR #383) — so users now get the full WINC-reset + PIC32-soft-reset chain whether they type `*RST` or `SYST:REBoot`.

## Verification on hardware

Flashed on NQ1 from `fix/386-rst-stub`:

```
$ scpi.sh "*IDN?"          # → DAQiFi,Nq1,0,01-02 (responsive)
$ scpi.sh "SYST:POW:STAT 1"
$ scpi.sh "*RST"           # → device disconnects (PIC32 soft reset)
$ ls /dev/ttyACM0          # → No such file or directory (re-enumerating)

# After re-attach via usbipd attach --wsl --busid <new>:
$ scpi.sh "*IDN?"          # → DAQiFi,Nq1,0,01-02 (booted back)
```

USB CDC re-enumeration on PIC32 soft reset is expected behavior (the whole MCU reboots) — same as `SYST:REBoot`. WSL/usbipd users will need to re-attach; Windows host users will land on a new COM port.

## Files touched

`firmware/src/services/SCPI/SCPIInterface.c`: 1 line of behavior change (table row callback) + 3 lines of comment explaining why we don't use libscpi's CoreRst dispatch.

## Test plan

- [x] Build clean (-O3, all warnings pass)
- [x] Flash to NQ1 via PICkit 4
- [x] `*RST` triggers MCU reset (USB CDC drops + re-enumerates)
- [x] Device boots back cleanly to default state after reset
- [ ] Reviewer note: USB CDC re-enumeration is expected (matches `SYST:REBoot` behavior). If undesirable, the alternative is Option 2 from #386 (route via `scpi_interface_t.reset` callback in both contexts) but Option 1 is one-liner with identical user-visible effect.

Closes #386