### PR TITLE
fix(power,wifi,scpi): WINC1500 power-architecture cleanup (#400 + 3 latent bugs)

### DIFF
--- a/firmware/src/HAL/Power/PowerApi.c
+++ b/firmware/src/HAL/Power/PowerApi.c
@@ -131,9 +131,14 @@ void Power_Init(
 
     // CRITICAL: Force 3.3V rail ON regardless of initial config
     // The microcontroller is running, so 3.3V must already be on
-    // This ensures it stays on during USB disconnect
-    PWR_3_3V_EN_OutputEnable();  // Set RH12 as output
-    PWR_3_3V_EN_Set();          // Drive 3.3V_EN high
+    // This ensures it stays on during USB disconnect.
+    //
+    // Order matters — RH12 must NEVER be driven LOW (see Power_Write
+    // for the full rationale). Set the latch HIGH first while the pin
+    // is still input (no pin change yet), THEN enable output, so the
+    // pin transitions HiZ → output-HIGH directly with no LOW glitch.
+    PWR_3_3V_EN_Set();           // LATH bit 12 = 1 (no pin change yet — still input)
+    PWR_3_3V_EN_OutputEnable();  // TRIS bit 12 = 0 (output, drives high)
     pWriteVariables->EN_3_3V_Val = true;
     
     // Initialize other power pins to their default states
@@ -185,19 +190,32 @@ void Power_Write(void) {
 
     // Check to see if we are changing the state of this power pin
     if (EN_3_3V_Val_Current != pWriteVariables->EN_3_3V_Val) {
-        
-        // CRITICAL: Only drive HIGH or set as INPUT (HiZ) - never drive LOW
-        // There's a pulldown resistor that will drop the line when in HiZ
+
+        // CRITICAL: Never drive RH12 LOW — even momentarily.
+        // RH12 (PWR_3_3V_EN) is held high externally by:
+        //   - USB power (forces EN high while VBUS present)
+        //   - Power-button press (pulses EN high)
+        //   - MCU output-high (firmware self-hold)
+        // and is pulled low by an external pulldown only when all three
+        // sources release. The MCU's only legal moves are output-HIGH or
+        // input (HiZ). A LOW pulse from the MCU could short an active
+        // external source and disturb the rail/latch.
+        //
+        // Subtle ordering: at cold boot LATH bit 12 = 0 (initial 0xa114).
+        // If we did OutputEnable first, the pin would transition HiZ →
+        // output-LOW for one instruction before _Set() drives it high —
+        // a brief but real LOW glitch on RH12. Set the latch HIGH FIRST
+        // (no-op while pin is still input), THEN enable output, so the
+        // pin transitions HiZ → output-HIGH directly.
         if (pWriteVariables->EN_3_3V_Val) {
-            // Set as OUTPUT and drive high to enable 3.3V
-            PWR_3_3V_EN_OutputEnable();
-            PWR_3_3V_EN_Set();
+            PWR_3_3V_EN_Set();           // LATH bit 12 = 1 (still input — no pin change yet)
+            PWR_3_3V_EN_OutputEnable();  // TRIS bit 12 = 0 (output, drives high)
         } else {
-            // Set as INPUT (HiZ) to disable - pulldown will handle the rest
-            // Never actively drive low to avoid conflicts
+            // Disable: HiZ. Pulldown drops the line if no other source
+            // (USB / button / MCU) is asserting it. Never drive low.
             PWR_3_3V_EN_InputEnable();
         }
-        
+
     }
 
     // Check to see if we are changing the state of these power pins

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -378,15 +378,19 @@ static scpi_result_t SCPI_Reset(scpi_t * context) {
               "be reset before PIC32 reboot");
     }
 
-    // Actively pump wifi_manager_ProcessState() during the 500 ms settle —
-    // not just sleep.  Reason: TCP-SCPI dispatch runs on app_WifiTask
-    // (post-#353), the same task that drains the WiFi event queue.  A
-    // passive vTaskDelay there blocks the queue and DEINIT never gets
-    // processed before RCON_SoftwareReset() reboots the chip.
+    // Actively pump wifi_manager_ProcessStateNoTcpRx() during the 500 ms
+    // settle — not just sleep.  Reason: TCP-SCPI dispatch runs on
+    // app_WifiTask (post-#353), the same task that drains the WiFi event
+    // queue.  A passive vTaskDelay there blocks the queue and DEINIT
+    // never gets processed before RCON_SoftwareReset() reboots the chip.
+    //
+    // NoTcpRx variant skips the deferred TCP-rx drain so we don't
+    // re-enter SCPI_Input() on the same scpiContext when *RST itself
+    // arrived over TCP.
     {
         TickType_t start = xTaskGetTickCount();
         while ((xTaskGetTickCount() - start) < pdMS_TO_TICKS(500)) {
-            wifi_manager_ProcessState();
+            wifi_manager_ProcessStateNoTcpRx();
             vTaskDelay(pdMS_TO_TICKS(5));
         }
     }
@@ -1236,9 +1240,12 @@ static scpi_result_t SCPI_SetPowerState(scpi_t * context) {
             LOG_E("SYST:POW:STAT 0: wifi_manager_Deinit failed; "
                   "WINC may wedge if rails drop before chip is idle");
         }
+        // NoTcpRx variant: skips the deferred TCP-rx drain so we don't
+        // re-enter SCPI_Input() on the same scpiContext when this SCPI
+        // command itself arrived over TCP.  Mirrors SCPI_Reset.
         TickType_t start = xTaskGetTickCount();
         while ((xTaskGetTickCount() - start) < pdMS_TO_TICKS(500)) {
-            wifi_manager_ProcessState();
+            wifi_manager_ProcessStateNoTcpRx();
             vTaskDelay(pdMS_TO_TICKS(5));
         }
     }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -1215,6 +1215,34 @@ static scpi_result_t SCPI_SetPowerState(scpi_t * context) {
         return SCPI_RES_OK;
     }
 
+    // #400: when transitioning from POWERED_UP* → STANDBY, clean up WiFi
+    // BEFORE PowerAndUITask runs Power_Down (which kills the WINC's 3.3V
+    // rail). Without this, app_WifiTask sees the power-state change only
+    // AFTER rails drop, calls wifi_manager_Deinit on a chip that no longer
+    // has power, gets stuck in WDRV_WINC_Status==SYS_STATUS_BUSY forever,
+    // and every subsequent POW:STAT 1 cycle never recovers WiFi (all
+    // SYST:COMM:LAN:* queries return -200 "WiFi not ready" indefinitely).
+    //
+    // Mirrors SCPI_Reset's pattern (above): wifi_manager_Deinit() just
+    // queues an event; we must pump wifi_manager_ProcessState() actively
+    // because if this SCPI command arrived over TCP it's running on
+    // app_WifiTask itself (post-#353) — sleeping there would deadlock
+    // the queue. 500 ms is enough for healthy WDRV_WINC_Deinitialize
+    // (~50 ms) plus margin for a busy HIF queue.
+    if (param1 == 0 &&
+        (pPowerData->powerState == POWERED_UP ||
+         pPowerData->powerState == POWERED_UP_EXT_DOWN)) {
+        if (!wifi_manager_Deinit()) {
+            LOG_E("SYST:POW:STAT 0: wifi_manager_Deinit failed; "
+                  "WINC may wedge if rails drop before chip is idle");
+        }
+        TickType_t start = xTaskGetTickCount();
+        while ((xTaskGetTickCount() - start) < pdMS_TO_TICKS(500)) {
+            wifi_manager_ProcessState();
+            vTaskDelay(pdMS_TO_TICKS(5));
+        }
+    }
+
     switch (param1) {
         case 0:  // STANDBY
             pPowerData->requestedPowerState = DO_POWER_DOWN;
@@ -1226,7 +1254,7 @@ static scpi_result_t SCPI_SetPowerState(scpi_t * context) {
             pPowerData->requestedPowerState = DO_POWER_UP_EXT_DOWN;
             break;
     }
-    
+
     BoardData_Set(
             BOARDDATA_POWER_DATA,
             0,

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3966,7 +3966,10 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "*IDN?", .callback = SCPI_CoreIdnQ,},
     {.pattern = "*OPC", .callback = SCPI_CoreOpc,},
     {.pattern = "*OPC?", .callback = SCPI_CoreOpcQ,},
-    {.pattern = "*RST", .callback = SCPI_CoreRst,},
+    // *RST → SCPI_Reset directly. libscpi's SCPI_CoreRst dispatches to
+    // interface->reset, which is NULL on both USB CDC and TCP server
+    // scpi_interface_t structs — going through CoreRst would no-op.
+    {.pattern = "*RST", .callback = SCPI_Reset,},
     {.pattern = "*SRE", .callback = SCPI_CoreSre,},
     {.pattern = "*SRE?", .callback = SCPI_CoreSreQ,},
     {.pattern = "*STB?", .callback = SCPI_CoreStbQ,},

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1550,28 +1550,36 @@ size_t wifi_manager_WriteToBuffer(const char* pData, size_t len) {
     return wifi_tcp_server_WriteBuffer(pData, len);
 }
 
-void wifi_manager_ProcessState() {
+// Internal worker for both ProcessState entry points.  drainTcpRx=true
+// is the normal WifiTask path (drains deferred TCP rx and re-arms recv).
+// drainTcpRx=false is the SCPI active-pump path: it drives WiFi
+// lifecycle/event-queue work without dispatching new TCP-arrived SCPI,
+// to prevent re-entrant SCPI_Input() on the same scpiContext when the
+// outer SCPI command itself arrived over TCP.
+static void wifi_manager_ProcessStateImpl(bool drainTcpRx) {
     wifi_manager_event_t event;
     wifi_manager_stateMachineReturnStatus_t ret;
     while (gEventQH == NULL) {
         return;
     }
 
-    // Serialize re-entrant callers (app_WifiTask + SCPI_Reset active pump,
-    // and any future call site).  Recursive — same task can re-enter
-    // (TCP SCPI nests ProcessState inside ProcessState); see
+    // Serialize re-entrant callers (app_WifiTask + SCPI active-pump
+    // paths, and any future call site).  Recursive — same task can
+    // re-enter (TCP SCPI nests ProcessState inside ProcessState); see
     // gProcessStateMutex declaration for the rationale.
     //
-    // Bounded 100 ms timeout (instead of portMAX_DELAY): if the holder
+    // Bounded 250 ms timeout (instead of portMAX_DELAY): if the holder
     // is genuinely wedged, the caller must be able to bail and return
-    // — otherwise the SCPI_Reset active pump would hang and the device
-    // could never reboot.  Normal ProcessState body completes in <10 ms,
-    // so 100 ms gives generous headroom for healthy operation while
+    // — otherwise SCPI active pumps would hang and the device could
+    // never reboot.  250 ms must exceed the worst-case in-mutex delay,
+    // which is nm_reset()'s ~120 ms during DEINIT (CHIP_EN/RESET_N
+    // pulse with vTaskDelays).  Normal body completes in <10 ms, so
+    // 250 ms gives generous headroom for healthy operation while
     // failing fast on actual stalls.  Skipped iterations recover
     // naturally on the next invocation.
     if (gProcessStateMutex != NULL) {
         if (xSemaphoreTakeRecursive(gProcessStateMutex,
-                                    pdMS_TO_TICKS(100)) != pdTRUE) {
+                                    pdMS_TO_TICKS(250)) != pdTRUE) {
             LOG_E("WiFi ProcessState: mutex timeout — skipping iteration");
             return;
         }
@@ -1620,10 +1628,16 @@ void wifi_manager_ProcessState() {
     // runs here, on WifiTask's stack, with ~4 KB of headroom for the
     // microrl + libscpi + handler chain.
     //
+    // Skipped on the SCPI active-pump path (drainTcpRx=false) so we
+    // don't re-enter SCPI_Input() on the same scpiContext when the
+    // outer command itself arrived over TCP.  TCP rx remains queued
+    // (gTcpRxPending stays set) and gets drained by the normal
+    // WifiTask loop after the SCPI handler returns.
+    //
     // Always clear the flag under the socket-valid guard, so a RECV that
     // arrived just before the client disconnected doesn't leave stale data
     // queued for the next client.
-    if (gTcpRxPending) {
+    if (drainTcpRx && gTcpRxPending) {
         gTcpRxPending = false;
         if (gStateMachineContext.pTcpServerContext != NULL &&
             gStateMachineContext.pTcpServerContext->client.clientSocket >= 0) {
@@ -1650,6 +1664,14 @@ void wifi_manager_ProcessState() {
     if (gProcessStateMutex != NULL) {
         xSemaphoreGiveRecursive(gProcessStateMutex);
     }
+}
+
+void wifi_manager_ProcessState() {
+    wifi_manager_ProcessStateImpl(true);
+}
+
+void wifi_manager_ProcessStateNoTcpRx(void) {
+    wifi_manager_ProcessStateImpl(false);
 }
 
 wifi_tcp_server_context_t* wifi_manager_GetTcpServerContext() {

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1358,6 +1358,24 @@ bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
             return false;
         }
     } else {
+        // Re-init path: queue already exists from a prior Init.  Previously
+        // this short-circuited with `return true`, but that path leaves the
+        // state machine stuck in DEINIT after a POW:STAT 0 → 1 cycle (queue
+        // and FSM state survive but the chip was reset by Deinit) — the
+        // chip never gets driven back through INIT.  Instead, re-arm
+        // isEnabled and queue a fresh INIT event to walk the state machine
+        // back up to MAIN.  Mirrors the deferred-INIT branch in
+        // wifi_manager_ProcessState.
+        if (pSettings != NULL) {
+            gStateMachineContext.pWifiSettings = pSettings;
+        }
+        if (gStateMachineContext.pWifiSettings != NULL) {
+            taskENTER_CRITICAL();
+            gWifiReinitDeadlineTick = 0;  // cancel any pending deferred-INIT
+            gStateMachineContext.pWifiSettings->isEnabled = 1;
+            taskEXIT_CRITICAL();
+        }
+        SendEvent(WIFI_MANAGER_EVENT_INIT);
         return true;
     }
     if (pSettings != NULL)

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -9,7 +9,6 @@
 #include "wifi_serial_bridge.h"
 #include "wifi_serial_bridge_interface.h"
 #include "iperf2/iperf2.h"
-#include "driver/winc/include/dev/wdrv_winc_gpio.h"
 #include "driver/winc/include/drv/common/nm_common.h"  // nm_reset (canonical WINC reset pulse)
 #include "semphr.h"
 #include "driver/winc/include/drv/driver/m2m_wifi.h"

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -10,6 +10,7 @@
 #include "wifi_serial_bridge_interface.h"
 #include "iperf2/iperf2.h"
 #include "driver/winc/include/dev/wdrv_winc_gpio.h"
+#include "driver/winc/include/drv/common/nm_common.h"  // nm_reset (canonical WINC reset pulse)
 #include "semphr.h"
 #include "driver/winc/include/drv/driver/m2m_wifi.h"
 
@@ -463,15 +464,26 @@ static uint8_t __attribute__((unused)) GetEventFlagStatus(wifi_manager_stateFlag
  * leaves the module in reset state by asserting reset but never deasserting it.
  */
 static void wifi_manager_FixWincResetState(void) {
-    // The WINC driver's deinit leaves the module with:
-    // - CHIP_EN deasserted (low)
-    // - RESET_N asserted (low) 
-    // This leaves the module in permanent reset. We need to take it out of reset
-    // so it can be re-initialized later.
-    
-    // Assert chip enable and deassert reset to take module out of reset state
-    WDRV_WINC_GPIOChipEnableAssert();
-    WDRV_WINC_GPIOResetDeassert();
+    // Run Microchip's canonical WINC1500 power-cycle pulse (nm_reset, in
+    // drv/common/nm_common.c).  Sequence + timing:
+    //
+    //   CHIP_EN low + RESET_N low   (held in full reset)
+    //   sleep 100 ms
+    //   CHIP_EN high                (power on)
+    //   sleep 10 ms                 (rail settle)
+    //   RESET_N high                (release from reset; chip starts boot)
+    //   sleep 10 ms                 (boot before next SPI access)
+    //
+    // Earlier this function only did a half-reset — Assert(CHIP_EN) +
+    // Deassert(RESET_N) — which left the chip "powered but undefined"
+    // between Deinit and the next Init.  Across multiple POW:STAT or
+    // HRESet cycles, the chip would accumulate stuck state that no
+    // amount of partial GPIO toggling could recover (#400 multi-cycle
+    // wedge).  The full nm_reset pulse is what Microchip's own driver
+    // (nmbus.c:66, nm_common.c:56) uses internally and what their
+    // wdrv_winc.c Deinit ends with — aligning ours fixes the
+    // unrecoverable-soft-wedge class.
+    nm_reset();
 }
 
 static void __attribute__((unused)) ResetAllEventFlags(wifi_manager_stateFlag_t *pEventFlagState) {

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -243,11 +243,25 @@ extern "C" {
 
     /**
      * @brief Processes the current state of the WiFi manager.
-     * 
+     *
      * Handles queued events and processes the WiFi state machine, including TCP and UDP operations,
      * and serial bridge communication if WiFi firmware update mode is active.
      */
     void wifi_manager_ProcessState();
+
+    /**
+     * @brief Same as wifi_manager_ProcessState, but skips draining
+     *        deferred TCP rx (SCPI dispatch).
+     *
+     * For use ONLY from inside a SCPI handler that needs to actively
+     * pump WiFi lifecycle (e.g. drive WIFI_MANAGER_EVENT_DEINIT
+     * forward without deadlocking the WifiTask).  Skipping the TCP
+     * rx drain prevents nested SCPI_Input() on the same scpiContext
+     * when the outer SCPI command itself arrived over TCP.  Queued
+     * TCP rx remains pending and is drained by the next normal
+     * WifiTask iteration after the SCPI handler returns.
+     */
+    void wifi_manager_ProcessStateNoTcpRx(void);
 
     /**
      * @brief Gets the available free size in the write buffer.


### PR DESCRIPTION
## Summary

Four architectural fixes plus a dead-include cleanup, all addressing latent bugs in the power/WiFi/SCPI control plane that surfaced during #400 debugging:

- **`*RST`** was a silent no-op. The command-table row pointed at libscpi's `SCPI_CoreRst`, which dispatches to `interface->reset` — `NULL` on both USB CDC and TCP server `scpi_interface_t` structs. Now points at `SCPI_Reset` directly.
- **RH12 (PWR_3_3V_EN) was being driven LOW** for ~5 ns at boot in `Power_Init` (TRIS=output before LATH=1) and at every 3.3V enable in `Power_Write`. User hardware spec: USB power forces RH12 high externally; the MCU's only legal moves are output-HIGH or HiZ. Reordered to set LATH=1 first while pin is still input, then enable output — pin transitions HiZ → output-HIGH directly.
- **`wifi_manager_FixWincResetState` was undoing prior Deinit's reset.** Old code did `Assert(CHIP_EN) + Deassert(RESET_N)` — half a reset that left the chip in undefined state. Replaced with the canonical Microchip `nm_reset()` pulse (CHIP_EN low + RESET_N low + 100 ms + CHIP_EN high + 10 ms + RESET_N high + 10 ms).
- **#400 race**: `SCPI POW:STAT 0` set `requestedPowerState=DO_POWER_DOWN`, then PowerAndUITask (priority 7) ran `Power_Down` and dropped 3.3V. app_WifiTask (priority 2) saw the state change *after* rails dropped and called `wifi_manager_Deinit` on a powered-off chip → stuck at `WDRV_WINC_Status==SYS_STATUS_BUSY` forever, so every subsequent `POW:STAT 1` cycle never recovered WiFi (`SYST:COMM:LAN:*` returned `-200 "WiFi not ready"` indefinitely). Fix: in the SCPI handler, run `wifi_manager_Deinit()` and pump `wifi_manager_ProcessState()` for 500 ms *before* setting `requestedPowerState`. Mirrors `SCPI_Reset`'s pattern (cannot `vTaskDelay` because post-#353 SCPI-over-TCP runs on app_WifiTask itself).

Build: clean at -O3, hex 1647724 bytes.

## Test plan

- [ ] `*RST` — confirm device resets (was previously silent no-op)
- [ ] `SYST:POW:STAT 0` then `SYST:POW:STAT 1` cycle, verify `SYST:COMM:LAN:ADDR?` returns valid IP (was previously stuck at `-200`)
- [ ] Multi-cycle: 5× `POW:STAT 0/1` with WiFi STA association between each — no `-200` accumulation
- [ ] Visual: power LED behavior unchanged from main (LED-off-via-SCPI bug exists on main, separate issue)
- [ ] Logic-analyzer probe RH12 at boot — no LOW transient

## Known unrelated bug (NOT regressed by this PR)

`POW:STAT?=1` immediately after USB plug (should be `0`), and `SCPI POW:STAT 1` doesn't light the LED while button-press DOES (both call same `Power_Up()`). Pre-existing on main — verified by inspecting `c422832e` and walking the code paths. Hypothesized cause: `plib_gpio.c` doesn't configure CNPDJ pull-down for Port J, so RJ14 (button) may read HIGH at idle and trigger `Button_Tasks` auto-power-up. Filed as a separate follow-up issue with concrete probe steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)