### PR TITLE
feat(dioprobe): runtime-flexible probe→DIO routing

### DIFF
--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -76,38 +76,74 @@ void DioProbe_Init(void) {
     gDioProbeAnyActive = false;
 
     /* Activate ad-hoc probes whose bit is set in the compile-time
-     * enable mask. Each ad-hoc probe i maps to DIO channel i. */
+     * enable mask. Default mapping is probe N -> DIO N; remap at
+     * runtime via DioProbe_AssignToChannel / SYST:DIOP:MAP. */
 #if (DIO_PROBE_ENABLE_MASK) != 0u
     for (uint8_t i = DIO_PROBE_ADHOC_FIRST; i < DIO_PROBE_SLOTS; ++i) {
         if (((DIO_PROBE_ENABLE_MASK) & (1u << i)) == 0u) continue;
         if (i > DIO_PROBE_MAX_DIO_CHANNEL) continue;
-
-        uint8_t channel = i;
-        if (!probe_configure_pin(channel)) {
-            LOG_E("DioProbe: ad-hoc probe %u pin config failed", (unsigned)i);
-            continue;
+        if (!DioProbe_AssignToChannel(i, i, DIO_PROBE_MODE_TOGGLE)) {
+            LOG_E("DioProbe: ad-hoc probe %u init failed", (unsigned)i);
         }
-
-        tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
-        const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
-
-        volatile DioProbeSlot_t* slot = &gDioProbeSlots[i];
-        slot->port    = dio->DataChannel;
-        slot->mask    = 1u << dio->DataBitPos;
-        slot->channel = channel;
-        slot->mode    = DIO_PROBE_MODE_TOGGLE;  /* publish last */
-
-        gDioProbeOwnedMask |= (1u << channel);
     }
-    recompute_any_active();
 #endif
 }
 
 bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode) {
     if (probeId >= DIO_PROBE_STANDARD_COUNT) return false;
     if (mode == DIO_PROBE_MODE_OFF) return DioProbe_Clear(probeId);
+    return DioProbe_AssignToChannel(probeId, probeId, mode);
+}
 
-    uint8_t channel = probeId;  /* standard probes: probe N -> DIO N */
+bool DioProbe_AssignToChannel(uint8_t probeId, uint8_t channel,
+                              DioProbeMode_t mode) {
+    if (probeId >= DIO_PROBE_SLOTS) return false;
+    if (channel > DIO_PROBE_MAX_DIO_CHANNEL) return false;
+    if (mode == DIO_PROBE_MODE_OFF) {
+        /* Standard probes go through the public Clear; ad-hoc slots
+         * use the same teardown via the inline path below. */
+        if (probeId < DIO_PROBE_STANDARD_COUNT) {
+            return DioProbe_Clear(probeId);
+        }
+        /* Ad-hoc clear: release pin + slot fields. Mirrors DioProbe_Clear
+         * but skips the DIO_WriteStateSingle restore (ad-hoc probes are
+         * developer-instrumentation; user runtime config doesn't apply). */
+        volatile DioProbeSlot_t* s = &gDioProbeSlots[probeId];
+        uint8_t prev_ch = s->channel;
+        s->mode = DIO_PROBE_MODE_OFF;
+        taskENTER_CRITICAL();
+        if (prev_ch <= DIO_PROBE_MAX_DIO_CHANNEL) {
+            probe_release_pin(prev_ch);
+            gDioProbeOwnedMask &= (uint16_t)~(1u << prev_ch);
+        }
+        s->channel = 0xFF;
+        s->mask = 0;
+        taskEXIT_CRITICAL();
+        recompute_any_active();
+        return true;
+    }
+
+    /* If this slot already owns a different channel, release the old
+     * one first so the owned-mask invariant stays clean across remap. */
+    volatile DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
+    uint8_t prev_ch = slot->channel;
+    if (prev_ch != 0xFF && prev_ch != channel &&
+        prev_ch <= DIO_PROBE_MAX_DIO_CHANNEL) {
+        slot->mode = DIO_PROBE_MODE_OFF;
+        taskENTER_CRITICAL();
+        probe_release_pin(prev_ch);
+        gDioProbeOwnedMask &= (uint16_t)~(1u << prev_ch);
+        taskEXIT_CRITICAL();
+        (void)DIO_WriteStateSingle(prev_ch);
+    }
+
+    /* Reject if the target channel is already owned by a DIFFERENT
+     * probe slot (avoid two probes fighting over one pin). */
+    if (prev_ch != channel && (gDioProbeOwnedMask & (1u << channel)) != 0u) {
+        LOG_E("DioProbe: channel %u already owned by another probe",
+              (unsigned)channel);
+        return false;
+    }
 
     if (!probe_configure_pin(channel)) {
         return false;
@@ -116,17 +152,11 @@ bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode) {
     tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
     const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
 
-    /* Publication protocol:
-     *   1. Clear mode to OFF (belt-and-suspenders — CS will block ISR
-     *      readers anyway, but any read that slips before the CS sees
-     *      OFF and bails)
-     *   2. Single critical section: rewrite fields + masks + publish
-     *      mode=NEW + set any_active. Mode publish MUST be inside the
-     *      CS so recompute_any_active on the other SCPI task cannot
-     *      observe mode=OFF and stomp any_active=false.
-     *   3. Volatile fields (see DioProbeSlot_t) prevent the compiler
-     *      from reordering writes out of the CS. */
-    volatile DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
+    /* Publication protocol: clear mode first (ISR readers bail on OFF),
+     * then critical section: rewrite fields + publish mode + set
+     * any_active. Mode publish MUST be inside the CS so a concurrent
+     * recompute_any_active on the other SCPI task can't observe mode=OFF
+     * and stomp any_active=false. */
     slot->mode = DIO_PROBE_MODE_OFF;
 
     taskENTER_CRITICAL();

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -123,47 +123,81 @@ bool DioProbe_AssignToChannel(uint8_t probeId, uint8_t channel,
         return true;
     }
 
-    volatile DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
-    uint8_t prev_ch = slot->channel;
+    /* Preflight: validate target channel BEFORE any destructive state
+     * change so a remap that's going to fail (channel out of range for
+     * BoardConfig, or PWM active on the channel) doesn't tear down the
+     * slot's existing working assignment. Mirrors the checks inside
+     * probe_configure_pin so that helper becomes the redundant belt. */
+    tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+    if (channel >= cfg->DIOChannels.Size) return false;
+    {
+        tBoardRuntimeConfig* rt =
+            BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_ALL_CONFIG);
+        if (rt->DIOChannels.Data[channel].IsPwmActive) {
+            LOG_E("DioProbe: channel %u rejected (PWM active)",
+                  (unsigned)channel);
+            return false;
+        }
+    }
+    const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
 
-    /* Reject FIRST if the target channel is already owned by a
-     * DIFFERENT probe slot. Order matters: if we released prev_ch
-     * before this check and the rejection then fired, the slot
-     * would be left holding stale (channel, mask) for a pin we no
-     * longer own — visible to LIST? and confusing the next remap. */
+    volatile DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
+    uint8_t prev_ch;
+
+    /* Atomic check-and-reserve. Two concurrent SCPI tasks (USB pri 7
+     * and WiFi pri 2) can both call AssignToChannel; if the ownership
+     * check on gDioProbeOwnedMask runs outside a CS, both can pass it
+     * for the same channel before either sets the owned bit. Hold the
+     * CS across check + prev_ch release + new-channel reservation so
+     * the second arrival sees the first's bit set and rejects. */
+    taskENTER_CRITICAL();
+    prev_ch = slot->channel;
     if (prev_ch != channel && (gDioProbeOwnedMask & (1u << channel)) != 0u) {
+        taskEXIT_CRITICAL();
         LOG_E("DioProbe: channel %u already owned by another probe",
               (unsigned)channel);
         return false;
     }
-
-    /* Now safe to release the old channel. Also clear slot fields
-     * so that if probe_configure_pin below fails, the slot lands in
-     * a clean unassigned state rather than referencing a released pin. */
+    /* Release prev_ch's pin and clear slot fields if remapping. */
     if (prev_ch != 0xFF && prev_ch != channel &&
         prev_ch <= DIO_PROBE_MAX_DIO_CHANNEL) {
         slot->mode = DIO_PROBE_MODE_OFF;
-        taskENTER_CRITICAL();
         probe_release_pin(prev_ch);
         gDioProbeOwnedMask &= (uint16_t)~(1u << prev_ch);
         slot->channel = 0xFF;
         slot->mask = 0;
-        taskEXIT_CRITICAL();
+    }
+    /* Reserve the new channel. Visible to other SCPI tasks immediately
+     * via the owned mask; their AssignToChannel calls will reject. */
+    gDioProbeOwnedMask |= (uint16_t)(1u << channel);
+    taskEXIT_CRITICAL();
+
+    /* Restore prev_ch to its user-DIO state outside CS (the DIO HAL
+     * uses its own mutex for this). */
+    if (prev_ch != 0xFF && prev_ch != channel &&
+        prev_ch <= DIO_PROBE_MAX_DIO_CHANNEL) {
         (void)DIO_WriteStateSingle(prev_ch);
     }
 
+    /* Configure the new pin. Preflight passed, so this should succeed,
+     * but DIO_ProbeActivatePair can still report failure (defensive
+     * check inside DIO HAL). On failure, roll back the reservation and
+     * recompute the any-active gate so it can't remain stale-true if
+     * we were the last live probe. */
     if (!probe_configure_pin(channel)) {
+        taskENTER_CRITICAL();
+        gDioProbeOwnedMask &= (uint16_t)~(1u << channel);
+        taskEXIT_CRITICAL();
+        recompute_any_active();
         return false;
     }
-
-    tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
-    const DIOConfig* dio = &cfg->DIOChannels.Data[channel];
 
     /* Publication protocol: clear mode first (ISR readers bail on OFF),
      * then critical section: rewrite fields + publish mode + set
      * any_active. Mode publish MUST be inside the CS so a concurrent
      * recompute_any_active on the other SCPI task can't observe mode=OFF
-     * and stomp any_active=false. */
+     * and stomp any_active=false. The owned-mask bit was already set
+     * above as the reservation. */
     slot->mode = DIO_PROBE_MODE_OFF;
 
     taskENTER_CRITICAL();
@@ -171,7 +205,6 @@ bool DioProbe_AssignToChannel(uint8_t probeId, uint8_t channel,
     slot->mask    = 1u << dio->DataBitPos;
     slot->channel = channel;
     slot->mode    = (uint8_t)mode;
-    gDioProbeOwnedMask |= (uint16_t)(1u << channel);
     gDioProbeAnyActive = true;
     taskEXIT_CRITICAL();
     return true;

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -123,26 +123,33 @@ bool DioProbe_AssignToChannel(uint8_t probeId, uint8_t channel,
         return true;
     }
 
-    /* If this slot already owns a different channel, release the old
-     * one first so the owned-mask invariant stays clean across remap. */
     volatile DioProbeSlot_t* slot = &gDioProbeSlots[probeId];
     uint8_t prev_ch = slot->channel;
+
+    /* Reject FIRST if the target channel is already owned by a
+     * DIFFERENT probe slot. Order matters: if we released prev_ch
+     * before this check and the rejection then fired, the slot
+     * would be left holding stale (channel, mask) for a pin we no
+     * longer own — visible to LIST? and confusing the next remap. */
+    if (prev_ch != channel && (gDioProbeOwnedMask & (1u << channel)) != 0u) {
+        LOG_E("DioProbe: channel %u already owned by another probe",
+              (unsigned)channel);
+        return false;
+    }
+
+    /* Now safe to release the old channel. Also clear slot fields
+     * so that if probe_configure_pin below fails, the slot lands in
+     * a clean unassigned state rather than referencing a released pin. */
     if (prev_ch != 0xFF && prev_ch != channel &&
         prev_ch <= DIO_PROBE_MAX_DIO_CHANNEL) {
         slot->mode = DIO_PROBE_MODE_OFF;
         taskENTER_CRITICAL();
         probe_release_pin(prev_ch);
         gDioProbeOwnedMask &= (uint16_t)~(1u << prev_ch);
+        slot->channel = 0xFF;
+        slot->mask = 0;
         taskEXIT_CRITICAL();
         (void)DIO_WriteStateSingle(prev_ch);
-    }
-
-    /* Reject if the target channel is already owned by a DIFFERENT
-     * probe slot (avoid two probes fighting over one pin). */
-    if (prev_ch != channel && (gDioProbeOwnedMask & (1u << channel)) != 0u) {
-        LOG_E("DioProbe: channel %u already owned by another probe",
-              (unsigned)channel);
-        return false;
     }
 
     if (!probe_configure_pin(channel)) {

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -105,9 +105,14 @@ bool DioProbe_AssignToChannel(uint8_t probeId, uint8_t channel,
         if (probeId < DIO_PROBE_STANDARD_COUNT) {
             return DioProbe_Clear(probeId);
         }
-        /* Ad-hoc clear: release pin + slot fields. Mirrors DioProbe_Clear
-         * but skips the DIO_WriteStateSingle restore (ad-hoc probes are
-         * developer-instrumentation; user runtime config doesn't apply). */
+        /* Ad-hoc clear: release pin + slot fields, then restore the
+         * channel's user-DIO state. The original implementation skipped
+         * DIO_WriteStateSingle on the assumption that ad-hoc probes only
+         * touched DIO_10..DIO_15 (no user runtime config). With
+         * DioProbe_AssignToChannel an ad-hoc probe can be remapped onto
+         * any DIO 0..15, including standard channels that DO carry
+         * runtime config — so the restore is required to avoid leaving
+         * a user pin in probe-output state after an OFF. */
         volatile DioProbeSlot_t* s = &gDioProbeSlots[probeId];
         uint8_t prev_ch = s->channel;
         s->mode = DIO_PROBE_MODE_OFF;
@@ -119,6 +124,9 @@ bool DioProbe_AssignToChannel(uint8_t probeId, uint8_t channel,
         s->channel = 0xFF;
         s->mask = 0;
         taskEXIT_CRITICAL();
+        if (prev_ch <= DIO_PROBE_MAX_DIO_CHANNEL) {
+            (void)DIO_WriteStateSingle(prev_ch);
+        }
         recompute_any_active();
         return true;
     }

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -112,11 +112,16 @@ bool DioProbe_AssignToChannel(uint8_t probeId, uint8_t channel,
          * DioProbe_AssignToChannel an ad-hoc probe can be remapped onto
          * any DIO 0..15, including standard channels that DO carry
          * runtime config — so the restore is required to avoid leaving
-         * a user pin in probe-output state after an OFF. */
+         * a user pin in probe-output state after an OFF.
+         *
+         * Read prev_ch and publish mode=OFF INSIDE the CS so a concurrent
+         * AssignToChannel from the other SCPI task can't see a half-torn-
+         * down slot or double-release the same pin. */
         volatile DioProbeSlot_t* s = &gDioProbeSlots[probeId];
-        uint8_t prev_ch = s->channel;
-        s->mode = DIO_PROBE_MODE_OFF;
+        uint8_t prev_ch;
         taskENTER_CRITICAL();
+        prev_ch = s->channel;
+        s->mode = DIO_PROBE_MODE_OFF;
         if (prev_ch <= DIO_PROBE_MAX_DIO_CHANNEL) {
             probe_release_pin(prev_ch);
             gDioProbeOwnedMask &= (uint16_t)~(1u << prev_ch);
@@ -225,17 +230,16 @@ bool DioProbe_Clear(uint8_t probeId) {
         return true;  /* already clear */
     }
 
-    uint8_t channel = slot->channel;
+    uint8_t channel;
 
-    /* Mode=OFF first (stops any further toggles from ISR context),
-     * then wrap everything else in a single critical section: pin
-     * release + owned mask clear + slot field reset all publish
-     * together. Tightens the "owned" invariant — there's no window
-     * where the mask says owned but the pin has already been reverted
-     * to high-Z. probe_release_pin only does SFR writes, safe in CS. */
-    slot->mode = DIO_PROBE_MODE_OFF;
-
+    /* Read channel + publish mode=OFF + release pin + clear slot fields
+     * all under one CS so a concurrent AssignToChannel on the other SCPI
+     * task can't observe a half-torn-down slot or race us into double-
+     * releasing the same pin. probe_release_pin only does SFR writes,
+     * safe in CS. */
     taskENTER_CRITICAL();
+    channel = slot->channel;
+    slot->mode = DIO_PROBE_MODE_OFF;
     if (channel <= DIO_PROBE_MAX_DIO_CHANNEL) {
         probe_release_pin(channel);
         gDioProbeOwnedMask &= (uint16_t)~(1u << channel);

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -77,7 +77,7 @@ void DioProbe_Init(void) {
 
     /* Activate ad-hoc probes whose bit is set in the compile-time
      * enable mask. Default mapping is probe N -> DIO N; remap at
-     * runtime via DioProbe_AssignToChannel / SYST:DIOP:MAP. */
+     * runtime via DioProbe_AssignToChannel / SYST:DIOP:ROUT. */
 #if (DIO_PROBE_ENABLE_MASK) != 0u
     for (uint8_t i = DIO_PROBE_ADHOC_FIRST; i < DIO_PROBE_SLOTS; ++i) {
         if (((DIO_PROBE_ENABLE_MASK) & (1u << i)) == 0u) continue;

--- a/firmware/src/HAL/DioProbe.h
+++ b/firmware/src/HAL/DioProbe.h
@@ -16,7 +16,7 @@
  * 1) STANDARD probes 0..9 — fired by `DioProbe_Toggle(N)` calls in
  *    the streaming/ADC pipeline. Default mapping is probe N -> DIO N
  *    via SCPI `SYSTem:DIOProbe:MODE <probe>,<OFF|TOGGLE|PULSE>`.
- *    Use `SYSTem:DIOProbe:MAP <probe>,<channel>,<mode>` to redirect
+ *    Use `SYSTem:DIOProbe:ROUTe <probe>,<channel>,<mode>` to redirect
  *    any standard probe to any DIO (handy when the LA isn't wired
  *    to DIO_0..DIO_9).
  *
@@ -24,7 +24,7 @@
  *    `DIO_PROBE_TOGGLE(n)` or `DIO_PROBE_PULSE_START(n)/END(n)` into
  *    any code path, set the corresponding bit in
  *    `DIO_PROBE_ENABLE_MASK`, recompile. Default mapping at boot is
- *    probe N -> DIO N. Override at runtime with `SYST:DIOP:MAP` to
+ *    probe N -> DIO N. Override at runtime with `SYST:DIOP:ROUT` to
  *    route the probe to whichever DIO is wired to the LA.
  *
  * Hot-path cost when disabled: one load + branch-if-zero. Zero cost
@@ -109,7 +109,7 @@ bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode);
  *  driver enabled. Rejects if PWM is active on the target channel.
  *
  *  Use cases:
- *    - SCPI `SYST:DIOP:MAP <probeId>,<channel>,<mode>` for ad-hoc
+ *    - SCPI `SYST:DIOP:ROUT <probeId>,<channel>,<mode>` for ad-hoc
  *      remapping during debug.
  *    - Re-routing standard probes 0..9 onto wired DIOs when the LA
  *      doesn't reach DIO_0..DIO_9.

--- a/firmware/src/HAL/DioProbe.h
+++ b/firmware/src/HAL/DioProbe.h
@@ -10,17 +10,22 @@
  * single spurious edge from another code path would make scope
  * measurements untrustworthy.
  *
- * Two probe classes:
+ * Two probe classes (distinguished by who initiates them, NOT by which
+ * DIO they drive — channel mapping is fully flexible at runtime):
  *
- * 1) STANDARD probes 0..9 — permanently wired to streaming pipeline
- *    stages. Mapped 1:1 to DIO_0..DIO_9. Mode set at runtime via
- *    SCPI `SYSTem:DIOProbe:MODE <probe>,<OFF|TOGGLE|PULSE>`
- *    (no abbreviation on MODE — all caps).
+ * 1) STANDARD probes 0..9 — fired by `DioProbe_Toggle(N)` calls in
+ *    the streaming/ADC pipeline. Default mapping is probe N -> DIO N
+ *    via SCPI `SYSTem:DIOProbe:MODE <probe>,<OFF|TOGGLE|PULSE>`.
+ *    Use `SYSTem:DIOProbe:MAP <probe>,<channel>,<mode>` to redirect
+ *    any standard probe to any DIO (handy when the LA isn't wired
+ *    to DIO_0..DIO_9).
  *
  * 2) AD-HOC probes 10..15 — compile-time instrumentation. Drop
  *    `DIO_PROBE_TOGGLE(n)` or `DIO_PROBE_PULSE_START(n)/END(n)` into
  *    any code path, set the corresponding bit in
- *    `DIO_PROBE_ENABLE_MASK`, recompile. Mapped 1:1 to DIO_10..DIO_15.
+ *    `DIO_PROBE_ENABLE_MASK`, recompile. Default mapping at boot is
+ *    probe N -> DIO N. Override at runtime with `SYST:DIOP:MAP` to
+ *    route the probe to whichever DIO is wired to the LA.
  *
  * Hot-path cost when disabled: one load + branch-if-zero. Zero cost
  * for ad-hoc probes whose bit is not set in DIO_PROBE_ENABLE_MASK.
@@ -89,11 +94,30 @@ extern volatile uint16_t gDioProbeOwnedMask;
  *  DIO_InitHardware so default DIO writes settle first. */
 void DioProbe_Init(void);
 
-/*! Assign a standard probe (0..9) to a mode. Channel = probeId.
- *  Forces pin LOW then configures as output with driver enabled.
- *  Rejects if PWM is active on the target channel.
+/*! Assign a standard probe (0..9) to a mode using the default 1:1
+ *  mapping (channel = probeId). Thin wrapper around
+ *  DioProbe_AssignToChannel for backward compatibility.
  *  @return true on success */
 bool DioProbe_Assign(uint8_t probeId, DioProbeMode_t mode);
+
+/*! Assign ANY probe slot (0..15) to ANY DIO channel (0..15) at runtime.
+ *  Decouples probe ID from physical pin so the caller can route a
+ *  probe to whichever DIO is wired to the logic analyzer.
+ *
+ *  Releases the slot's previous channel (if any) before claiming the
+ *  new one. Forces the new pin LOW, configures it as output with
+ *  driver enabled. Rejects if PWM is active on the target channel.
+ *
+ *  Use cases:
+ *    - SCPI `SYST:DIOP:MAP <probeId>,<channel>,<mode>` for ad-hoc
+ *      remapping during debug.
+ *    - Re-routing standard probes 0..9 onto wired DIOs when the LA
+ *      doesn't reach DIO_0..DIO_9.
+ *    - Configuring ad-hoc probes 10..15 to drive arbitrary DIOs
+ *      (overrides the default DIO_PROBE_ENABLE_MASK auto-init mapping).
+ *  @return true on success */
+bool DioProbe_AssignToChannel(uint8_t probeId, uint8_t channel,
+                              DioProbeMode_t mode);
 
 /*! Release a standard probe. Drives pin LOW, clears ownership,
  *  returns channel to normal DIO control. */

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3524,6 +3524,33 @@ static scpi_result_t SCPI_DioProbePipeline(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+static scpi_result_t SCPI_DioProbeMap(scpi_t * context) {
+    int32_t probeId, channel;
+    if (!SCPI_ParamInt32(context, &probeId, TRUE)) return SCPI_RES_ERR;
+    if (probeId < 0 || probeId >= DIO_PROBE_SLOTS) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    if (!SCPI_ParamInt32(context, &channel, TRUE)) return SCPI_RES_ERR;
+    if (channel < 0 || channel > DIO_PROBE_MAX_DIO_CHANNEL) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    const char* modeStr;
+    size_t modeLen;
+    if (!SCPI_ParamCharacters(context, &modeStr, &modeLen, TRUE)) return SCPI_RES_ERR;
+    DioProbeMode_t mode;
+    if (!dioprobe_parse_mode(modeStr, modeLen, &mode)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    if (!DioProbe_AssignToChannel((uint8_t)probeId, (uint8_t)channel, mode)) {
+        SCPI_ExecutionError(context, "SYST:DIOP:ROUT: assign failed (PWM active or channel owned?)");
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
 static scpi_result_t SCPI_DioProbeList(scpi_t * context) {
     for (uint8_t i = 0; i < DIO_PROBE_SLOTS; ++i) {
         DioProbeSlot_t s;
@@ -4254,6 +4281,7 @@ static const scpi_command_t scpi_commands[] = {
     // DIO debug probe framework
     {.pattern = "SYSTem:DIOProbe:MODE", .callback = SCPI_DioProbeModeSet,},
     {.pattern = "SYSTem:DIOProbe:MODE?", .callback = SCPI_DioProbeModeGet,},
+    {.pattern = "SYSTem:DIOProbe:ROUTe", .callback = SCPI_DioProbeMap,},
     {.pattern = "SYSTem:DIOProbe:CLEar", .callback = SCPI_DioProbeClear,},
     {.pattern = "SYSTem:DIOProbe:CLEar:ALL", .callback = SCPI_DioProbeClearAll,},
     {.pattern = "SYSTem:DIOProbe:PIPELine", .callback = SCPI_DioProbePipeline,},


### PR DESCRIPTION
## Summary

- New `DioProbe_AssignToChannel(probeId, channel, mode)` API decouples probe ID from physical DIO channel — any probe slot 0..15 can drive any DIO 0..15 at runtime.
- New SCPI command `SYSTem:DIOProbe:ROUTe <probe>,<channel>,<mode>` (abbrev `SYST:DIOP:ROUT`) exposes runtime remapping.
- `DioProbe_Assign` and the `DIO_PROBE_ENABLE_MASK` auto-init loop both refactored to funnel through `AssignToChannel`, deduplicating the publication protocol.

## Why

The probe framework used to hardcode probe N -> DIO N. That broke when the bench logic analyzer only had 8 channels wired to DIO_0..DIO_7 but the streaming pipeline already owned probes 0..2, leaving no headroom to instrument new code paths on the wired DIOs. Runtime remapping fixes this without changing the wiring or the existing 1:1 default for callers that don't care.

Applies to standard probes 0..9 (firmware-driven pipeline events) and ad-hoc probes 10..15 (compile-time `DIO_PROBE_TOGGLE(N)` macros). Both classes pick up the same flexibility for free since they share the slot table.

## Test plan

- [x] Build clean on default config (NQ1)
- [x] Bench-test on NQ1 hardware:
  - Map standard probe 0 to DIO_5 then DIO_4 — release/claim sequence works
  - Map ad-hoc probe 13 to DIO_3 with `DIO_PROBE_ENABLE_MASK` bit 13 set
  - Conflict rejection: claim already-owned DIO returns `-200 Execution error`
  - `OFF` mode via ROUTe clears slot
  - Out-of-range probeId / channel / bogus mode all return `-224`
- [x] Verified existing `MODE`, `CLEar`, `PIPELine`, `LIST?` unchanged
- [ ] Qodo review

## Note on testing

After IPE flash, the new SCPI command requires one `SYST:REBoot` before the libscpi context picks up the new pattern table — see `feedback_post_flash_softreboot.md` in project memory. Same root cause as #406 (retained-RAM after MCLR reset). Not introduced by this PR; just a heads-up for reviewers running on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)