### PR TITLE
fix(init,power): defensive zero-init + volatile cross-context state (#409 + #410)

### DIFF
--- a/firmware/src/HAL/Power/PowerApi.c
+++ b/firmware/src/HAL/Power/PowerApi.c
@@ -6,6 +6,7 @@
 #define LOG_MODULE LOG_MODULE_POWER
 
 #include "HAL/Power/PowerApi.h"
+#include <string.h>  /* memset (#409 retained-RAM defensive init) */
 #include "definitions.h"
 #include "state/board/BoardConfig.h"
 #include "state/data/BoardData.h"
@@ -118,9 +119,16 @@ void Power_Init(
     pData = pInitData;
     pWriteVariables = pInitVars;
 
-    // NOTE: This is called before the RTOS is running.  
+    /* Defensive zero-init for retained-RAM safety (#409). tPowerData and
+     * tPowerWriteVars live in COHERENTBSS / kseg0 best-fit .bss.* — neither
+     * is zeroed by crt0, so values survive MCLR / IPE flash unless we wipe
+     * them here. */
+    memset(pData, 0, sizeof(*pData));
+    memset(pWriteVariables, 0, sizeof(*pWriteVariables));
+
+    // NOTE: This is called before the RTOS is running.
     // Don't call any RTOS functions here!
-    
+
     // Initialize auto external power control (enabled by default)
     pData->autoExtPowerEnabled = true;
     

--- a/firmware/src/HAL/Power/PowerApi.h
+++ b/firmware/src/HAL/Power/PowerApi.h
@@ -91,8 +91,13 @@ typedef struct sPowerConfig{
 typedef struct sPowerData{
 
     uint8_t chargePct;
-    POWER_STATE powerState;
-    POWER_STATE_REQUEST requestedPowerState;
+    /* volatile: written by app_PowerAndUITask (pri 7), read across loop
+     * iterations by app_WifiTask (pri 2) and app_SDCardTask (pri 5).
+     * Function-call compiler-barriers in those loops currently force
+     * re-loads each iteration at -O3, so this is defense-in-depth
+     * against future inlining or refactoring. See #410. */
+    volatile POWER_STATE powerState;
+    volatile POWER_STATE_REQUEST requestedPowerState;
     EXT_POWER_SOURCE externalPowerSource;
 
     // Variables below are meant to be updated externally

--- a/firmware/src/HAL/UI/UI.c
+++ b/firmware/src/HAL/UI/UI.c
@@ -13,6 +13,7 @@
 /* ************************************************************************** */
 
 #include "UI.h"
+#include <string.h>  /* memset (#409 retained-RAM defensive init) */
 #include "state/runtime/StreamingRuntimeConfig.h"
 
 #define UI_TASK_CALLING_PRD 100 //  100ms
@@ -31,14 +32,19 @@ static tUIReadVars *gpReadVariables;
 //! Pointer to the data structure where the UI Power Data will be stored
 static tPowerData *gpPowerData;
 
-void UI_Init(                                                               
-                tUIConfig *pConfigInit,                                     
-                tUIReadVars *pReadVarsInit,                                 
+void UI_Init(
+                tUIConfig *pConfigInit,
+                tUIReadVars *pReadVarsInit,
                 tPowerData *pPowerDataInit )
 {
     gpConfig = pConfigInit;
     gpReadVariables = pReadVarsInit;
     gpPowerData = pPowerDataInit;
+
+    /* Defensive zero of the UI read-vars struct (LED1/LED2/button bools).
+     * Lives in retained RAM; without this, button state could be
+     * misread immediately at boot before the first GPIO read. See #409. */
+    memset(pReadVarsInit, 0, sizeof(*pReadVarsInit));
 }
 
 void Button_Tasks( void )

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -534,7 +534,14 @@ void app_SystemInit() {
                 DaqifiSettings_UserAInCalParams,
                 &gpBoardRuntimeConfig->AInChannels);
     }
-    // Power initialization - enables 3.3V rail by default - other power 
+    /* Defensive boot-time zero-init of file-static module state for
+     * subsystems whose globals live in retained-RAM regions (kseg0
+     * best-fit `.bss.*` outside `_bss_begin..end`, COHERENTBSS in
+     * kseg1). crt0 does not zero those; without these calls the
+     * statics retain values across MCLR / IPE flash. See #409. */
+    wifi_manager_BootInit();
+
+    // Power initialization - enables 3.3V rail by default - other power
     // functions are in power task
     Power_Init(&gpBoardConfig->PowerConfig,
             &gpBoardData->PowerData,

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -922,6 +922,11 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     gFlowWindowOverride = 0;
     gQuesBits = 0;
     gInTimerHandler = false;
+    /* buffer/bufferSize are file-statics that may also live in
+     * retained-RAM. Reset before the `if (buffer == NULL)` guard
+     * below so a stale non-NULL pointer doesn't skip the pool fetch. */
+    buffer = NULL;
+    bufferSize = 0;
 
     gpStreamingConfig = pStreamingConfigInit;
     gpRuntimeConfigStream = pStreamingRuntimeConfigInit;

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -904,6 +904,25 @@ static void Streaming_Stop(void) {
 
 void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
         StreamingRuntimeConfig* pStreamingRuntimeConfigInit) {
+    /* Defensive zero-init for retained-RAM safety (#409). With -fdata-sections
+     * each file-static lands in its own .bss.<name> section, often placed by
+     * the best-fit allocator OUTSIDE [_bss_begin,_bss_end] — so the
+     * compile-time `= 0` initializers are not honored across MCLR / IPE flash.
+     * No critical section needed: this runs pre-scheduler with interrupts off. */
+    gTestPattern = 0;
+    gTestPatternSampleCount = 0;
+    gBenchmarkMode = BENCHMARK_OFF;
+    gSdPbMetadataSent = false;
+    gSdFileWasReady = false;
+    memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
+    gTimerISRCalls = 0;
+    memset(gFlowWindow, 0, sizeof(gFlowWindow));
+    gFlowWindowCount = 0;
+    gFlowWindowSize = FLOW_WINDOW_MIN;
+    gFlowWindowOverride = 0;
+    gQuesBits = 0;
+    gInTimerHandler = false;
+
     gpStreamingConfig = pStreamingConfigInit;
     gpRuntimeConfigStream = pStreamingRuntimeConfigInit;
 

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1342,6 +1342,23 @@ void fwUpdateTask(void *pvParameters) {
     }
 }
 
+void wifi_manager_BootInit(void) {
+    /* Defensive zero-init of every file-static in this module so retained
+     * RAM doesn't leak across MCLR / IPE flash (#409). Must run BEFORE
+     * the scheduler starts and BEFORE wifi_manager_Init can be called.
+     * No locking needed — pre-scheduler, single-threaded. */
+    memset(&gStateMachineContext, 0, sizeof(gStateMachineContext));
+    memset(&gTcpServerContext, 0, sizeof(gTcpServerContext));
+    memset(&gProcessStateMutexBuf, 0, sizeof(gProcessStateMutexBuf));
+    gEventQH = NULL;
+    gProcessStateMutex = NULL;
+    gRssiUpdatePending = false;
+    gRssiUpdateComplete = false;
+    gTcpRxPending = false;
+    gLastRssiPercentage = 0;
+    gWifiReinitDeadlineTick = 0;
+}
+
 bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
 
     // Init order matters: mutex first (so ProcessState calls before queue

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -179,6 +179,20 @@ extern "C" {
      * @return True if initialization is successful, false otherwise.
      */
     bool wifi_manager_Init(wifi_manager_settings_t* settings);
+
+    /**
+     * @brief Boot-time defensive zero-init of file-static module state.
+     *
+     * Called once from app_freertos.c BEFORE the scheduler starts and
+     * before the WiFi task can run. Zeroes module-level state (state
+     * machine context, FreeRTOS handles, RSSI flags, etc.) so retained
+     * RAM (kseg0 best-fit `.bss.*` outside `_bss_begin..end`) cannot
+     * leak across MCLR / IPE flash. See #409.
+     *
+     * Distinct from `wifi_manager_Init`, which is re-entrant and runs
+     * after the scheduler is up.
+     */
+    void wifi_manager_BootInit(void);
     /**
      * @brief Reads the Wi-Fi chip information and populates the provided structure.
      *


### PR DESCRIPTION
## Summary

Closes #409 and #410. Bundles two related defensive-coding fixes that together kill the retained-RAM + compiler-cache bug class that produced #406's auto-power-up + LED-off symptom under -O3 + IPE flash.

## Why bundled

PR #413 (just the volatile change) was merged into this branch's base, then accidentally overwritten by a force-push during rebase. Rather than re-split, the volatile commit was cherry-picked back onto this branch — same code lands either way.

## What's in this PR

### Defensive zero-init in subsystem inits (#409)

| Module | Function | Approach |
|---|---|---|
| Power | `Power_Init` | `memset(pData)` + `memset(pWriteVariables)` |
| Streaming | `Streaming_Init` | Per-static reset of `gTimerISRCalls`, `gQuesBits`, `gFlowWindow`, `gStreamStats`, `gTestPattern`, `gBenchmarkMode`, `buffer`, `bufferSize`, etc. |
| WiFi | `wifi_manager_BootInit` (NEW) | New separate boot-time function so re-entrant `wifi_manager_Init` doesn't memset live FreeRTOS handles |
| UI | `UI_Init` | `memset(pReadVarsInit)` |

All run pre-scheduler with interrupts off — no critical section needed.

### Volatile cross-context state (#410)

`tPowerData.powerState` and `tPowerData.requestedPowerState` are now `volatile`. Written by `app_PowerAndUITask` (pri 7), read across loop iterations by `app_WifiTask` (pri 2) and `app_SDCardTask` (pri 5). Current consumer loops contain external function calls that act as compiler barriers, so this is defense-in-depth against future inlining or refactoring.

### Decision: drop `debug/406-coherent-bss-zero`
That branch defensively zeroed all 505 KB at boot. The per-module `memset` discipline in this PR covers the same bug class with smaller scope. Two patches preserved in `/tmp/daqifi-firmware-patches/` as a safety net.

## Test plan

- [x] Build clean — no new warnings, hex generated (1.66 MB, same as baseline)
- [x] Code review (pre-PR gate): 0 findings
- [x] Security review: 0 findings
- [x] Qodo `/improve` + `/agentic_review`: 0 bugs, 0 rule violations. One requirement gap (missing `docs/UNINIT_AUDIT.md` / `VOLATILE_AUDIT.md`) intentionally skipped — audits performed and findings applied as code, but the docs themselves were not committed per project convention ("we don't need to generate analysis docs or the like unless asked")
- [ ] Hardware: flash on the bench, power-cycle through `*RST`, IPE re-flash, verify no auto-power-up regression

## Follow-up (separate PRs)

- **CI: cppcheck on push/PR.** A `tools/lint/cppcheck.sh` wrapper was prototyped during the audit but pulled from this PR — without CI enforcement it's deadweight. Will be added with a GitHub Actions workflow + CLAUDE.md docs as a dedicated PR.
- **Apply defensive-init pattern to remaining `*_Init` candidates**: `ADC_Init`, `DAC7718_Init`, `TimerApi_Initialize`, `OcmpApi_Initialize`, `Iperf2_Initialize`, `wifi_tcp_server_Initialize`. Lower priority — state is smaller or only read after explicit setup.

Closes #409
Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)