### PR TITLE
fix(power): mark tPowerData state fields volatile (#410)

### DIFF
--- a/firmware/src/HAL/Power/PowerApi.h
+++ b/firmware/src/HAL/Power/PowerApi.h
@@ -91,8 +91,13 @@ typedef struct sPowerConfig{
 typedef struct sPowerData{
 
     uint8_t chargePct;
-    POWER_STATE powerState;
-    POWER_STATE_REQUEST requestedPowerState;
+    /* volatile: written by app_PowerAndUITask (pri 7), read across loop
+     * iterations by app_WifiTask (pri 2) and app_SDCardTask (pri 5).
+     * Function-call compiler-barriers in those loops currently force
+     * re-loads each iteration at -O3, so this is defense-in-depth
+     * against future inlining or refactoring. See #410. */
+    volatile POWER_STATE powerState;
+    volatile POWER_STATE_REQUEST requestedPowerState;
     EXT_POWER_SOURCE externalPowerSource;
 
     // Variables below are meant to be updated externally


### PR DESCRIPTION
## Summary

Defense-in-depth `volatile` qualifier for cross-task power state fields, plus the audit doc that motivated it. **Stacked on top of #412 (audit/409-uninit) — merge that first.**

## What's in this PR

### Audit — `docs/VOLATILE_AUDIT.md`
ISR ↔ task and cross-task globals audit per #410 scope.

**Findings:**
- **12 ISR ↔ task variables** — all SAFE (volatile + atomic, or RMW protected by `taskENTER_CRITICAL`)
- **9 cross-task globals** — 8 SAFE
- **1 defensive recommendation**: `tPowerData.powerState` and `requestedPowerState` not declared `volatile`. Written by `app_PowerAndUITask` (pri 7), read across loop iterations by `app_WifiTask` (pri 2) and `app_SDCardTask` (pri 5).

**No bugs.** The agent first-pass flagged `powerState` as a NEEDS-VOLATILE bug; verification on `app_freertos.c:236–263` and `:344–414` showed the consumer loops contain external function calls (`wifi_manager_ProcessState`, `vTaskDelay`, `DRV_SDSPI_Tasks`) that act as compiler barriers, forcing re-loads each iteration even at -O3.

### Fix — `volatile POWER_STATE` on the two fields
Adds `volatile` to `tPowerData.powerState` and `tPowerData.requestedPowerState`. Defensive change — protects against future inlining or refactor that removes a function-call barrier from a power-state-checking loop. Cost: 1-line struct decl change; no performance impact.

## Test plan

- [x] Build clean on `audit/410-volatile` — no new warnings, hex generated
- [x] Code review (pre-PR gate): 0 findings
- [x] Security review: 0 findings (volatile qualifier is a compiler hint, no new attack surface)
- [ ] Hardware smoke test post-merge

## Stacking note

This PR depends on #412. After #412 merges, GitHub will automatically retarget this PR onto `main`. If you'd prefer to merge them in one shot, squash-merge #412 first, then this one will rebase cleanly.

Refs #410, #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)