### PR TITLE
ci(cppcheck): add static-analysis gate on PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -47,3 +47,10 @@
 Makefile text eol=lf
 makefile text eol=lf
 *.mk text eol=lf
+
+# CI-consumed files must stay LF regardless of the .txt/.yml defaults
+# above — Linux runners compare these byte-for-byte and a stray CR
+# would fail the cppcheck baseline diff.
+.github/workflows/*.yml text eol=lf
+tools/lint/cppcheck-baseline.txt text eol=lf
+tools/lint/cppcheck-suppress.txt text eol=lf

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,6 +14,9 @@ on:
       - 'tools/lint/**'
       - '.github/workflows/cppcheck.yml'
 
+permissions:
+  contents: read   # only checking out + running a local tool, no writes
+
 jobs:
   lint:
     name: Static analysis
@@ -23,10 +26,23 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install cppcheck
+        env:
+          # Pin the version we developed/baselined against. Future Ubuntu
+          # apt updates that bump cppcheck can change output for the same
+          # source — without this gate, that would silently fail every PR
+          # until someone regenerates the baseline.
+          EXPECTED_CPPCHECK_VERSION: "Cppcheck 2.13.0"
         run: |
           sudo apt-get update
           sudo apt-get install -y cppcheck
-          cppcheck --version
+          ACTUAL=$(cppcheck --version)
+          echo "$ACTUAL"
+          if [ "$ACTUAL" != "$EXPECTED_CPPCHECK_VERSION" ]; then
+            echo "::error::cppcheck version drift — got '$ACTUAL', expected '$EXPECTED_CPPCHECK_VERSION'"
+            echo "Either bump EXPECTED_CPPCHECK_VERSION in this workflow + regenerate the baseline,"
+            echo "or pin runs-on to an Ubuntu image that still ships the expected version."
+            exit 1
+          fi
 
       - name: Run cppcheck
         run: bash tools/lint/cppcheck.sh /tmp/cppcheck-current.txt

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -33,7 +33,11 @@ jobs:
 
       - name: Compare against committed baseline
         run: |
-          if diff -u tools/lint/cppcheck-baseline.txt /tmp/cppcheck-current.txt; then
+          # --strip-trailing-cr makes the comparison robust against
+          # CRLF stragglers from .gitattributes drift on Windows-edited
+          # files. The baseline + suppress + workflow files are pinned
+          # to LF in .gitattributes, but this is a cheap safety net.
+          if diff -u --strip-trailing-cr tools/lint/cppcheck-baseline.txt /tmp/cppcheck-current.txt; then
             echo "✓ Cppcheck baseline unchanged ($(wc -l < tools/lint/cppcheck-baseline.txt) lines)"
             exit 0
           fi

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,53 @@
+name: cppcheck
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'firmware/src/**'
+      - 'tools/lint/**'
+      - '.github/workflows/cppcheck.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'firmware/src/**'
+      - 'tools/lint/**'
+      - '.github/workflows/cppcheck.yml'
+
+jobs:
+  lint:
+    name: Static analysis
+    runs-on: ubuntu-24.04   # ships cppcheck 2.13.0 — matches the baseline
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cppcheck
+          cppcheck --version
+
+      - name: Run cppcheck
+        run: bash tools/lint/cppcheck.sh /tmp/cppcheck-current.txt
+
+      - name: Compare against committed baseline
+        run: |
+          if diff -u tools/lint/cppcheck-baseline.txt /tmp/cppcheck-current.txt; then
+            echo "✓ Cppcheck baseline unchanged ($(wc -l < tools/lint/cppcheck-baseline.txt) lines)"
+            exit 0
+          fi
+
+          echo ""
+          echo "::error::cppcheck findings differ from committed baseline"
+          echo ""
+          echo "If new findings appeared (lines starting with '+'):"
+          echo "  - Real bug → fix it"
+          echo "  - False positive → add to tools/lint/cppcheck-suppress.txt"
+          echo ""
+          echo "If existing findings were resolved (lines starting with '-'):"
+          echo "  - Regenerate the baseline:"
+          echo "      bash tools/lint/cppcheck.sh"
+          echo "    and commit the updated tools/lint/cppcheck-baseline.txt"
+          echo ""
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,40 @@ The XC32 linker script (`p32MZ2048EFM144.ld`) uses a "best-fit allocator" for `.
 
 **When upgrading XC32 or third-party libraries**, try removing source patches 1 and 3 and rebuild with -Werror. If the build passes clean, the patches can be deleted. The FreeRTOS O1 override should be kept regardless of compiler version.
 
+### Static Analysis (cppcheck)
+
+`tools/lint/cppcheck.sh` runs cppcheck on `firmware/src/` excluding
+third-party (`third_party/`, `libraries/`, `config/`). The committed
+baseline `tools/lint/cppcheck-baseline.txt` is the accepted finding
+set; suppressions live in `tools/lint/cppcheck-suppress.txt`.
+
+Run locally:
+
+```bash
+bash tools/lint/cppcheck.sh
+```
+
+CI gate: `.github/workflows/cppcheck.yml` runs on every PR push that
+touches `firmware/src/**` or `tools/lint/**` and **fails the check
+if the new output differs from the committed baseline** (added
+findings = potential bugs; removed findings = baseline drift). The
+runner is Ubuntu 24.04 (cppcheck 2.13.0) — same version we develop
+against locally.
+
+When the gate fails:
+- New findings (`+` lines in the diff) → either fix the bug or, if
+  it's a false positive, add a suppression to
+  `tools/lint/cppcheck-suppress.txt` and regenerate the baseline.
+- Removed findings (`-` lines) → someone fixed an existing finding;
+  regenerate the baseline (`bash tools/lint/cppcheck.sh`) and commit
+  the updated `cppcheck-baseline.txt`.
+
+The current baseline is 2 style findings (both in
+`firmware/src/services/wifi_services/wifi_serial_bridge.c` —
+ergonomic, not bugs). The suppression file documents the
+DioProbe.c array-bounds false positive and the FreeRTOS portmacro
+FPU-guard `#error` (chip-specific macro that cppcheck doesn't see).
+
 ### Programming with PICkit 4 from Command Line
 1. Connect PICkit 4 to the device
 2. Use ipecmd to program the hex file:

--- a/tools/lint/cppcheck-baseline.txt
+++ b/tools/lint/cppcheck-baseline.txt
@@ -1,0 +1,6 @@
+firmware/src/services/wifi_services/wifi_serial_bridge.c:65:19: style: The scope of the variable 'cnt' can be reduced. [variableScope]
+    uint_fast16_t cnt;
+                  ^
+firmware/src/services/wifi_services/wifi_serial_bridge.c:155:69: style: Parameter 'pContext' can be declared as pointer to const [constParameterPointer]
+void wifi_serial_bridge_Deinit(wifi_serial_bridge_context_t * const pContext) {
+                                                                    ^

--- a/tools/lint/cppcheck-baseline.txt
+++ b/tools/lint/cppcheck-baseline.txt
@@ -1,6 +1,2 @@
 firmware/src/services/wifi_services/wifi_serial_bridge.c:65:19: style: The scope of the variable 'cnt' can be reduced. [variableScope]
-    uint_fast16_t cnt;
-                  ^
 firmware/src/services/wifi_services/wifi_serial_bridge.c:155:69: style: Parameter 'pContext' can be declared as pointer to const [constParameterPointer]
-void wifi_serial_bridge_Deinit(wifi_serial_bridge_context_t * const pContext) {
-                                                                    ^

--- a/tools/lint/cppcheck-baseline.txt
+++ b/tools/lint/cppcheck-baseline.txt
@@ -1,2 +1,2 @@
-firmware/src/services/wifi_services/wifi_serial_bridge.c:65:19: style: The scope of the variable 'cnt' can be reduced. [variableScope]
 firmware/src/services/wifi_services/wifi_serial_bridge.c:155:69: style: Parameter 'pContext' can be declared as pointer to const [constParameterPointer]
+firmware/src/services/wifi_services/wifi_serial_bridge.c:65:19: style: The scope of the variable 'cnt' can be reduced. [variableScope]

--- a/tools/lint/cppcheck-suppress.txt
+++ b/tools/lint/cppcheck-suppress.txt
@@ -1,0 +1,14 @@
+# Cppcheck suppressions — false positives + accepted findings.
+# Format: <id>:<file>:<line>   (line optional)
+# Tracked here instead of in-source so the diff stays out of firmware code.
+
+# DioProbe.c:120 — cppcheck flow analysis can't see that probeId is bounded
+# by DIO_PROBE_SLOTS (16) at the function entry, so it warns about a path
+# where probeId could be 17. Verified safe by code review (#409).
+arrayIndexOutOfBoundsCond:firmware/src/HAL/DioProbe.c
+
+# FreeRTOS portmacro.h:150 — cppcheck doesn't define the chip-specific
+# FPU support macro (__PIC32_HAS_FPU64 etc.) so it triggers the
+# guard #error meant to fire on parts without an FPU. PIC32MZ EFM
+# does have hardware FPU — the build sets the macro correctly.
+preprocessorErrorDirective:firmware/src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ/portmacro.h

--- a/tools/lint/cppcheck-suppress.txt
+++ b/tools/lint/cppcheck-suppress.txt
@@ -5,7 +5,7 @@
 # DioProbe.c:120 — cppcheck flow analysis can't see that probeId is bounded
 # by DIO_PROBE_SLOTS (16) at the function entry, so it warns about a path
 # where probeId could be 17. Verified safe by code review (#409).
-arrayIndexOutOfBoundsCond:firmware/src/HAL/DioProbe.c
+arrayIndexOutOfBoundsCond:firmware/src/HAL/DioProbe.c:120
 
 # FreeRTOS portmacro.h:150 — cppcheck doesn't define the chip-specific
 # FPU support macro (__PIC32_HAS_FPU64 etc.) so it triggers the

--- a/tools/lint/cppcheck-suppress.txt
+++ b/tools/lint/cppcheck-suppress.txt
@@ -2,10 +2,16 @@
 # Format: <id>:<file>:<line>   (line optional)
 # Tracked here instead of in-source so the diff stays out of firmware code.
 
-# DioProbe.c:120 — cppcheck flow analysis can't see that probeId is bounded
+# DioProbe.c — cppcheck flow analysis can't see that probeId is bounded
 # by DIO_PROBE_SLOTS (16) at the function entry, so it warns about a path
-# where probeId could be 17. Verified safe by code review (#409).
-arrayIndexOutOfBoundsCond:firmware/src/HAL/DioProbe.c:120
+# where probeId could be 17. The actual access site is around line 120;
+# scoped to the whole file (not :120) because line-pinned suppressions
+# break on any edit above the warning, causing CI flap on harmless
+# refactors. The accepted trade-off: a real array-bounds bug elsewhere
+# in DioProbe.c (small file, <300 lines) would be caught by code review
+# and the manual audits in #409 — losing some cppcheck signal here is
+# cheaper than a flaky gate. Verified safe by code review (#409).
+arrayIndexOutOfBoundsCond:firmware/src/HAL/DioProbe.c
 
 # FreeRTOS portmacro.h:150 — cppcheck doesn't define the chip-specific
 # FPU support macro (__PIC32_HAS_FPU64 etc.) so it triggers the

--- a/tools/lint/cppcheck.sh
+++ b/tools/lint/cppcheck.sh
@@ -38,9 +38,14 @@ cppcheck \
   -I firmware/src/third_party/rtos/FreeRTOS/Source/include \
   -I firmware/src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ \
   -DHAVE_CONFIG_H \
-  -j"$(nproc)" \
   firmware/src/ 2>"$OUT"
+# Note: no -j flag — parallel cppcheck emits findings in non-deterministic
+# order, which makes the CI baseline diff flaky. The whole-tree scan is
+# fast enough single-threaded (~10 s) that the determinism is worth more
+# than the parallelism.
 
 echo "Findings: $(wc -l < "$OUT") lines → $OUT"
 echo "By severity:"
-grep -oE '\[[a-zA-Z]+\]' "$OUT" | sort | uniq -c | sort -rn | head -20
+# `|| true` so the script doesn't exit non-zero under `set -euo pipefail`
+# when there are zero findings (grep returns 1 when nothing matches).
+grep -oE '\[[a-zA-Z]+\]' "$OUT" | sort | uniq -c | sort -rn | head -20 || true

--- a/tools/lint/cppcheck.sh
+++ b/tools/lint/cppcheck.sh
@@ -17,7 +17,16 @@ cd "$(git rev-parse --show-toplevel)"
 
 OUT="${1:-tools/lint/cppcheck-baseline.txt}"
 
-LC_ALL=C LANG=C cppcheck \
+# Capture cppcheck output to a temp file first, then sort into the final
+# OUT path. Sorting (LC_ALL=C bytewise) eliminates baseline drift from
+# filesystem-traversal-order differences across runners and OSes.
+TMP_OUT="$(mktemp)"
+trap 'rm -f "$TMP_OUT"' EXIT
+
+# `if !` so set -e doesn't abort on cppcheck failure; we want to surface
+# cppcheck's own error output (which goes to TMP_OUT via stderr) before
+# exiting, otherwise CI just shows "step failed" with no diagnostic.
+if ! LC_ALL=C LANG=C cppcheck \
   --quiet \
   --template='{file}:{line}:{column}: {severity}: {message} [{id}]' \
   --enable=warning,style,performance,portability \
@@ -40,11 +49,16 @@ LC_ALL=C LANG=C cppcheck \
   -I firmware/src/third_party/rtos/FreeRTOS/Source/include \
   -I firmware/src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ \
   -DHAVE_CONFIG_H \
-  firmware/src/ 2>"$OUT"
+  firmware/src/ 2>"$TMP_OUT"; then
+  echo "::error::cppcheck exited non-zero — captured output below:"
+  cat "$TMP_OUT"
+  exit 1
+fi
 # Note: no -j flag — parallel cppcheck emits findings in non-deterministic
-# order, which makes the CI baseline diff flaky. The whole-tree scan is
-# fast enough single-threaded (~10 s) that the determinism is worth more
-# than the parallelism.
+# order, which sort below would normalize anyway, but single-threaded is
+# also a belt-and-suspenders against any future ordering oddities.
+
+LC_ALL=C sort "$TMP_OUT" >"$OUT"
 
 echo "Findings: $(wc -l < "$OUT") lines → $OUT"
 echo "By severity:"

--- a/tools/lint/cppcheck.sh
+++ b/tools/lint/cppcheck.sh
@@ -18,6 +18,8 @@ cd "$(git rev-parse --show-toplevel)"
 OUT="${1:-tools/lint/cppcheck-baseline.txt}"
 
 cppcheck \
+  --quiet \
+  --template='{file}:{line}:{column}: {severity}: {message} [{id}]' \
   --enable=warning,style,performance,portability \
   --inconclusive \
   --suppressions-list=tools/lint/cppcheck-suppress.txt \

--- a/tools/lint/cppcheck.sh
+++ b/tools/lint/cppcheck.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Reproducible cppcheck wrapper for the firmware tree.
+# Used by audits #409 (uninit RAM) and #410 (volatile qualifier),
+# and by CI to gate PRs against new findings.
+#
+# Excludes third-party trees that we don't own:
+#   - firmware/src/third_party (FreeRTOS, wolfSSL, nanopb, zlib)
+#   - firmware/src/libraries (scpi, microrl)
+#   - firmware/src/config (Harmony-generated)
+#
+# Suppressions file: tools/lint/cppcheck-suppress.txt
+# Include paths derived from firmware/daqifi.X/nbproject/Makefile-default.mk.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+OUT="${1:-tools/lint/cppcheck-baseline.txt}"
+
+cppcheck \
+  --enable=warning,style,performance,portability \
+  --inconclusive \
+  --suppressions-list=tools/lint/cppcheck-suppress.txt \
+  --suppress=missingIncludeSystem \
+  --suppress=unusedFunction \
+  --suppress=unusedStructMember \
+  -i firmware/src/third_party \
+  -i firmware/src/libraries \
+  -i firmware/src/config \
+  -I firmware/src \
+  -I firmware/src/config/default \
+  -I firmware/src/config/default/driver/winc/include \
+  -I firmware/src/config/default/driver/winc/include/dev \
+  -I firmware/src/config/default/peripheral/cache \
+  -I firmware/src/config/default/system/fs/fat_fs/file_system \
+  -I firmware/src/config/default/system/fs/fat_fs/hardware_access \
+  -I firmware/src/libraries/scpi/libscpi/inc \
+  -I firmware/src/third_party/rtos/FreeRTOS/Source/include \
+  -I firmware/src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ \
+  -DHAVE_CONFIG_H \
+  -j"$(nproc)" \
+  firmware/src/ 2>"$OUT"
+
+echo "Findings: $(wc -l < "$OUT") lines → $OUT"
+echo "By severity:"
+grep -oE '\[[a-zA-Z]+\]' "$OUT" | sort | uniq -c | sort -rn | head -20

--- a/tools/lint/cppcheck.sh
+++ b/tools/lint/cppcheck.sh
@@ -17,7 +17,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 OUT="${1:-tools/lint/cppcheck-baseline.txt}"
 
-cppcheck \
+LC_ALL=C LANG=C cppcheck \
   --quiet \
   --template='{file}:{line}:{column}: {severity}: {message} [{id}]' \
   --enable=warning,style,performance,portability \
@@ -50,4 +50,4 @@ echo "Findings: $(wc -l < "$OUT") lines → $OUT"
 echo "By severity:"
 # `|| true` so the script doesn't exit non-zero under `set -euo pipefail`
 # when there are zero findings (grep returns 1 when nothing matches).
-grep -oE '\[[a-zA-Z]+\]' "$OUT" | sort | uniq -c | sort -rn | head -20 || true
+grep -oE '\[[[:alnum:]_]+\]' "$OUT" | sort | uniq -c | sort -rn | head -20 || true


### PR DESCRIPTION
## Summary

Adds the cppcheck wrapper that was prototyped during the #409/#410 audits (and pulled from #412 because it had no CI), plus a GitHub Actions workflow that enforces it on every PR.

Without CI enforcement the wrapper would be deadweight — a tool that "exists" rather than a tripwire. This PR is what makes it valuable.

## What's in this PR

### `tools/lint/cppcheck.sh`
Reproducible cppcheck wrapper. Excludes third-party trees we don't own (`third_party/`, `libraries/`, `config/` Harmony-generated). Uses our build's include paths.

### `tools/lint/cppcheck-suppress.txt`
Two documented false positives:
- DioProbe.c array-bounds (cppcheck flow analysis can't see the function-entry bound)
- FreeRTOS portmacro.h FPU-guard `#error` (cppcheck doesn't define the chip-specific FPU support macro)

### `tools/lint/cppcheck-baseline.txt`
Current baseline: 2 style findings (both in `wifi_serial_bridge.c`, ergonomic — pre-existing, not bugs).

### `.github/workflows/cppcheck.yml`
- Triggers on PR push and main push, when `firmware/src/**`, `tools/lint/**`, or the workflow itself changes
- Runs on `ubuntu-24.04` (cppcheck 2.13.0 — same version we develop against locally)
- Fails the check if the new output diverges from the committed baseline (added findings = bug; removed findings = baseline drift)
- Failure output guides the contributor through both cases

### CLAUDE.md
New "Static Analysis (cppcheck)" subsection documenting local + CI usage and the resolution path for both failure modes.

## Test plan

- [x] Local: `bash tools/lint/cppcheck.sh` → 2 findings, matches committed baseline
- [x] Build: no firmware code changes, no rebuild needed
- [ ] CI: this PR is the test — the workflow runs against the merged-#412 main as the baseline, expect green
- [ ] Negative test: introduce a deliberate finding in a follow-up commit, confirm CI fails

## Follow-up

If CI passes on this PR, consider:
- Adding `clang-format` or similar formatter check
- Adding the cppcheck status check as **required** in branch protection (currently optional — gives us a chance to see the workflow run cleanly first)

Refs #409, #410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)