### PR TITLE
chore(streaming,interrupts): rip out #421 diag instrumentation

### DIFF
--- a/firmware/src/config/default/interrupts.c
+++ b/firmware/src/config/default/interrupts.c
@@ -184,19 +184,8 @@ void __attribute__((used)) ADC_DATA4_Handler(void) {
     ADC_DATA4_InterruptHandler();
 }
 
-// #421 diagnostic counters: prove whether the broken-set Type 2 ISRs
-// (CH5/6/7/8/11) actually fire at runtime. Read via Streaming_Stop log.
-volatile uint32_t gAdcIsrCount_5  = 0;
-volatile uint32_t gAdcIsrCount_6  = 0;
-volatile uint32_t gAdcIsrCount_7  = 0;
-volatile uint32_t gAdcIsrCount_8  = 0;
-volatile uint32_t gAdcIsrCount_11 = 0;
-volatile uint32_t gAdcIsrCount_24 = 0;  // working — control sample
-volatile uint32_t gAdcIsrCount_38 = 0;  // working — control sample
-
 void __attribute__((used)) ADC_DATA5_Handler (void)
 {
-    gAdcIsrCount_5++;
     if (ADCHS_ChannelResultIsReady(5)) {
         ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(5), 5);
     }
@@ -205,7 +194,6 @@ void __attribute__((used)) ADC_DATA5_Handler (void)
 
 void __attribute__((used)) ADC_DATA6_Handler (void)
 {
-    gAdcIsrCount_6++;
     if (ADCHS_ChannelResultIsReady(6)) {
         ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(6), 6);
     }
@@ -214,7 +202,6 @@ void __attribute__((used)) ADC_DATA6_Handler (void)
 
 void __attribute__((used)) ADC_DATA7_Handler (void)
 {
-    gAdcIsrCount_7++;
     if (ADCHS_ChannelResultIsReady(7)) {
         ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(7), 7);
     }
@@ -223,7 +210,6 @@ void __attribute__((used)) ADC_DATA7_Handler (void)
 
 void __attribute__((used)) ADC_DATA8_Handler (void)
 {
-    gAdcIsrCount_8++;
     if (ADCHS_ChannelResultIsReady(8)) {
         ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(8), 8);
     }
@@ -232,7 +218,6 @@ void __attribute__((used)) ADC_DATA8_Handler (void)
 
 void __attribute__((used)) ADC_DATA11_Handler (void)
 {
-    gAdcIsrCount_11++;
     if (ADCHS_ChannelResultIsReady(11)) {
         ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(11), 11);
     }
@@ -241,7 +226,6 @@ void __attribute__((used)) ADC_DATA11_Handler (void)
 
 void __attribute__((used)) ADC_DATA24_Handler (void)
 {
-    gAdcIsrCount_24++;
     if (ADCHS_ChannelResultIsReady(24)) {
         ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(24), 24);
     }
@@ -274,7 +258,6 @@ void __attribute__((used)) ADC_DATA27_Handler (void)
 
 void __attribute__((used)) ADC_DATA38_Handler (void)
 {
-    gAdcIsrCount_38++;
     if (ADCHS_ChannelResultIsReady(38)) {
         ADC_ReadADCSampleFromISR(ADCHS_ChannelResultGet(38), 38);
     }

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -834,30 +834,6 @@ static void Streaming_Start(void) {
                             (gpRuntimeConfigStream->ChannelScanFreqDiv <= 1);
             MC12b_ConfigureHardwareTrigger(true, hwShared);
 
-            // #421 diagnostic: zero per-channel ISR counters so the Stop-time
-            // log reflects fires from this session only (not cumulative across
-            // boots/streams). Wrapped in a critical section so an
-            // ADC_DATAn_Handler can't read-modify-write its counter between
-            // the load and our store, which would lose the reset.
-            extern volatile uint32_t gAdcIsrCount_5, gAdcIsrCount_6, gAdcIsrCount_7;
-            extern volatile uint32_t gAdcIsrCount_8, gAdcIsrCount_11;
-            extern volatile uint32_t gAdcIsrCount_24, gAdcIsrCount_38;
-            taskENTER_CRITICAL();
-            gAdcIsrCount_5 = gAdcIsrCount_6 = gAdcIsrCount_7 = 0;
-            gAdcIsrCount_8 = gAdcIsrCount_11 = 0;
-            gAdcIsrCount_24 = gAdcIsrCount_38 = 0;
-            taskEXIT_CRITICAL();
-
-            // #421 diagnostic: dump SFRs immediately after trigger config so we
-            // can see how the Type 2 scan list (CSS1/2) and CH5/6/7/8/11 IRQ
-            // enable bits are programmed at stream start.
-            LOG_E("diag421-start: hwShared=%d CSS1=0x%x CSS2=0x%x GIRQEN1=0x%x GIRQEN2=0x%x",
-                  (int)hwShared, (unsigned)ADCCSS1, (unsigned)ADCCSS2,
-                  (unsigned)ADCGIRQEN1, (unsigned)ADCGIRQEN2);
-            LOG_E("diag421-start: TRG1=0x%x TRG2=0x%x TRG3=0x%x CON1=0x%x ANCON=0x%x",
-                  (unsigned)ADCTRG1, (unsigned)ADCTRG2, (unsigned)ADCTRG3,
-                  (unsigned)ADCCON1, (unsigned)ADCANCON);
-
             // #292: EOS stays enabled across all modes. The EOS deferred
             // task now reads T1 user channels (moved from ADC_DATA3 ISR),
             // so disabling EOS would break T1 streaming. OBDiag=0 gating
@@ -878,31 +854,10 @@ static void Streaming_Stop(void) {
         TimerApi_Stop(gpStreamingConfig->TimerIndex);
         TimerApi_InterruptDisable(gpStreamingConfig->TimerIndex);
 
-        // #421 diagnostic: read SFRs BEFORE Configure(false,false) reverts them.
-        // Captures the during-streaming peripheral state, which is the actual
-        // moment of the bug. Production firmware needed because mdb's debug
-        // build masks the bug via xc32_monitor BSS-layout shift.
-        LOG_E("diag421: streaming SFRs — CSS1=0x%x GIRQEN1=0x%x DSTAT1=0x%x",
-              (unsigned)ADCCSS1, (unsigned)ADCGIRQEN1, (unsigned)ADCDSTAT1);
-        LOG_E("diag421: streaming SFRs — TRG1=0x%x TRG2=0x%x TRG3=0x%x",
-              (unsigned)ADCTRG1, (unsigned)ADCTRG2, (unsigned)ADCTRG3);
-        LOG_E("diag421: streaming SFRs — CON1=0x%x ANCON=0x%x IEC2=0x%x",
-              (unsigned)ADCCON1, (unsigned)ADCANCON, (unsigned)IEC2);
-
         // Revert ADC to software triggering so non-streaming reads
         // (ADC_Tasks polling) still work.
         MC12b_ConfigureHardwareTrigger(false, false);
         gpRuntimeConfigStream->Running = false;
-
-        // #421 diagnostic: dump per-channel ADC ISR fire counts.
-        extern volatile uint32_t gAdcIsrCount_5, gAdcIsrCount_6, gAdcIsrCount_7;
-        extern volatile uint32_t gAdcIsrCount_8, gAdcIsrCount_11;
-        extern volatile uint32_t gAdcIsrCount_24, gAdcIsrCount_38;
-        LOG_E("diag421: ISR counts CH5=%u CH6=%u CH7=%u CH8=%u CH11=%u | CH24=%u CH38=%u",
-              (unsigned)gAdcIsrCount_5, (unsigned)gAdcIsrCount_6,
-              (unsigned)gAdcIsrCount_7, (unsigned)gAdcIsrCount_8,
-              (unsigned)gAdcIsrCount_11, (unsigned)gAdcIsrCount_24,
-              (unsigned)gAdcIsrCount_38);
 
         // #367 diagnostics: snapshot bytes still sitting in the WiFi TCP
         // circular buffer at session end.  If TotalBytesStreamed -


### PR DESCRIPTION
## Summary

Remove the `diag421` LOG_E spam and per-channel ISR counters that
were left behind after PR #422 (TRGSRC=3 fix) merged. These were
investigation-time diagnostics that survived the squash-merge and
now pollute every `SYST:LOG?` response with stream-start/stop SFR
dumps and ISR-count summaries.

Removed from `firmware/src/services/streaming.c`:
- `Streaming_Start`: `diag421-start` LOG_E SFR dumps + the
  `taskENTER_CRITICAL`-wrapped per-channel counter zero block
- `Streaming_Stop`: `diag421` LOG_E SFR snapshot before
  `Configure(false,false)` revert + the Stop-time ISR-counter dump

Removed from `firmware/src/config/default/interrupts.c`:
- `gAdcIsrCount_5/6/7/8/11/24/38` globals
- The `gAdcIsrCount_*++` increments inside `ADC_DATA{5,6,7,8,11,24,38}_Handler`

Net: -62 lines, no behavioural change.

## Why

Surfaced as Finding 2 during PR #420 wedge-probe testing on 2026-05-07.
With the spam in place every streaming session adds 6 LOG_E lines to
the buffer, making the buffer harder to read for actual diagnostics
(e.g. WiFi error reasons, stack overflow warnings).

## Test plan

- [x] Build clean at -O3
- [x] Bench-flash, run 16ch CSV streaming at 2 kHz × 3 s — verdict FIXED, all 16 channels nonzero (post-strip sanity check before opening this PR)
- [ ] Qodo `/agentic_review` clean
- [ ] Qodo `/improve` clean

## Refs

- Closes the unintentional spam introduced by #422
- #423 (newly filed wifi re-apply false-positive — separate fix)