### PR TITLE
kernel: define configLIST_VOLATILE, drop FreeRTOS_tasks.c -O1 clamp (#426)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,9 @@ The project builds with **-O3** globally, with per-file overrides where needed. 
 
 | File | Optimization | Reason | Permanent? |
 |------|-------------|--------|-----------|
-| `third_party/rtos/FreeRTOS/Source/FreeRTOS_tasks.c` | **-O1** | O2 miscompiles FreeRTOS list operations — `listINSERT_END` stores reordered so `pxContainer` is NULL when `xTaskResumeAll` reads it, causing crash (BadVAddr=4). See Issue #271. | **Yes** — common RTOS practice; kernel perf impact negligible |
 | `third_party/wolfssl/wolfcrypt/src/tfm.c` | -O3 with `-Wno-error=array-bounds` | GCC loses track of loop variable range after inlining in wolfSSL big-number math. Known third-party issue. | No — reevaluate after wolfSSL upgrade (currently pinned to v5.4.0) |
+
+The previous `FreeRTOS_tasks.c -O1` override was replaced (issue #426) by defining `configLIST_VOLATILE volatile` in `FreeRTOSConfig.h` — the upstream-blessed back door for compilers that hoist/reorder stores in `listINSERT_END` at -O2+. The kernel now builds at the global -O3 level alongside the rest of the firmware.
 
 #### Source Patches for -O2/-O3
 
@@ -59,9 +60,9 @@ The project builds with **-O3** globally, with per-file overrides where needed. 
 
 #### Known Linker Issue (Issue #271, informational)
 
-The XC32 linker script (`p32MZ2048EFM144.ld`) uses a "best-fit allocator" for `.bss.*` sections. At O2+ with `-fdata-sections`, this can place variables at two addresses (`.sbss` GP-relative vs `.bss.*` best-fit), causing dual-address bugs. This was the root cause of the O2 FreeRTOS crash. The fix is to keep `FreeRTOS_tasks.c` at O1 (which prevents `.bss.*` section creation for its statics). The linker script is left at Microchip default — no modification needed as long as FreeRTOS stays at O1.
+The XC32 linker script (`p32MZ2048EFM144.ld`) uses a "best-fit allocator" for `.bss.*` sections. At O2+ with `-fdata-sections`, this can place variables at two addresses (`.sbss` GP-relative vs `.bss.*` best-fit), causing dual-address bugs. This was the original symptom that triggered investigation of the O2 FreeRTOS crash, but the actual fix landed elsewhere: defining `configLIST_VOLATILE volatile` in `FreeRTOSConfig.h` forces the kernel's list-item link fields to be volatile, preventing the reorder of `listINSERT_END` stores that was the real cause. With that macro defined, `FreeRTOS_tasks.c` builds cleanly at -O3 alongside the rest of the firmware. The linker script is left at Microchip default.
 
-**When upgrading XC32 or third-party libraries**, try removing source patches 1 and 3 and rebuild with -Werror. If the build passes clean, the patches can be deleted. The FreeRTOS O1 override should be kept regardless of compiler version.
+**When upgrading XC32 or third-party libraries**, try removing source patches 1 and 3 (under "Source Patches for -O2/-O3" above) and rebuild with -Werror. If the build passes clean, the patches can be deleted. The `configLIST_VOLATILE` define should be kept regardless of compiler version — it's the upstream FreeRTOS-blessed pattern, not a workaround.
 
 ### Static Analysis (cppcheck)
 

--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -2275,7 +2275,7 @@
           <property key="oXC16gcc-sfr-warn" value="false"/>
           <property key="oXC16gcc-smar-io-lvl" value="1"/>
           <property key="oXC16gcc-smart-io-fmt" value=""/>
-          <property key="optimization-level" value="-O1"/>
+          <property key="optimization-level" value="-O3"/>
           <property key="place-data-into-section" value="true"/>
           <property key="post-instruction-scheduling" value="default"/>
           <property key="pre-instruction-scheduling" value="default"/>

--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -2275,7 +2275,7 @@
           <property key="oXC16gcc-sfr-warn" value="false"/>
           <property key="oXC16gcc-smar-io-lvl" value="1"/>
           <property key="oXC16gcc-smart-io-fmt" value=""/>
-          <property key="optimization-level" value="-O3"/>
+          <property key="optimization-level" value=""/>
           <property key="place-data-into-section" value="true"/>
           <property key="post-instruction-scheduling" value="default"/>
           <property key="pre-instruction-scheduling" value="default"/>

--- a/firmware/src/config/default/FreeRTOSConfig.h
+++ b/firmware/src/config/default/FreeRTOSConfig.h
@@ -54,6 +54,17 @@
  * calculated from the configCPU_CLOCK_HZ value. */
 #define configTICK_RATE_HZ                      ( ( TickType_t ) 1000 )
 
+/* Force list-item link fields (pxNext/pxPrevious/pxContainer/xItemValue) to
+ * be volatile — upstream-blessed back door for compilers that hoist/reorder
+ * stores in listINSERT_END at -O2 and above. Without this, GCC at -O3 on
+ * MIPS reordered the listINSERT_END stores so xTaskResumeAll → listREMOVE_ITEM
+ * read NULL pxContainer and crashed (see issue #271). The previous fix was a
+ * per-file -O1 override on FreeRTOS_tasks.c; defining this macro lets that
+ * file go to -O3 like the rest of the kernel.
+ *
+ * Source: https://forums.freertos.org/t/configlist-volatile-required-missing-configassert-in-listremove-item/16400 */
+#define configLIST_VOLATILE                     volatile
+
 /* Set configUSE_PREEMPTION to 1 to use pre-emptive scheduling.  Set
  * configUSE_PREEMPTION to 0 to use co-operative scheduling.
  * See https://www.freertos.org/single-core-amp-smp-rtos-scheduling.html. */


### PR DESCRIPTION
## Summary

Replace the per-file `-O1` override on `FreeRTOS_tasks.c` (PR #275, around since 2024-08) with the upstream-blessed back door:

```c
#define configLIST_VOLATILE                     volatile
```

The kernel has explicit hooks for this on `pxNext` / `pxPrevious` / `pxContainer` / `xItemValue` (see `FreeRTOS-Kernel/include/list.h`). With the macro defined, `listINSERT_END`'s stores cannot be reordered past the link-field updates — which was the root cause of the `xTaskResumeAll → listREMOVE_ITEM` NULL `pxContainer` crash that originally triggered the `-O1` workaround (issue #271).

Source: https://forums.freertos.org/t/configlist-volatile-required-missing-configassert-in-listremove-item/16400

Richard Barry's own comment on this: *"due to this kind of issue we left a back door to be able to add them back in without changing the source code."*

## Changes

| File | Diff |
|---|---|
| `firmware/src/config/default/FreeRTOSConfig.h` | `+11` (new `#define` + comment block citing #271 and the forum source) |
| `firmware/daqifi.X/nbproject/configurations.xml` | `+1/-1` — `optimization-level value="-O1"` → `value="-O3"` for `FreeRTOS_tasks.c` |
| `CLAUDE.md` | `+5/-3` — remove the `FreeRTOS_tasks.c -O1` row from the Per-File Optimization Overrides table; update the linker-issue note to reflect that `configLIST_VOLATILE` supersedes the `-O1` workaround |

## Bench validation

Run on bench primary (PICkit `BUR184882598`, device serial `7E2898F46200E8A7`):

- [x] Build clean at `-O3` globally — `Program Succeeded`
- [x] Boot smoke test — scheduler comes up clean, `*IDN?` responsive
- [x] **60s × 16ch CSV streaming endurance** — 59,982 / 60,000 rows captured (100.0%), all 16 channels nonzero (min/max within 1), no #271-class crash. This exercises `xTaskResumeAll`, `vTaskSwitchContext`, `listINSERT_END`, `listREMOVE_ITEM` thousands of times across 60s of preemption.
- [x] **5/5 power-cycle reboots** — all boot clean, `*IDN?` responsive each cycle
- [x] Empty `SYST:LOG?` after stream — no panic events

Test artifacts: `/tmp/420_ab/endurance_O3.txt`, `/tmp/420_ab/powercycle_O3.txt` (local).

## Why this is a strict improvement

- Removes a "permanent" build-system caveat that has lived since PR #275
- Aligns the kernel with the rest of the firmware at `-O3`
- Uses the upstream FreeRTOS-blessed pattern instead of a per-file optimization quirk
- The `#define` survives compiler upgrades; the per-file `-O1` clamp would need re-evaluation each XC32 release

## Refs

- #271 (original O2 root cause investigation)
- #275 (the `-O1` override being replaced here)
- #420 (volatile deep-dive that surfaced this fix)
- #426 (this PR)

## Test plan

- [x] Build clean at -O3
- [x] Bench: 60s 16ch streaming + 5x power cycle (above)
- [ ] Qodo `/agentic_review` clean
- [ ] Qodo `/improve` clean