### PR TITLE
fix(wifi): gate APPLY while previous REINIT in flight (#425)

### DIFF
--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -543,6 +543,14 @@ scpi_result_t SCPI_LANSettingsApply(scpi_t * context) {
 
     // Concurrent WiFi and SD card operations now supported with enhanced SPI coordination
 
+    // #425: apply first so a gate rejection (REINIT in flight) doesn't leave
+    // the rejected settings persisted in NVM after we tell the client the
+    // call failed.  The gate is centralized inside UpdateNetworkSettings
+    // (atomic test-and-set); false return = surface as -200.
+    if (!wifi_manager_UpdateNetworkSettings(pRunTimeWifiSettings)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
     if (saveSettings) {
         DaqifiSettings daqifiSettings;
         memcpy(&daqifiSettings.settings.wifi, pRunTimeWifiSettings, sizeof (wifi_manager_settings_t));
@@ -550,13 +558,6 @@ scpi_result_t SCPI_LANSettingsApply(scpi_t * context) {
         if (!daqifi_settings_SaveToNvm(&daqifiSettings)) {
             return SCPI_RES_ERR;
         }
-    }
-    // #425: gate is now centralized inside wifi_manager_UpdateNetworkSettings
-    // (atomic test-and-set under taskENTER_CRITICAL).  A false return here
-    // means a prior APPLY's REINIT is still in flight; surface as -200.
-    if (!wifi_manager_UpdateNetworkSettings(pRunTimeWifiSettings)) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        return SCPI_RES_ERR;
     }
     // Note: WiFi firmware update mode request (if set via FWUPDATE) is handled by the WiFi state machine.
     // The REQUESTED flag will be checked and cleared in ENTRY event handler.
@@ -626,17 +627,21 @@ scpi_result_t SCPI_LANSettingsLoad(scpi_t * context) {
             &daqifiSettings)) {
         return SCPI_RES_ERR;
     }
-    
-    // Copy loaded settings to runtime config
-    memcpy(pRunTimeWifiSettings, &daqifiSettings.settings.wifi, sizeof(wifi_manager_settings_t));
 
     if (applySettings) {
-        // #425: gate covered by UpdateNetworkSettings's atomic test-and-set;
-        // false return = APPLY in flight, surface as -200.
-        if (!wifi_manager_UpdateNetworkSettings(pRunTimeWifiSettings)) {
+        // #425: pass the loaded struct straight to UpdateNetworkSettings —
+        // it copies into runtime config under the gate's critical section
+        // and fires REINIT.  If the gate rejects (REINIT in flight), runtime
+        // stays at the prior values: callers get -200 with no half-applied
+        // mutation.  Don't memcpy first.
+        if (!wifi_manager_UpdateNetworkSettings(&daqifiSettings.settings.wifi)) {
             SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
             return SCPI_RES_ERR;
         }
+    } else {
+        // No apply requested — just stage in runtime so callers can inspect /
+        // edit before a future APPLY.
+        memcpy(pRunTimeWifiSettings, &daqifiSettings.settings.wifi, sizeof(wifi_manager_settings_t));
     }
 
     return SCPI_RES_OK;
@@ -658,17 +663,15 @@ scpi_result_t SCPI_LANSettingsFactoryLoad(scpi_t * context) {
             &daqifiSettings)) {
         return SCPI_RES_ERR;
     }
-    
-    // Copy loaded settings to runtime config
-    memcpy(pRunTimeWifiSettings, &daqifiSettings.settings.wifi, sizeof(wifi_manager_settings_t));
 
     if (applySettings) {
-        // #425: gate covered by UpdateNetworkSettings's atomic test-and-set;
-        // false return = APPLY in flight, surface as -200.
-        if (!wifi_manager_UpdateNetworkSettings(pRunTimeWifiSettings)) {
+        // #425: see SCPI_LANSettingsLoad for rationale — gated copy + REINIT.
+        if (!wifi_manager_UpdateNetworkSettings(&daqifiSettings.settings.wifi)) {
             SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
             return SCPI_RES_ERR;
         }
+    } else {
+        memcpy(pRunTimeWifiSettings, &daqifiSettings.settings.wifi, sizeof(wifi_manager_settings_t));
     }
 
     return SCPI_RES_OK;

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -540,7 +540,16 @@ scpi_result_t SCPI_LANSettingsApply(scpi_t * context) {
     if (SCPI_ParamInt32(context, &param1, FALSE)) {
         saveSettings = (bool) param1;
     }
-    
+
+    // #425 gate: reject APPLY while a previous APPLY's REINIT is still in
+    // flight.  Without this, rapid APPLY storms collide with in-flight WINC
+    // HIF requests, the state machine spins on WDRV_WINC_STATUS_REQUEST_ERROR
+    // (8) returned by IPUseDHCPSet, and the device wedges until power-cycle.
+    if (wifi_manager_IsApplyInProgress()) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+
     // Concurrent WiFi and SD card operations now supported with enhanced SPI coordination
 
     if (saveSettings) {

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -541,15 +541,6 @@ scpi_result_t SCPI_LANSettingsApply(scpi_t * context) {
         saveSettings = (bool) param1;
     }
 
-    // #425 gate: reject APPLY while a previous APPLY's REINIT is still in
-    // flight.  Without this, rapid APPLY storms collide with in-flight WINC
-    // HIF requests, the state machine spins on WDRV_WINC_STATUS_REQUEST_ERROR
-    // (8) returned by IPUseDHCPSet, and the device wedges until power-cycle.
-    if (wifi_manager_IsApplyInProgress()) {
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        return SCPI_RES_ERR;
-    }
-
     // Concurrent WiFi and SD card operations now supported with enhanced SPI coordination
 
     if (saveSettings) {
@@ -560,7 +551,11 @@ scpi_result_t SCPI_LANSettingsApply(scpi_t * context) {
             return SCPI_RES_ERR;
         }
     }
+    // #425: gate is now centralized inside wifi_manager_UpdateNetworkSettings
+    // (atomic test-and-set under taskENTER_CRITICAL).  A false return here
+    // means a prior APPLY's REINIT is still in flight; surface as -200.
     if (!wifi_manager_UpdateNetworkSettings(pRunTimeWifiSettings)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         return SCPI_RES_ERR;
     }
     // Note: WiFi firmware update mode request (if set via FWUPDATE) is handled by the WiFi state machine.
@@ -636,7 +631,10 @@ scpi_result_t SCPI_LANSettingsLoad(scpi_t * context) {
     memcpy(pRunTimeWifiSettings, &daqifiSettings.settings.wifi, sizeof(wifi_manager_settings_t));
 
     if (applySettings) {
+        // #425: gate covered by UpdateNetworkSettings's atomic test-and-set;
+        // false return = APPLY in flight, surface as -200.
         if (!wifi_manager_UpdateNetworkSettings(pRunTimeWifiSettings)) {
+            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
             return SCPI_RES_ERR;
         }
     }
@@ -665,7 +663,10 @@ scpi_result_t SCPI_LANSettingsFactoryLoad(scpi_t * context) {
     memcpy(pRunTimeWifiSettings, &daqifiSettings.settings.wifi, sizeof(wifi_manager_settings_t));
 
     if (applySettings) {
+        // #425: gate covered by UpdateNetworkSettings's atomic test-and-set;
+        // false return = APPLY in flight, surface as -200.
         if (!wifi_manager_UpdateNetworkSettings(pRunTimeWifiSettings)) {
+            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
             return SCPI_RES_ERR;
         }
     }

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -556,7 +556,15 @@ scpi_result_t SCPI_LANSettingsApply(scpi_t * context) {
         memcpy(&daqifiSettings.settings.wifi, pRunTimeWifiSettings, sizeof (wifi_manager_settings_t));
         daqifiSettings.type = DaqifiSettings_Wifi;
         if (!daqifi_settings_SaveToNvm(&daqifiSettings)) {
-            return SCPI_RES_ERR;
+            // Apply already succeeded and REINIT may already be in flight.
+            // Returning -200 here would mislead the client into thinking
+            // the apply itself failed (#425 r4 Qodo bug 5).  Instead push
+            // an error so SYST:ERR? reports the persistence failure, but
+            // return OK because the apply itself succeeded.  Settings will
+            // revert to NVM contents on next boot.
+            LOG_E("WiFi APPLY: settings applied, but NVM save failed");
+            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+            return SCPI_RES_OK;
         }
     }
     // Note: WiFi firmware update mode request (if set via FWUPDATE) is handled by the WiFi state machine.

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -141,6 +141,30 @@ static SemaphoreHandle_t gProcessStateMutex = NULL;
 static volatile bool gRssiUpdateComplete = false;
 static volatile uint8_t gLastRssiPercentage = 0;
 
+// Apply-in-progress gate (#425).
+// Set true when wifi_manager_UpdateNetworkSettings queues a REINIT and the
+// device is enabled+powered; cleared when the state machine reaches a
+// steady state (STA_CONNECTED or AP_STARTED) or the safety deadline elapses.
+//
+// SCPI APPLY (SCPI_LANSettingsApply) checks this and returns -200 Execution
+// error while true, so back-to-back APPLY storms can't stack REINIT events
+// faster than the state machine can drain them.  Without this gate,
+// WDRV_WINC_IPUseDHCPSet returns WDRV_WINC_STATUS_REQUEST_ERROR (the WINC
+// chip rejects HIF requests during a prior REINIT's teardown) and the
+// state machine spins on WIFI_MANAGER_EVENT_ERROR until power-cycle.
+//
+// 32-bit/bool reads+writes are atomic on PIC32MZ; volatile prevents -O3
+// caching across cross-context reads (USB SCPI task pri 7 sets, WifiTask
+// pri 2 clears; SCPI Apply pri 7 reads).
+static volatile bool gApplyInProgress = false;
+// Safety deadline: clear gApplyInProgress unconditionally if the state
+// machine hasn't reached steady state within ~30 s (e.g. unreachable AP,
+// stuck WINC).  Without this, a stuck transition could permanently lock
+// out further APPLYs.  0 = no deadline armed.  Read from
+// wifi_manager_ProcessState every tick when gApplyInProgress is true.
+#define WIFI_APPLY_GATE_TIMEOUT_MS 30000u
+static volatile TickType_t gApplyInProgressDeadlineTick = 0;
+
 //===========================================================
 //=====================Private Callbacks=====================
 
@@ -835,7 +859,10 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 }
 
                 SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED);
-                
+                // Reached steady state — release APPLY gate (#425).
+                gApplyInProgress = false;
+                gApplyInProgressDeadlineTick = 0;
+
                 // IMPORTANT: Register socket callback BEFORE opening sockets
                 // This ensures we don't miss the SOCKET_MSG_BIND event
                 WDRV_WINC_SocketRegisterEventCallback(pInstance->wdrvHandle, &SocketEventCallback);
@@ -865,7 +892,10 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
         case WIFI_MANAGER_EVENT_STA_CONNECTED:
             returnStatus = WIFI_MANAGER_STATE_MACHINE_RETURN_STATUS_HANDLED;
             SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
-            
+            // Reached steady state — release APPLY gate (#425).
+            gApplyInProgress = false;
+            gApplyInProgressDeadlineTick = 0;
+
             // Reset reconnect attempts on successful connection
             pInstance->staReconnectAttempts = 0;
             LOG_D("STA connection successful, reset reconnect counter\r\n");
@@ -1535,6 +1565,10 @@ bool wifi_manager_HardReset(void) {
     return SendEvent(WIFI_MANAGER_EVENT_DEINIT);
 }
 
+bool wifi_manager_IsApplyInProgress(void) {
+    return gApplyInProgress;
+}
+
 bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t * pSettings) {
 
     // Always allow settings to be updated regardless of power state
@@ -1566,7 +1600,12 @@ bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t * pSettings) {
         bool wifiFwUpdateRequested = GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_REQUESTED);
 
         if ((pSettings->isEnabled || wifiFwUpdateRequested) && isPowered) {
-            // WiFi is enabled or WiFi firmware update requested, and board is powered - apply changes immediately
+            // WiFi is enabled or WiFi firmware update requested, and board is
+            // powered - apply changes immediately.  Arm the gate so SCPI
+            // APPLY rejects further requests until the state machine settles
+            // (#425).
+            gApplyInProgressDeadlineTick = xTaskGetTickCount() + pdMS_TO_TICKS(WIFI_APPLY_GATE_TIMEOUT_MS);
+            gApplyInProgress = true;
             SendEvent(WIFI_MANAGER_EVENT_REINIT);
         } else {
             // Settings saved but not applied - they'll be applied when WiFi is enabled
@@ -1648,6 +1687,18 @@ static void wifi_manager_ProcessStateImpl(bool drainTcpRx) {
     }
     if (doInit) {
         SendEvent(WIFI_MANAGER_EVENT_INIT);
+    }
+
+    // APPLY gate safety release (#425): drop gApplyInProgress if the state
+    // machine hasn't reached STA_CONNECTED / AP_STARTED within the timeout.
+    // Without this, a stuck transition (e.g. unreachable AP) would lock
+    // out further SCPI APPLYs permanently.
+    if (gApplyInProgress &&
+        gApplyInProgressDeadlineTick != 0 &&
+        (int32_t)(xTaskGetTickCount() - gApplyInProgressDeadlineTick) >= 0) {
+        LOG_E("APPLY gate safety release after %u ms", (unsigned)WIFI_APPLY_GATE_TIMEOUT_MS);
+        gApplyInProgress = false;
+        gApplyInProgressDeadlineTick = 0;
     }
 
     wifi_tcp_server_TransmitBufferedData();

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1602,7 +1602,10 @@ bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t * pSettings) {
     // This allows configuration while the device is off or WiFi is disabled
 
     if (pSettings == NULL || gStateMachineContext.pWifiSettings == NULL) {
-        return true;
+        // Caller programming error — surface as -200 rather than silently
+        // pretending success.
+        LOG_E("WiFi UpdateNetworkSettings: NULL settings pointer");
+        return false;
     }
 
     // Decide up front whether this call would queue a REINIT.  If yes, the
@@ -1757,12 +1760,25 @@ static void wifi_manager_ProcessStateImpl(bool drainTcpRx) {
     // APPLYs permanently.  The arm path bumps the computed deadline from 0
     // to 1, so deadline is never 0 while armed — no separate sentinel check
     // needed (and dropping it lets us recover even if a race somehow leaves
-    // flag=true with deadline=0).  Reverse store order on release.
+    // flag=true with deadline=0).
+    //
+    // Critical section: between the condition check and the clear, a
+    // preempting Deinit→APPLY sequence (USB SCPI pri 7 vs WifiTask pri 2)
+    // could clear the gate then re-arm with a fresh deadline.  Without the
+    // critical section, we would then stomp that new state and trigger a
+    // spurious safety release.  Reverse store order is preserved inside.
+    bool armed_release = false;
+    taskENTER_CRITICAL();
     if (gApplyInProgress &&
         (int32_t)(xTaskGetTickCount() - gApplyInProgressDeadlineTick) >= 0) {
-        LOG_E("APPLY gate safety release after %u ms", (unsigned)WIFI_APPLY_GATE_TIMEOUT_MS);
         gApplyInProgressDeadlineTick = 0;
         gApplyInProgress = false;
+        armed_release = true;
+    }
+    taskEXIT_CRITICAL();
+    if (armed_release) {
+        // LOG_E does its own queue work — keep it outside the critical section.
+        LOG_E("APPLY gate safety release after %u ms", (unsigned)WIFI_APPLY_GATE_TIMEOUT_MS);
     }
 
     wifi_tcp_server_TransmitBufferedData();

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -142,26 +142,30 @@ static volatile bool gRssiUpdateComplete = false;
 static volatile uint8_t gLastRssiPercentage = 0;
 
 // Apply-in-progress gate (#425).
-// Set true when wifi_manager_UpdateNetworkSettings queues a REINIT and the
-// device is enabled+powered; cleared when the state machine reaches a
-// steady state (STA_CONNECTED or AP_STARTED) or the safety deadline elapses.
+// Set true under taskENTER_CRITICAL by wifi_manager_UpdateNetworkSettings
+// when a REINIT is about to be queued; cleared when the state machine
+// reaches a steady state (STA_CONNECTED, AP_STARTED, or FW_UPDATE_READY)
+// or the safety deadline elapses.
 //
-// SCPI APPLY (SCPI_LANSettingsApply) checks this and returns -200 Execution
-// error while true, so back-to-back APPLY storms can't stack REINIT events
-// faster than the state machine can drain them.  Without this gate,
-// WDRV_WINC_IPUseDHCPSet returns WDRV_WINC_STATUS_REQUEST_ERROR (the WINC
-// chip rejects HIF requests during a prior REINIT's teardown) and the
-// state machine spins on WIFI_MANAGER_EVENT_ERROR until power-cycle.
+// Test-and-set is atomic so concurrent SCPI callers (USB pri 7 + WifiTask
+// TCP-SCPI pri 2) can't both pass the gate and stack REINIT events faster
+// than the state machine can drain them.  Without this gate, the second-
+// and-later REINIT enters INIT processing while the WINC chip is still
+// tearing down the prior attempt, WDRV_WINC_IPUseDHCPSet returns
+// WDRV_WINC_STATUS_REQUEST_ERROR (8), and the manager spins on
+// WIFI_MANAGER_EVENT_ERROR until power-cycle.
 //
-// 32-bit/bool reads+writes are atomic on PIC32MZ; volatile prevents -O3
-// caching across cross-context reads (USB SCPI task pri 7 sets, WifiTask
-// pri 2 clears; SCPI Apply pri 7 reads).
+// volatile because cleared from WifiTask (pri 2 — steady-state events,
+// safety deadline) but set from any task that calls UpdateNetworkSettings
+// (USB SCPI pri 7, TCP SCPI on WifiTask itself).
 static volatile bool gApplyInProgress = false;
 // Safety deadline: clear gApplyInProgress unconditionally if the state
 // machine hasn't reached steady state within ~30 s (e.g. unreachable AP,
 // stuck WINC).  Without this, a stuck transition could permanently lock
 // out further APPLYs.  0 = no deadline armed.  Read from
 // wifi_manager_ProcessState every tick when gApplyInProgress is true.
+// Computed deadline is bumped from 0 to 1 to keep the sentinel reliable
+// across tick wraparound.
 #define WIFI_APPLY_GATE_TIMEOUT_MS 30000u
 static volatile TickType_t gApplyInProgressDeadlineTick = 0;
 
@@ -695,6 +699,13 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
             }
             wifi_serial_bridge_Init(&pInstance->serialBridgeContext);
             SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_READY);
+            // Reached steady state for FW-update mode — release APPLY gate (#425).
+            // Without this, FW-update mode never clears the gate (no STA_CONNECTED
+            // / AP_STARTED in this lifecycle), so APPLY is locked out for 30 s
+            // and a misleading "safety release" log fires every FW-update cycle.
+            // Reverse store order — see AP_STARTED comment.
+            gApplyInProgressDeadlineTick = 0;
+            gApplyInProgress = false;
             vTaskResume(pInstance->fwUpdateTaskHandle);
         }
             break;
@@ -860,8 +871,13 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
 
                 SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED);
                 // Reached steady state — release APPLY gate (#425).
-                gApplyInProgress = false;
+                // Order: deadline first, flag second.  If a higher-priority
+                // task preempts between the two stores and tries to claim
+                // the gate, it will see flag=true and reject — preventing
+                // a corrupt (flag=true, deadline=0) state where the safety
+                // release path would never fire.
                 gApplyInProgressDeadlineTick = 0;
+                gApplyInProgress = false;
 
                 // IMPORTANT: Register socket callback BEFORE opening sockets
                 // This ensures we don't miss the SOCKET_MSG_BIND event
@@ -892,9 +908,11 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
         case WIFI_MANAGER_EVENT_STA_CONNECTED:
             returnStatus = WIFI_MANAGER_STATE_MACHINE_RETURN_STATUS_HANDLED;
             SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
-            // Reached steady state — release APPLY gate (#425).
-            gApplyInProgress = false;
+            // Reached steady state — release APPLY gate (#425).  Reverse
+            // store order (deadline first, flag second) — see AP_STARTED
+            // comment for why.
             gApplyInProgressDeadlineTick = 0;
+            gApplyInProgress = false;
 
             // Reset reconnect attempts on successful connection
             pInstance->staReconnectAttempts = 0;
@@ -1387,6 +1405,8 @@ void wifi_manager_BootInit(void) {
     gTcpRxPending = false;
     gLastRssiPercentage = 0;
     gWifiReinitDeadlineTick = 0;
+    gApplyInProgress = false;
+    gApplyInProgressDeadlineTick = 0;
 }
 
 bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
@@ -1530,6 +1550,10 @@ bool wifi_manager_Deinit() {
     taskENTER_CRITICAL();
     gWifiReinitDeadlineTick = 0;
     gStateMachineContext.pWifiSettings->isEnabled = 0;
+    // Explicit teardown — release APPLY gate so a follow-up APPLY isn't
+    // blocked by the 30 s safety timeout.  Reverse store order (#425).
+    gApplyInProgressDeadlineTick = 0;
+    gApplyInProgress = false;
     taskEXIT_CRITICAL();
     return SendEvent(WIFI_MANAGER_EVENT_DEINIT);
 }
@@ -1561,56 +1585,80 @@ bool wifi_manager_HardReset(void) {
     taskENTER_CRITICAL();
     gStateMachineContext.pWifiSettings->isEnabled = 0;
     gWifiReinitDeadlineTick = xTaskGetTickCount() + pdMS_TO_TICKS(2000);
+    // Explicit teardown — release APPLY gate (#425).  Reverse store order.
+    gApplyInProgressDeadlineTick = 0;
+    gApplyInProgress = false;
     taskEXIT_CRITICAL();
     return SendEvent(WIFI_MANAGER_EVENT_DEINIT);
-}
-
-bool wifi_manager_IsApplyInProgress(void) {
-    return gApplyInProgress;
 }
 
 bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t * pSettings) {
 
     // Always allow settings to be updated regardless of power state
     // This allows configuration while the device is off or WiFi is disabled
-    
-    if (pSettings != NULL && gStateMachineContext.pWifiSettings != NULL) {
-        
-        // Preserve the MAC address before copying new settings
-        WDRV_WINC_MAC_ADDR savedMacAddr;
-        memcpy(&savedMacAddr, &gStateMachineContext.pWifiSettings->macAddr, sizeof(WDRV_WINC_MAC_ADDR));
-        
-        // Copy new settings
-        memcpy(gStateMachineContext.pWifiSettings, pSettings, sizeof (wifi_manager_settings_t));
-        
-        // Restore the MAC address
-        memcpy(&gStateMachineContext.pWifiSettings->macAddr, &savedMacAddr, sizeof(WDRV_WINC_MAC_ADDR));
-        
-        // Also update BoardData so the app task sees the changes
-        BoardData_Set(BOARDDATA_WIFI_SETTINGS, 0, gStateMachineContext.pWifiSettings);
-        // LOG_D("BoardData updated with new WiFi settings\r\n");
-        
-        // Only trigger a reinit if WiFi is enabled and powered
-        const tPowerData *pPowerState = (tPowerData *) BoardData_Get(BOARDDATA_POWER_DATA, 0);
-        bool isPowered = (pPowerState != NULL && 
-                         (pPowerState->powerState == POWERED_UP || 
-                          pPowerState->powerState == POWERED_UP_EXT_DOWN));
-        
-        // Trigger REINIT if WiFi is enabled OR if WiFi firmware update mode is requested
-        bool wifiFwUpdateRequested = GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_REQUESTED);
 
-        if ((pSettings->isEnabled || wifiFwUpdateRequested) && isPowered) {
-            // WiFi is enabled or WiFi firmware update requested, and board is
-            // powered - apply changes immediately.  Arm the gate so SCPI
-            // APPLY rejects further requests until the state machine settles
-            // (#425).
-            gApplyInProgressDeadlineTick = xTaskGetTickCount() + pdMS_TO_TICKS(WIFI_APPLY_GATE_TIMEOUT_MS);
-            gApplyInProgress = true;
-            SendEvent(WIFI_MANAGER_EVENT_REINIT);
-        } else {
-            // Settings saved but not applied - they'll be applied when WiFi is enabled
-            // and the board is powered
-            // No SCPI error here - settings are successfully saved
+    if (pSettings == NULL || gStateMachineContext.pWifiSettings == NULL) {
+        return true;
+    }
+
+    // Decide up front whether this call would queue a REINIT.  If yes, the
+    // gate must be claimed atomically before we touch runtime state — see
+    // #425 bugs 2 & 3: a check-then-act window let two concurrent SCPI
+    // tasks (USB pri 7 + WifiTask TCP-SCPI) both pass the check and stack
+    // REINIT events, AND callers other than SCPI APPLY (LANSettingsLoad,
+    // LANSettingsFactoryLoad) bypassed the gate entirely.  Centralizing
+    // the gate here protects every caller automatically.
+    const tPowerData *pPowerState = (tPowerData *) BoardData_Get(BOARDDATA_POWER_DATA, 0);
+    bool isPowered = (pPowerState != NULL &&
+                     (pPowerState->powerState == POWERED_UP ||
+                      pPowerState->powerState == POWERED_UP_EXT_DOWN));
+    bool wifiFwUpdateRequested = GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_REQUESTED);
+    bool willReinit = (pSettings->isEnabled || wifiFwUpdateRequested) && isPowered;
+
+    if (willReinit) {
+        TickType_t deadline = xTaskGetTickCount() + pdMS_TO_TICKS(WIFI_APPLY_GATE_TIMEOUT_MS);
+        // 0 is the "unarmed" sentinel — bump to 1 so a wraparound landing
+        // exactly on 0 doesn't disable the safety release.
+        if (deadline == 0) {
+            deadline = 1;
+        }
+        // Atomic test-and-set.  Without the critical section, two SCPI
+        // contexts can both observe gApplyInProgress=false and both
+        // proceed to set it true and queue REINIT — defeating the gate.
+        taskENTER_CRITICAL();
+        if (gApplyInProgress) {
+            taskEXIT_CRITICAL();
+            return false;  // gate engaged — caller translates to -200
+        }
+        gApplyInProgress = true;
+        gApplyInProgressDeadlineTick = deadline;
+        taskEXIT_CRITICAL();
+    }
+
+    // Preserve the MAC address before copying new settings
+    WDRV_WINC_MAC_ADDR savedMacAddr;
+    memcpy(&savedMacAddr, &gStateMachineContext.pWifiSettings->macAddr, sizeof(WDRV_WINC_MAC_ADDR));
+
+    // Copy new settings
+    memcpy(gStateMachineContext.pWifiSettings, pSettings, sizeof (wifi_manager_settings_t));
+
+    // Restore the MAC address
+    memcpy(&gStateMachineContext.pWifiSettings->macAddr, &savedMacAddr, sizeof(WDRV_WINC_MAC_ADDR));
+
+    // Also update BoardData so the app task sees the changes
+    BoardData_Set(BOARDDATA_WIFI_SETTINGS, 0, gStateMachineContext.pWifiSettings);
+
+    if (willReinit) {
+        if (!SendEvent(WIFI_MANAGER_EVENT_REINIT)) {
+            // Queue full or queue not initialized — REINIT won't fire, so
+            // the gate would lock APPLY for 30 s with nothing in flight.
+            // Roll back atomically (#425).  Reverse store order on release.
+            taskENTER_CRITICAL();
+            gApplyInProgressDeadlineTick = 0;
+            gApplyInProgress = false;
+            taskEXIT_CRITICAL();
+            LOG_E("WiFi REINIT enqueue failed; APPLY gate rolled back");
+            return false;
         }
     }
     return true;
@@ -1690,15 +1738,17 @@ static void wifi_manager_ProcessStateImpl(bool drainTcpRx) {
     }
 
     // APPLY gate safety release (#425): drop gApplyInProgress if the state
-    // machine hasn't reached STA_CONNECTED / AP_STARTED within the timeout.
-    // Without this, a stuck transition (e.g. unreachable AP) would lock
-    // out further SCPI APPLYs permanently.
+    // machine hasn't reached steady state within the timeout.  Without this,
+    // a stuck transition (e.g. unreachable AP) would lock out further SCPI
+    // APPLYs permanently.  The arm path bumps the computed deadline from 0
+    // to 1, so deadline is never 0 while armed — no separate sentinel check
+    // needed (and dropping it lets us recover even if a race somehow leaves
+    // flag=true with deadline=0).  Reverse store order on release.
     if (gApplyInProgress &&
-        gApplyInProgressDeadlineTick != 0 &&
         (int32_t)(xTaskGetTickCount() - gApplyInProgressDeadlineTick) >= 0) {
         LOG_E("APPLY gate safety release after %u ms", (unsigned)WIFI_APPLY_GATE_TIMEOUT_MS);
-        gApplyInProgress = false;
         gApplyInProgressDeadlineTick = 0;
+        gApplyInProgress = false;
     }
 
     wifi_tcp_server_TransmitBufferedData();

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1643,6 +1643,14 @@ bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t * pSettings) {
     WDRV_WINC_MAC_ADDR savedMacAddr;
     memcpy(&savedMacAddr, &gStateMachineContext.pWifiSettings->macAddr, sizeof(WDRV_WINC_MAC_ADDR));
 
+    // Snapshot prior settings so we can roll back on REINIT enqueue failure
+    // (#425 round 3 / Qodo).  When willReinit is false we don't need this —
+    // there's no failure path that mutates between this point and return.
+    wifi_manager_settings_t prevSettings;
+    if (willReinit) {
+        memcpy(&prevSettings, gStateMachineContext.pWifiSettings, sizeof(prevSettings));
+    }
+
     // Copy new settings
     memcpy(gStateMachineContext.pWifiSettings, pSettings, sizeof (wifi_manager_settings_t));
 
@@ -1654,14 +1662,16 @@ bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t * pSettings) {
 
     if (willReinit) {
         if (!SendEvent(WIFI_MANAGER_EVENT_REINIT)) {
-            // Queue full or queue not initialized — REINIT won't fire, so
-            // the gate would lock APPLY for 30 s with nothing in flight.
-            // Roll back atomically (#425).  Reverse store order on release.
+            // Queue full or queue not initialized — REINIT won't fire.
+            // Roll back the settings copy so a "false" return cleanly means
+            // "no state changed", and release the gate (reverse store order).
+            memcpy(gStateMachineContext.pWifiSettings, &prevSettings, sizeof(prevSettings));
+            BoardData_Set(BOARDDATA_WIFI_SETTINGS, 0, gStateMachineContext.pWifiSettings);
             taskENTER_CRITICAL();
             gApplyInProgressDeadlineTick = 0;
             gApplyInProgress = false;
             taskEXIT_CRITICAL();
-            LOG_E("WiFi REINIT enqueue failed; APPLY gate rolled back");
+            LOG_E("WiFi REINIT enqueue failed; settings + APPLY gate rolled back");
             return false;
         }
     }

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -872,10 +872,14 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED);
                 // Reached steady state — release APPLY gate (#425).
                 // Order: deadline first, flag second.  If a higher-priority
-                // task preempts between the two stores and tries to claim
-                // the gate, it will see flag=true and reject — preventing
-                // a corrupt (flag=true, deadline=0) state where the safety
-                // release path would never fire.
+                // SCPI APPLY preempts between the two stores, it enters
+                // UpdateNetworkSettings's critical section and sees flag=true
+                // (still set by us) — so it cleanly rejects with -200.
+                // Original order (flag first) would let the preempting arm
+                // observe flag=false, set its own deadline+flag, and then
+                // we'd resume to overwrite its deadline with 0 — causing
+                // the safety release to fire prematurely against the
+                // newly-armed gate.
                 gApplyInProgressDeadlineTick = 0;
                 gApplyInProgress = false;
 

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -254,23 +254,6 @@ extern "C" {
      */
     bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t* pSettings);
 
-    /**
-     * @brief Returns true while a previous APPLY's REINIT is still being
-     *        processed by the state machine.
-     *
-     * Used by SCPI APPLY (and FWUpdate APPLY) to reject back-to-back
-     * APPLYs faster than the state machine can drain them — without this
-     * gate, rapid APPLY storms collide with in-flight WINC HIF requests
-     * and wedge the state machine into a tight WDRV_WINC_STATUS_REQUEST_ERROR
-     * loop that requires a power-cycle to clear (#425).
-     *
-     * Cleared automatically when the state machine reaches STA_CONNECTED
-     * or AP_STARTED, or after a 30 s safety deadline.
-     *
-     * @return True if a re-apply is in flight; false if APPLY may proceed.
-     */
-    bool wifi_manager_IsApplyInProgress(void);
-
 
     /**
      * @brief Processes the current state of the WiFi manager.

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -254,6 +254,23 @@ extern "C" {
      */
     bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t* pSettings);
 
+    /**
+     * @brief Returns true while a previous APPLY's REINIT is still being
+     *        processed by the state machine.
+     *
+     * Used by SCPI APPLY (and FWUpdate APPLY) to reject back-to-back
+     * APPLYs faster than the state machine can drain them — without this
+     * gate, rapid APPLY storms collide with in-flight WINC HIF requests
+     * and wedge the state machine into a tight WDRV_WINC_STATUS_REQUEST_ERROR
+     * loop that requires a power-cycle to clear (#425).
+     *
+     * Cleared automatically when the state machine reaches STA_CONNECTED
+     * or AP_STARTED, or after a 30 s safety deadline.
+     *
+     * @return True if a re-apply is in flight; false if APPLY may proceed.
+     */
+    bool wifi_manager_IsApplyInProgress(void);
+
 
     /**
      * @brief Processes the current state of the WiFi manager.


### PR DESCRIPTION
## Summary

Reject `SYST:COMM:LAN:APPLy` with `-200 Execution error` while a previous APPLY's REINIT is still being processed by the WiFi state machine. Without this gate, rapid back-to-back APPLY storms stack `WIFI_MANAGER_EVENT_REINIT` events faster than the state machine can drain them; the second-and-later REINIT enters INIT processing while the WINC chip is still tearing down the prior attempt, `WDRV_WINC_IPUseDHCPSet` returns `WDRV_WINC_STATUS_REQUEST_ERROR (8)`, and the manager spins on `WIFI_MANAGER_EVENT_ERROR` until power-cycle.

Addresses ticket case 1 (5× rapid APPLY). Case 2 (APPLY while a TCP-SCPI client is connected) has a different root cause — the TCP server doesn't tear down cleanly before the WINC reinit — and will be a separate follow-up.

## Mechanism

**V evidence (instrumented run, pre-fix on `b020090d`):**
```
WINC_IPUseDHCPSet=8 initFlag=1 alreadyInit=0
[wifi_manager.c:768]Error WiFi init  (looping at error_count: 1390+)
```
`8 = WDRV_WINC_STATUS_REQUEST_ERROR` — chip rejects HIF requests during prior REINIT teardown.

**Gate design:**
- `gApplyInProgress` set true when `wifi_manager_UpdateNetworkSettings` queues a REINIT for an enabled+powered device.
- Cleared on `WIFI_MANAGER_EVENT_STA_CONNECTED` (STA path) or `WIFI_MANAGER_STATE_FLAG_AP_STARTED` (AP path) — i.e. state machine reached steady state.
- Safety release after `WIFI_APPLY_GATE_TIMEOUT_MS` (30 s) in `wifi_manager_ProcessState` so a stuck transition (unreachable AP, wedged WINC) doesn't permanently lock out future APPLYs.
- Public `wifi_manager_IsApplyInProgress()` — `SCPI_LANSettingsApply` checks it and returns `SCPI_RES_ERR` while true.

Concurrency: volatile on both fields; PIC32MZ atomic 32-bit/bool stores; arm orders tick-then-flag, release orders flag-then-tick (so a reader observing `flag=true` always sees the tick set). Cross-task: SCPI Apply (USB pri 7) arms, WifiTask (pri 2) clears; safety release runs on WifiTask only — same-task serialization there.

## E evidence (post-fix on bench, `fix/425-apply-gate`)

5× rapid APPLY storm from clean Tesla STA state:
```
iter 1: accepted
iter 2: REJECTED -200
iter 3: REJECTED -200
iter 4: REJECTED -200
iter 5: REJECTED -200
+20s settle: ADDR=192.168.1.160, SSIDSTR=94, error_count: 10
```
Device fully recovers on Tesla, no power-cycle required (vs. 1390+ errors and required reboot pre-fix).

Single APPLY still works normally — gate engages only when a REINIT is in flight, and a single APPLY's REINIT clears the gate cleanly when STA_CONNECTED fires.

## Test plan

- [x] Build clean with `-O3 -Werror`
- [x] Single APPLY: succeeds, device reaches STA_CONNECTED on Tesla
- [x] 5× rapid APPLY: 1 accepted + 4 rejected with -200, device recovers cleanly
- [x] Manual back-to-back APPLY (200 ms gap): 1st OK, 2nd `-200, "Execution error"`
- [ ] Case 2 (APPLY with TCP-SCPI client connected) — separate follow-up; this PR does not fix that scenario

Refs #425.