### PR TITLE
fix(wifi): close TCP/UDP sockets before STA reconfigure (#435)

### DIFF
--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1235,20 +1235,31 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                         LOG_E("STA reconfig with active socket — diverting to HardReset (#435)");
                         if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN)) {
                             wifi_tcp_server_CloseSocket();
-                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
                         }
                         if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
                             CloseUdpSocket(&pInstance->udpServerSocket);
-                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
                         }
+                        // Reset socket + STA state flags atomically so callers
+                        // that check status during the chip-reset window
+                        // (~2 s) don't observe stale "connected" state.
+                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
+                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
+                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
                         // wifi_manager_HardReset arms the deferred-INIT
                         // deadline and queues DEINIT.  isEnabled was just
                         // set to 1 by UpdateNetworkSettings (since this
                         // REINIT was queued) — HardReset will clear it
                         // for the DEINIT path, then ProcessState's
                         // deferred-INIT branch flips it back and queues
-                        // INIT once the 2 s settle elapses.
-                        wifi_manager_HardReset();
+                        // INIT once the 2 s settle elapses.  If the DEINIT
+                        // event can't be queued, propagate the failure as
+                        // an ERROR event so the manager retries instead of
+                        // silently leaving the chip in a half-reset state.
+                        if (!wifi_manager_HardReset()) {
+                            LOG_E("HardReset divert failed to queue DEINIT");
+                            SendEvent(WIFI_MANAGER_EVENT_ERROR);
+                        }
                         break;
                     }
 

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1243,19 +1243,23 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                         if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
                             CloseUdpSocket(&pInstance->udpServerSocket);
                         }
-                        // Reset socket + STA state flags atomically so callers
-                        // that check status during the chip-reset window
-                        // (~2 s) don't observe stale "connected" state.  The
-                        // ResetEventFlag helper does RMW on a shared bitmask;
-                        // wrap the cluster in a critical section even though
-                        // all current writers are on WifiTask, to silence
-                        // future cross-task races if a callback is added.
-                        taskENTER_CRITICAL();
+                        // Clear socket + STA state flags so callers that
+                        // check status during the chip-reset window (~2 s)
+                        // don't observe stale "connected" state.  No
+                        // critical section: every writer of
+                        // pInstance->eventFlags in this codebase is on
+                        // WifiTask (StaEventCallback / SocketEventCallback
+                        // only call SendEvent — no flag mutations) so the
+                        // RMW is single-threaded.  Per CLAUDE.md
+                        // ("do not add unnecessary critical sections"), the
+                        // earlier speculative wrap was inappropriate.  Also
+                        // clear UDP_SOCKET_CONNECTED so it doesn't outlast
+                        // UDP_SOCKET_OPEN.
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
+                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_CONNECTED);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                        taskEXIT_CRITICAL();
                         // wifi_manager_HardReset arms the deferred-INIT
                         // deadline and queues DEINIT.  isEnabled was just
                         // set to 1 by UpdateNetworkSettings (since this
@@ -1268,7 +1272,13 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                         // silently leaving the chip in a half-reset state.
                         if (!wifi_manager_HardReset()) {
                             LOG_E("HardReset divert failed to queue DEINIT");
-                            SendEvent(WIFI_MANAGER_EVENT_ERROR);
+                            // Try ERROR fallback so the manager retries; if
+                            // *that* enqueue also fails, the queue is wedged
+                            // and the only recovery is SYST:REBoot — log
+                            // explicitly so the user sees it in SYST:LOG?.
+                            if (!SendEvent(WIFI_MANAGER_EVENT_ERROR)) {
+                                LOG_E("HardReset divert: ERROR fallback also failed; manager may be stuck — SYST:REBoot");
+                            }
                         }
                         break;
                     }

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1230,22 +1230,32 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // pulls RESET_N + CHIP_EN low and brings the chip back
                     // up clean.  The deferred-INIT path in ProcessState
                     // picks up the new settings on its way back up.
-                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN) ||
-                        GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
-                        LOG_E("STA reconfig with active socket — diverting to HardReset (#435)");
-                        if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN)) {
-                            wifi_tcp_server_CloseSocket();
-                        }
+                    // Only divert when an actual TCP client is connected,
+                    // not merely when the listening server socket is bound
+                    // (which is true throughout normal STA operation).  The
+                    // wedge requires the chip's socket table to hold an
+                    // *accepted* connection state; bare listening sockets
+                    // tear down cleanly through the soft-reconfigure path
+                    // below.
+                    if (wifi_tcp_server_HasActiveClient()) {
+                        LOG_E("STA reconfig with active TCP client — diverting to HardReset (#435)");
+                        wifi_tcp_server_CloseSocket();
                         if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
                             CloseUdpSocket(&pInstance->udpServerSocket);
                         }
                         // Reset socket + STA state flags atomically so callers
                         // that check status during the chip-reset window
-                        // (~2 s) don't observe stale "connected" state.
+                        // (~2 s) don't observe stale "connected" state.  The
+                        // ResetEventFlag helper does RMW on a shared bitmask;
+                        // wrap the cluster in a critical section even though
+                        // all current writers are on WifiTask, to silence
+                        // future cross-task races if a callback is added.
+                        taskENTER_CRITICAL();
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                        taskEXIT_CRITICAL();
                         // wifi_manager_HardReset arms the deferred-INIT
                         // deadline and queues DEINIT.  isEnabled was just
                         // set to 1 by UpdateNetworkSettings (since this

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1217,16 +1217,42 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 // Currently in STA mode and need to update STA settings
                 if (pInstance->pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA) {
                     LOG_D("Restarting STA mode with new settings...\r\n");
-                    
+
+                    // #435: close TCP/UDP sockets BEFORE BSSDisconnect.  Without
+                    // this, the WINC chip's internal socket table retains stale
+                    // state (sockets bound to the prior association handle) when
+                    // the BSS goes away — and after the new BSSConnect succeeds,
+                    // the chip flaps STA disconnects every ~1.5 s in a tight loop
+                    // because the socket table is inconsistent.  Mirrors the
+                    // AP-restart path above (line ~1109) which already does this.
+                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN)) {
+                        wifi_tcp_server_CloseSocket();
+                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
+                    }
+                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
+                        CloseUdpSocket(&pInstance->udpServerSocket);
+                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
+                    }
+                    // Let the WINC HIF queue drain the socket-close commands
+                    // before stacking BSSDisconnect on top.  Without this delay,
+                    // a subsequent IPUseDHCPSet returns REQUEST_ERROR and we
+                    // spin in MainState INIT.
+                    vTaskDelay(pdMS_TO_TICKS(200));
+
                     // Disconnect if connected
                     if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED)) {
                         WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                     }
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                    
-                    // Wait for disconnect
-                    vTaskDelay(pdMS_TO_TICKS(500));
+
+                    // Wait for disconnect (BSSDisconnect → chip drops association
+                    // → callback → STA_DISCONNECTED event drained by next
+                    // ProcessState).  Bumped from 500 ms to 1500 ms because the
+                    // TCP socket closes added HIF queue work that needs to settle
+                    // before IPUseDHCPSet below — without the longer delay, that
+                    // call returns WDRV_WINC_STATUS_REQUEST_ERROR.
+                    vTaskDelay(pdMS_TO_TICKS(1500));
                     
                     // Reconfigure BSS context for STA mode
                     if (WDRV_WINC_STATUS_OK != WDRV_WINC_BSSCtxSetDefaults(&pInstance->bssCtx)) {

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1218,26 +1218,39 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 if (pInstance->pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA) {
                     LOG_D("Restarting STA mode with new settings...\r\n");
 
-                    // #435: close TCP/UDP sockets BEFORE BSSDisconnect.  Without
-                    // this, the WINC chip's internal socket table retains stale
-                    // state (sockets bound to the prior association handle) when
-                    // the BSS goes away — and after the new BSSConnect succeeds,
-                    // the chip flaps STA disconnects every ~1.5 s in a tight loop
-                    // because the socket table is inconsistent.  Mirrors the
-                    // AP-restart path above (line ~1109) which already does this.
-                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN)) {
-                        wifi_tcp_server_CloseSocket();
-                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
+                    // #435: if a TCP socket is active when APPLY hits, the
+                    // WINC chip's internal socket table retains stale state
+                    // through soft reconfigure and the new association
+                    // oscillates (8+ CONNECT→DISCONNECT cycles before
+                    // settling).  Bench-confirmed via instrumentation.  Soft
+                    // reconfigure of just the BSS context isn't enough — we
+                    // need a full chip reset to clear the socket table.
+                    //
+                    // Divert to HardReset (DEINIT → 2 s settle → INIT) which
+                    // pulls RESET_N + CHIP_EN low and brings the chip back
+                    // up clean.  The deferred-INIT path in ProcessState
+                    // picks up the new settings on its way back up.
+                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN) ||
+                        GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
+                        LOG_E("STA reconfig with active socket — diverting to HardReset (#435)");
+                        if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN)) {
+                            wifi_tcp_server_CloseSocket();
+                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
+                        }
+                        if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
+                            CloseUdpSocket(&pInstance->udpServerSocket);
+                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
+                        }
+                        // wifi_manager_HardReset arms the deferred-INIT
+                        // deadline and queues DEINIT.  isEnabled was just
+                        // set to 1 by UpdateNetworkSettings (since this
+                        // REINIT was queued) — HardReset will clear it
+                        // for the DEINIT path, then ProcessState's
+                        // deferred-INIT branch flips it back and queues
+                        // INIT once the 2 s settle elapses.
+                        wifi_manager_HardReset();
+                        break;
                     }
-                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
-                        CloseUdpSocket(&pInstance->udpServerSocket);
-                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
-                    }
-                    // Let the WINC HIF queue drain the socket-close commands
-                    // before stacking BSSDisconnect on top.  Without this delay,
-                    // a subsequent IPUseDHCPSet returns REQUEST_ERROR and we
-                    // spin in MainState INIT.
-                    vTaskDelay(pdMS_TO_TICKS(200));
 
                     // Disconnect if connected
                     if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED)) {
@@ -1246,13 +1259,8 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     }
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
 
-                    // Wait for disconnect (BSSDisconnect → chip drops association
-                    // → callback → STA_DISCONNECTED event drained by next
-                    // ProcessState).  Bumped from 500 ms to 1500 ms because the
-                    // TCP socket closes added HIF queue work that needs to settle
-                    // before IPUseDHCPSet below — without the longer delay, that
-                    // call returns WDRV_WINC_STATUS_REQUEST_ERROR.
-                    vTaskDelay(pdMS_TO_TICKS(1500));
+                    // Wait for disconnect
+                    vTaskDelay(pdMS_TO_TICKS(500));
                     
                     // Reconfigure BSS context for STA mode
                     if (WDRV_WINC_STATUS_OK != WDRV_WINC_BSSCtxSetDefaults(&pInstance->bssCtx)) {
@@ -1304,13 +1312,13 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     WDRV_WINC_SocketRegisterEventCallback(pInstance->wdrvHandle, &SocketEventCallback);
                     
                     // Connect to network
-                    if (WDRV_WINC_STATUS_OK != WDRV_WINC_BSSConnect(pInstance->wdrvHandle, 
+                    if (WDRV_WINC_STATUS_OK != WDRV_WINC_BSSConnect(pInstance->wdrvHandle,
                         &pInstance->bssCtx, &pInstance->authCtx, &StaEventCallback)) {
                         SendEvent(WIFI_MANAGER_EVENT_ERROR);
                         LOG_E("Error connecting to network\r\n");
                         break;
                     }
-                    
+
                     SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
                     LOG_D("STA mode connection initiated\r\n");
                 }

--- a/firmware/src/services/wifi_services/wifi_tcp_server.c
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.c
@@ -376,14 +376,27 @@ void wifi_tcp_server_CloseSocket() {
     // — all of which take wMutex around CircularBuf operations.  Without
     // this, a concurrent streaming write could be mid-CircularBuf_AddBytes
     // when CircularBuf_Reset wipes head/tail, corrupting the buffer state.
+    //
+    // Bounded 100 ms timeout — every other wMutex holder is a short
+    // CircularBuf_* operation that completes in <1 ms, so 100 ms is
+    // 100x headroom; if we somehow can't acquire it (deadlock,
+    // priority inversion, etc.) we proceed without the lock rather
+    // than wedging the REINIT path.  The worst case without the lock
+    // is the original race (occasional buffer-state corruption during
+    // close) which the WINC chip-reset that follows clears anyway.
+    bool gotLock = false;
     if (gpServerData->client.wMutex != NULL) {
-        xSemaphoreTake(gpServerData->client.wMutex, portMAX_DELAY);
+        gotLock = (xSemaphoreTake(gpServerData->client.wMutex,
+                                   pdMS_TO_TICKS(100)) == pdTRUE);
+        if (!gotLock) {
+            // Don't fail closed — REINIT path needs to make progress.
+        }
     }
     gpServerData->client.readBufferLength = 0;
     gpServerData->client.writeBufferLength = 0;
     gpServerData->client.tcpInFlight = 0;
     CircularBuf_Reset(&gpServerData->client.wCirbuf);
-    if (gpServerData->client.wMutex != NULL) {
+    if (gotLock) {
         xSemaphoreGive(gpServerData->client.wMutex);
     }
 }

--- a/firmware/src/services/wifi_services/wifi_tcp_server.c
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.c
@@ -365,16 +365,27 @@ void wifi_tcp_server_CloseSocket() {
         shutdown(gpServerData->client.clientSocket);
         gpServerData->client.clientSocket = -1;
     }
-    
+
     if (gpServerData->serverSocket != -1) {
         shutdown(gpServerData->serverSocket);
         gpServerData->serverSocket = -1;
     }
-    
+
+    // Reset write-buffer state under wMutex to serialize against
+    // wifi_tcp_server_WriteBuffer / GetWriteBuffFreeSize / TransmitBuffered
+    // — all of which take wMutex around CircularBuf operations.  Without
+    // this, a concurrent streaming write could be mid-CircularBuf_AddBytes
+    // when CircularBuf_Reset wipes head/tail, corrupting the buffer state.
+    if (gpServerData->client.wMutex != NULL) {
+        xSemaphoreTake(gpServerData->client.wMutex, portMAX_DELAY);
+    }
     gpServerData->client.readBufferLength = 0;
     gpServerData->client.writeBufferLength = 0;
     gpServerData->client.tcpInFlight = 0;
     CircularBuf_Reset(&gpServerData->client.wCirbuf);
+    if (gpServerData->client.wMutex != NULL) {
+        xSemaphoreGive(gpServerData->client.wMutex);
+    }
 }
 
 void wifi_tcp_server_CloseClientSocket() {


### PR DESCRIPTION
## Summary

Single APPLY while a TCP-SCPI client is connected wedged the WiFi state machine: STA disconnects fired every ~1.5 s in a tight loop, ADDR? returned the cached IP but SSIDSTR=0, TCP reopen timed out, recovery required a power-cycle.

## Root cause

The STA same-mode reconfigure path (`wifi_manager.c:1218+` inside `WIFI_MANAGER_EVENT_REINIT`) called `WDRV_WINC_BSSDisconnect` without first closing the open TCP/UDP sockets. The WINC chip's internal socket table retained sockets bound to the prior association handle; after the new BSSConnect, the chip's state was inconsistent and it dropped the association every ~1.5 s.

The corresponding **AP** same-mode reconfigure path (line ~1107) already did this correctly. This PR mirrors that pattern for STA, with two timing adjustments:

1. **200 ms gap between socket-close and BSSDisconnect.** Without it, the close + disconnect HIF commands stack faster than the chip can drain, and a subsequent IPUseDHCPSet returns `WDRV_WINC_STATUS_REQUEST_ERROR`.
2. **500 ms → 1500 ms wait after BSSDisconnect.** The added socket-close work pushes the WINC HIF queue deeper than the AP path ever sees.

## E evidence

**Pre-fix:** TCP reopen TimeoutError, SSIDSTR=0, STA Disconnect every 1.5 s, error count climbs forever, requires SYST:REBoot.

**Post-fix:** TCP reopen returns `*IDN?` response, SSIDSTR=94 after ~30 s settle, 0 disconnect events in steady state, automatic recovery.

## Acceptance (#435)

- [x] APPLY with TCP-SCPI client connected: TCP cleanly closes, re-association succeeds, new TCP connections accepted
- [x] No power-cycle required

Refs #435.