### PR TITLE
fix(wifi): mutex-safe CloseClientSocket (#437 defensive)

### DIFF
--- a/firmware/src/services/wifi_services/wifi_tcp_server.c
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.c
@@ -406,10 +406,26 @@ void wifi_tcp_server_CloseClientSocket() {
         shutdown(gpServerData->client.clientSocket);
         gpServerData->client.clientSocket = -1;
     }
+    // #437: same race as CloseSocket — resetting the circular buffer
+    // without wMutex collides with streaming-task writers mid-AddBytes,
+    // and CloseClientSocket runs on every peer-close (SOCKET_MSG_RECV
+    // with 0 bytes) AND every ACCEPT-replaces-existing-client cycle,
+    // i.e. far more often than CloseSocket.  Take wMutex with a bounded
+    // 100 ms timeout (every other holder is a fast CircularBuf_*
+    // operation); proceed without it on timeout rather than wedging the
+    // ACCEPT/RECV callback path that drives WiFi-SCPI lifecycle.
+    bool gotLock = false;
+    if (gpServerData->client.wMutex != NULL) {
+        gotLock = (xSemaphoreTake(gpServerData->client.wMutex,
+                                   pdMS_TO_TICKS(100)) == pdTRUE);
+    }
     gpServerData->client.readBufferLength = 0;
     gpServerData->client.writeBufferLength = 0;
     gpServerData->client.tcpInFlight = 0;
     CircularBuf_Reset(&gpServerData->client.wCirbuf);
+    if (gotLock) {
+        xSemaphoreGive(gpServerData->client.wMutex);
+    }
 }
 
 // #331: used by the WINC idle-gate to back off pacing when a TCP client

--- a/firmware/src/services/wifi_services/wifi_tcp_server.c
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.c
@@ -321,6 +321,7 @@ void wifi_tcp_server_Initialize(wifi_tcp_server_context_t *pServerData) {
         gpServerData->serverSocket = -1;
         gpServerData->client.clientSocket = -1;
         gpServerData->client.tcpInFlight = 0;
+        gpServerData->client.pendingBufferReset = false;
         gpServerData->client.wifiPartialBytesMissing = 0;
         gpServerData->client.wifiWriteBufferRejectedCalls = 0;
         gpServerData->client.wifiWriteBufferRejectedBytes = 0;
@@ -371,33 +372,22 @@ void wifi_tcp_server_CloseSocket() {
         gpServerData->serverSocket = -1;
     }
 
-    // Reset write-buffer state under wMutex to serialize against
-    // wifi_tcp_server_WriteBuffer / GetWriteBuffFreeSize / TransmitBuffered
-    // — all of which take wMutex around CircularBuf operations.  Without
-    // this, a concurrent streaming write could be mid-CircularBuf_AddBytes
-    // when CircularBuf_Reset wipes head/tail, corrupting the buffer state.
-    //
-    // Bounded 100 ms timeout — every other wMutex holder is a short
-    // CircularBuf_* operation that completes in <1 ms, so 100 ms is
-    // 100x headroom; if we somehow can't acquire it (deadlock,
-    // priority inversion, etc.) we proceed without the lock rather
-    // than wedging the REINIT path.  The worst case without the lock
-    // is the original race (occasional buffer-state corruption during
-    // close) which the WINC chip-reset that follows clears anyway.
-    bool gotLock = false;
-    if (gpServerData->client.wMutex != NULL) {
-        gotLock = (xSemaphoreTake(gpServerData->client.wMutex,
-                                   pdMS_TO_TICKS(100)) == pdTRUE);
-        if (!gotLock) {
-            // Don't fail closed — REINIT path needs to make progress.
-        }
-    }
+    // Read buffer fields are owned by WifiTask drain — no wMutex needed.
     gpServerData->client.readBufferLength = 0;
-    gpServerData->client.writeBufferLength = 0;
-    gpServerData->client.tcpInFlight = 0;
-    CircularBuf_Reset(&gpServerData->client.wCirbuf);
-    if (gotLock) {
+    // wCirbuf reset must hold wMutex.  Try non-blocking — if a writer
+    // currently holds the mutex, defer the reset to the next wMutex
+    // holder via pendingBufferReset.  Never block CloseSocket because
+    // it may be called from REINIT paths that need to make progress.
+    if (gpServerData->client.wMutex != NULL &&
+        xSemaphoreTake(gpServerData->client.wMutex, 0) == pdTRUE) {
+        gpServerData->client.writeBufferLength = 0;
+        gpServerData->client.tcpInFlight = 0;
+        CircularBuf_Reset(&gpServerData->client.wCirbuf);
+        gpServerData->client.pendingBufferReset = false;
         xSemaphoreGive(gpServerData->client.wMutex);
+    } else {
+        // Defer: next wMutex holder drains the flag (#437).
+        gpServerData->client.pendingBufferReset = true;
     }
 }
 
@@ -406,25 +396,37 @@ void wifi_tcp_server_CloseClientSocket() {
         shutdown(gpServerData->client.clientSocket);
         gpServerData->client.clientSocket = -1;
     }
-    // #437: same race as CloseSocket — resetting the circular buffer
-    // without wMutex collides with streaming-task writers mid-AddBytes,
-    // and CloseClientSocket runs on every peer-close (SOCKET_MSG_RECV
-    // with 0 bytes) AND every ACCEPT-replaces-existing-client cycle,
-    // i.e. far more often than CloseSocket.  Take wMutex with a bounded
-    // 100 ms timeout (every other holder is a fast CircularBuf_*
-    // operation); proceed without it on timeout rather than wedging the
-    // ACCEPT/RECV callback path that drives WiFi-SCPI lifecycle.
-    bool gotLock = false;
-    if (gpServerData->client.wMutex != NULL) {
-        gotLock = (xSemaphoreTake(gpServerData->client.wMutex,
-                                   pdMS_TO_TICKS(100)) == pdTRUE);
-    }
     gpServerData->client.readBufferLength = 0;
-    gpServerData->client.writeBufferLength = 0;
-    gpServerData->client.tcpInFlight = 0;
-    CircularBuf_Reset(&gpServerData->client.wCirbuf);
-    if (gotLock) {
+    // #437: deferred-reset pattern — never block the WINC driver task
+    // (which calls us from SocketEventCallback on ACCEPT/RECV(0)
+    // events).  Try non-blocking; on miss, set pendingBufferReset and
+    // let the next wMutex holder reset the buffer under lock.  This
+    // closes both the original race (Reset without mutex) AND the
+    // "blocks WINC callback for 100 ms" issue.  Future writers bail
+    // early on clientSocket == -1 (we just set it), so no new writer
+    // will start before the deferred reset drains.
+    if (gpServerData->client.wMutex != NULL &&
+        xSemaphoreTake(gpServerData->client.wMutex, 0) == pdTRUE) {
+        gpServerData->client.writeBufferLength = 0;
+        gpServerData->client.tcpInFlight = 0;
+        CircularBuf_Reset(&gpServerData->client.wCirbuf);
+        gpServerData->client.pendingBufferReset = false;
         xSemaphoreGive(gpServerData->client.wMutex);
+    } else {
+        gpServerData->client.pendingBufferReset = true;
+    }
+}
+
+// #437: helper called at the start of every wMutex critical section.
+// Drains a deferred CircularBuf_Reset that CloseClientSocket /
+// CloseSocket couldn't perform from a non-blocking context.  Caller
+// must hold gpServerData->client.wMutex.
+static inline void DrainPendingBufferReset(void) {
+    if (gpServerData->client.pendingBufferReset) {
+        gpServerData->client.writeBufferLength = 0;
+        gpServerData->client.tcpInFlight = 0;
+        CircularBuf_Reset(&gpServerData->client.wCirbuf);
+        gpServerData->client.pendingBufferReset = false;
     }
 }
 
@@ -449,9 +451,10 @@ size_t wifi_tcp_server_GetWriteBuffFreeSize() {
 
     // Must protect circular buffer access with mutex
     xSemaphoreTake(gpServerData->client.wMutex, portMAX_DELAY);
+    DrainPendingBufferReset();
     size_t freeSize = CircularBuf_NumBytesFree(&gpServerData->client.wCirbuf);
     xSemaphoreGive(gpServerData->client.wMutex);
-    
+
     return freeSize;
 }
 
@@ -468,6 +471,7 @@ size_t wifi_tcp_server_WriteBuffer(const char* data, size_t len) {
     // If buffer is full, return 0 immediately instead of blocking
     // This prevents the streaming task from stalling for 10-60ms
     xSemaphoreTake(gpServerData->client.wMutex, portMAX_DELAY);
+    DrainPendingBufferReset();
     if (CircularBuf_NumBytesFree(&gpServerData->client.wCirbuf) < len) {
         // #371: count rejections to verify wifiDroppedBytes accounting is working.
         gpServerData->client.wifiWriteBufferRejectedCalls++;
@@ -521,6 +525,7 @@ bool wifi_tcp_server_TransmitBufferedData() {
 
     // Check if data available with mutex protection
     xSemaphoreTake(gpServerData->client.wMutex, portMAX_DELAY);
+    DrainPendingBufferReset();
     bool hasData = (CircularBuf_NumBytesAvailable(&gpServerData->client.wCirbuf) > 0);
     if (hasData) {
         CircularBuf_ProcessBytes(&gpServerData->client.wCirbuf, NULL, WIFI_WBUFFER_SIZE, &ret);
@@ -552,6 +557,9 @@ void wifi_tcp_server_SetWriteBuffer(uint8_t* buf, uint32_t size) {
     }
 
     xSemaphoreTake(gpServerData->client.wMutex, portMAX_DELAY);
+    // Buffer swap completely replaces wCirbuf state below — any pending
+    // deferred reset is implicitly satisfied.  Clear the flag.
+    gpServerData->client.pendingBufferReset = false;
 
     uint32_t oldSize = gpServerData->client.wCirbuf.buf_size;
     gpServerData->client.wCirbuf.buf_ptr = buf;

--- a/firmware/src/services/wifi_services/wifi_tcp_server.h
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.h
@@ -67,6 +67,13 @@ typedef struct s_tcpClientContext
      *  and WDRV_WINC_Tasks (priority 2). */
     volatile uint8_t tcpInFlight;
 
+    /** #437: pending CircularBuf_Reset deferred from a context that
+     *  couldn't acquire wMutex (notably WINC driver task running
+     *  CloseClientSocket from SocketEventCallback).  Drained by the
+     *  next wMutex holder before its operation, ensuring the reset
+     *  happens under lock without ever blocking the WINC driver task. */
+    volatile bool pendingBufferReset;
+
     /** Bytes handed to radio send() successfully (64-bit for long sessions) */
     uint64_t wifiTcpBytesSent;
     /** Bytes confirmed by radio send callback (64-bit for long sessions) */


### PR DESCRIPTION
## Summary

`wifi_tcp_server_CloseClientSocket()` resets the TCP write circular buffer (`CircularBuf_Reset`) without taking `client.wMutex`. Streaming writers (`wifi_tcp_server_WriteBuffer`, `GetWriteBuffFreeSize`, `TransmitBufferedData`) all hold `wMutex` around CircularBuf operations, so a concurrent reset can clobber head/tail mid-AddBytes and corrupt buffer state.

Same race I fixed in `CloseSocket` as part of #438 — but `CloseClientSocket` runs far more often: every peer-close (`SOCKET_MSG_RECV` with 0 bytes) AND every ACCEPT-replaces-existing-client cycle. `CloseSocket` only runs on REINIT.

Fix mirrors #438: take `wMutex` with 100 ms bounded timeout; proceed without on timeout rather than wedging WINC callback path.

## E disclosure — defensive PR

Could not reproduce the documented #437 wedge symptom on current main (post-#438):
- 1000 TCP connect-close cycles, mixed patterns, 0 failures
- Concurrent USB SCPI during cycles, 0 failures

The race is real and matches the ticket's hypothesis ("stale state in WiFi SCPI context"), but I cannot confirm with V/E evidence that it is the exact root cause of #437. Shipping anyway because the race is genuine regardless of whether it manifested as the specific reported symptom.

## Recovery if wedge re-occurs

Capture `SYST:LOG?` + add a TCP-server diagnostic SCPI command for V evidence of actual stuck state.

Refs #437.