### PR TITLE
fix(wifi): broaden HardReset divert to bound listening sockets (#435 follow-up)

### DIFF
--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1230,15 +1230,26 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // pulls RESET_N + CHIP_EN low and brings the chip back
                     // up clean.  The deferred-INIT path in ProcessState
                     // picks up the new settings on its way back up.
-                    // Only divert when an actual TCP client is connected,
-                    // not merely when the listening server socket is bound
-                    // (which is true throughout normal STA operation).  The
-                    // wedge requires the chip's socket table to hold an
-                    // *accepted* connection state; bare listening sockets
-                    // tear down cleanly through the soft-reconfigure path
-                    // below.
-                    if (wifi_tcp_server_HasActiveClient()) {
-                        LOG_E("STA reconfig with active TCP client — diverting to HardReset (#435)");
+                    // Divert to HardReset whenever ANY socket is bound on
+                    // the chip (server-listening counts).  Bench evidence
+                    // (#437b regression, 2026-05-09) showed that even a
+                    // bare listening server socket retains stale state
+                    // across BSSDisconnect+BSSConnect and produces the
+                    // same flap-every-1.5 s symptom as the active-client
+                    // case (#435).  The earlier #438 round-3 narrowing
+                    // to HasActiveClient() was based on Qodo's "too broad"
+                    // critique but was disproven by bench storm-after-bind
+                    // testing — soft-reconfigure cannot fully clear the
+                    // chip's per-association socket table without RESET_N.
+                    //
+                    // Cost: ~30 s HardReset cycle on every APPLY in normal
+                    // STA operation (server is bound throughout).  Soft-
+                    // reconfigure was ~10-25 s anyway, so the practical
+                    // difference is minor; reliability beats speed.
+                    if (wifi_tcp_server_HasActiveClient() ||
+                        GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN) ||
+                        GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
+                        LOG_E("STA reconfig with bound socket — diverting to HardReset (#435/#437b)");
                         wifi_tcp_server_CloseSocket();
                         if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
                             CloseUdpSocket(&pInstance->udpServerSocket);


### PR DESCRIPTION
## Summary

Pre-existing bug uncovered by post-merge regression suite for #437/#439.

The #438 round-3 narrowing of the divert condition to `HasActiveClient()` was based on Qodo's argument that bare listening sockets would tear down cleanly through soft-reconfigure. **Bench-disproven**: a bare listening server socket retains stale state in the WINC's per-association socket table across BSSDisconnect+BSSConnect, producing the same 1.5 s flap symptom as the active-client case (#435).

## Repro on plain main (post-#439)

1. Baseline TCP probe → PASS
2. 500 connect-close cycles → PASS
3. 5× rapid APPLY storm → gate rejects 4/5
4. Wait 35 s → after-storm TCP probe TIMEOUT
5. `SYST:INFo?` → WiFi: Disconnected, IP cached
6. `SYST:LOG?` → "WiFi STA Disconnected - Error Code: 0" every 1.5 s

Same flap mechanism as #435 case 2.

## Fix

Divert to HardReset when **any** of:
- `wifi_tcp_server_HasActiveClient()` (original #435 case 2)
- `WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN` (bare server bound)
- `WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN` (UDP bound)

## Cost

Server stays bound throughout normal STA operation, so divert fires on most APPLYs in steady state. HardReset is ~30 s; soft-reconfigure was ~10-25 s but wedges. Reliability beats speed.

## E evidence

All paths PASS post-fix:
- Baseline TCP probe
- 500 connect-close cycles
- 5× rapid APPLY storm + after-storm probe
- APPLY with active TCP client + after-apply probe
- 30 s steady-state: SSIDSTR=92, 0 events

Refs #435, #437.