### PR TITLE
fix(scpi): populate *IDN? SN field with real silicon serial (#436)

### DIFF
--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -432,6 +432,12 @@ void app_SystemInit() {
     // transport creates its SCPI context or dispatches a callback.
     SCPI_ResponseBuf_Init();
 
+    // #436: build the device-wide *IDN? model and serial-number strings now,
+    // before any task spawns — once filled they are read-only, so concurrent
+    // CreateSCPIContext() calls from USB and WiFi tasks see stable values
+    // without needing per-context storage or a runtime lock.
+    SCPI_InitIdentification();
+
     // Initialize SPI coordination framework (currently disabled)
     // Note: Coordination disabled (SPI0_COORDINATION_ENABLED=0) - no runtime overhead
     // To enable frequency benchmarking: Set SPI0_COORDINATION_ENABLED=1 and rebuild

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -472,10 +472,13 @@ void app_SystemInit() {
     InitBoardConfig(&tmpTopLevelSettings.settings.topLevelSettings);
     InitBoardRuntimeConfig(tmpTopLevelSettings.settings.topLevelSettings.boardVariant);
 
-    // #436 round 2: build *IDN? model+SN AFTER InitBoardConfig populates
-    // boardSerialNumber from DEVSN1:DEVSN0.  Earlier placement (right after
-    // SCPI_ResponseBuf_Init) reads the pre-init zero serial.  Still pre-
-    // scheduler, so the writes are race-free.
+    // #436: build *IDN? model+SN strings here, AFTER InitBoardConfig
+    // populated boardSerialNumber from DEVSN1:DEVSN0 and BEFORE any of
+    // the transport tasks (USB / WiFi / SCPI) are xTaskCreate'd later in
+    // this same function.  Sequential ordering inside app_SystemInit is
+    // the synchronization — see SCPI_InitIdentification's docstring for
+    // the full rationale, including why "pre-scheduler" is the wrong
+    // mental model (we're inside priority-1 APP_FREERTOS_Tasks).
     SCPI_InitIdentification();
 
     CoherentPool_Init();

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -432,12 +432,6 @@ void app_SystemInit() {
     // transport creates its SCPI context or dispatches a callback.
     SCPI_ResponseBuf_Init();
 
-    // #436: build the device-wide *IDN? model and serial-number strings now,
-    // before any task spawns — once filled they are read-only, so concurrent
-    // CreateSCPIContext() calls from USB and WiFi tasks see stable values
-    // without needing per-context storage or a runtime lock.
-    SCPI_InitIdentification();
-
     // Initialize SPI coordination framework (currently disabled)
     // Note: Coordination disabled (SPI0_COORDINATION_ENABLED=0) - no runtime overhead
     // To enable frequency benchmarking: Set SPI0_COORDINATION_ENABLED=1 and rebuild
@@ -477,6 +471,13 @@ void app_SystemInit() {
     // Load board config structures with the correct board variant values
     InitBoardConfig(&tmpTopLevelSettings.settings.topLevelSettings);
     InitBoardRuntimeConfig(tmpTopLevelSettings.settings.topLevelSettings.boardVariant);
+
+    // #436 round 2: build *IDN? model+SN AFTER InitBoardConfig populates
+    // boardSerialNumber from DEVSN1:DEVSN0.  Earlier placement (right after
+    // SCPI_ResponseBuf_Init) reads the pre-init zero serial.  Still pre-
+    // scheduler, so the writes are race-free.
+    SCPI_InitIdentification();
+
     CoherentPool_Init();
     // Allocate WiFi SPI DMA staging buffer from coherent pool at boot
     // (needed before WiFi init; auto-balanced at stream start)

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -80,6 +80,14 @@
 // SCPI_IDN3 (serial number) is constructed dynamically from BoardConfig.boardSerialNumber (#436)
 #define SCPI_IDN4 "01-02"
 
+// File-scope IDN strings: built once by SCPI_InitIdentification() pre-scheduler
+// and then read-only.  libscpi stores these as raw pointers in every per-
+// transport SCPI context, so the storage must outlive every context.  Module-
+// scope avoids the data race that function-static buffers would have when
+// CreateSCPIContext() is called concurrently from USB and WiFi tasks (#441
+// Qodo finding) — the writes happen before any SCPI task spawns.
+static char gIdnModel[8]   = "Nq?";  // Filled from BoardConfig.BoardVariant
+static char gIdnSerial[17] = "0";    // 16 hex digits of uint64 + null
 
 // Declare force bootloader RAM flag location
 volatile uint32_t force_bootloader_flag __attribute__((persistent, coherent, address(FORCE_BOOTLOADER_FLAG_ADDR)));
@@ -457,6 +465,26 @@ void SCPI_ResponseBuf_Init(void) {
         gScpiRespMutex = xSemaphoreCreateMutexStatic(&gScpiRespMutexStorage);
     }
     taskEXIT_CRITICAL();
+}
+
+void SCPI_InitIdentification(void) {
+    // #441 Qodo finding: must run pre-scheduler.  CreateSCPIContext is called
+    // from both UsbCdc_Initialize (USB task) and wifi_tcp_server_Initialize
+    // (WiFi task) — concurrent snprintf() into shared gIdn* buffers would race
+    // and libscpi stores the raw pointers, so corruption would persist in the
+    // *IDN? response.  Calling this once from app_SystemInit before any task
+    // spawns makes the writes atomic by construction.
+    const tBoardConfig* pBoardConfig = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+    if (pBoardConfig != NULL) {
+        snprintf(gIdnModel, sizeof(gIdnModel), "Nq%d", pBoardConfig->BoardVariant);
+        // SCPI 1999.0 §10.14.1 requires a real per-unit identifier.  Use the
+        // silicon serial (DEVSN1:DEVSN0) the rest of the firmware already
+        // exposes via SYST:SN? and the streaming CSV metadata header.
+        snprintf(gIdnSerial, sizeof(gIdnSerial), "%016llX",
+                 (unsigned long long)pBoardConfig->boardSerialNumber);
+    }
+    // pBoardConfig == NULL leaves the file-scope defaults ("Nq?", "0") in
+    // place — same fallback as before, but now no concurrent-write hazard.
 }
 
 uint8_t* SCPI_ResponseBuf_Take(void) {
@@ -4396,34 +4424,16 @@ scpi_t CreateSCPIContext(scpi_interface_t* interface, void* user_context) {
     // mutex is guaranteed to exist before any callback could dispatch.
     SCPI_ResponseBuf_Init();
 
-    // Construct model + SN strings from BoardConfig (libscpi keeps the pointers,
-    // so the storage must outlive the call — module-shared statics are fine
-    // because every transport gets the same model and SN).
-    static char modelString[8] = {0};
-    static char snString[17] = {0};  // 16 hex digits of uint64 + null
-    const tBoardConfig* pBoardConfig = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
-    if (pBoardConfig) {
-        snprintf(modelString, sizeof(modelString), "Nq%d", pBoardConfig->BoardVariant);
-        // #436: SCPI 1999.0 §10.14.1 requires a real per-unit identifier.
-        // Use the silicon serial (DEVSN1:DEVSN0) the rest of the firmware
-        // already exposes via SYST:SN? and the streaming CSV metadata header.
-        snprintf(snString, sizeof(snString), "%016llX",
-                 (unsigned long long)pBoardConfig->boardSerialNumber);
-    } else {
-        strncpy(modelString, "Nq?", sizeof(modelString));
-        modelString[sizeof(modelString) - 1] = '\0';
-        strncpy(snString, "0", sizeof(snString));
-        snString[sizeof(snString) - 1] = '\0';
-    }
-
     // Create a context
     scpi_t daqifiScpiContext;
-    // Init context
+    // Init context.  gIdnModel and gIdnSerial are populated once pre-scheduler
+    // by SCPI_InitIdentification() so concurrent CreateSCPIContext() calls
+    // from USB and WiFi tasks just read the same finished strings.
     SCPI_Init(&daqifiScpiContext,
             scpi_commands,
             interface,
             scpi_units_def,
-            SCPI_IDN1, modelString, snString, SCPI_IDN4,
+            SCPI_IDN1, gIdnModel, gIdnSerial, SCPI_IDN4,
             scpi_input_buffer, SCPI_INPUT_BUFFER_LENGTH,
             scpi_error_queue_data, SCPI_ERROR_QUEUE_SIZE);
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -77,7 +77,7 @@
 //
 #define SCPI_IDN1 "DAQiFi"
 // SCPI_IDN2 (model) is constructed dynamically from BoardConfig.BoardVariant
-#define SCPI_IDN3 NULL
+// SCPI_IDN3 (serial number) is constructed dynamically from BoardConfig.boardSerialNumber (#436)
 #define SCPI_IDN4 "01-02"
 
 
@@ -4396,14 +4396,24 @@ scpi_t CreateSCPIContext(scpi_interface_t* interface, void* user_context) {
     // mutex is guaranteed to exist before any callback could dispatch.
     SCPI_ResponseBuf_Init();
 
-    // Construct model string from BoardConfig.BoardVariant (e.g., "Nq3")
-    static char modelString[8] = {0};  // Initialize to prevent garbage data
+    // Construct model + SN strings from BoardConfig (libscpi keeps the pointers,
+    // so the storage must outlive the call — module-shared statics are fine
+    // because every transport gets the same model and SN).
+    static char modelString[8] = {0};
+    static char snString[17] = {0};  // 16 hex digits of uint64 + null
     const tBoardConfig* pBoardConfig = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
     if (pBoardConfig) {
         snprintf(modelString, sizeof(modelString), "Nq%d", pBoardConfig->BoardVariant);
+        // #436: SCPI 1999.0 §10.14.1 requires a real per-unit identifier.
+        // Use the silicon serial (DEVSN1:DEVSN0) the rest of the firmware
+        // already exposes via SYST:SN? and the streaming CSV metadata header.
+        snprintf(snString, sizeof(snString), "%016llX",
+                 (unsigned long long)pBoardConfig->boardSerialNumber);
     } else {
         strncpy(modelString, "Nq?", sizeof(modelString));
-        modelString[sizeof(modelString) - 1] = '\0';  // Ensure null termination
+        modelString[sizeof(modelString) - 1] = '\0';
+        strncpy(snString, "0", sizeof(snString));
+        snString[sizeof(snString) - 1] = '\0';
     }
 
     // Create a context
@@ -4413,7 +4423,7 @@ scpi_t CreateSCPIContext(scpi_interface_t* interface, void* user_context) {
             scpi_commands,
             interface,
             scpi_units_def,
-            SCPI_IDN1, modelString, SCPI_IDN3, SCPI_IDN4,
+            SCPI_IDN1, modelString, snString, SCPI_IDN4,
             scpi_input_buffer, SCPI_INPUT_BUFFER_LENGTH,
             scpi_error_queue_data, SCPI_ERROR_QUEUE_SIZE);
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -468,12 +468,18 @@ void SCPI_ResponseBuf_Init(void) {
 }
 
 void SCPI_InitIdentification(void) {
-    // #441 Qodo finding: must run pre-scheduler.  CreateSCPIContext is called
-    // from both UsbCdc_Initialize (USB task) and wifi_tcp_server_Initialize
-    // (WiFi task) — concurrent snprintf() into shared gIdn* buffers would race
-    // and libscpi stores the raw pointers, so corruption would persist in the
-    // *IDN? response.  Calling this once from app_SystemInit before any task
-    // spawns makes the writes atomic by construction.
+    // #441 Qodo finding: CreateSCPIContext is called from both
+    // UsbCdc_Initialize (USB task) and wifi_tcp_server_Initialize (WiFi
+    // task) — concurrent snprintf() into shared gIdn* buffers would race
+    // and libscpi stores the raw pointers, so corruption would persist in
+    // the *IDN? response.  We avoid that race by populating the strings
+    // sequentially in app_SystemInit, AFTER InitBoardConfig sets the
+    // silicon serial AND BEFORE any of those transport tasks are created
+    // (their xTaskCreate calls happen later in the same app_SystemInit
+    // body).  The scheduler is technically running by this point — we're
+    // inside the priority-1 APP_FREERTOS_Tasks boot task — but no higher-
+    // priority task has reached CreateSCPIContext yet because none have
+    // been created.
     const tBoardConfig* pBoardConfig = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
     if (pBoardConfig != NULL) {
         snprintf(gIdnModel, sizeof(gIdnModel), "Nq%d", pBoardConfig->BoardVariant);

--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -27,10 +27,14 @@ extern "C" {
     /**
      * Build the device-wide model and serial-number strings used in *IDN?
      * (#436).  Reads BoardConfig once and writes module-scope statics that
-     * CreateSCPIContext later passes to SCPI_Init.  MUST be called once
-     * pre-scheduler so the strings are stable before any transport task
-     * creates its SCPI context — running it from a task context with
-     * pre-emption enabled would race the writes.
+     * CreateSCPIContext later passes to SCPI_Init.  MUST be called from
+     * app_SystemInit, AFTER InitBoardConfig populates boardSerialNumber
+     * AND BEFORE any transport task is created (USB/WiFi/SCPI tasks all
+     * call CreateSCPIContext during their own initialization).  The
+     * scheduler IS already running by this point — app_SystemInit runs
+     * inside the priority-1 APP_FREERTOS_Tasks task — but no other task
+     * has reached CreateSCPIContext yet because their xTaskCreate calls
+     * happen later in the same app_SystemInit body, sequentially.
      * Idempotent: subsequent calls just rewrite the same value.
      */
     void SCPI_InitIdentification(void);

--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -25,6 +25,17 @@ extern "C" {
     void SCPI_ResponseBuf_Init(void);
 
     /**
+     * Build the device-wide model and serial-number strings used in *IDN?
+     * (#436).  Reads BoardConfig once and writes module-scope statics that
+     * CreateSCPIContext later passes to SCPI_Init.  MUST be called once
+     * pre-scheduler so the strings are stable before any transport task
+     * creates its SCPI context — running it from a task context with
+     * pre-emption enabled would race the writes.
+     * Idempotent: subsequent calls just rewrite the same value.
+     */
+    void SCPI_InitIdentification(void);
+
+    /**
      * Creates a new SCPI context object.
      * This allows us to have multiple independent consoles.
      * @param interface Defines the SCPI callback functions


### PR DESCRIPTION
## Summary
- `*IDN?` over USB CDC and WiFi-SCPI was returning the literal `"0"` placeholder in the SN field — two different physical units on the same workstation produced identical `*IDN?` strings.
- Root cause: `SCPI_IDN3` was `#define`'d to `NULL`; libscpi prints `0` for a NULL serial-number argument.
- Fix: build the SN string from `pBoardConfig->boardSerialNumber` (silicon `DEVSN1:DEVSN0`, already exposed via `SYST:SN?` and the streaming CSV metadata header) and pass it to `SCPI_Init`.
- Format: `%016llX` for stable 16-char hex width.

After: `DAQiFi,Nq1,7E2898F46200E8A7,01-02` (per-unit SN, SCPI 1999.0 §10.14.1 compliant).

## Test plan
- [ ] Bench-flash on NQ1 unit, run `*IDN?` over USB CDC — verify SN matches `SYST:SN?` output (both 16 hex digits)
- [ ] Run `*IDN?` over WiFi-SCPI (TCP/9760) — verify same SN string
- [ ] Verify on a second physical unit that the SNs differ
- [ ] Confirm format matches CSV metadata `# Serial <16 hex>` header
- [ ] Build at -O3 — already verified clean

Closes #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)