### PR TITLE
chore(entire): commit checkpoint_remote in project settings

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,8 +1,12 @@
 {
-  "strategy": "manual-commit",
   "enabled": true,
-  "telemetry": true,
   "strategy_options": {
+    "checkpoint_remote": {
+      "provider": "github",
+      "repo": "daqifi/nyquist-firmware-entire"
+    },
     "push_sessions": false
-  }
+  },
+  "telemetry": true,
+  "strategy": "manual-commit"
 }


### PR DESCRIPTION
## Summary
- `entire push` was emitting a discovery warning on every push because the `checkpoint_remote` was only configured in the gitignored `.entire/settings.local.json`.
- Move it into the committed `.entire/settings.json` so entire.io can discover the `daqifi/nyquist-firmware-entire` checkpoint mirror.
- Generated by `entire configure --checkpoint-remote github:daqifi/nyquist-firmware-entire`.

## Test plan
- [ ] After merge, run `entire push` locally — verify the discovery-warning line is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)