### PR TITLE
fix(adc,streaming): T * volatile on set-once shared static pointers (#421)

### DIFF
--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -123,6 +123,16 @@ void MC12bADC_EosInterruptTask(void) {
         }
 
         DioProbe_PulseStart(6);  /* probe 6: result read loop duration */
+        // Snapshot `T * volatile` globals once per wake — set-once at boot,
+        // safe to cache through this iteration.  Saves a volatile load on
+        // every loop iteration below (#421 round 2).
+        tBoardConfig *pCfg = gpBoardConfig;
+        tBoardRuntimeConfig *pRtCfg = gpBoardRuntimeConfig;
+        if (pCfg == NULL || pRtCfg == NULL) {
+            DioProbe_PulseEnd(6);
+            continue;
+        }
+
         AInSample sample;
         int i = 0;
         uint32_t adcval;
@@ -130,14 +140,14 @@ void MC12bADC_EosInterruptTask(void) {
         uint32_t *valueTMR = (uint32_t*) BoardData_Get(BOARDDATA_STREAMING_TIMESTAMP, 0);
         uint32_t timestamp = (valueTMR != NULL) ? *valueTMR : 0;
 
-        bool streamingActive = gpBoardRuntimeConfig->StreamingConfig.Running;
+        bool streamingActive = pRtCfg->StreamingConfig.Running;
         bool diagScanning = !streamingActive ||
-                            gpBoardRuntimeConfig->StreamingConfig.OnboardDiagEnabled;
+                            pRtCfg->StreamingConfig.OnboardDiagEnabled;
 
-        for (i = 0; i < gpBoardConfig->AInChannels.Size; i++) {
-            const AInChannel* cfg = &gpBoardConfig->AInChannels.Data[i];
+        for (i = 0; i < pCfg->AInChannels.Size; i++) {
+            const AInChannel* cfg = &pCfg->AInChannels.Data[i];
             if (cfg->Type != AIn_MC12bADC) continue;
-            if (gpBoardRuntimeConfig->AInChannels.Data[i].IsEnabled != 1) continue;
+            if (pRtCfg->AInChannels.Data[i].IsEnabled != 1) continue;
 
             bool isMonitoring = (cfg->Config.MC12b.IsPublic != 1);
             bool isType1User = (!isMonitoring && cfg->Config.MC12b.ChannelType == 1);
@@ -488,18 +498,24 @@ static uint8_t ADC_FindModuleIndex(const AInModule* pModule) {
 }
 
 bool ADC_ReadADCSampleFromISR(uint32_t value, uint8_t bufferIndex) {
+    // Snapshot the `T * volatile` globals into locals once per ISR entry to
+    // avoid a fresh volatile load on every loop iteration.  Set-once at boot,
+    // so caching for the duration of this call is safe (#421 round 2).
+    tBoardConfig *pCfg = gpBoardConfig;
+    tBoardRuntimeConfig *pRtCfg = gpBoardRuntimeConfig;
+    if (pCfg == NULL || pRtCfg == NULL) return false;
 
     AInSample sample;
     bool status = false;
     int i = 0;
     sample.Value = value;
     uint32_t *valueTMR = (uint32_t*) BoardData_Get(BOARDDATA_STREAMING_TIMESTAMP, 0);
-    for (i = 0; i < gpBoardConfig->AInChannels.Size; i++) {
-        if (gpBoardConfig->AInChannels.Data[i].Config.MC12b.ChannelId == bufferIndex
-                && gpBoardRuntimeConfig->AInChannels.Data[i].IsEnabled == 1) {
+    for (i = 0; i < pCfg->AInChannels.Size; i++) {
+        if (pCfg->AInChannels.Data[i].Config.MC12b.ChannelId == bufferIndex
+                && pRtCfg->AInChannels.Data[i].IsEnabled == 1) {
 
             sample.Timestamp = *valueTMR;
-            sample.Channel =gpBoardConfig->AInChannels.Data[i].DaqifiAdcChannelId ;
+            sample.Channel = pCfg->AInChannels.Data[i].DaqifiAdcChannelId;
             BoardData_Set(
                     BOARDDATA_AIN_LATEST,
                     i,
@@ -510,7 +526,7 @@ bool ADC_ReadADCSampleFromISR(uint32_t value, uint8_t bufferIndex) {
 
         }
     }
-    
+
     return status;
 }
 

--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -19,13 +19,17 @@
 
 #define UNUSED(x) (void)(x)
 
-//! Pointer to the board configuration data structure to be set in initialization
-static tBoardConfig *gpBoardConfig;
-//! Pointer to the board runtime configuration data structure, to be set 
-// !in initialization
-static tBoardRuntimeConfig *gpBoardRuntimeConfig;
-// Pointer to the BoardData data structure, to be set in initialization
-static tBoardData* gpBoardData;
+//! Pointer to the board configuration data structure to be set in initialization.
+//! `T * volatile` per #421 — set once in ADC_Init (pre-scheduler) and
+//! dereferenced from ADC ISRs (priority 1) + tasks; without the qualifier,
+//! -O3 hoists/merges loads across the task↔ISR boundary (#354 ch15 regression).
+static tBoardConfig * volatile gpBoardConfig;
+//! Pointer to the board runtime configuration data structure, to be set
+//! in initialization.  Same volatile rationale as gpBoardConfig (#421).
+static tBoardRuntimeConfig * volatile gpBoardRuntimeConfig;
+// Pointer to the BoardData data structure, to be set in initialization.
+// Same volatile rationale as gpBoardConfig (#421).
+static tBoardData * volatile gpBoardData;
 static TaskHandle_t gADCInterruptHandle;
 
 // FreeRTOS tick count of the last successful monitoring channel read.

--- a/firmware/src/HAL/ADC/AD7609.c
+++ b/firmware/src/HAL/ADC/AD7609.c
@@ -81,8 +81,11 @@ static uint32_t AD7609_Extract18Bit(const uint8_t* buf, uint16_t bitPos) {
 //! Timeout: 10x datasheet spec = 100us for safety margin
 #define AD7609_BSY_SETTLE_TIMEOUT_US 100
 
-//! Pointer to the module configuration data structure to be set in initialization
-static const AD7609ModuleConfig* pModuleConfigAD7609;
+//! Pointer to the module configuration data structure to be set in initialization.
+//! `T * volatile` per #421 — set once in AD7609_InitHardware and dereferenced
+//! from AD7609_BSY_InterruptCallback (GPIO ISR) + deferred task; same -O3
+//! task↔ISR-load-hoisting hazard as the ADC.c gpBoardConfig set (#354 ch15).
+static const AD7609ModuleConfig * volatile pModuleConfigAD7609;
 //! Pointer to the module configuration data structure in runtime
 static AInModuleRuntimeConfig* pModuleRuntimeConfigAD7609 __attribute__((unused));
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -180,12 +180,15 @@ static volatile uint32_t bufferSize = 0;
 //! Pointer to the board configuration data structure to be set in 
 //! initialization
 //static tStreamingConfig *pConfigStream;
-//! Pointer to the board runtime configuration data structure, to be
-//! set in initialization
-static StreamingRuntimeConfig *gpRuntimeConfigStream;
-//! Pointer to the board configuration data structure, to be
-//! set in initialization
-static tStreamingConfig *gpStreamingConfig;
+//! Pointer to the streaming runtime configuration data structure, to be
+//! set in initialization.  `T * volatile` per #421 — set once in
+//! Streaming_Init and dereferenced from Streaming_TimerHandler (timer ISR
+//! priority 1) + multiple tasks; same -O3 task↔ISR-load-hoisting hazard
+//! as the ADC.c gpBoardConfig set (#354 ch15 regression).
+static StreamingRuntimeConfig * volatile gpRuntimeConfigStream;
+//! Pointer to the streaming configuration data structure, to be
+//! set in initialization.  Same volatile rationale as gpRuntimeConfigStream (#421).
+static tStreamingConfig * volatile gpStreamingConfig;
 //! Indicate if handler is used 
 // volatile per #421 — re-entry guard; written and read in timer ISR.
 // Without volatile, -O3 may elide the read or hoist it out of the function.


### PR DESCRIPTION
## Summary

Re-audit of #410 with the expanded definition that includes set-once-shared-pointer patterns (the #354 ch15 regression class). Six sites identified, all matching the shape `static T *gp = NULL;` set once in `Init()` (pre-scheduler) and dereferenced from BOTH a task AND an ISR (or higher-priority deferred-interrupt task):

| File | Line | Pointer | Read contexts |
|---|---|---|---|
| `firmware/src/HAL/ADC.c` | 23 | `gpBoardConfig` | `ADC_ReadADCSampleFromISR` (priority-1 ADC ISR), deferred tasks |
| `firmware/src/HAL/ADC.c` | 26 | `gpBoardRuntimeConfig` | same |
| `firmware/src/HAL/ADC.c` | 28 | `gpBoardData` | deferred tasks via `ADC_HandleAD7609Interrupt`, `MC12bADC_EosInterruptTask` |
| `firmware/src/HAL/ADC/AD7609.c` | 85 | `pModuleConfigAD7609` | `AD7609_BSY_InterruptCallback` (GPIO ISR) + deferred task |
| `firmware/src/services/streaming.c` | 185 | `gpRuntimeConfigStream` | `Streaming_TimerHandler` (timer ISR priority 1) + tasks |
| `firmware/src/services/streaming.c` | 188 | `gpStreamingConfig` | same |

## Why this matters

Without `volatile`, GCC at -O3 may hoist/merge address loads across the task↔ISR boundary because the pointer is effectively constant — the same miscompile shape that produced the #354 ch15 regression. The pointer-volatile form (`T * volatile p`) per CLAUDE.md "Atomicity & Concurrency Rules" forces a fresh load at each access, which is the empirically-working fix for this class on PIC32MZ + XC32 v4.60.

The pointed-to data is not RMW'd across contexts (cross-task RMW is already protected by critical sections elsewhere), so data-volatile (`volatile T *`) is not required and would propagate qualifier-mismatch cascade through every API.

## Audit ruled out (already volatile or no ISR dereference)

- `HAL/ADC/MC12bADC.c` — `gpModuleConfigMC12`, `gpModuleRuntimeConfigMC12` (read only from deferred task, not ISR)
- `HAL/Power/PowerApi.c` — pointers read only from `Power_Tasks` (FreeRTOS task)
- `HAL/DIO.c`, `HAL/UI/UI.c`, `HAL/BQ24297/BQ24297.c` — task-only access
- `services/sd_card_services/sd_card_manager.c::gSdSharedBuffer` — SD task only
- `state/data/AInSample.c::samplePoolBase`, `nextFree` — mutex-guarded
- `Util/StreamingBufferPool.c::gPool` — task-only access
- Function-pointer tables (`ADCHS_CallbackObj[]`) — already `volatile`-qualified

## Supersedes closed PR #420

PR #420 covered only the three `HAL/ADC.c` sites. It was closed without merging. This PR bundles the full audit + the additional three sites surfaced.

## Test plan
- [x] Build at -O3 with `-Werror` — clean
- [ ] Bench-flash on NQ1 unit (PICkit `BUR184882598`, COM3, busid 2-4, serial `7E2898F46200E8A7`)
- [ ] Run 16-channel CSV streaming test with all channels at 2 V — every channel should read ~2000 (the original #354 ch15 regression test)
- [ ] Run streaming throughput regression to confirm no perf regression vs Session 22 ceilings (1×T1 PB ≈ 19 kHz, 16ch CSV ≈ 6 kHz)
- [ ] `*IDN?` over USB CDC (and TCP if WiFi configured) — quick smoke test that ADC/streaming init still completes

Closes #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)