### PR TITLE
fix(wifi): apply reconnect backoff to initial-association failures (#416)

### DIFF
--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -77,6 +77,7 @@ struct stateMachineInst {
     tstrM2mRev wifiFirmwareVersion;
     TaskHandle_t fwUpdateTaskHandle;
     uint8_t staReconnectAttempts;  // Track STA reconnection attempts
+    TickType_t retryAfterTick;     // Earliest tick the next REINIT attempt is allowed (#416 round 2)
 };
 //===============Private Function Declrations================
 static void __attribute__((unused)) SetEventFlag(wifi_manager_stateFlag_t *pEventFlagState, uint16_t flag);
@@ -973,6 +974,19 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
             SendEvent(WIFI_MANAGER_EVENT_ERROR);
             break;
         case WIFI_MANAGER_EVENT_REINIT:
+            // #416 / #446: deadline-based retry backoff.  The ERROR
+            // handler sets retryAfterTick on STA failure; honor it by
+            // polling at 50 ms (same pattern as the BUSY case below)
+            // instead of holding the state-machine mutex for up to 30 s.
+            if (pInstance->retryAfterTick != 0) {
+                TickType_t now = xTaskGetTickCount();
+                if ((int32_t)(pInstance->retryAfterTick - now) > 0) {
+                    vTaskDelay(pdMS_TO_TICKS(50));
+                    SendEvent(WIFI_MANAGER_EVENT_REINIT);
+                    break;
+                }
+                pInstance->retryAfterTick = 0;  // deadline reached
+            }
             if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_READY)) {
                 //If WiFi firmware update is running and again initialized, then deinit WiFi firmware update
                 ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_READY);
@@ -1439,10 +1453,14 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // never fires (we never connected), so its attempt-
                     // counter increment at line ~969 is skipped — bump it
                     // here in that case so backoff escalates the same way
-                    // it does after a disconnect.
+                    // it does after a disconnect.  Clamp to prevent the
+                    // uint8_t from wrapping to 0 on long-running failures
+                    // (#446 Qodo round 1 finding 3).
                     if (!GetEventFlagStatus(pInstance->eventFlags,
                                             WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
-                        pInstance->staReconnectAttempts++;
+                        if (pInstance->staReconnectAttempts < 200) {
+                            pInstance->staReconnectAttempts++;
+                        }
                     }
 
                     uint32_t delayMs;
@@ -1460,9 +1478,13 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                         }
                     }
 
-                    // Wait before attempting reconnection
-                    vTaskDelay(pdMS_TO_TICKS(delayMs));
-
+                    // Set a deadline and let the REINIT handler poll the
+                    // BUSY/RETRY-wait path that's already there (50 ms
+                    // vTaskDelay + re-queue).  Without this, we'd hold
+                    // the state-machine mutex during the 30 s delay,
+                    // blocking SCPI active-pump commands (#446 Qodo
+                    // round 1 finding 2).
+                    pInstance->retryAfterTick = xTaskGetTickCount() + pdMS_TO_TICKS(delayMs);
                     SendEvent(WIFI_MANAGER_EVENT_REINIT);
                 } else {
                     // For AP mode or other errors, reinit immediately

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1425,10 +1425,26 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     errorLogged = true;
                 }
                 
-                // Implement power-efficient reconnect logic for STA mode
-                if (pInstance->pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA &&
-                    GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
-                    
+                // Implement power-efficient reconnect logic for STA mode.
+                // #416: applies to BOTH initial-association failures (the
+                // configured AP isn't reachable yet) AND reconnect-after-
+                // disconnect, not just post-STA_STARTED.  Previously the
+                // STA_STARTED gate let the else branch below hammer the
+                // WINC at ~30/sec on unreachable APs (200 Hz state-machine
+                // dispatch × ~30 ms per failed BSSConnect cycle) — measured
+                // 18,920 retries in 10 min in the field.
+                if (pInstance->pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA) {
+
+                    // For initial-association failures, STA_DISCONNECTED
+                    // never fires (we never connected), so its attempt-
+                    // counter increment at line ~969 is skipped — bump it
+                    // here in that case so backoff escalates the same way
+                    // it does after a disconnect.
+                    if (!GetEventFlagStatus(pInstance->eventFlags,
+                                            WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
+                        pInstance->staReconnectAttempts++;
+                    }
+
                     uint32_t delayMs;
                     if (pInstance->staReconnectAttempts < 5) {
                         // First 5 attempts: 1 second delay
@@ -1443,10 +1459,10 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                             LOG_D("Switching to power save mode - reconnect attempts with 30s delay\r\n");
                         }
                     }
-                    
+
                     // Wait before attempting reconnection
                     vTaskDelay(pdMS_TO_TICKS(delayMs));
-                    
+
                     SendEvent(WIFI_MANAGER_EVENT_REINIT);
                 } else {
                     // For AP mode or other errors, reinit immediately

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -985,14 +985,23 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
             // handler sets retryAfterTick on STA failure; honor it by
             // polling at 50 ms (same pattern as the BUSY case below)
             // instead of holding the state-machine mutex for up to 30 s.
+            //
+            // Round-5: gate on STA mode.  If the user APPLY'd a mode
+            // change mid-backoff (STA→AP, FW-update entry, etc.), the
+            // STA-side deadline becomes stale — clear it instead of
+            // delaying the unrelated reinit path.
             if (pInstance->retryAfterTick != 0) {
-                TickType_t now = xTaskGetTickCount();
-                if ((int32_t)(pInstance->retryAfterTick - now) > 0) {
-                    vTaskDelay(pdMS_TO_TICKS(50));
-                    SendEvent(WIFI_MANAGER_EVENT_REINIT);
-                    break;
+                if (pInstance->pWifiSettings->networkMode != WIFI_MANAGER_NETWORK_MODE_STA) {
+                    pInstance->retryAfterTick = 0;
+                } else {
+                    TickType_t now = xTaskGetTickCount();
+                    if ((int32_t)(pInstance->retryAfterTick - now) > 0) {
+                        vTaskDelay(pdMS_TO_TICKS(50));
+                        SendEvent(WIFI_MANAGER_EVENT_REINIT);
+                        break;
+                    }
+                    pInstance->retryAfterTick = 0;  // deadline reached
                 }
-                pInstance->retryAfterTick = 0;  // deadline reached
             }
             if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_READY)) {
                 //If WiFi firmware update is running and again initialized, then deinit WiFi firmware update
@@ -1505,9 +1514,18 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // if the tick arithmetic happens to land on 0 (rare
                     // at 32-bit wrap), bump to 1 so the REINIT handler's
                     // `retryAfterTick != 0` check still trips.
-                    pInstance->retryAfterTick = xTaskGetTickCount() + pdMS_TO_TICKS(delayMs);
-                    if (pInstance->retryAfterTick == 0) {
-                        pInstance->retryAfterTick = 1;
+                    //
+                    // Round-5: keep the earliest existing deadline if one
+                    // is already armed.  A burst of ERROR events (e.g.
+                    // queued faster than REINIT drains) would otherwise
+                    // each push the deadline forward, starving the retry.
+                    TickType_t newDeadline = xTaskGetTickCount() + pdMS_TO_TICKS(delayMs);
+                    if (newDeadline == 0) {
+                        newDeadline = 1;
+                    }
+                    if (pInstance->retryAfterTick == 0 ||
+                        (int32_t)(pInstance->retryAfterTick - newDeadline) > 0) {
+                        pInstance->retryAfterTick = newDeadline;
                     }
                     SendEvent(WIFI_MANAGER_EVENT_REINIT);
                 } else {

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -667,6 +667,13 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
             pInstance->udpServerSocket = -1;
             pInstance->wdrvHandle = DRV_HANDLE_INVALID;
             pInstance->assocHandle = WDRV_WINC_ASSOC_HANDLE_INVALID;
+            // Clear any retry-backoff deadline carried over from a previous
+            // ERROR cycle.  ENTRY also fires on transitions back to
+            // MainState (FW-update divert, fresh-init fallback at the
+            // bottom of MainState, #437b HardReset re-entry), where a
+            // stale deadline would unnecessarily delay the next REINIT
+            // attempt by up to 30 s.  Qodo round-3 finding (medium).
+            pInstance->retryAfterTick = 0;
 
             if (wifiFwUpdateRequested) {
                 SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_REQUESTED);

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1449,6 +1449,14 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 // 18,920 retries in 10 min in the field.
                 if (pInstance->pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA) {
 
+                    // Snapshot the counter BEFORE the increment so the
+                    // delay/log decisions reflect the attempt that JUST
+                    // failed.  Without the snapshot, the increment below
+                    // would bump it to 1 on the first failure and the
+                    // `attempt == 0` log branch would never fire (Qodo
+                    // round-2 suggestion on PR #446).
+                    uint8_t attempt = pInstance->staReconnectAttempts;
+
                     // For initial-association failures, STA_DISCONNECTED
                     // never fires (we never connected), so its attempt-
                     // counter increment at line ~969 is skipped — bump it
@@ -1464,16 +1472,17 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     }
 
                     uint32_t delayMs;
-                    if (pInstance->staReconnectAttempts < 5) {
+                    if (attempt < 5) {
                         // First 5 attempts: 1 second delay
                         delayMs = 1000;
-                        if (pInstance->staReconnectAttempts == 0) {  // Only log first attempt
-                            LOG_D("STA reconnect attempt %d/5 with 1s delay\r\n", pInstance->staReconnectAttempts + 1);
+                        if (attempt == 0) {  // Only log first attempt
+                            LOG_D("STA reconnect attempt %u/5 with 1s delay\r\n",
+                                  (unsigned)(attempt + 1));
                         }
                     } else {
                         // After 5 attempts: 30 second delay to save power
                         delayMs = 30000;
-                        if (pInstance->staReconnectAttempts == 5) {  // Only log when switching to power save
+                        if (attempt == 5) {  // Only log when switching to power save
                             LOG_D("Switching to power save mode - reconnect attempts with 30s delay\r\n");
                         }
                     }
@@ -1484,7 +1493,15 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // the state-machine mutex during the 30 s delay,
                     // blocking SCPI active-pump commands (#446 Qodo
                     // round 1 finding 2).
+                    //
+                    // Sentinel-collision guard: `0` means "no deadline";
+                    // if the tick arithmetic happens to land on 0 (rare
+                    // at 32-bit wrap), bump to 1 so the REINIT handler's
+                    // `retryAfterTick != 0` check still trips.
                     pInstance->retryAfterTick = xTaskGetTickCount() + pdMS_TO_TICKS(delayMs);
+                    if (pInstance->retryAfterTick == 0) {
+                        pInstance->retryAfterTick = 1;
+                    }
                     SendEvent(WIFI_MANAGER_EVENT_REINIT);
                 } else {
                     // For AP mode or other errors, reinit immediately


### PR DESCRIPTION
## Summary
- ERROR handler's backoff path was gated on `WIFI_MANAGER_STATE_FLAG_STA_STARTED` — only set AFTER a successful BSSConnect.
- On boot with an unreachable configured AP, the gate was false; the else branch fired with an immediate `SendEvent(REINIT)`; the state machine hammered the WINC at ~30 retries/sec (200 Hz dispatch × ~30 ms per failed cycle).
- Field-measured **18,920 retries in 10 minutes** per the issue body — WINC power / longevity hazard.

## Fix
- Drop the `STA_STARTED` gate so the backoff path also covers pre-`STA_STARTED` failures.
- For the initial-association case the existing counter increment in `STA_DISCONNECTED` never fires (we never connected). Bump `staReconnectAttempts` inline before the delay-selection logic when `!STA_STARTED` — this preserves escalation to the 30 s delay after 5 failed initial attempts.

Reconnect-after-disconnect path is unchanged (counter still bumped in `STA_DISCONNECTED`; the new conditional increment is gated by `!STA_STARTED` so we don't double-count).

## Test plan
- [x] Build clean at -O3
- [ ] Configure STA with an unreachable SSID, power-cycle, capture `SYST:LOG?` after 1 minute. Expect ~60 retries (1/sec for first 5, then 1/30sec thereafter) instead of ~1,800 retries (~30/sec).
- [ ] Reconnect-after-disconnect regression: associate with a reachable AP, then take the AP down. Confirm backoff cadence is unchanged (1 s × 5 then 30 s).

Closes #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)