### PR TITLE
fix(wifi): suppress false-positive Auth-Failed log during APPLY teardown (#423)

### DIFF
--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -170,6 +170,31 @@ static volatile bool gApplyInProgress = false;
 #define WIFI_APPLY_GATE_TIMEOUT_MS 30000u
 static volatile TickType_t gApplyInProgressDeadlineTick = 0;
 
+// #423 round-3: bounded deadline armed immediately before each APPLY-
+// driven BSSDisconnect / HardReset call site.  The async WINC disconnect
+// callback that ensues should be demoted (deliberate teardown, not a
+// real failure) — but ONLY for the ~callback-arrival window.  Past the
+// deadline, fresh BSSConnect failures (wrong password, scan miss, etc.)
+// still surface as LOG_E.  This outlives gApplyInProgress and
+// STA_CONNECTED across the HardReset cycle (which clears both), which
+// the round-2 (gApplyInProgress && STA_CONNECTED) check could not.
+// Sentinel 0 = no deadline armed; bumped to 1 on wrap.
+#define WIFI_APPLY_TEARDOWN_DEADLINE_MS 2000u
+static volatile TickType_t gApplyTeardownDeadlineTick = 0;
+
+// Arm the teardown-demotion deadline iff an APPLY is in flight; called
+// immediately before any BSSDisconnect / HardReset on an APPLY path.
+static inline void ArmApplyTeardownDeadline(void) {
+    if (gApplyInProgress) {
+        TickType_t deadline = xTaskGetTickCount() +
+                              pdMS_TO_TICKS(WIFI_APPLY_TEARDOWN_DEADLINE_MS);
+        if (deadline == 0) {
+            deadline = 1;
+        }
+        gApplyTeardownDeadlineTick = deadline;
+    }
+}
+
 //===========================================================
 //=====================Private Callbacks=====================
 
@@ -266,19 +291,18 @@ static void StaEventCallback(DRV_HANDLE handle, WDRV_WINC_ASSOC_HANDLE assocHand
               (errorCode == WDRV_WINC_CONN_ERROR_SCAN) ? "Scan Failed" :
               (errorCode == WDRV_WINC_CONN_ERROR_NOCRED) ? "No Credentials" :
               "Unknown";
-        // #423: demote LOG_E only when this disconnect is the teardown of
-        // an *existing* connection caused by an APPLY in flight (#440
-        // HardReset divert tears the association down before re-init —
-        // the WINC reports its canonical AUTH errorCode on the way out).
-        // Distinguish teardown-of-existing-connection from new-attempt-
-        // failed by checking STA_CONNECTED: it's still set when we tear
-        // down an established connection, but is false when a fresh
-        // BSSConnect attempt fails (e.g. wrong-password APPLY).  Using
-        // gApplyInProgress alone would over-demote real failures during
-        // the APPLY window (PR #447 Qodo round-1 findings #2/#3).
-        bool isApplyTeardown = gApplyInProgress &&
-            GetEventFlagStatus(gStateMachineContext.eventFlags,
-                               WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+        // #423 round-3: demote LOG_E only when the disconnect callback
+        // arrives within the short window after an APPLY-driven teardown
+        // was initiated.  The deadline is armed at each BSSDisconnect /
+        // HardReset call site (ArmApplyTeardownDeadline), so this check
+        // doesn't depend on gApplyInProgress / STA_CONNECTED still being
+        // true at callback time — both are cleared synchronously by the
+        // REINIT and HardReset paths before the async callback fires
+        // (Qodo round-2 finding #1).  Past the 2 s deadline, fresh
+        // BSSConnect failures on new settings still surface as LOG_E.
+        TickType_t teardownDeadline = gApplyTeardownDeadlineTick;
+        bool isApplyTeardown = (teardownDeadline != 0) &&
+                               (xTaskGetTickCount() < teardownDeadline);
         if (isApplyTeardown) {
             LOG_I("WiFi STA Disconnected during APPLY teardown - errorCode=%d (%s)\r\n",
                   errorCode, reason);
@@ -1074,11 +1098,12 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 
                 // Disconnect STA if connected
                 if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED)) {
+                    ArmApplyTeardownDeadline();  // #423: demote the impending async disconnect callback
                     WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                 }
                 ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                
+
                 // Close sockets
                 if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
                     CloseUdpSocket(&pInstance->udpServerSocket);
@@ -1106,11 +1131,12 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     
                     // Disconnect if connected
                     if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED)) {
+                        ArmApplyTeardownDeadline();  // #423
                         WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                     }
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                    
+
                     // Don't deinitialize - the driver gets into a bad state after deinit
                     // Instead, just wait for STA to disconnect and then configure for AP mode
                     vTaskDelay(pdMS_TO_TICKS(500));  // Let STA fully disconnect
@@ -1330,6 +1356,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                         // event can't be queued, propagate the failure as
                         // an ERROR event so the manager retries instead of
                         // silently leaving the chip in a half-reset state.
+                        ArmApplyTeardownDeadline();  // #423: HardReset triggers an async disconnect callback during deinit
                         if (!wifi_manager_HardReset()) {
                             LOG_E("HardReset divert failed to queue DEINIT");
                             // Try ERROR fallback so the manager retries; if
@@ -1345,6 +1372,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
 
                     // Disconnect if connected
                     if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED)) {
+                        ArmApplyTeardownDeadline();  // #423
                         WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                     }
@@ -1603,6 +1631,7 @@ void wifi_manager_BootInit(void) {
     gWifiReinitDeadlineTick = 0;
     gApplyInProgress = false;
     gApplyInProgressDeadlineTick = 0;
+    gApplyTeardownDeadlineTick = 0;
 }
 
 bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -199,14 +199,24 @@ static inline void ArmApplyTeardownDeadline(void) {
     }
 }
 
-// True iff we're still inside the teardown-demotion window.  Wrap-safe.
+// True iff we're still inside the teardown-demotion window.  Wrap-safe
+// via unsigned subtraction.  On window-expiry detection, also clears the
+// start tick to avoid a long-uptime + no-APPLY false-positive: if the
+// device never APPLYs for ~50 days (unlikely but reachable), the tick
+// counter wraps back near the stored start value and `elapsed` would
+// collapse to near-zero — putting us spuriously back "inside the
+// window."  Self-disarming closes that hole.
 static inline bool IsWithinApplyTeardownWindow(void) {
     TickType_t start = gApplyTeardownStartTick;
     if (start == 0) {
         return false;
     }
     TickType_t elapsed = xTaskGetTickCount() - start;
-    return elapsed < pdMS_TO_TICKS(WIFI_APPLY_TEARDOWN_WINDOW_MS);
+    if (elapsed >= pdMS_TO_TICKS(WIFI_APPLY_TEARDOWN_WINDOW_MS)) {
+        gApplyTeardownStartTick = 0;  // disarm; prevents post-wrap false positive
+        return false;
+    }
+    return true;
 }
 
 //===========================================================
@@ -1512,22 +1522,27 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 // intentional, not faults.  Same wrap-safe time-window
                 // discriminator used in StaEventCallback so genuine
                 // failures (wrong password etc.) past the window still
-                // LOG_E and bump the counter.
-                bool isApplyTeardown = IsWithinApplyTeardownWindow();
-
-                if (isApplyTeardown) {
-                    // Quietly observe; don't fire the error pipeline.
+                // LOG_E and bump the counter.  Short-circuit the rest of
+                // the recovery pipeline as well: the existing power-
+                // efficient reconnect logic below is already gated on
+                // STA_STARTED (cleared by the teardown) so it's a no-op
+                // in practice, but breaking here makes the intent
+                // explicit and stops future refactors from accidentally
+                // driving reconnects during a deliberate teardown.
+                if (IsWithinApplyTeardownWindow()) {
                     LOG_I("WiFi event ERROR during APPLY teardown\r\n");
-                } else {
-                    consecutiveErrors++;
-                    // Only log error on first occurrence or every 10th error.
-                    if (!errorLogged || (consecutiveErrors % 10 == 0)) {
-                        LOG_E("[%s:%d]WiFi error occurred (count: %d)\r\n",
-                              __FILE__, __LINE__, consecutiveErrors);
-                        errorLogged = true;
-                    }
+                    returnStatus = WIFI_MANAGER_STATE_MACHINE_RETURN_STATUS_HANDLED;
+                    break;
                 }
-                
+
+                consecutiveErrors++;
+                // Only log error on first occurrence or every 10th error.
+                if (!errorLogged || (consecutiveErrors % 10 == 0)) {
+                    LOG_E("[%s:%d]WiFi error occurred (count: %d)\r\n",
+                          __FILE__, __LINE__, consecutiveErrors);
+                    errorLogged = true;
+                }
+
                 // Implement power-efficient reconnect logic for STA mode.
                 // #416: applies to BOTH initial-association failures (the
                 // configured AP isn't reachable yet) AND reconnect-after-

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -260,13 +260,25 @@ static void StaEventCallback(DRV_HANDLE handle, WDRV_WINC_ASSOC_HANDLE assocHand
             gStateMachineContext.assocHandle != WDRV_WINC_ASSOC_HANDLE_INVALID) {
             return;  // Stale disconnect callback from previous connection
         }
-        LOG_E("WiFi STA Disconnected - Error Code: %d, Time: %u ticks, Reason: %s\r\n",
-              errorCode, (unsigned int)xTaskGetTickCount(),
+        const char *reason =
               (errorCode == WDRV_WINC_CONN_ERROR_AUTH) ? "Auth Failed" :
               (errorCode == WDRV_WINC_CONN_ERROR_ASSOC) ? "Association Failed" :
               (errorCode == WDRV_WINC_CONN_ERROR_SCAN) ? "Scan Failed" :
               (errorCode == WDRV_WINC_CONN_ERROR_NOCRED) ? "No Credentials" :
-              "Unknown");
+              "Unknown";
+        // #423: when an APPLY is in flight (e.g. user re-issued LAN APPLY
+        // while STA was connected — the broadened HardReset divert from
+        // #440 tears the association down before re-init), the WINC
+        // reports the canonical AUTH errorCode on the way out.  That's
+        // expected teardown noise, not a real authentication failure.
+        // Demote to LOG_I so SYST:LOG? doesn't show a spurious error.
+        if (gApplyInProgress) {
+            LOG_I("WiFi STA Disconnected during APPLY teardown - errorCode=%d (%s)\r\n",
+                  errorCode, reason);
+        } else {
+            LOG_E("WiFi STA Disconnected - Error Code: %d, Time: %u ticks, Reason: %s\r\n",
+                  errorCode, (unsigned int)xTaskGetTickCount(), reason);
+        }
         gStateMachineContext.assocHandle = WDRV_WINC_ASSOC_HANDLE_INVALID;  // Clear association handle
         SendEvent(WIFI_MANAGER_EVENT_STA_DISCONNECTED);
     }
@@ -1449,9 +1461,17 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 
                 consecutiveErrors++;
                 
-                // Only log error on first occurrence or every 10th error
+                // Only log error on first occurrence or every 10th error.
+                // #423: when an APPLY is in flight, the cascade from the
+                // intentional teardown lands here too — demote so SYST:LOG?
+                // doesn't show a spurious "WiFi error occurred" on every
+                // legitimate re-association.
                 if (!errorLogged || (consecutiveErrors % 10 == 0)) {
-                    LOG_E("[%s:%d]WiFi error occurred (count: %d)\r\n", __FILE__, __LINE__, consecutiveErrors);
+                    if (gApplyInProgress) {
+                        LOG_I("WiFi event ERROR during APPLY teardown (count: %d)\r\n", consecutiveErrors);
+                    } else {
+                        LOG_E("[%s:%d]WiFi error occurred (count: %d)\r\n", __FILE__, __LINE__, consecutiveErrors);
+                    }
                     errorLogged = true;
                 }
                 

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -170,29 +170,43 @@ static volatile bool gApplyInProgress = false;
 #define WIFI_APPLY_GATE_TIMEOUT_MS 30000u
 static volatile TickType_t gApplyInProgressDeadlineTick = 0;
 
-// #423 round-3: bounded deadline armed immediately before each APPLY-
+// #423 round-3: bounded window opened immediately before each APPLY-
 // driven BSSDisconnect / HardReset call site.  The async WINC disconnect
 // callback that ensues should be demoted (deliberate teardown, not a
 // real failure) — but ONLY for the ~callback-arrival window.  Past the
-// deadline, fresh BSSConnect failures (wrong password, scan miss, etc.)
+// window, fresh BSSConnect failures (wrong password, scan miss, etc.)
 // still surface as LOG_E.  This outlives gApplyInProgress and
 // STA_CONNECTED across the HardReset cycle (which clears both), which
 // the round-2 (gApplyInProgress && STA_CONNECTED) check could not.
-// Sentinel 0 = no deadline armed; bumped to 1 on wrap.
-#define WIFI_APPLY_TEARDOWN_DEADLINE_MS 2000u
-static volatile TickType_t gApplyTeardownDeadlineTick = 0;
+//
+// Round-4: store the *start* tick and compare elapsed `(now - start)`
+// against the window.  Unsigned subtraction handles FreeRTOS tick wrap
+// (TickType_t rolls over after ~50 days at 1 kHz), which `now < deadline`
+// would silently mis-classify.  Sentinel 0 = disarmed; bumped to 1 if
+// the captured start lands on 0.
+#define WIFI_APPLY_TEARDOWN_WINDOW_MS 2000u
+static volatile TickType_t gApplyTeardownStartTick = 0;
 
-// Arm the teardown-demotion deadline iff an APPLY is in flight; called
+// Arm the teardown-demotion window iff an APPLY is in flight; called
 // immediately before any BSSDisconnect / HardReset on an APPLY path.
 static inline void ArmApplyTeardownDeadline(void) {
     if (gApplyInProgress) {
-        TickType_t deadline = xTaskGetTickCount() +
-                              pdMS_TO_TICKS(WIFI_APPLY_TEARDOWN_DEADLINE_MS);
-        if (deadline == 0) {
-            deadline = 1;
+        TickType_t start = xTaskGetTickCount();
+        if (start == 0) {
+            start = 1;  // keep 0 reserved as the disarmed sentinel
         }
-        gApplyTeardownDeadlineTick = deadline;
+        gApplyTeardownStartTick = start;
     }
+}
+
+// True iff we're still inside the teardown-demotion window.  Wrap-safe.
+static inline bool IsWithinApplyTeardownWindow(void) {
+    TickType_t start = gApplyTeardownStartTick;
+    if (start == 0) {
+        return false;
+    }
+    TickType_t elapsed = xTaskGetTickCount() - start;
+    return elapsed < pdMS_TO_TICKS(WIFI_APPLY_TEARDOWN_WINDOW_MS);
 }
 
 //===========================================================
@@ -291,18 +305,15 @@ static void StaEventCallback(DRV_HANDLE handle, WDRV_WINC_ASSOC_HANDLE assocHand
               (errorCode == WDRV_WINC_CONN_ERROR_SCAN) ? "Scan Failed" :
               (errorCode == WDRV_WINC_CONN_ERROR_NOCRED) ? "No Credentials" :
               "Unknown";
-        // #423 round-3: demote LOG_E only when the disconnect callback
-        // arrives within the short window after an APPLY-driven teardown
-        // was initiated.  The deadline is armed at each BSSDisconnect /
-        // HardReset call site (ArmApplyTeardownDeadline), so this check
-        // doesn't depend on gApplyInProgress / STA_CONNECTED still being
-        // true at callback time — both are cleared synchronously by the
+        // #423: demote LOG_E only when the disconnect callback arrives
+        // within the short window after an APPLY-driven teardown was
+        // initiated (ArmApplyTeardownDeadline, called at each call site).
+        // This decouples the demotion decision from gApplyInProgress /
+        // STA_CONNECTED, both of which are cleared synchronously by the
         // REINIT and HardReset paths before the async callback fires
-        // (Qodo round-2 finding #1).  Past the 2 s deadline, fresh
-        // BSSConnect failures on new settings still surface as LOG_E.
-        TickType_t teardownDeadline = gApplyTeardownDeadlineTick;
-        bool isApplyTeardown = (teardownDeadline != 0) &&
-                               (xTaskGetTickCount() < teardownDeadline);
+        // (Qodo round-2 finding #1).  Past the window, fresh BSSConnect
+        // failures on new settings still surface as LOG_E.
+        bool isApplyTeardown = IsWithinApplyTeardownWindow();
         if (isApplyTeardown) {
             LOG_I("WiFi STA Disconnected during APPLY teardown - errorCode=%d (%s)\r\n",
                   errorCode, reason);
@@ -1495,16 +1506,14 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 static int consecutiveErrors = 0;
 
                 // #423: when this ERROR is the cascade from an APPLY-
-                // triggered teardown of an *existing* connection (#440
-                // HardReset divert path), demote the log and do NOT bump
-                // the consecutive-error counter — those events are
-                // intentional, not faults.  Same STA_CONNECTED-based
-                // teardown discriminator used in StaEventCallback so
-                // genuine failures (wrong password etc.) during an APPLY
-                // window remain LOG_E and still bump the counter.
-                bool isApplyTeardown = gApplyInProgress &&
-                    GetEventFlagStatus(pInstance->eventFlags,
-                                       WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                // triggered teardown (#440 HardReset divert path or
+                // BSSDisconnect-then-reconfig), demote the log and don't
+                // bump the consecutive-error counter — those events are
+                // intentional, not faults.  Same wrap-safe time-window
+                // discriminator used in StaEventCallback so genuine
+                // failures (wrong password etc.) past the window still
+                // LOG_E and bump the counter.
+                bool isApplyTeardown = IsWithinApplyTeardownWindow();
 
                 if (isApplyTeardown) {
                     // Quietly observe; don't fire the error pipeline.
@@ -1631,7 +1640,7 @@ void wifi_manager_BootInit(void) {
     gWifiReinitDeadlineTick = 0;
     gApplyInProgress = false;
     gApplyInProgressDeadlineTick = 0;
-    gApplyTeardownDeadlineTick = 0;
+    gApplyTeardownStartTick = 0;
 }
 
 bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -266,13 +266,20 @@ static void StaEventCallback(DRV_HANDLE handle, WDRV_WINC_ASSOC_HANDLE assocHand
               (errorCode == WDRV_WINC_CONN_ERROR_SCAN) ? "Scan Failed" :
               (errorCode == WDRV_WINC_CONN_ERROR_NOCRED) ? "No Credentials" :
               "Unknown";
-        // #423: when an APPLY is in flight (e.g. user re-issued LAN APPLY
-        // while STA was connected — the broadened HardReset divert from
-        // #440 tears the association down before re-init), the WINC
-        // reports the canonical AUTH errorCode on the way out.  That's
-        // expected teardown noise, not a real authentication failure.
-        // Demote to LOG_I so SYST:LOG? doesn't show a spurious error.
-        if (gApplyInProgress) {
+        // #423: demote LOG_E only when this disconnect is the teardown of
+        // an *existing* connection caused by an APPLY in flight (#440
+        // HardReset divert tears the association down before re-init —
+        // the WINC reports its canonical AUTH errorCode on the way out).
+        // Distinguish teardown-of-existing-connection from new-attempt-
+        // failed by checking STA_CONNECTED: it's still set when we tear
+        // down an established connection, but is false when a fresh
+        // BSSConnect attempt fails (e.g. wrong-password APPLY).  Using
+        // gApplyInProgress alone would over-demote real failures during
+        // the APPLY window (PR #447 Qodo round-1 findings #2/#3).
+        bool isApplyTeardown = gApplyInProgress &&
+            GetEventFlagStatus(gStateMachineContext.eventFlags,
+                               WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+        if (isApplyTeardown) {
             LOG_I("WiFi STA Disconnected during APPLY teardown - errorCode=%d (%s)\r\n",
                   errorCode, reason);
         } else {
@@ -1458,21 +1465,30 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
             {
                 static bool errorLogged = false;
                 static int consecutiveErrors = 0;
-                
-                consecutiveErrors++;
-                
-                // Only log error on first occurrence or every 10th error.
-                // #423: when an APPLY is in flight, the cascade from the
-                // intentional teardown lands here too — demote so SYST:LOG?
-                // doesn't show a spurious "WiFi error occurred" on every
-                // legitimate re-association.
-                if (!errorLogged || (consecutiveErrors % 10 == 0)) {
-                    if (gApplyInProgress) {
-                        LOG_I("WiFi event ERROR during APPLY teardown (count: %d)\r\n", consecutiveErrors);
-                    } else {
-                        LOG_E("[%s:%d]WiFi error occurred (count: %d)\r\n", __FILE__, __LINE__, consecutiveErrors);
+
+                // #423: when this ERROR is the cascade from an APPLY-
+                // triggered teardown of an *existing* connection (#440
+                // HardReset divert path), demote the log and do NOT bump
+                // the consecutive-error counter — those events are
+                // intentional, not faults.  Same STA_CONNECTED-based
+                // teardown discriminator used in StaEventCallback so
+                // genuine failures (wrong password etc.) during an APPLY
+                // window remain LOG_E and still bump the counter.
+                bool isApplyTeardown = gApplyInProgress &&
+                    GetEventFlagStatus(pInstance->eventFlags,
+                                       WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+
+                if (isApplyTeardown) {
+                    // Quietly observe; don't fire the error pipeline.
+                    LOG_I("WiFi event ERROR during APPLY teardown\r\n");
+                } else {
+                    consecutiveErrors++;
+                    // Only log error on first occurrence or every 10th error.
+                    if (!errorLogged || (consecutiveErrors % 10 == 0)) {
+                        LOG_E("[%s:%d]WiFi error occurred (count: %d)\r\n",
+                              __FILE__, __LINE__, consecutiveErrors);
+                        errorLogged = true;
                     }
-                    errorLogged = true;
                 }
                 
                 // Implement power-efficient reconnect logic for STA mode.


### PR DESCRIPTION
## Summary
When the user re-applies LAN settings while STA is connected, PR #440's broadened HardReset divert tears the WINC association down before re-init. On the way out, the WINC reports the canonical `WDRV_WINC_CONN_ERROR_AUTH` errorCode in its disconnect callback — **expected chip-teardown behavior, not a real authentication failure.**

Two `LOG_E` sites currently emit during that window and make `SYST:LOG?` show spurious errors on every legitimate re-apply:

- `wifi_manager.c::StaEventCallback` (line 262) — *"WiFi STA Disconnected - Error Code: 3 ... Reason: Auth Failed"*
- `wifi_manager.c::WIFI_MANAGER_EVENT_ERROR` handler (line 1424) — *"WiFi error occurred (count: N)"*

## Fix
Gate both on the existing `gApplyInProgress` flag from PR #434. When APPLY is in flight, demote `LOG_E → LOG_I` — teardown noise stays visible for debugging but doesn't surface as an error. When APPLY is NOT in flight, the original `LOG_E` fires unchanged — genuine auth failures still surface as expected.

The `gApplyInProgress` flag covers exactly the right window: set in `wifi_manager_UpdateNetworkSettings` when APPLY is queued, cleared on `STA_CONNECTED` (or `AP_STARTED`/`FW_UPDATE_READY`/safety-release).

## Test plan
- [x] Build clean at -O3
- [ ] Bench: connect to a reachable AP, confirm clean state via `SYST:LOG?`. Re-issue `LAN:APPLY` with same credentials. After re-association, `SYST:LOG?` should show NO `LOG_E` Auth-Failed/WiFi-error lines (only `LOG_I` teardown noise).
- [ ] Negative: with a wrong password, `LAN:APPLY` should still produce `LOG_E "Auth Failed"` (gApplyInProgress clears on `STA_CONNECTED`; a genuine wrong-password attempt never reaches that, so the LOG_E path is still in effect by the time it eventually fails — verify the timing).

Closes #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)