### PR TITLE
fix(streaming): USB silent-loss — gate by ActiveInterface, not hasUsb (#372)

### DIFF
--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1236,9 +1236,16 @@ void streaming_Task(void) {
             }
         }
 
-        // Single-interface streaming: only stream to the interface that initiated streaming.
-        // Only hasSD is consulted by the write path now (USB/WiFi gate on
-        // ActiveInterface directly per #371/#372 silent-loss fixes).
+        // Compute hasSD for the SD write block below.  ActiveInterface
+        // selects which outputs are streamed to:
+        //   - USB:        USB only
+        //   - WiFi:       WiFi only (WiFi+SD unsupported — share SPI bus)
+        //   - SD:         SD only
+        //   - UsbAndSd:   USB + SD concurrent
+        // USB and WiFi write blocks gate on ActiveInterface directly
+        // (per #371 / #372 silent-loss fixes).  Only the SD write block
+        // still consults a free-space flag, since its retry path needs
+        // to distinguish "buffer too full right now" from "SD not active".
         switch (pRunTimeStreamConf->ActiveInterface) {
             case StreamingInterface_SD:
             case StreamingInterface_UsbAndSd:

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1148,6 +1148,7 @@ void streaming_Task(void) {
     NanopbFlagsArray nanopbFlag;
     size_t usbSize, wifiSize, sdSize, maxSize;
     bool hasUsb, hasWifi, hasSD;
+    (void)hasUsb;   /* #372: ActiveInterface check used directly now; flag retained for symmetry */
     (void)hasWifi;  /* #371: ActiveInterface check used directly now; flag retained for symmetry */
     bool AINDataAvailable;
     bool DIODataAvailable;
@@ -1359,7 +1360,16 @@ void streaming_Task(void) {
             // USB/WiFi: all-or-nothing without retry. Full packet written
             // or cleanly dropped (no garbled partial data). No retry because
             // the ISR→encoder feedback loop causes sample queue overflow.
-            if (hasUsb) {
+            // #372: ActiveInterface == USB / UsbAndSd means we should ALWAYS push
+            // to USB (or count the drop).  Previously `hasUsb = (usbSize >= 128)`
+            // made this per-iteration, silently skipping UsbCdc_WriteToBuffer
+            // when the buffer was nearly full — bytes lost with usbDroppedBytes
+            // never incremented.  Same bug class as #371 on the WiFi path.
+            // Now we call UsbCdc_WriteToBuffer unconditionally when USB is in
+            // the active set; its own pre-check returns 0 on no-space, and
+            // we count that as a drop.
+            if (pRunTimeStreamConf->ActiveInterface == StreamingInterface_USB ||
+                pRunTimeStreamConf->ActiveInterface == StreamingInterface_UsbAndSd) {
                 if (Streaming_UsbWrite((const char*)buffer, packetSize) != packetSize) {
                     gStreamStats.usbDroppedBytes += packetSize;
                     taskENTER_CRITICAL();

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1237,15 +1237,17 @@ void streaming_Task(void) {
         }
 
         // Compute hasSD for the SD write block below.  ActiveInterface
-        // selects which outputs are streamed to:
-        //   - USB:        USB only
-        //   - WiFi:       WiFi only (WiFi+SD unsupported — share SPI bus)
+        // selects which network/USB output(s) are streamed to:
+        //   - USB:        USB only       (+ SD if SD-logging is enabled — see override below)
+        //   - WiFi:       WiFi only      (WiFi+SD unsupported; share SPI bus)
         //   - SD:         SD only
         //   - UsbAndSd:   USB + SD concurrent
         // USB and WiFi write blocks gate on ActiveInterface directly
         // (per #371 / #372 silent-loss fixes).  Only the SD write block
         // still consults a free-space flag, since its retry path needs
         // to distinguish "buffer too full right now" from "SD not active".
+        // The "SD-logging enabled" override below can also enable SD
+        // writes for ActiveInterface=USB or SD — only WiFi is excluded.
         switch (pRunTimeStreamConf->ActiveInterface) {
             case StreamingInterface_SD:
             case StreamingInterface_UsbAndSd:

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1147,9 +1147,11 @@ void streaming_Task(void) {
      TickType_t xBlockTime = portMAX_DELAY;
     NanopbFlagsArray nanopbFlag;
     size_t usbSize, wifiSize, sdSize, maxSize;
-    bool hasUsb, hasWifi, hasSD;
-    (void)hasUsb;   /* #372: ActiveInterface check used directly now; flag retained for symmetry */
-    (void)hasWifi;  /* #371: ActiveInterface check used directly now; flag retained for symmetry */
+    /* #371/#372: USB/WiFi gates moved to ActiveInterface checks at the
+     * write sites — hasUsb / hasWifi are no longer consulted, removed
+     * from the per-iteration switch.  hasSD is still consulted by the SD
+     * write block below. */
+    bool hasSD = false;
     bool AINDataAvailable;
     bool DIODataAvailable;
     size_t packetSize=0;    
@@ -1234,36 +1236,15 @@ void streaming_Task(void) {
             }
         }
 
-        // Single-interface streaming: only stream to the interface that initiated streaming
-        // This prevents bandwidth overload at high sample rates
+        // Single-interface streaming: only stream to the interface that initiated streaming.
+        // Only hasSD is consulted by the write path now (USB/WiFi gate on
+        // ActiveInterface directly per #371/#372 silent-loss fixes).
         switch (pRunTimeStreamConf->ActiveInterface) {
-            case StreamingInterface_USB:
-                hasUsb = (usbSize >= 128);
-                hasWifi = false;
-                hasSD = false;
-                break;
-            case StreamingInterface_WiFi:
-                hasUsb = false;
-                hasWifi = (wifiSize >= 128);
-                hasSD = false;
-                break;
             case StreamingInterface_SD:
-                hasUsb = false;
-                hasWifi = false;
-                hasSD = (sdSize >= 128);
-                break;
             case StreamingInterface_UsbAndSd:
-                // USB+SD concurrent mode (WiFi excluded — shares SPI bus with SD).
-                hasUsb = (usbSize >= 128);
-                hasWifi = false;
                 hasSD = (sdSize >= 128);
                 break;
             default:
-                // Unreachable with a validated enum, but fail closed so a
-                // future ActiveInterface value not covered above can't
-                // silently fall through with a USB+SD-shaped allocation.
-                hasUsb = false;
-                hasWifi = false;
                 hasSD = false;
                 break;
         }


### PR DESCRIPTION
## Summary

- Mirror of #371's fix on the WiFi path — gate USB streaming write on `ActiveInterface == USB || UsbAndSd` instead of the per-iteration `hasUsb = (usbSize >= 128)` flag
- `UsbCdc_WriteToBuffer` already has the right "return 0 on no-space" semantics so the writer's pre-check now surfaces as a counted drop instead of silent loss
- Retained `hasUsb` flag for symmetry with the existing `hasWifi` placeholder

## Why

`streaming.c:1240-1267` computed `hasUsb` per iteration based on free buffer space. When the USB circular buffer fell below 128 bytes free, the entire `if (hasUsb) { Streaming_UsbWrite(...) }` block was skipped — dropping the packet without incrementing `gStreamStats.usbDroppedBytes`. Identical bug pattern to #371 on WiFi.

`UsbCdc_WriteToBuffer` (UsbCdc.c:776-805) already returns 0 cleanly on mutex-busy or buffer-full; no spurious side effects. So letting it be called unconditionally and counting `return != packetSize` as a drop is the same shape that worked for WiFi in PR #370.

## Test plan

- [x] Builds clean at -O3
- [x] Device boots, `*IDN?` responds
- [ ] **Saturation test**: run USB CSV 16ch at a rate above the documented ceiling and confirm `SYST:STR:STATS?` now reports `UsbDroppedBytes > 0` instead of 0
- [ ] **Regression test**: run USB CSV 16ch below ceiling and confirm `UsbDroppedBytes == 0`
- [ ] **CLAUDE.md update**: USB ceiling numbers in "Session 22" need re-validation post-merge

Closes #372.
