### PR TITLE
fix(adc,streaming): NQ3 union safety (#139) + T2 muxed-cap SCPI error (#232)

### DIFF
--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -491,7 +491,12 @@ bool ADC_ReadADCSampleFromISR(uint32_t value, uint8_t bufferIndex) {
     sample.Value = value;
     uint32_t *valueTMR = (uint32_t*) BoardData_Get(BOARDDATA_STREAMING_TIMESTAMP, 0);
     for (i = 0; i < gpBoardConfig->AInChannels.Size; i++) {
-        if (gpBoardConfig->AInChannels.Data[i].Config.MC12b.ChannelId == bufferIndex
+        /* #139: gate Config.MC12b access on Type so AD7609 channels
+         * (NQ3) don't read garbage from the wrong union member.  NQ1/NQ2
+         * only have MC12b channels so this branch always passed before;
+         * NQ3 needs the explicit type check. */
+        if (gpBoardConfig->AInChannels.Data[i].Type == AIn_MC12bADC
+                && gpBoardConfig->AInChannels.Data[i].Config.MC12b.ChannelId == bufferIndex
                 && gpBoardRuntimeConfig->AInChannels.Data[i].IsEnabled == 1) {
 
             sample.Timestamp = *valueTMR;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2485,6 +2485,42 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         // See https://github.com/daqifi/daqifi-nyquist-firmware/issues/215
         // Bypass cap in benchmark mode to measure pure interface throughput.
         if (Streaming_GetBenchmarkMode() == BENCHMARK_OFF) {
+            // #232: reject up-front when any Type 2 (muxed) MC12b channel is
+            // enabled and the requested freq would silently cap the muxed
+            // scan rate.  The firmware always sets
+            //   ChannelScanFreqDiv = freq / 1000 (when freq > 1000)
+            // so T2 channels sample at most 1 kHz regardless of timer rate.
+            // Pre-#232 we silently throttled — user saw "5 kHz streaming"
+            // but T2 data was 1 kHz.  Now we surface that as a SCPI error
+            // so the client can either reduce freq, disable T2 channels,
+            // or opt-in via SYST:STR:BENCHmark (which bypasses the check
+            // since benchmarks intentionally measure timer-rate throughput).
+            if (freq > (int32_t)STREAMING_MUXED_CAP_HZ) {
+                bool hasMuxed = false;
+                volatile AInRuntimeArray* rt = (volatile AInRuntimeArray*)pRuntimeAInChannels;
+                volatile AInArray* cfg = (volatile AInArray*)pBoardConfigADC;
+                size_t cnt = (cfg->Size < rt->Size) ? cfg->Size : rt->Size;
+                for (size_t i = 0; i < cnt; i++) {
+                    if (rt->Data[i].IsEnabled != 1) continue;
+                    if (cfg->Data[i].Type != AIn_MC12bADC) continue;
+                    if (!cfg->Data[i].Config.MC12b.IsPublic) continue;
+                    if (cfg->Data[i].Config.MC12b.ChannelType == 2) {
+                        hasMuxed = true;
+                        break;
+                    }
+                }
+                if (hasMuxed) {
+                    LOG_I("Streaming rejected: T2 channels max %u Hz (requested %d Hz)",
+                          (unsigned)STREAMING_MUXED_CAP_HZ, (int)freq);
+                    static char muxedErrMsg[] =
+                        "T2 (muxed) channels cap at 1000 Hz; reduce freq, "
+                        "disable T2 channels, or use SYST:STR:BENCHmark to bypass";
+                    SCPI_ErrorPushEx(context, SCPI_ERROR_SETTINGS_CONFLICT,
+                                     muxedErrMsg, sizeof(muxedErrMsg) - 1);
+                    return SCPI_RES_ERR;
+                }
+            }
+
             uint32_t maxFreq = Streaming_ComputeMaxFreq(
                 activeType1ChannelCount, totalEnabledPublicChannels);
             if (freq > (int32_t)maxFreq) {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2504,7 +2504,7 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
                     if (rt->Data[i].IsEnabled != 1) continue;
                     if (cfg->Data[i].Type != AIn_MC12bADC) continue;
                     if (!cfg->Data[i].Config.MC12b.IsPublic) continue;
-                    if (cfg->Data[i].Config.MC12b.ChannelType == 2) {
+                    if (cfg->Data[i].Config.MC12b.ChannelType == MC12B_CHANNEL_TYPE_MUXED) {
                         hasMuxed = true;
                         break;
                     }
@@ -2512,11 +2512,19 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
                 if (hasMuxed) {
                     LOG_I("Streaming rejected: T2 channels max %u Hz (requested %d Hz)",
                           (unsigned)STREAMING_MUXED_CAP_HZ, (int)freq);
-                    static char muxedErrMsg[] =
-                        "T2 (muxed) channels cap at 1000 Hz; reduce freq, "
-                        "disable T2 channels, or use SYST:STR:BENCHmark to bypass";
+                    /* Stringify STREAMING_MUXED_CAP_HZ into the user-facing
+                     * error so the message stays in sync if the constant
+                     * ever changes (#449 Qodo r2 finding). */
+                    #define MUXED_CAP_STR_HELPER(x) #x
+                    #define MUXED_CAP_STR(x) MUXED_CAP_STR_HELPER(x)
+                    static const char muxedErrMsg[] =
+                        "T2 (muxed) channels cap at " MUXED_CAP_STR(STREAMING_MUXED_CAP_HZ)
+                        " Hz; reduce freq, disable T2 channels, or use "
+                        "SYST:STR:BENCHmark to bypass";
+                    #undef MUXED_CAP_STR
+                    #undef MUXED_CAP_STR_HELPER
                     SCPI_ErrorPushEx(context, SCPI_ERROR_SETTINGS_CONFLICT,
-                                     muxedErrMsg, sizeof(muxedErrMsg) - 1);
+                                     (char *)muxedErrMsg, sizeof(muxedErrMsg) - 1);
                     return SCPI_RES_ERR;
                 }
             }

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -55,6 +55,14 @@ extern "C" {
 #define STREAMING_TICK_BUDGET       110000
 #define STREAMING_TICK_OVERHEAD     6
 
+// Type 2 (shared MODULE7 mux) hard cap.  T2 channels are scanned via the
+// analog multiplexer sequentially; the firmware applies
+// ChannelScanFreqDiv = freq/1000 in SCPI_StartStreaming so the muxed scan
+// rate stays at 1 kHz regardless of timer rate.  When BENCHMARK_OFF, any
+// freq > this constant with T2 channels enabled is rejected up-front
+// instead of being silently throttled (#232).
+#define STREAMING_MUXED_CAP_HZ      1000
+
 /**
  * Compute maximum safe streaming frequency for a given channel configuration.
  * Uses three-constraint model validated against empirical benchmark data.

--- a/firmware/src/state/board/AInConfig.h
+++ b/firmware/src/state/board/AInConfig.h
@@ -122,7 +122,9 @@ extern "C" {
         ADCHS_MODULE_MASK ModuleId;
 
         /**
-         * Indicates that this is a type 1 channel
+         * MC12b channel type — see MC12B_CHANNEL_TYPE_* defines below.
+         *   1 = dedicated module (ch 4/8/10/12/14 on NQ1, fast)
+         *   2 = shared MODULE7 mux (sequential scan, ~1 kHz max)
          */
         uint8_t ChannelType;
 
@@ -158,6 +160,10 @@ extern "C" {
          */
         double TempReferenceC;
     } MC12bChannelConfig;
+
+    /** MC12bChannelConfig::ChannelType values (#232). */
+    #define MC12B_CHANNEL_TYPE_DEDICATED  1  /**< Dedicated module — fast (T1) */
+    #define MC12B_CHANNEL_TYPE_MUXED      2  /**< Shared MODULE7 mux — ~1 kHz cap (T2) */
 
     /**
      * Holds intrinsic channel information for an AD7609-backed channel


### PR DESCRIPTION
## Summary

Bundle of two correctness fixes (one on NQ3 ADC ISR path, one on streaming-freq validation) plus two issues closed-as-resolved.

### #139: gate Config.MC12b union access on Type in ISR sample path

`ADC_ReadADCSampleFromISR` matched `Config.MC12b.ChannelId == bufferIndex` without first checking `Type == AIn_MC12bADC`. NQ1/NQ2 worked by accident (all channels are MC12b); NQ3 with AD7609 channels read garbage from the wrong union member. Audit confirmed this was the only remaining unguarded `.Config.MC12b.` site in firmware/src.

### #232: reject `freq > 1000` with T2 channels in normal mode

Pre-#232 the firmware silently set `ChannelScanFreqDiv = freq / 1000` whenever freq > 1000, so Type 2 (muxed MODULE7) channels were always throttled to 1 kHz regardless of timer rate. Issue #230 surfaced the symptom (pool barely used at 16ch×5kHz because actual rate was 1875 Hz).

Now: when `BENCHMARK_OFF` and any T2 channel is enabled and `freq > STREAMING_MUXED_CAP_HZ` (1000 Hz), return SCPI error `-221 Settings conflict` with an info string explaining the cap and how to bypass. The user can:
- Reduce the streaming frequency to ≤ 1000 Hz
- Disable Type 2 channels (keep only Type 1: ch 4/8/10/12/14)
- Opt into a benchmark mode (`SYST:STR:BENCHmark 1` or 2) which intentionally bypasses caps to measure timer-rate throughput

Benchmarks (CLAUDE.md "Session 22" T2-heavy configs at 11+ kHz) continue to work unchanged — they already drive `BENCHMARK_NOCAP` or `BENCHMARK_PIPELINE` to bypass caps.

### #138: closed — already silently resolved
`GetModuleChannelRuntimeData` was removed during the ADC.c refactor (around PR #354 / #356). Every driver entry point now has explicit `Type ==` filters. Verified on `main` (`bb49e22f`). Issue commented + closed; no code change in this PR.

### #198: closed — wontfix per CLAUDE.md "validate at boundaries" mantra
Bundle initially included a defensive NULL-check on `BQ24297_Read_I2C(out)`, but `BQ24297_Read_I2C` is a HAL-internal function — no external API or untrusted input. The issue itself acknowledges "Existing callers pass valid pointers." That's the pattern CLAUDE.md tells us to reject (mirrored by the `BoardRunTimeConfig_Get` precedent). Reverted; #198 closed as not-planned.

## Test plan

- [x] Builds clean at -O3
- [x] NQ1 bench: `*IDN?` + `MEAS:VOLT:DC?` on ch 0/4/14 all return cleanly (#139 no regression by construction)
- [x] NQ1 bench #232 verified:
  - T1 only @ 5000 Hz, normal → ALLOW ✓
  - T2 only @ 5000 Hz, normal → REJECT `-221 Settings conflict` ✓
  - T2 only @ 5000 Hz, BENCH=1 → ALLOW (bypass) ✓
  - T2 only @ 800 Hz, normal → ALLOW (under cap) ✓
- [ ] NQ3 verification of #139: deferred (no NQ3 hardware on bench); fix is correctness-by-construction

## Refs

Closes #139, closes #232. #138 and #198 closed separately on their issues.
