### PR TITLE
fix(wifi): one-client-per-port TCP policy (#452)

### DIFF
--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -443,9 +443,28 @@ static void SocketEventCallback(SOCKET socket, uint8_t messageType, void *pMessa
             if (NULL != pAcceptMessage) {
                 char s[20];
                 (void)s;  // May be unused when LOG_D is disabled
-                if (gStateMachineContext.pTcpServerContext->client.clientSocket >= 0) // close any open client (only one client supported at one time)
-                {
-                    wifi_tcp_server_CloseClientSocket();
+                // One client per port.  If a client is already
+                // connected, refuse the new connection by shutting
+                // down the just-accept'd socket — NOT the active
+                // client's socket.  The existing client keeps
+                // streaming intact.
+                //
+                // Why not close the active client like we used to:
+                // that path called shutdown() on the streaming socket
+                // from this WDRV_WINC_Tasks callback context while the
+                // streaming task was mid-send() on the same socket.
+                // The synchronous WINC HIF re-entrancy corrupted the
+                // chip state and wedged all TCP I/O until SYST:COMM:
+                // LAN:HRESet (or power-cycle in worse cases).  See
+                // #452.  The just-accept'd socket has no in-flight
+                // state on our side — no buffer, no send queue, no
+                // streaming task references — so a sync shutdown of
+                // it is safe (the WINC sends a RST to the new peer,
+                // no corruption of the active session).
+                if (gStateMachineContext.pTcpServerContext->client.clientSocket >= 0) {
+                    LOG_I("TCP: refusing 2nd client on listen socket (one-client policy, #452)");
+                    shutdown(pAcceptMessage->sock);
+                    break;
                 }
                 gStateMachineContext.pTcpServerContext->client.clientSocket = pAcceptMessage->sock;
                 LOG_D("Connection from %s:%d\r\n", inet_ntop(AF_INET, &pAcceptMessage->strAddr.sin_addr.s_addr, s, sizeof (s)), pAcceptMessage->strAddr.sin_port);

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -463,7 +463,14 @@ static void SocketEventCallback(SOCKET socket, uint8_t messageType, void *pMessa
                 // no corruption of the active session).
                 if (gStateMachineContext.pTcpServerContext->client.clientSocket >= 0) {
                     LOG_I("TCP: refusing 2nd client on listen socket (one-client policy, #452)");
-                    shutdown(pAcceptMessage->sock);
+                    int8_t rc = shutdown(pAcceptMessage->sock);
+                    if (rc != SOCK_ERR_NO_ERROR) {
+                        // WINC shutdown() clears local socket state even on
+                        // HIF send failure (winc/drv/socket/socket.c:1012),
+                        // so we cannot retry — the WINC side may hold the
+                        // refused-client socket resource until next reset.
+                        LOG_E("TCP: shutdown(refused 2nd client sock=%d) failed rc=%d", pAcceptMessage->sock, rc);
+                    }
                     break;
                 }
                 gStateMachineContext.pTcpServerContext->client.clientSocket = pAcceptMessage->sock;


### PR DESCRIPTION
## Summary

Closes #452 — TCP listen-socket wedges when a 2nd client tries to connect during active streaming.

**Root cause (V):** The old `SOCKET_MSG_ACCEPT` handler at `wifi_manager.c:443` called `wifi_tcp_server_CloseClientSocket()` when a 2nd client arrived, which calls `shutdown()` on the **active** streaming socket. That `shutdown()` ran in the `WDRV_WINC_Tasks` callback context while `app_WifiTask` was mid-`send()` on the same socket — synchronous WINC HIF re-entrancy corrupted the chip state and wedged all TCP I/O until `SYST:COMM:LAN:HRESet` (sometimes a power-cycle).

**Fix:** Refuse the 2nd client by `shutdown()`ing the just-accept'd socket instead. The new socket has no in-flight state on our side (no buffer, no send queue, no streaming task references), so a sync `shutdown` of it is safe — the WINC sends a RST to the new peer and the active session continues uninterrupted.

**Policy:** One client per port. Existing clients keep streaming; late-arrivals get a RST.

## Test plan

Bench: Tesla AP STA, 16ch CSV @ 2 kHz, repro-452.py with 2 TCP threads + USB CDC thread, 30s.

- [x] Pre-fix: device wedges in ~10s, recoverable only via SYST:COMM:LAN:HRESet
- [x] Post-fix: Thread A streamed 572,005 bytes uninterrupted over 28s
- [x] Post-fix: Thread B got 0-byte RST on 22 reconnect attempts (expected)
- [x] Post-fix: `SYST:STR:STATS?` clean — TotalSamplesStreamed == TimerISRCalls, no drops
- [x] Post-fix: fresh TCP `*IDN?` after Thread A disconnected succeeded — listen socket still healthy, no HRESet needed
- [x] USB CDC alive throughout, no SCPI corruption
- [x] cppcheck baseline unchanged (2 pre-existing style findings in wifi_serial_bridge.c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)