### PR TITLE
feat(streaming): self-heal + auto-stop on dead transports (#397)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,6 +523,7 @@ Set on `StartStreamData`, cleared on `StopStreamData`.
 | 9   | 512   | WiFi Overflow | WiFi circular buffer overflow detected |
 | 10  | 1024  | SD Overflow | SD write failure detected |
 | 11  | 2048  | Encoder Fail | Encoder returned 0 bytes with data available |
+| 12  | 4096  | Transport Down | All configured transports unhealthy >grace; streaming auto-stopped (#397). Cleared on next start. Grace tunable via `SYST:STR:CONSumer:GRACe <sec>` (5..300, default 60). LOG_E line `Streaming: all configured transports down >Ns — auto-stop` captures the stop reason. |
 
 QUES bits are set in real-time during streaming and cleared when streaming stops. The QUES CONDition register reflects the *current* health; the QUES EVENt register latches transitions (clears on read).
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -70,8 +70,9 @@
 #define QUES_WIFI_OVERFLOW  (1 << 9)   // Bit 9: WiFi buffer overflow
 #define QUES_SD_OVERFLOW    (1 << 10)  // Bit 10: SD write failure
 #define QUES_ENCODER_FAIL   (1 << 11)  // Bit 11: Encoder failure
+#define QUES_TRANSPORT_DOWN (1 << 12)  // Bit 12: all configured transports down >grace (#397 auto-stop)
 #define QUES_ALL_BITS       (QUES_DATA_LOSS | QUES_USB_OVERFLOW | QUES_WIFI_OVERFLOW | \
-                             QUES_SD_OVERFLOW | QUES_ENCODER_FAIL)
+                             QUES_SD_OVERFLOW | QUES_ENCODER_FAIL | QUES_TRANSPORT_DOWN)
 
 #define UNUSED(x) (void)(x)
 //
@@ -2259,6 +2260,31 @@ static scpi_result_t SCPI_GetFlowWindow(scpi_t * context) {
 }
 
 /**
+ * #397 SYST:STReam:CONSumer:GRACe <sec> — grace window in seconds for the
+ * self-heal transport check.  Streaming auto-stops only when every
+ * configured transport (USB/WiFi/SD per ActiveInterface) has been
+ * unhealthy for longer than this window.  Range 5..300, default 60.
+ * Runtime-only.
+ */
+static scpi_result_t SCPI_SetTransportGrace(scpi_t * context) {
+    int32_t sec;
+    if (!SCPI_ParamInt32(context, &sec, TRUE)) {
+        return SCPI_RES_ERR;
+    }
+    if (sec < 5 || sec > 300) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    Streaming_SetTransportGraceSec((uint32_t)sec);
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_GetTransportGrace(scpi_t * context) {
+    SCPI_ResultInt32(context, (int32_t)Streaming_GetTransportGraceSec());
+    return SCPI_RES_OK;
+}
+
+/**
  * STATus:QUEStionable:CONDition? wrapper that syncs streaming health
  * bits from the streaming engine before reading the register.
  */
@@ -4314,6 +4340,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:STReam:LOSS:THREshold?", .callback = SCPI_GetLossThreshold,},
     {.pattern = "SYSTem:STReam:LOSS:WINDow", .callback = SCPI_SetFlowWindow,},
     {.pattern = "SYSTem:STReam:LOSS:WINDow?", .callback = SCPI_GetFlowWindow,},
+    {.pattern = "SYSTem:STReam:CONSumer:GRACe", .callback = SCPI_SetTransportGrace,},
+    {.pattern = "SYSTem:STReam:CONSumer:GRACe?", .callback = SCPI_GetTransportGrace,},
     {.pattern = "SYSTem:STReam:TEST:PATtern", .callback = SCPI_SetTestPattern,}, // 0=off, 1=counter, 2=midscale, 3=fullscale, 4=walking, 5=triangle, 6=sine
     {.pattern = "SYSTem:STReam:TEST:PATtern?", .callback = SCPI_GetTestPattern,},
     {.pattern = "SYSTem:STReam:BENCHmark", .callback = SCPI_SetBenchmarkMode,}, // 0=normal, 1=nocap, 2=pipeline (skip ADC)

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -147,7 +147,11 @@ static volatile TickType_t gTransportDownSinceSd = 0;
 #define TRANSPORT_GRACE_DEFAULT_SEC 60
 #define TRANSPORT_GRACE_MIN_SEC     5
 #define TRANSPORT_GRACE_MAX_SEC     300
-static uint32_t gTransportGraceSec = TRANSPORT_GRACE_DEFAULT_SEC;
+// volatile: written by SCPI callback context (USBDeviceTask pri 7 or
+// app_WifiTask pri 2) and read by streaming_Task (pri 6) every iteration.
+// 32-bit write/read is atomic on PIC32MZ; volatile prevents -O3 caching
+// the value across the streaming task's tight loop.
+static volatile uint32_t gTransportGraceSec = TRANSPORT_GRACE_DEFAULT_SEC;
 
 // SD protobuf metadata field tags for standalone metadata message
 static const NanopbFlagsArray fields_sd_metadata = {
@@ -989,9 +993,14 @@ static void Streaming_Stop(void) {
                         gStreamStats.encoderFailures > 0 ||
                         gStreamStats.dioDroppedSamples > 0 ||
                         gStreamStats.eosOverruns > 0;
-        // Clear QUES condition bits so they don't persist after streaming ends.
-        // Stats remain available via SYST:STR:STATS? until next session.
-        gQuesBits = 0;  // 32-bit write is atomic on PIC32MZ
+        // Clear runtime overflow / data-loss condition bits — they refer to
+        // the live session that just ended.  Preserve QUES_BIT_TRANSPORT_DOWN
+        // (#397) because it captures the REASON streaming stopped; clearing
+        // it here would make the auto-stop bit unobservable via SCPI
+        // immediately after the stop.  It's cleared by Streaming_ClearStats
+        // at next session start, so STAT:QUES:COND? between auto-stop and
+        // next start correctly reports "transport down was the cause".
+        gQuesBits &= QUES_BIT_TRANSPORT_DOWN;  // keep only bit 12 if set
 
         if (hadDrops) {
             uint64_t totalAttempted = gStreamStats.totalSamplesStreamed +
@@ -1039,6 +1048,14 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     gFlowWindowOverride = 0;
     gQuesBits = 0;
     gInTimerHandler = false;
+    /* #397 self-heal: defensive reset of transport-down trackers and the
+     * grace window. These live in retained-RAM along with the other
+     * file-statics; the static initializer values are not guaranteed to
+     * survive MCLR / IPE flash. */
+    gTransportDownSinceUsb = 0;
+    gTransportDownSinceWifi = 0;
+    gTransportDownSinceSd = 0;
+    gTransportGraceSec = TRANSPORT_GRACE_DEFAULT_SEC;
     /* buffer/bufferSize are file-statics that may also live in
      * retained-RAM. Reset before the `if (buffer == NULL)` guard
      * below so a stale non-NULL pointer doesn't skip the pool fetch. */

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1000,7 +1000,12 @@ static void Streaming_Stop(void) {
         // immediately after the stop.  It's cleared by Streaming_ClearStats
         // at next session start, so STAT:QUES:COND? between auto-stop and
         // next start correctly reports "transport down was the cause".
-        gQuesBits &= QUES_BIT_TRANSPORT_DOWN;  // keep only bit 12 if set
+        // RMW (`&=`) needs taskENTER_CRITICAL per the CLAUDE.md atomicity
+        // rules — gQuesBits is also `|=`'d by the deferred ISR task and
+        // streaming task at the overflow sites.
+        taskENTER_CRITICAL();
+        gQuesBits &= QUES_BIT_TRANSPORT_DOWN;
+        taskEXIT_CRITICAL();
 
         if (hadDrops) {
             uint64_t totalAttempted = gStreamStats.totalSamplesStreamed +

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -101,6 +101,7 @@ static void Streaming_UpdateFlowWindow(bool dropped);
 #define QUES_BIT_WIFI_OVERFLOW (1 << 9)  // Bit 9: WiFi buffer overflow
 #define QUES_BIT_SD_OVERFLOW  (1 << 10)  // Bit 10: SD write failure
 #define QUES_BIT_ENCODER_FAIL (1 << 11)  // Bit 11: Encoder failure
+#define QUES_BIT_TRANSPORT_DOWN (1 << 12) // Bit 12: all configured transports down >grace (auto-stop fired)
 
 #define FLOW_WINDOW_MIN   20
 #define FLOW_WINDOW_MAX   10000
@@ -131,6 +132,22 @@ static uint32_t gFlowWindowOverride = 0;  // 0 = auto
 // SCPI tasks. Critical sections protect the RMW; volatile prevents -O3 from
 // caching the value across loop iterations / function calls.
 static volatile uint32_t gQuesBits = 0;
+
+// #397 Self-heal transport tracking.  Per-transport tick of "first observed
+// unhealthy"; 0 = healthy.  Once (now - downSince) exceeds the grace window,
+// the transport is considered dead.  If every transport in ActiveInterface
+// is dead at the same time, streaming auto-stops with QUES_BIT_TRANSPORT_DOWN.
+// Transient blips (router hiccup, brief USB unenum) ride out and recover.
+// Per-transport overflow QUES bits (USB/WiFi/SD) still fire as before for
+// pre-grace drops.  Only written from streaming_Task; volatile so external
+// debug reads via JTAG see the live value.
+static volatile TickType_t gTransportDownSinceUsb = 0;
+static volatile TickType_t gTransportDownSinceWifi = 0;
+static volatile TickType_t gTransportDownSinceSd = 0;
+#define TRANSPORT_GRACE_DEFAULT_SEC 60
+#define TRANSPORT_GRACE_MIN_SEC     5
+#define TRANSPORT_GRACE_MAX_SEC     300
+static uint32_t gTransportGraceSec = TRANSPORT_GRACE_DEFAULT_SEC;
 
 // SD protobuf metadata field tags for standalone metadata message
 static const NanopbFlagsArray fields_sd_metadata = {
@@ -850,7 +867,96 @@ static void Streaming_Start(void) {
     }
 }
 
-/*! 
+/*!
+ * #397 Self-heal: check the health of every transport selected by
+ * ActiveInterface.  Returns true if every configured transport has been
+ * unhealthy for longer than the grace window (auto-stop trigger);
+ * returns false otherwise.  Recovered transports clear their down-since
+ * counter and log a recovery line.
+ */
+static bool Streaming_AllConfiguredTransportsDead(StreamingRuntimeConfig *cfg) {
+    TickType_t now = xTaskGetTickCount();
+    TickType_t graceTicks = pdMS_TO_TICKS((TickType_t)gTransportGraceSec * 1000U);
+    bool wantUsb = (cfg->ActiveInterface == StreamingInterface_USB ||
+                    cfg->ActiveInterface == StreamingInterface_UsbAndSd);
+    bool wantWifi = (cfg->ActiveInterface == StreamingInterface_WiFi);
+    bool wantSd  = (cfg->ActiveInterface == StreamingInterface_SD ||
+                    cfg->ActiveInterface == StreamingInterface_UsbAndSd);
+
+    bool usbDead = false, wifiDead = false, sdDead = false;
+
+    if (wantUsb) {
+        if (UsbCdc_IsConfigured()) {
+            if (gTransportDownSinceUsb != 0) {
+                LOG_I("Streaming: USB transport recovered");
+                gTransportDownSinceUsb = 0;
+            }
+        } else {
+            if (gTransportDownSinceUsb == 0) {
+                // Use 1 as "armed" sentinel to disambiguate from 0=healthy.
+                gTransportDownSinceUsb = (now == 0) ? 1 : now;
+            }
+            usbDead = ((now - gTransportDownSinceUsb) >= graceTicks);
+        }
+    } else {
+        gTransportDownSinceUsb = 0;
+    }
+
+    if (wantWifi) {
+        if (wifi_manager_IsWiFiConnected()) {
+            if (gTransportDownSinceWifi != 0) {
+                LOG_I("Streaming: WiFi transport recovered");
+                gTransportDownSinceWifi = 0;
+            }
+        } else {
+            if (gTransportDownSinceWifi == 0) {
+                gTransportDownSinceWifi = (now == 0) ? 1 : now;
+            }
+            wifiDead = ((now - gTransportDownSinceWifi) >= graceTicks);
+        }
+    } else {
+        gTransportDownSinceWifi = 0;
+    }
+
+    if (wantSd) {
+        if (sd_card_manager_IsWriteReady()) {
+            if (gTransportDownSinceSd != 0) {
+                LOG_I("Streaming: SD transport recovered");
+                gTransportDownSinceSd = 0;
+            }
+        } else {
+            if (gTransportDownSinceSd == 0) {
+                gTransportDownSinceSd = (now == 0) ? 1 : now;
+            }
+            sdDead = ((now - gTransportDownSinceSd) >= graceTicks);
+        }
+    } else {
+        gTransportDownSinceSd = 0;
+    }
+
+    bool anyConfigured = wantUsb || wantWifi || wantSd;
+    if (!anyConfigured) return false;
+
+    bool allDead = true;
+    if (wantUsb)  allDead = allDead && usbDead;
+    if (wantWifi) allDead = allDead && wifiDead;
+    if (wantSd)   allDead = allDead && sdDead;
+    return allDead;
+}
+
+uint32_t Streaming_GetTransportGraceSec(void) {
+    return gTransportGraceSec;
+}
+
+bool Streaming_SetTransportGraceSec(uint32_t sec) {
+    if (sec < TRANSPORT_GRACE_MIN_SEC || sec > TRANSPORT_GRACE_MAX_SEC) {
+        return false;
+    }
+    gTransportGraceSec = sec;
+    return true;
+}
+
+/*!
  * Stops the streaming timer
  */
 static void Streaming_Stop(void) {
@@ -1022,6 +1128,11 @@ void Streaming_ClearStats(void) {
     memset(gFlowWindow, 0, sizeof(gFlowWindow));
     gFlowWindowCount = 0;
     gQuesBits = 0;
+    // #397 reset per-transport down-since trackers so a new session starts
+    // with every transport considered healthy, regardless of pre-session state.
+    gTransportDownSinceUsb = 0;
+    gTransportDownSinceWifi = 0;
+    gTransportDownSinceSd = 0;
     Logger_ResetSessionOneShots();
     taskEXIT_CRITICAL();
     // NOTE: Pool max-used is NOT reset here — it persists across sessions
@@ -1167,6 +1278,22 @@ void streaming_Task(void) {
         // Don't process data or update QUES bits after streaming stops.
         // A notification may already be pending when Stop clears gQuesBits.
         if (!pRunTimeStreamConf->IsEnabled) {
+            continue;
+        }
+
+        // #397 self-heal check: if every configured transport has been
+        // down for longer than the grace window, auto-stop the stream
+        // and surface the reason via QUES bit 12 + LOG_E.  Individual
+        // overflow bits (USB/WiFi/SD) still fire pre-grace for transient
+        // drops — this only fires when nothing is consuming our data.
+        if (Streaming_AllConfiguredTransportsDead(pRunTimeStreamConf)) {
+            taskENTER_CRITICAL();
+            gQuesBits |= QUES_BIT_TRANSPORT_DOWN;
+            taskEXIT_CRITICAL();
+            LOG_E("Streaming: all configured transports down >%u s — auto-stop",
+                  (unsigned)gTransportGraceSec);
+            pRunTimeStreamConf->IsEnabled = false;
+            Streaming_Stop();
             continue;
         }
 

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -185,12 +185,22 @@ void Streaming_IncrEosOverruns(uint32_t missed);
 /**
  * Returns current SCPI STATus:QUEStionable condition bits for streaming health.
  * Bit 4 = windowed sample loss >= threshold, Bit 8 = USB overflow,
- * Bit 9 = WiFi overflow, Bit 10 = SD overflow, Bit 11 = encoder failure.
+ * Bit 9 = WiFi overflow, Bit 10 = SD overflow, Bit 11 = encoder failure,
+ * Bit 12 = all-transports-down auto-stop (#397).
  * Definitions match QUES_* constants in SCPIInterface.c.
  * Called by SCPI_SyncQuesBits() in SCPIInterface.c before register queries.
  * Bits are cleared automatically when streaming stops.
  */
 uint32_t Streaming_GetQuesBits(void);
+
+/**
+ * #397 self-heal grace window — seconds an active transport may be
+ * unhealthy before the streaming task counts it as "dead".  Default 60.
+ * Range [5, 300].  Runtime-only (not NVM-persisted, reset on reboot).
+ * Used by Streaming_AllConfiguredTransportsDead() inside streaming_Task.
+ */
+uint32_t Streaming_GetTransportGraceSec(void);
+bool     Streaming_SetTransportGraceSec(uint32_t sec);
 
 /**
  * Compute optimal circular buffer sizes based on currently active interfaces.


### PR DESCRIPTION
## Summary

Phase 1 of #397. The streaming pipeline now polls per-transport health each iteration and auto-stops cleanly only when every configured transport (USB / WiFi / SD per `ActiveInterface`) has been unhealthy for longer than a tunable grace window. Transient blips ride out without stopping the stream; sustained outages stop with a recorded reason.

## What changed

- **New QUES bit 12 `TRANSPORT_DOWN`** (`4096`) — set when auto-stop fires.
- **Per-transport health predicates** in `streaming.c::Streaming_AllConfiguredTransportsDead`:
  - USB: `UsbCdc_IsConfigured()`
  - WiFi: `wifi_manager_IsWiFiConnected()` (handles STA + AP-with-client correctly)
  - SD: `sd_card_manager_IsWriteReady()`
- **Per-transport down-since trackers** (`gTransportDownSinceUsb/Wifi/Sd`) — armed on first unhealthy observation, cleared on recovery (which logs `Streaming: <X> transport recovered` via LOG_I).
- **Auto-stop hook** in the streaming task loop, right after the `IsEnabled` guard. Flips `IsEnabled`, calls `Streaming_Stop`, sets QUES bit 12, logs `Streaming: all configured transports down >Ns — auto-stop`.
- **New SCPI knob** `SYSTem:STReam:CONSumer:GRACe <sec>` (range 5..300, default 60).
- **CLAUDE.md** QUES bit table updated.

## What this does NOT do (deferred)

- SD store-and-forward durable tier → tracked as #455 (months-of-logging survivability).
- Network-impairment test harness (`tc netem`, `hostapd_cli`, smart-plug AP power-cycle) → tracked as #456 (programmable WiFi blip / loss / latency injection).
- USB host-down detection independent of `isConfigured` (e.g. slow-reader with host still attached).
- Auto-restart on transport recovery after auto-stop has fired. Phase 1 chose "stop cleanly + user restarts" for scope-tightness.

## Test plan

Bench-verified on bench primary (NQ1 `7E2898F46200E8A7`, fresh main + this branch, 2026-05-13).

- [x] **Auto-stop fires at grace boundary.** `SYST:STR:CONS:GRAC 5` + WiFi STA pointing at a non-existent SSID + `SYST:STR:INT 1` + `SYST:STR:START 1000` → at exactly t=5 s the log line `Streaming: all configured transports down >5 s — auto-stop` fires; `TotalSamplesStreamed=5001` confirms the stream stayed alive across the grace window.
- [x] **Longer grace boundary.** Same test with grace=20 → auto-stop at exactly t=20, `TotalSamplesStreamed=20001`.
- [x] **No false stop with healthy transport.** USB present, grace=10, 15 s stream → no auto-stop log line, QUES bit 12 (`4096`) stays clear.
- [x] **SCPI knob validates range.** `SYST:STR:CONS:GRAC 1000` → `-224 Illegal parameter value`, current setting preserved.
- [x] **Counter reset across sessions.** `Streaming_ClearStats` (called by every Streaming_Start) zeroes all three `gTransportDownSince*` so each session starts with every transport considered healthy.
- [x] **Build PASS** (`xc32-gcc.exe` -O3 -Werror).
- [x] **Cppcheck baseline unchanged** (2 pre-existing style findings in `wifi_serial_bridge.c`).
- [ ] **Real WiFi blip → recovery LOG_I → no auto-stop** — code-reviewed but not bench-verified this session. The current bench lacks a programmable WiFi-down injection (Tesla AP isn't CLI-controllable from here). Deferred to #456's harness.

## Related

- Closes part of #397 (Phase 1 — auto-stop side). The recovery-replay durable-tier work is #455; the impairment-test harness is #456. The Phase 1 auto-stop is the visible behavior fix for the "wedged device" symptom #397 originally calls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)