### PR TITLE
fix(streaming): Running=1 only when timer truly running (#379)

### DIFF
--- a/firmware/src/HAL/TimerApi/TimerApi.c
+++ b/firmware/src/HAL/TimerApi/TimerApi.c
@@ -222,22 +222,27 @@ void TimerApi_InterruptEnable(uint8_t index) {
 }
 
 void TimerApi_InterruptDisable(uint8_t index) {
+    // Also clear the pending IFS flag — Harmony's TMRx_InterruptDisable
+    // only clears IEC (enable bit), so a pending IF could still trigger
+    // a spurious ISR the moment IEC is re-enabled later (#458 Qodo).
+    // For 32-bit pairs T4+T5 and T6+T7 the upper-half timer holds the
+    // interrupt (T5IF / T7IF), so case 4 uses T5IF and case 6 uses T7IF.
     switch (index) {
         case 2:
             TMR2_InterruptDisable();
-            //IFS0CLR = _IFS0_T2IF_MASK;
+            IFS0CLR = _IFS0_T2IF_MASK;
             break;
         case 3:
             TMR3_InterruptDisable();
-            //IFS0CLR = _IFS0_T3IF_MASK;
+            IFS0CLR = _IFS0_T3IF_MASK;
             break;
         case 4:
             TMR4_InterruptDisable();
-            //IFS0CLR = _IFS0_T5IF_MASK;
+            IFS0CLR = _IFS0_T5IF_MASK;
             break;
         case 6:
             TMR6_InterruptDisable();
-            //IFS1CLR=_IFS1_T7IF_MASK;
+            IFS1CLR = _IFS1_T7IF_MASK;
             break;
         default:
             break;

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -860,9 +860,15 @@ static void Streaming_Start(void) {
             // is handled in the task body (skips monitoring reads when
             // Running && !OnboardDiagEnabled).
 
+            // Order matters: set Running=1 BEFORE arming the IRQ and
+            // starting the timer, so any ISR firing on the first tick
+            // sees Running=true.  Streaming_TimerHandler itself gates on
+            // IsEnabled (not Running) so this only matters for async
+            // consumers (HAL/ADC.c:129) that could otherwise momentarily
+            // see Running=0 while the timer is already firing.
+            gpRuntimeConfigStream->Running = 1;
             TimerApi_InterruptEnable(gpStreamingConfig->TimerIndex);
             TimerApi_Start(gpStreamingConfig->TimerIndex);
-            gpRuntimeConfigStream->Running = 1;
         }
     }
 }

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -828,10 +828,18 @@ static void Streaming_Start(void) {
         TimerApi_CallbackRegister(gpStreamingConfig->TimerIndex, Streaming_TimerHandler, 0);
         TimerApi_InterruptEnable(gpStreamingConfig->TimerIndex);
 
-        // Enable hardware ADC triggering only when actually streaming.
-        // Streaming_Start runs at boot (via Streaming_UpdateState) before
-        // ADC_Init — must not write ADCTRG/ADCCON1 until ADC is ready.
+        // Actually start the timer + flip Running only when streaming is
+        // truly enabled.  Streaming_Start runs at boot (via Streaming_
+        // UpdateState's unconditional Stop→Start cycle) with IsEnabled
+        // false; previously we set Running=1 anyway, which lied about
+        // the hardware state to every downstream consumer that checked
+        // `Running` alone (e.g. ADC.c:129, SCPIADC.c:64/439).  Now
+        // `Running` invariant: true iff the streaming timer is actually
+        // ticking — see #379.
         if (gpRuntimeConfigStream->IsEnabled) {
+            // Enable hardware ADC triggering only when actually streaming.
+            // Streaming_Start runs at boot before ADC_Init — must not
+            // write ADCTRG/ADCCON1 until ADC is ready.
             // hwShared: enable MODULE7 scan trigger unless onboard diag is
             // disabled (max dedicated throughput mode).
             bool hwShared = gpRuntimeConfigStream->OnboardDiagEnabled &&
@@ -843,10 +851,10 @@ static void Streaming_Start(void) {
             // so disabling EOS would break T1 streaming. OBDiag=0 gating
             // is handled in the task body (skips monitoring reads when
             // Running && !OnboardDiagEnabled).
-        }
 
-        TimerApi_Start(gpStreamingConfig->TimerIndex);
-        gpRuntimeConfigStream->Running = 1;
+            TimerApi_Start(gpStreamingConfig->TimerIndex);
+            gpRuntimeConfigStream->Running = 1;
+        }
     }
 }
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -826,6 +826,11 @@ static void Streaming_Start(void) {
         TimerApi_Initialize(gpStreamingConfig->TimerIndex);
         TimerApi_PeriodSet(gpStreamingConfig->TimerIndex, gpRuntimeConfigStream->ClockPeriod);
         TimerApi_CallbackRegister(gpStreamingConfig->TimerIndex, Streaming_TimerHandler, 0);
+        // Harmony's TMRx_Initialize (e.g. plib_tmr4.c:80) sets the IEC bit
+        // as a side effect — disable it here so the InterruptEnable gate
+        // below is authoritative.  Without this defensive disable, the IRQ
+        // is armed at boot even though we gate TimerApi_Start on IsEnabled.
+        TimerApi_InterruptDisable(gpStreamingConfig->TimerIndex);
 
         // Arm the timer ISR + start the timer + flip Running only when
         // streaming is truly enabled.  Streaming_Start runs at boot via

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -860,12 +860,14 @@ static void Streaming_Start(void) {
             // is handled in the task body (skips monitoring reads when
             // Running && !OnboardDiagEnabled).
 
-            // Order matters: set Running=1 BEFORE arming the IRQ and
-            // starting the timer, so any ISR firing on the first tick
-            // sees Running=true.  Streaming_TimerHandler itself gates on
-            // IsEnabled (not Running) so this only matters for async
-            // consumers (HAL/ADC.c:129) that could otherwise momentarily
-            // see Running=0 while the timer is already firing.
+            // Order matters: publish Running=1 BEFORE arming the IRQ
+            // and starting the timer.  Streaming_TimerHandler itself
+            // gates on IsEnabled (not Running), so this is NOT about
+            // protecting the ISR — it's about async TASK consumers
+            // (HAL/ADC.c:129 EOS deferred task, SCPI handlers) that
+            // could otherwise observe Running=0 for a few cycles while
+            // the timer is already ticking, producing inconsistent
+            // hardware-state reads.
             gpRuntimeConfigStream->Running = 1;
             TimerApi_InterruptEnable(gpStreamingConfig->TimerIndex);
             TimerApi_Start(gpStreamingConfig->TimerIndex);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -826,16 +826,19 @@ static void Streaming_Start(void) {
         TimerApi_Initialize(gpStreamingConfig->TimerIndex);
         TimerApi_PeriodSet(gpStreamingConfig->TimerIndex, gpRuntimeConfigStream->ClockPeriod);
         TimerApi_CallbackRegister(gpStreamingConfig->TimerIndex, Streaming_TimerHandler, 0);
-        TimerApi_InterruptEnable(gpStreamingConfig->TimerIndex);
 
-        // Actually start the timer + flip Running only when streaming is
-        // truly enabled.  Streaming_Start runs at boot (via Streaming_
-        // UpdateState's unconditional Stop→Start cycle) with IsEnabled
-        // false; previously we set Running=1 anyway, which lied about
-        // the hardware state to every downstream consumer that checked
-        // `Running` alone (e.g. ADC.c:129, SCPIADC.c:64/439).  Now
-        // `Running` invariant: true iff the streaming timer is actually
-        // ticking — see #379.
+        // Arm the timer ISR + start the timer + flip Running only when
+        // streaming is truly enabled.  Streaming_Start runs at boot via
+        // Streaming_UpdateState's unconditional Stop→Start cycle with
+        // IsEnabled=false; pre-fix this set Running=1 unconditionally,
+        // lying about hardware state to every consumer checking `Running`
+        // alone (HAL/ADC.c:129, SCPIInterface.c:1916 "streaming already
+        // active" guard, SCPIADC.c:64/439).  Now the invariant: Running
+        // == true iff the timer is actually ticking — see #379.
+        // InterruptEnable was previously also unconditional; moving it
+        // inside the gate keeps it symmetric with Streaming_Stop's
+        // TimerApi_InterruptDisable (which only fires when Running was
+        // true), so the timer ISR is never armed-without-source.
         if (gpRuntimeConfigStream->IsEnabled) {
             // Enable hardware ADC triggering only when actually streaming.
             // Streaming_Start runs at boot before ADC_Init — must not
@@ -852,6 +855,7 @@ static void Streaming_Start(void) {
             // is handled in the task body (skips monitoring reads when
             // Running && !OnboardDiagEnabled).
 
+            TimerApi_InterruptEnable(gpStreamingConfig->TimerIndex);
             TimerApi_Start(gpStreamingConfig->TimerIndex);
             gpRuntimeConfigStream->Running = 1;
         }

--- a/firmware/src/state/runtime/StreamingRuntimeConfig.h
+++ b/firmware/src/state/runtime/StreamingRuntimeConfig.h
@@ -40,9 +40,12 @@ extern "C" {
          * volatile so -O3 cannot cache reads across loop iterations
          * or function-call boundaries — per CLAUDE.md PIC32MZ
          * cross-context atomicity rules (32-bit RW atomic but
-         * volatile needed for visibility).
+         * volatile needed for visibility).  Type widened to uint32_t per
+         * the bus-native-width convention used by the other cross-context
+         * shared flags (gQuesBits in streaming.c): single-instruction
+         * load/store on PIC32MZ, no sub-word zero-extend overhead.
          */
-        volatile bool Running;
+        volatile uint32_t Running;
         
         /**
          * The base clock divider

--- a/firmware/src/state/runtime/StreamingRuntimeConfig.h
+++ b/firmware/src/state/runtime/StreamingRuntimeConfig.h
@@ -33,10 +33,16 @@ extern "C" {
         bool IsEnabled;
         
         /**
-         * Indicates whether the alarm has been registered
-         * TODO: This probably belongs in 'Data'
+         * Indicates whether the streaming timer is actually ticking.
+         * Written by streaming.c (Streaming_Start sets, Streaming_Stop
+         * clears) and read by ADC.c:129 (EOS deferred task, pri 9),
+         * SCPIInterface/SCPIADC (USB pri 7 / WiFi pri 2).  Marked
+         * volatile so -O3 cannot cache reads across loop iterations
+         * or function-call boundaries — per CLAUDE.md PIC32MZ
+         * cross-context atomicity rules (32-bit RW atomic but
+         * volatile needed for visibility).
          */
-        bool Running;
+        volatile bool Running;
         
         /**
          * The base clock divider


### PR DESCRIPTION
## Summary

Closes #379.  `gpRuntimeConfigStream->Running` was set to `true` at boot — `Streaming_UpdateState()` runs its unconditional Stop→Start cycle during initialization with `IsEnabled=false`, and the Start path flipped `Running=1` and called `TimerApi_Start` regardless.  Every consumer that gated on `Running` alone saw a false positive at boot.

## What changed

`firmware/src/services/streaming.c::Streaming_Start` — `TimerApi_Start` and the `Running=1` assignment now live inside the existing `IsEnabled` gate (which already protected the hardware-trigger config below them).  `Streaming_Stop` already gated on `Running`, so the post-fix invariant is clean:

> **`Running == true` iff the streaming timer is actually ticking right now.**

That's the semantic every consumer needed all along.  In particular, the comment at `SCPIADC.c:60-64` explicitly says:

> *"Running (actual hardware state) rather than IsEnabled (user intent) — needed for correctness"*

— so the original intent was always for `Running` to track hardware state.  The Start path was lying about it.

## Affected consumers (all become correct automatically)

These read `Running` alone and were vulnerable to the boot-true false positive — no code change needed, the producer fix flows through:

- `HAL/ADC.c:129` — `streamingActive` → `diagScanning` gate
- `SCPIInterface.c:1006` — `Running && !OnboardDiagEnabled`
- `SCPIInterface.c:1916` — throughput benchmark "streaming already active" rejection ← visible symptom
- `SCPIInterface.c:1954` — throughput benchmark post-Start verifier
- `SCPIADC.c:64` — range gating
- `SCPIADC.c:439` — range-change rejection during stream

Tolerant consumers that paired `IsEnabled && Running` keep working (the second check becomes redundant but harmless).

## Test plan

- [x] **Visible boot symptom gone.** Fresh flash → `SYST:STR:THR 1000,2` returns stats (`EncoderFail=1999 LossPercent=0 PoolMaxUsed=1`).  Pre-fix this would return `-200 streaming already active` because the boot-true `Running` tripped the guard at `SCPIInterface.c:1916`.
- [x] **Build PASS** (`xc32-gcc.exe` -O3 -Werror).
- [x] **Cppcheck baseline unchanged** (2 pre-existing style findings).
- [x] **No regression on normal start/stop.** Streaming starts (`SYST:STR:START`) and the throughput-benchmark Start-verifier at `SCPIInterface.c:1954` still works (proves `Running` does become true when streaming is actually enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)