### PR TITLE
chore(lint): parallelize cppcheck (-j nproc), 10m → 23s

### DIFF
--- a/tools/lint/cppcheck.sh
+++ b/tools/lint/cppcheck.sh
@@ -29,11 +29,17 @@ trap 'rm -f "$TMP_OUT"' EXIT
 # Override with CPPCHECK_JOBS env var when bisecting an ordering oddity.
 # Validate: cppcheck rejects non-positive / non-numeric values with a
 # generic argument error; reject early with a clear message instead.
-JOBS="${CPPCHECK_JOBS:-$(nproc 2>/dev/null || echo 1)}"
-if ! [[ "$JOBS" =~ ^[1-9][0-9]*$ ]]; then
-  echo "::error::CPPCHECK_JOBS must be a positive integer, got: '$JOBS'" >&2
-  exit 2
-fi
+JOBS="${CPPCHECK_JOBS:-$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)}"
+case "$JOBS" in
+  ''|*[!0-9]*)
+    echo "::error::CPPCHECK_JOBS must be a positive integer, got: '$JOBS'" >&2
+    exit 2
+    ;;
+  0)
+    echo "::error::CPPCHECK_JOBS must be > 0, got: '$JOBS'" >&2
+    exit 2
+    ;;
+esac
 
 # `if !` so set -e doesn't abort on cppcheck failure; we want to surface
 # cppcheck's own error output (which goes to TMP_OUT via stderr) before

--- a/tools/lint/cppcheck.sh
+++ b/tools/lint/cppcheck.sh
@@ -27,7 +27,13 @@ trap 'rm -f "$TMP_OUT"' EXIT
 # `-j N`, but the LC_ALL=C sort below normalizes ordering — so parallel
 # + sort produces exactly the same baseline as single-threaded + sort.
 # Override with CPPCHECK_JOBS env var when bisecting an ordering oddity.
+# Validate: cppcheck rejects non-positive / non-numeric values with a
+# generic argument error; reject early with a clear message instead.
 JOBS="${CPPCHECK_JOBS:-$(nproc 2>/dev/null || echo 1)}"
+if ! [[ "$JOBS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::CPPCHECK_JOBS must be a positive integer, got: '$JOBS'" >&2
+  exit 2
+fi
 
 # `if !` so set -e doesn't abort on cppcheck failure; we want to surface
 # cppcheck's own error output (which goes to TMP_OUT via stderr) before

--- a/tools/lint/cppcheck.sh
+++ b/tools/lint/cppcheck.sh
@@ -23,10 +23,17 @@ OUT="${1:-tools/lint/cppcheck-baseline.txt}"
 TMP_OUT="$(mktemp)"
 trap 'rm -f "$TMP_OUT"' EXIT
 
+# Parallelism: cppcheck emits findings in non-deterministic order under
+# `-j N`, but the LC_ALL=C sort below normalizes ordering — so parallel
+# + sort produces exactly the same baseline as single-threaded + sort.
+# Override with CPPCHECK_JOBS env var when bisecting an ordering oddity.
+JOBS="${CPPCHECK_JOBS:-$(nproc 2>/dev/null || echo 1)}"
+
 # `if !` so set -e doesn't abort on cppcheck failure; we want to surface
 # cppcheck's own error output (which goes to TMP_OUT via stderr) before
 # exiting, otherwise CI just shows "step failed" with no diagnostic.
 if ! LC_ALL=C LANG=C cppcheck \
+  -j "$JOBS" \
   --quiet \
   --template='{file}:{line}:{column}: {severity}: {message} [{id}]' \
   --enable=warning,style,performance,portability \
@@ -54,9 +61,6 @@ if ! LC_ALL=C LANG=C cppcheck \
   cat "$TMP_OUT"
   exit 1
 fi
-# Note: no -j flag — parallel cppcheck emits findings in non-deterministic
-# order, which sort below would normalize anyway, but single-threaded is
-# also a belt-and-suspenders against any future ordering oddities.
 
 LC_ALL=C sort "$TMP_OUT" >"$OUT"
 


### PR DESCRIPTION
## Summary

`tools/lint/cppcheck.sh` previously ran single-threaded because of a stated determinism concern that hasn't applied since the script sorted its output:

```bash
# Note: no -j flag — parallel cppcheck emits findings in non-deterministic
# order, which sort below would normalize anyway, but single-threaded is
# also a belt-and-suspenders against any future ordering oddities.
```

The `LC_ALL=C sort` on the next line normalizes ordering regardless of `-j`. Single-threaded was leaving CPU on the floor for no real benefit.

## Change

Added `-j $(nproc)` (with `CPPCHECK_JOBS` env-var override for bisection if a future cppcheck regresses on parallel-with-sort ordering).

## Test plan

Measured on a 20-core WSL host:

| Mode | Wall time | Output diff |
|---|---:|---|
| Single-threaded (`CPPCHECK_JOBS=1`) | **10m 11.6s** | reference |
| Parallel (default `-j 20`) | **22.9s** | bit-identical (`diff -q` clean) |

Speedup: **~27×**. Output baseline unchanged (still the same 2 pre-existing style findings: 1 `variableScope`, 1 `constParameterPointer` in `wifi_serial_bridge.c`).

## Notes

- CI gate behavior unchanged (same baseline, same suppressions, same findings).
- The `CPPCHECK_JOBS=1` escape hatch lets us revert to single-threaded without a code change if needed.
- Local `bash tools/lint/cppcheck.sh` runs went from "go make coffee" to "blink and miss it".

🤖 Generated with [Claude Code](https://claude.com/claude-code)