### PR TITLE
feat(power): NVM auto-power-up on USB connect (#454)

### DIFF
--- a/firmware/src/HAL/Power/PowerApi.c
+++ b/firmware/src/HAL/Power/PowerApi.c
@@ -15,6 +15,7 @@
 #include "Util/Logger.h"
 #include "../../services/wifi_services/wifi_manager.h"
 #include "../../services/UsbCdc/UsbCdc.h"
+#include "../../services/daqifi_settings.h"  // #454: load autoPowerOnUsb from NVM
 #include "../../services/sd_card_services/sd_card_manager.h"
 #include "driver/usb/usbhs/src/plib_usbhs_header.h"
 #include <xc.h>
@@ -131,7 +132,23 @@ void Power_Init(
 
     // Initialize auto external power control (enabled by default)
     pData->autoExtPowerEnabled = true;
-    
+
+    /* #454: seed autoPowerOnUsb from NVM-persisted TopLevelSettings.
+     * Power_Init runs AFTER app_freertos.c's TopLevelSettings load
+     * (line 465), so the latest NVM value is already in NVM and we
+     * just re-fetch it here.  On load failure (uninitialized NVM),
+     * fall back to the safe default (false).  pData->autoPromotedThis
+     * VbusSession was already zeroed by the memset above. */
+    {
+        DaqifiSettings nvm;
+        memset(&nvm, 0, sizeof(nvm));
+        if (daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings, &nvm)) {
+            pData->autoPowerOnUsb = nvm.settings.topLevelSettings.autoPowerOnUsb;
+        } else {
+            pData->autoPowerOnUsb = false;
+        }
+    }
+
     BQ24297_InitHardware(
             &pConfig->BQ24297Config,
             &pWriteVariables->BQ24297WriteVars,
@@ -455,6 +472,25 @@ static bool Power_HasSufficientPower(void) {
  *   - Update status (faster on USB for button response)
  */
 static void Power_HandleStandbyState(void) {
+    /* #454: Auto-power-up on VBUS-present.  Fires at boot (if USB
+     * plugged at power-on) and on VBUS-rising mid-session (cable
+     * inserted while device is in STANDBY on battery).  Suppressed
+     * after the user explicitly returns to STANDBY in the same VBUS
+     * session — only re-arms when VBUS goes away and comes back.
+     * Skipped on battery-only (pgStat=0).  */
+    if (pData->autoPowerOnUsb && pData->requestedPowerState == NO_CHANGE) {
+        bool vbusPresent = pData->BQ24297Data.status.pgStat;
+        if (!vbusPresent) {
+            /* VBUS gone — re-arm auto-promote for next plug-in */
+            pData->autoPromotedThisVbusSession = false;
+        } else if (!pData->autoPromotedThisVbusSession) {
+            /* VBUS present, haven't auto-promoted in this session yet */
+            LOG_I("Power: auto-power-up on USB (#454)");
+            pData->requestedPowerState = DO_POWER_UP;
+            pData->autoPromotedThisVbusSession = true;
+        }
+    }
+
     /* Priority 1: Handle user power-up requests */
     if (pData->requestedPowerState == DO_POWER_UP ||
         pData->requestedPowerState == DO_POWER_UP_EXT_DOWN) {

--- a/firmware/src/HAL/Power/PowerApi.h
+++ b/firmware/src/HAL/Power/PowerApi.h
@@ -107,6 +107,16 @@ typedef struct sPowerData{
     double battVoltage;
     bool pONBattPresent;
     bool autoExtPowerEnabled;  /* Auto-manage external power based on battery level (default: true) */
+    /* #454: Auto-transition STANDBY → POWERED_UP whenever VBUS (USB) is
+     * present.  Default false (opt-in).  Loaded from NVM at boot
+     * (TopLevelSettings.autoPowerOnUsb); persisted via SYST:POW:AUTOOn:SAVE. */
+    bool autoPowerOnUsb;
+    /* #454 tracking: have we already auto-promoted during the current
+     * VBUS session?  Set when we issue the auto DO_POWER_UP request,
+     * cleared when VBUS goes away.  Prevents re-promote after the user
+     * manually returns to STANDBY (POW:STAT 0) while USB stays plugged
+     * in. */
+    bool autoPromotedThisVbusSession;
 
     tBQ24297Data BQ24297Data;
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -1394,6 +1394,7 @@ static scpi_result_t SCPI_SetAutoPowerOnUsb(scpi_t * context) {
      * plugged in triggers the auto-promote on the next Power_Tasks
      * call instead of waiting for the next VBUS rising-edge. */
     pPowerData->autoPromotedThisVbusSession = false;
+    BoardData_Set(BOARDDATA_POWER_DATA, 0, pPowerData);
     return SCPI_RES_OK;
 }
 
@@ -1447,6 +1448,7 @@ static scpi_result_t SCPI_LoadAutoPowerOnUsb(scpi_t * context) {
     tPowerData *pPowerData = BoardData_Get(BOARDDATA_POWER_DATA, 0);
     pPowerData->autoPowerOnUsb = pSettings->settings.topLevelSettings.autoPowerOnUsb;
     pPowerData->autoPromotedThisVbusSession = false;  // re-arm
+    BoardData_Set(BOARDDATA_POWER_DATA, 0, pPowerData);
     SCPI_ResponseBuf_Give();
     return SCPI_RES_OK;
 }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -446,7 +446,10 @@ scpi_result_t SCPI_Help(scpi_t* context);
 // no heap-allocation failure path.
 _Static_assert(SCPI_RESPONSE_BUF_SIZE >= DaqifiOutMessage_size,
                "SCPI_RESPONSE_BUF_SIZE must hold the largest SCPI response");
-static uint8_t gScpiRespBuf[SCPI_RESPONSE_BUF_SIZE];
+/* Aligned to 8 bytes so callers can safely cast the pointer to any
+ * scratch struct (e.g. DaqifiSettings, which contains uint32_t /
+ * uint64_t fields).  PIC32MZ MIPS32 traps unaligned word accesses. */
+static uint8_t gScpiRespBuf[SCPI_RESPONSE_BUF_SIZE] __attribute__((aligned(8)));
 static StaticSemaphore_t gScpiRespMutexStorage;
 static SemaphoreHandle_t gScpiRespMutex = NULL;
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -1355,14 +1355,72 @@ static scpi_result_t SCPI_SetAutoExtPower(scpi_t * context) {
     }
     
     pPowerData->autoExtPowerEnabled = (param1 != 0);
-    LOG_D("Auto external power switching %s", 
+    LOG_D("Auto external power switching %s",
           pPowerData->autoExtPowerEnabled ? "enabled" : "disabled");
-    
+
     BoardData_Set(
             BOARDDATA_POWER_DATA,
             0,
             pPowerData);
-    
+
+    return SCPI_RES_OK;
+}
+
+/**
+ * #454 SCPI: SYSTem:POWer:AUTOOn 0|1
+ * When enabled, the device auto-transitions STANDBY → POWERED_UP
+ * whenever VBUS is detected (at boot or on cable insertion mid-session).
+ * Runtime-only; use :SAVE to persist to NVM.
+ */
+static scpi_result_t SCPI_SetAutoPowerOnUsb(scpi_t * context) {
+    int param1;
+    if (!SCPI_ParamInt32(context, &param1, TRUE)) {
+        return SCPI_RES_ERR;
+    }
+    if (param1 < 0 || param1 > 1) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    tPowerData *pPowerData = BoardData_Get(BOARDDATA_POWER_DATA, 0);
+    pPowerData->autoPowerOnUsb = (param1 != 0);
+    /* Re-arm the per-session latch so toggling 0→1 with USB already
+     * plugged in triggers the auto-promote on the next Power_Tasks
+     * call instead of waiting for the next VBUS rising-edge. */
+    pPowerData->autoPromotedThisVbusSession = false;
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_GetAutoPowerOnUsb(scpi_t * context) {
+    tPowerData *pPowerData = BoardData_Get(BOARDDATA_POWER_DATA, 0);
+    SCPI_ResultInt32(context, pPowerData->autoPowerOnUsb ? 1 : 0);
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_SaveAutoPowerOnUsb(scpi_t * context) {
+    DaqifiSettings settings;
+    memset(&settings, 0, sizeof(settings));
+    /* Load existing NVM to preserve other TopLevelSettings fields
+     * (voltagePrecision, calVals, etc.) — SaveToNvm captures the
+     * current runtime autoPowerOnUsb automatically via PowerData. */
+    if (!daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings, &settings)) {
+        daqifi_settings_LoadFactoryDeafult(DaqifiSettings_TopLevelSettings, &settings);
+    }
+    settings.type = DaqifiSettings_TopLevelSettings;
+    if (!daqifi_settings_SaveToNvm(&settings)) {
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_LoadAutoPowerOnUsb(scpi_t * context) {
+    DaqifiSettings settings;
+    memset(&settings, 0, sizeof(settings));
+    if (!daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings, &settings)) {
+        return SCPI_RES_ERR;
+    }
+    tPowerData *pPowerData = BoardData_Get(BOARDDATA_POWER_DATA, 0);
+    pPowerData->autoPowerOnUsb = settings.settings.topLevelSettings.autoPowerOnUsb;
+    pPowerData->autoPromotedThisVbusSession = false;  // re-arm
     return SCPI_RES_OK;
 }
 
@@ -4205,6 +4263,10 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:POWer:STATe", .callback = SCPI_SetPowerState,},
     {.pattern = "SYSTem:POWer:AUTO:EXTernal?", .callback = SCPI_GetAutoExtPower,},
     {.pattern = "SYSTem:POWer:AUTO:EXTernal", .callback = SCPI_SetAutoExtPower,},
+    {.pattern = "SYSTem:POWer:AUTOOn", .callback = SCPI_SetAutoPowerOnUsb,},      // #454
+    {.pattern = "SYSTem:POWer:AUTOOn?", .callback = SCPI_GetAutoPowerOnUsb,},
+    {.pattern = "SYSTem:POWer:AUTOOn:SAVE", .callback = SCPI_SaveAutoPowerOnUsb,},
+    {.pattern = "SYSTem:POWer:AUTOOn:LOAD", .callback = SCPI_LoadAutoPowerOnUsb,},
     {.pattern = "SYSTem:POWer:BQ:REGisters?", .callback = SCPI_GetBQRegisters,},
     {.pattern = "SYSTem:POWer:BQ:ILIM", .callback = SCPI_SetBQILim,},
     {.pattern = "SYSTem:POWer:BQ:DPDM", .callback = SCPI_ForceDPDM,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -1300,6 +1300,10 @@ static scpi_result_t SCPI_SetPowerState(scpi_t * context) {
     switch (param1) {
         case 0:  // STANDBY
             pPowerData->requestedPowerState = DO_POWER_DOWN;
+            // #454: latch the per-VBUS-session auto-promote suppression
+            // so the Standby handler doesn't immediately re-promote.
+            // The latch already clears when VBUS goes away.
+            pPowerData->autoPromotedThisVbusSession = true;
             break;
         case 1:  // POWERED_UP
             pPowerData->requestedPowerState = DO_POWER_UP;
@@ -1397,30 +1401,50 @@ static scpi_result_t SCPI_GetAutoPowerOnUsb(scpi_t * context) {
 }
 
 static scpi_result_t SCPI_SaveAutoPowerOnUsb(scpi_t * context) {
-    DaqifiSettings settings;
-    memset(&settings, 0, sizeof(settings));
-    /* Load existing NVM to preserve other TopLevelSettings fields
-     * (voltagePrecision, calVals, etc.) — SaveToNvm captures the
-     * current runtime autoPowerOnUsb automatically via PowerData. */
-    if (!daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings, &settings)) {
-        daqifi_settings_LoadFactoryDeafult(DaqifiSettings_TopLevelSettings, &settings);
-    }
-    settings.type = DaqifiSettings_TopLevelSettings;
-    if (!daqifi_settings_SaveToNvm(&settings)) {
+    /* Use shared SCPI response buffer instead of stack-local —
+     * DaqifiSettings is ~500 bytes (union includes WiFi settings),
+     * and WiFi-task stack peak is ~780 words / 3120 bytes already.
+     * Pattern matches the SCPI buffer-discipline rule (#347).
+     */
+    DaqifiSettings *pSettings = (DaqifiSettings *)SCPI_ResponseBuf_Take();
+    if (pSettings == NULL) {
+        SCPI_ErrorPush(context, SCPI_ERROR_SYSTEM_ERROR);
         return SCPI_RES_ERR;
     }
-    return SCPI_RES_OK;
+    memset(pSettings, 0, sizeof(*pSettings));
+    /* Load existing NVM to preserve other TopLevelSettings fields.
+     * Set autoPowerOnUsb from PowerData runtime explicitly (don't rely
+     * on SaveToNvm's auto-capture — that path would also affect
+     * unrelated saves like CONF:VOLT:SAVE).
+     */
+    if (!daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings, pSettings)) {
+        daqifi_settings_LoadFactoryDeafult(DaqifiSettings_TopLevelSettings, pSettings);
+    }
+    pSettings->type = DaqifiSettings_TopLevelSettings;
+    tPowerData *pPwr = BoardData_Get(BOARDDATA_POWER_DATA, 0);
+    if (pPwr != NULL) {
+        pSettings->settings.topLevelSettings.autoPowerOnUsb = pPwr->autoPowerOnUsb;
+    }
+    bool ok = daqifi_settings_SaveToNvm(pSettings);
+    SCPI_ResponseBuf_Give();
+    return ok ? SCPI_RES_OK : SCPI_RES_ERR;
 }
 
 static scpi_result_t SCPI_LoadAutoPowerOnUsb(scpi_t * context) {
-    DaqifiSettings settings;
-    memset(&settings, 0, sizeof(settings));
-    if (!daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings, &settings)) {
+    DaqifiSettings *pSettings = (DaqifiSettings *)SCPI_ResponseBuf_Take();
+    if (pSettings == NULL) {
+        SCPI_ErrorPush(context, SCPI_ERROR_SYSTEM_ERROR);
+        return SCPI_RES_ERR;
+    }
+    memset(pSettings, 0, sizeof(*pSettings));
+    if (!daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings, pSettings)) {
+        SCPI_ResponseBuf_Give();
         return SCPI_RES_ERR;
     }
     tPowerData *pPowerData = BoardData_Get(BOARDDATA_POWER_DATA, 0);
-    pPowerData->autoPowerOnUsb = settings.settings.topLevelSettings.autoPowerOnUsb;
+    pPowerData->autoPowerOnUsb = pSettings->settings.topLevelSettings.autoPowerOnUsb;
     pPowerData->autoPromotedThisVbusSession = false;  // re-arm
+    SCPI_ResponseBuf_Give();
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/daqifi_settings.c
+++ b/firmware/src/services/daqifi_settings.c
@@ -5,6 +5,8 @@
 #include "state/board/BoardConfig.h"
 #include "state/board/NQ3BoardConfig.h"
 #include "state/runtime/BoardRuntimeConfig.h"
+#include "state/data/BoardData.h"
+#include "HAL/Power/PowerApi.h"
 
 uint8_t gTempFflashBuffer[NVM_FLASH_ROWSIZE] __attribute__((coherent, aligned(16)));
 
@@ -62,6 +64,7 @@ bool daqifi_settings_LoadFactoryDeafult(DaqifiSettingsType type, DaqifiSettings*
             const tBoardConfig* pBoardConfig = (const tBoardConfig*)NqBoardConfig_Get();
             pTopLevelSettings->calVals = 0;
             pTopLevelSettings->voltagePrecision = pBoardConfig->DefaultVoltagePrecision;
+            pTopLevelSettings->autoPowerOnUsb = false;  // #454: opt-in
             strcpy(pTopLevelSettings->boardHardwareRev, HARDWARE_REVISION);
             strcpy(pTopLevelSettings->boardFirmwareRev, FIRMWARE_REVISION);
             pTopLevelSettings->boardVariant = pBoardConfig->BoardVariant;
@@ -141,6 +144,12 @@ bool daqifi_settings_SaveToNvm(DaqifiSettings* settings) {
             if (pStreamCfg != NULL) {
                 settings->settings.topLevelSettings.voltagePrecision =
                         pStreamCfg->VoltagePrecision;
+            }
+            // #454: capture current autoPowerOnUsb from PowerData runtime
+            tPowerData *pPwr = BoardData_Get(BOARDDATA_POWER_DATA, 0);
+            if (pPwr != NULL) {
+                settings->settings.topLevelSettings.autoPowerOnUsb =
+                        pPwr->autoPowerOnUsb;
             }
             address = TOP_LEVEL_SETTINGS_ADDR;
             dataSize = sizeof (TopLevelSettings);

--- a/firmware/src/services/daqifi_settings.c
+++ b/firmware/src/services/daqifi_settings.c
@@ -5,8 +5,6 @@
 #include "state/board/BoardConfig.h"
 #include "state/board/NQ3BoardConfig.h"
 #include "state/runtime/BoardRuntimeConfig.h"
-#include "state/data/BoardData.h"
-#include "HAL/Power/PowerApi.h"
 
 uint8_t gTempFflashBuffer[NVM_FLASH_ROWSIZE] __attribute__((coherent, aligned(16)));
 
@@ -145,12 +143,11 @@ bool daqifi_settings_SaveToNvm(DaqifiSettings* settings) {
                 settings->settings.topLevelSettings.voltagePrecision =
                         pStreamCfg->VoltagePrecision;
             }
-            // #454: capture current autoPowerOnUsb from PowerData runtime
-            tPowerData *pPwr = BoardData_Get(BOARDDATA_POWER_DATA, 0);
-            if (pPwr != NULL) {
-                settings->settings.topLevelSettings.autoPowerOnUsb =
-                        pPwr->autoPowerOnUsb;
-            }
+            // #454 autoPowerOnUsb is NOT captured here — the caller is
+            // responsible for setting it explicitly before SaveToNvm.
+            // Auto-capture would clobber the persisted value on every
+            // unrelated save (e.g. CONF:VOLT:SAVE) if PowerData has been
+            // toggled at runtime without an AUTOOn:SAVE.
             address = TOP_LEVEL_SETTINGS_ADDR;
             dataSize = sizeof (TopLevelSettings);
             break;

--- a/firmware/src/services/daqifi_settings.h
+++ b/firmware/src/services/daqifi_settings.h
@@ -96,6 +96,14 @@ extern "C" {
          */
         uint8_t voltagePrecision;
 
+        /**
+         * #454: when true, auto-transition STANDBY → POWERED_UP whenever
+         * VBUS (USB) is present.  Fires at boot (if USB is plugged in
+         * at power-on) and on VBUS-rising edge mid-session.  Default
+         * false for back-compat.
+         */
+        bool autoPowerOnUsb;
+
     } TopLevelSettings;
 
     


### PR DESCRIPTION
## Summary

Closes #454. Adds opt-in `SYST:POW:AUTOOn` setting (default off, back-compat preserved). When enabled, the device auto-transitions `STANDBY → POWERED_UP` whenever VBUS is present — at boot or on cable insertion mid-session. Removes the manual `SYST:POW:STAT 1` step for first-time users and field-deployed loggers that reboot under USB power.

## SCPI

```bash
SYSTem:POWer:AUTOOn 0|1      # set runtime
SYSTem:POWer:AUTOOn?         # query runtime
SYSTem:POWer:AUTOOn:SAVE     # persist to NVM
SYSTem:POWer:AUTOOn:LOAD     # restore from NVM
```

## Implementation

- `TopLevelSettings.autoPowerOnUsb` — NVM-persisted field (default `false`).
- `tPowerData.autoPowerOnUsb` — runtime mirror, seeded from NVM in `Power_Init`.
- `Power_HandleStandbyState` polls VBUS (`BQ24297.status.pgStat`) each cycle. If `autoPowerOnUsb && VBUS && !autoPromotedThisVbusSession`, request `DO_POWER_UP`. Per-session latch prevents re-promote after a manual `POW:STAT 0` while USB stays plugged in; clears when VBUS goes away.

Battery-only operation is unaffected — `pgStat=0` means VBUS not present, so auto-promote never fires.

## Test plan

Bench-verified on NQ1 `7E2898F46200E8A7` (2026-05-14):

- [x] **Default boot (no prior NVM)**: `AUTOOn=0`, `POW:STAT=0` — back-compat preserved
- [x] **Runtime enable**: `SYST:POW:AUTOOn 1` → `POW:STAT` becomes `1` within ~100 ms
- [x] **Persist + reboot**: `AUTOOn:SAVE` → `REBoot` → `AUTOOn=1` AND `POW:STAT=1` at boot
- [x] **Manual `POW:STAT 0` doesn't re-promote**: stays `0` for 5+ seconds with USB plugged (per-session latch)
- [x] **Disable + persist + reboot**: `AUTOOn 0 + SAVE + REBoot` → `AUTOOn=0`, `POW:STAT=0` (back-compat preserved)
- [x] Build PASS
- [x] Cppcheck baseline unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)