### PR TITLE
fix(wifi): unconditionally disconnect on STA reconfigure to clear stuck isConnected (#467)

### DIFF
--- a/firmware/src/Util/Logger.h
+++ b/firmware/src/Util/Logger.h
@@ -172,6 +172,9 @@ extern "C" {
      */
     typedef enum {
         LOG_ONCE_USB_WRITE_MISMATCH = 0,  /**< UsbCdc.c: USB CDC write length mismatch */
+        LOG_ONCE_WIFI_DISCONNECT_DISABLE, /**< wifi_manager.c: forced BSS disconnect on !isEnabled (#467) */
+        LOG_ONCE_WIFI_DISCONNECT_STA2AP,  /**< wifi_manager.c: forced BSS disconnect on STA->AP switch (#467) */
+        LOG_ONCE_WIFI_DISCONNECT_STA2STA, /**< wifi_manager.c: forced BSS disconnect on STA reconfigure (#467) */
         /* Add new entries above this line */
         LOG_ONCE_COUNT                     /**< Must be <= 32 */
     } LogOnceBit_t;

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1236,6 +1236,9 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // isConnected is already false; we ignore the return.
                     if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED) ||
                         GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
+                        LOG_I("WiFi: forcing BSS disconnect on STA reconfigure (sta_connected=%u sta_started=%u)",
+                              (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED),
+                              (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED));
                         ArmApplyTeardownDeadline();  // #423
                         (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
@@ -1490,6 +1493,9 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // isConnected is already false; we ignore the return.
                     if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED) ||
                         GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
+                        LOG_I("WiFi: forcing BSS disconnect on STA reconfigure (sta_connected=%u sta_started=%u)",
+                              (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED),
+                              (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED));
                         ArmApplyTeardownDeadline();  // #423
                         (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1188,10 +1188,23 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED);
                 }
                 
-                // Disconnect STA if connected
-                if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED)) {
+                // Disconnect STA if connected — or even just started.
+                // Same #467 reasoning as the STA reconfigure paths below:
+                // the WINC driver's pCtrl->isConnected can be stuck true
+                // after a failed prior association (e.g. bad-password
+                // retry).  Without this disconnect on the disable path,
+                // a later re-enable goes through INIT which calls
+                // WDRV_WINC_IPUseDHCPSet, sees isConnected==true, and
+                // returns REQUEST_ERROR — recreating the same wedge the
+                // STA-reconfigure fix is designed to prevent.  Found by
+                // Qodo /agentic_review pass 1.
+                if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED) ||
+                    GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
+                    LOG_I("WiFi: forcing BSS disconnect on disable (sta_connected=%u sta_started=%u)",
+                          (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED),
+                          (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED));
                     ArmApplyTeardownDeadline();  // #423: demote the impending async disconnect callback
-                    WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                    (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                 }
                 ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1215,7 +1215,18 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                 ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
                 ArmApplyTeardownDeadline();  // #423: demote the impending async disconnect callback
-                (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                {
+                    // Log unexpected return values (Qodo /improve pass 5
+                    // importance 6).  REQUEST_ERROR is the harmless
+                    // "isConnected already false" case; OK is success.
+                    // Anything else (INVALID_ARG, NOT_OPEN, DISCONNECT_FAIL)
+                    // indicates a deeper driver/chip issue worth recording.
+                    const WDRV_WINC_STATUS discStatus = WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                    if ((WDRV_WINC_STATUS_OK != discStatus) &&
+                        (WDRV_WINC_STATUS_REQUEST_ERROR != discStatus)) {
+                        LOG_E("WiFi: BSS disconnect failed on disable (status=%d)", (int)discStatus);
+                    }
+                }
 
                 // Close sockets
                 if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
@@ -1265,7 +1276,13 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
                     ArmApplyTeardownDeadline();  // #423
-                    (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                    {
+                        const WDRV_WINC_STATUS discStatus = WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                        if ((WDRV_WINC_STATUS_OK != discStatus) &&
+                            (WDRV_WINC_STATUS_REQUEST_ERROR != discStatus)) {
+                            LOG_E("WiFi: BSS disconnect failed on STA->AP (status=%d)", (int)discStatus);
+                        }
+                    }
 
                     // Don't deinitialize - the driver gets into a bad state after deinit
                     // Instead, just wait for STA to disconnect and then configure for AP mode
@@ -1520,7 +1537,13 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
                     ArmApplyTeardownDeadline();  // #423
-                    (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                    {
+                        const WDRV_WINC_STATUS discStatus = WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                        if ((WDRV_WINC_STATUS_OK != discStatus) &&
+                            (WDRV_WINC_STATUS_REQUEST_ERROR != discStatus)) {
+                            LOG_E("WiFi: BSS disconnect failed on STA reconfigure (status=%d)", (int)discStatus);
+                        }
+                    }
 
                     // Wait for disconnect
                     vTaskDelay(pdMS_TO_TICKS(500));

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1208,7 +1208,12 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     const uint8_t staConnected = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                     const uint8_t staStarted   = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
                     if (staConnected || staStarted) {
-                        LOG_I("WiFi: forcing BSS disconnect on disable (sta_connected=%u sta_started=%u)",
+                        // LOG_I_ONCE: caps log spam if user toggles
+                        // ENA 0/1 repeatedly while WIFI level is INFO.
+                        // Resets on SYST:LOG?/CLEAR so each diagnostic
+                        // session still sees the event (#467 pass 3).
+                        LOG_I_ONCE(LOG_ONCE_WIFI_DISCONNECT_DISABLE,
+                              "WiFi: forcing BSS disconnect on disable (sta_connected=%u sta_started=%u)",
                               (unsigned)staConnected, (unsigned)staStarted);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
@@ -1264,7 +1269,8 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                         const uint8_t staConnected = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                         const uint8_t staStarted   = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
                         if (staConnected || staStarted) {
-                            LOG_I("WiFi: forcing BSS disconnect on STA->AP mode switch (sta_connected=%u sta_started=%u)",
+                            LOG_I_ONCE(LOG_ONCE_WIFI_DISCONNECT_STA2AP,
+                                  "WiFi: forcing BSS disconnect on STA->AP mode switch (sta_connected=%u sta_started=%u)",
                                   (unsigned)staConnected, (unsigned)staStarted);
                             ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                             ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
@@ -1528,7 +1534,8 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                         const uint8_t staConnected = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                         const uint8_t staStarted   = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
                         if (staConnected || staStarted) {
-                            LOG_I("WiFi: forcing BSS disconnect on STA reconfigure (sta_connected=%u sta_started=%u)",
+                            LOG_I_ONCE(LOG_ONCE_WIFI_DISCONNECT_STA2STA,
+                                  "WiFi: forcing BSS disconnect on STA reconfigure (sta_connected=%u sta_started=%u)",
                                   (unsigned)staConnected, (unsigned)staStarted);
                             ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                             ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1221,10 +1221,23 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // Reset reconnect counter when switching modes
                     pInstance->staReconnectAttempts = 0;
                     
-                    // Disconnect if connected
-                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED)) {
+                    // Disconnect if connected — or even just started.  A
+                    // previous association attempt (e.g. bad-password retry
+                    // cycle) may leave the WINC driver's pCtrl->isConnected
+                    // stuck true even after our STA_CONNECTED flag was
+                    // cleared by the STA_DISCONNECTED handler — observed
+                    // when WINC emits CONNECTED briefly during 4-way
+                    // handshake then auth-fail DISCONNECTED.  Without
+                    // this disconnect the next WDRV_WINC_IPUseDHCPSet
+                    // below returns REQUEST_ERROR and the manager wedges
+                    // into "Error setting DHCP" -> ERROR -> REINIT loop
+                    // recoverable only by SYST:POW:STAT 0/1 (#467).
+                    // BSSDisconnect returns REQUEST_ERROR harmlessly when
+                    // isConnected is already false; we ignore the return.
+                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED) ||
+                        GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
                         ArmApplyTeardownDeadline();  // #423
-                        WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                        (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                     }
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
@@ -1462,10 +1475,23 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                         break;
                     }
 
-                    // Disconnect if connected
-                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED)) {
+                    // Disconnect if connected — or even just started.  A
+                    // previous association attempt (e.g. bad-password retry
+                    // cycle) may leave the WINC driver's pCtrl->isConnected
+                    // stuck true even after our STA_CONNECTED flag was
+                    // cleared by the STA_DISCONNECTED handler — observed
+                    // when WINC emits CONNECTED briefly during 4-way
+                    // handshake then auth-fail DISCONNECTED.  Without
+                    // this disconnect the next WDRV_WINC_IPUseDHCPSet
+                    // below returns REQUEST_ERROR and the manager wedges
+                    // into "Error setting DHCP" -> ERROR -> REINIT loop
+                    // recoverable only by SYST:POW:STAT 0/1 (#467).
+                    // BSSDisconnect returns REQUEST_ERROR harmlessly when
+                    // isConnected is already false; we ignore the return.
+                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED) ||
+                        GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
                         ArmApplyTeardownDeadline();  // #423
-                        WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                        (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
                     }
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1198,31 +1198,24 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 // returns REQUEST_ERROR — recreating the same wedge the
                 // STA-reconfigure fix is designed to prevent.  Found by
                 // Qodo /agentic_review pass 1.
-                {
-                    // Snapshot flags so the LOG_I and the if-condition see
-                    // identical values, and clear software state BEFORE
-                    // BSSDisconnect so the async DISCONNECTED callback
-                    // (and any other code path that observes flags during
-                    // the chip-disconnect window) sees consistent "torn
-                    // down" state — Qodo /improve pass 2 finding.
-                    const uint8_t staConnected = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
-                    const uint8_t staStarted   = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                    if (staConnected || staStarted) {
-                        // LOG_I_ONCE: caps log spam if user toggles
-                        // ENA 0/1 repeatedly while WIFI level is INFO.
-                        // Resets on SYST:LOG?/CLEAR so each diagnostic
-                        // session still sees the event (#467 pass 3).
-                        LOG_I_ONCE(LOG_ONCE_WIFI_DISCONNECT_DISABLE,
-                              "WiFi: forcing BSS disconnect on disable (sta_connected=%u sta_started=%u)",
-                              (unsigned)staConnected, (unsigned)staStarted);
-                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
-                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                        ArmApplyTeardownDeadline();  // #423: demote the impending async disconnect callback
-                        (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
-                    } else {
-                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                    }
-                }
+                // Disconnect is unconditional — Qodo /improve pass 4
+                // finding (importance 7): defensive against any state
+                // where our flags are 0 but the driver's pCtrl->isConnected
+                // is stuck true (chip ↔ driver state-flag desync).
+                // BSSDisconnect returns REQUEST_ERROR harmlessly when
+                // isConnected is already false.
+                //
+                // LOG_I_ONCE uses a static string (no format args) because
+                // the ONCE macro's ISR-safe branch can't carry varargs —
+                // pre-existing limitation of Logger.h.  Resets on
+                // SYST:LOG?/CLEAR so each diagnostic session still sees
+                // the event (#467 pass 3).
+                LOG_I_ONCE(LOG_ONCE_WIFI_DISCONNECT_DISABLE,
+                           "WiFi: forcing BSS disconnect on disable");
+                ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                ArmApplyTeardownDeadline();  // #423: demote the impending async disconnect callback
+                (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
 
                 // Close sockets
                 if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
@@ -1265,21 +1258,14 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // Snapshot flags and clear before disconnect so the
                     // async DISCONNECTED callback sees consistent torn-
                     // down state (Qodo /improve pass 2 finding).
-                    {
-                        const uint8_t staConnected = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
-                        const uint8_t staStarted   = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                        if (staConnected || staStarted) {
-                            LOG_I_ONCE(LOG_ONCE_WIFI_DISCONNECT_STA2AP,
-                                  "WiFi: forcing BSS disconnect on STA->AP mode switch (sta_connected=%u sta_started=%u)",
-                                  (unsigned)staConnected, (unsigned)staStarted);
-                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
-                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                            ArmApplyTeardownDeadline();  // #423
-                            (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
-                        } else {
-                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                        }
-                    }
+                    // Disconnect unconditionally — see pass 4 note in
+                    // the disable path for the rationale.
+                    LOG_I_ONCE(LOG_ONCE_WIFI_DISCONNECT_STA2AP,
+                               "WiFi: forcing BSS disconnect on STA->AP mode switch");
+                    ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                    ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                    ArmApplyTeardownDeadline();  // #423
+                    (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
 
                     // Don't deinitialize - the driver gets into a bad state after deinit
                     // Instead, just wait for STA to disconnect and then configure for AP mode
@@ -1527,24 +1513,14 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // recoverable only by SYST:POW:STAT 0/1 (#467).
                     // BSSDisconnect returns REQUEST_ERROR harmlessly when
                     // isConnected is already false; we ignore the return.
-                    // Snapshot flags and clear before disconnect so the
-                    // async DISCONNECTED callback sees consistent torn-
-                    // down state (Qodo /improve pass 2 finding).
-                    {
-                        const uint8_t staConnected = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
-                        const uint8_t staStarted   = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                        if (staConnected || staStarted) {
-                            LOG_I_ONCE(LOG_ONCE_WIFI_DISCONNECT_STA2STA,
-                                  "WiFi: forcing BSS disconnect on STA reconfigure (sta_connected=%u sta_started=%u)",
-                                  (unsigned)staConnected, (unsigned)staStarted);
-                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
-                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                            ArmApplyTeardownDeadline();  // #423
-                            (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
-                        } else {
-                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
-                        }
-                    }
+                    // Disconnect unconditionally — see pass 4 note in
+                    // the disable path for the rationale.
+                    LOG_I_ONCE(LOG_ONCE_WIFI_DISCONNECT_STA2STA,
+                               "WiFi: forcing BSS disconnect on STA reconfigure");
+                    ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                    ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                    ArmApplyTeardownDeadline();  // #423
+                    (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
 
                     // Wait for disconnect
                     vTaskDelay(pdMS_TO_TICKS(500));

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1198,16 +1198,26 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 // returns REQUEST_ERROR — recreating the same wedge the
                 // STA-reconfigure fix is designed to prevent.  Found by
                 // Qodo /agentic_review pass 1.
-                if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED) ||
-                    GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
-                    LOG_I("WiFi: forcing BSS disconnect on disable (sta_connected=%u sta_started=%u)",
-                          (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED),
-                          (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED));
-                    ArmApplyTeardownDeadline();  // #423: demote the impending async disconnect callback
-                    (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
-                    ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                {
+                    // Snapshot flags so the LOG_I and the if-condition see
+                    // identical values, and clear software state BEFORE
+                    // BSSDisconnect so the async DISCONNECTED callback
+                    // (and any other code path that observes flags during
+                    // the chip-disconnect window) sees consistent "torn
+                    // down" state — Qodo /improve pass 2 finding.
+                    const uint8_t staConnected = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                    const uint8_t staStarted   = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                    if (staConnected || staStarted) {
+                        LOG_I("WiFi: forcing BSS disconnect on disable (sta_connected=%u sta_started=%u)",
+                              (unsigned)staConnected, (unsigned)staStarted);
+                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                        ArmApplyTeardownDeadline();  // #423: demote the impending async disconnect callback
+                        (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                    } else {
+                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                    }
                 }
-                ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
 
                 // Close sockets
                 if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
@@ -1230,10 +1240,10 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED) ||
                     GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
                     LOG_D("Switching from STA to AP mode\r\n");
-                    
+
                     // Reset reconnect counter when switching modes
                     pInstance->staReconnectAttempts = 0;
-                    
+
                     // Disconnect if connected — or even just started.  A
                     // previous association attempt (e.g. bad-password retry
                     // cycle) may leave the WINC driver's pCtrl->isConnected
@@ -1247,16 +1257,23 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // recoverable only by SYST:POW:STAT 0/1 (#467).
                     // BSSDisconnect returns REQUEST_ERROR harmlessly when
                     // isConnected is already false; we ignore the return.
-                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED) ||
-                        GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
-                        LOG_I("WiFi: forcing BSS disconnect on STA reconfigure (sta_connected=%u sta_started=%u)",
-                              (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED),
-                              (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED));
-                        ArmApplyTeardownDeadline();  // #423
-                        (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
-                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                    // Snapshot flags and clear before disconnect so the
+                    // async DISCONNECTED callback sees consistent torn-
+                    // down state (Qodo /improve pass 2 finding).
+                    {
+                        const uint8_t staConnected = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                        const uint8_t staStarted   = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                        if (staConnected || staStarted) {
+                            LOG_I("WiFi: forcing BSS disconnect on STA->AP mode switch (sta_connected=%u sta_started=%u)",
+                                  (unsigned)staConnected, (unsigned)staStarted);
+                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                            ArmApplyTeardownDeadline();  // #423
+                            (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                        } else {
+                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                        }
                     }
-                    ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
 
                     // Don't deinitialize - the driver gets into a bad state after deinit
                     // Instead, just wait for STA to disconnect and then configure for AP mode
@@ -1504,16 +1521,23 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // recoverable only by SYST:POW:STAT 0/1 (#467).
                     // BSSDisconnect returns REQUEST_ERROR harmlessly when
                     // isConnected is already false; we ignore the return.
-                    if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED) ||
-                        GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED)) {
-                        LOG_I("WiFi: forcing BSS disconnect on STA reconfigure (sta_connected=%u sta_started=%u)",
-                              (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED),
-                              (unsigned)GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED));
-                        ArmApplyTeardownDeadline();  // #423
-                        (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
-                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                    // Snapshot flags and clear before disconnect so the
+                    // async DISCONNECTED callback sees consistent torn-
+                    // down state (Qodo /improve pass 2 finding).
+                    {
+                        const uint8_t staConnected = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                        const uint8_t staStarted   = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                        if (staConnected || staStarted) {
+                            LOG_I("WiFi: forcing BSS disconnect on STA reconfigure (sta_connected=%u sta_started=%u)",
+                                  (unsigned)staConnected, (unsigned)staStarted);
+                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                            ArmApplyTeardownDeadline();  // #423
+                            (void)WDRV_WINC_BSSDisconnect(pInstance->wdrvHandle);
+                        } else {
+                            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
+                        }
                     }
-                    ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED);
 
                     // Wait for disconnect
                     vTaskDelay(pdMS_TO_TICKS(500));


### PR DESCRIPTION
## Summary

Fixes #467 — bad-password APPLY followed by good-password APPLY wedges the WiFi state machine into an `Error setting DHCP` → ERROR → REINIT loop, recoverable only by full WINC power cycle.

## Root cause

After a bad-password APPLY enters #416's backoff retry, the WINC driver's `pCtrl->isConnected` can get stuck `true` even though our STA_CONNECTED flag is 0. The WINC fires `M2M_WIFI_CONNECTED` briefly during the 4-way handshake then `M2M_WIFI_DISCONNECTED` on auth-fail; under rapid retries the DISCONNECTED event's effect on the driver descriptor doesn't always stick.

When the user APPLYs new credentials, REINIT enters path B (STA-same-mode reconfigure) and gates `BSSDisconnect` on `STA_CONNECTED` — which is 0, so no chip-level disconnect happens. The subsequent `WDRV_WINC_IPUseDHCPSet` sees `isConnected == true` and returns `REQUEST_ERROR` → `"Error setting DHCP"` → ERROR → REINIT → same fail forever. Falls through to fresh INIT path which hits the same wedge at line 939, producing the `Error WiFi init` storm.

## Fix

Broaden the `BSSDisconnect` call in REINIT path B from `STA_CONNECTED` to `STA_CONNECTED || STA_STARTED`. STA_STARTED set means we previously issued a `BSSConnect` that may not have torn down; calling `BSSDisconnect` unconditionally clears `isConnected` if stuck. `WDRV_WINC_BSSDisconnect` returns `REQUEST_ERROR` harmlessly when `isConnected` is already false; return value now `(void)`-cast to document best-effort semantics.

Same widening applied to the STA→AP mode-switch path for consistency (same latent vulnerability).

## Verification on bench (BUR184882598 / 7E2898F46200E8A7)

**Pre-fix**: reproducer wedged at 192.168.1.1, log showed `Error setting DHCP` + 10+ `:939 Error WiFi init` lines, only `SYST:POW:STAT 0/1` recovered.

**Post-fix**: same reproducer recovered cleanly on the first restore APPLY, associated at 192.168.1.160 within 5 s. Log shows 3 clean auth-fail backoff lines (#416 working as designed) and zero init-error storm.

Reproducer in `/tmp/wifi_badpass_test.txt` + `/tmp/wifi_restore.txt` (per #467).

## Epistemic sourcing (V/E/I/X/N)

- **V** `wdrv_winc_socket.c:411-415` — IPUseDHCPSet returns REQUEST_ERROR iff isConnected==true
- **V** `wdrv_winc_sta.c:512` — BSSDisconnect clears isConnected after m2m_wifi_disconnect
- **V** `wdrv_winc_sta.c:501` — BSSDisconnect returns REQUEST_ERROR harmlessly if isConnected already false
- **V** `wdrv_winc.c:783-798` — CONNECTED/DISCONNECTED events drive isConnected
- **E** bench log 2026-05-17 — reproducer + recovery verified
- **I → E** isConnected gets stuck true after rapid auth-fail cycles (initially inferred from IPUseDHCPSet return; now empirically verified by the fix recovering)

## Test plan

- [x] Bench reproducer (#467 step list) recovers within 5 s of good-pw APPLY
- [x] No `Error setting DHCP` or `:939 Error WiFi init` in log
- [x] cppcheck baseline unchanged (still 2 style findings)
- [x] Build clean under -O3
- [ ] (suggested) Overnight WiFi suite to confirm no regression on normal STA reconnect / mode-switch flows

Closes #467.