### PR TITLE
chore(version): bump FIRMWARE_REVISION to 3.4.7b1

### DIFF
--- a/firmware/src/version.h
+++ b/firmware/src/version.h
@@ -16,7 +16,7 @@ extern "C" {
 #define HARDWARE_REVISION "2.0.0"
 
 //! Firmware revision string
-#define FIRMWARE_REVISION "3.4.6b1"
+#define FIRMWARE_REVISION "3.4.7b1"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary

Version bump for the v3.4.7b1 release.  103+ commits since v3.4.6b1 (12 Mar 2026) covering streaming, WiFi, ADC, power management, SCPI, and FreeRTOS kernel build.

## Highlights of in-scope work

- **#406/#409**: retained-RAM zero-init + COHERENTBSS zero
- **#410**: volatile qualifier audit
- **#416/#446**: WiFi bad-password backoff
- **#425/#434**: WiFi APPLY gate
- **#454/#462**: NVM auto-power-up on USB
- **#369/#466**: ADC Resolution FPU-contamination fix (#466 in flight)
- **#467/#468**: STA reconfigure stuck-isConnected wedge (just merged)
- **iperf2 + TXBlast** streaming work
- **#426/#432**: kernel built at global -O3 (\`configLIST_VOLATILE\` replaces FreeRTOS_tasks.c -O1)
- Various WiFi/streaming/SD throughput improvements

Full categorized PR list and validation matrix in #464.  Detailed release notes in flight per #469.

## Test plan

- [ ] Overnight probe sweep / benchmark / soak (in progress on bench)
- [ ] Manual MED-tier functional tests (already done — see #464 checklist)
- [ ] Desktop app verification — FlaUI scaffold in daqifi-desktop#531
- [ ] Final regression of #467 reproducer on this build (post-merge)

## Sequencing

Should land **last** after #466 (Resolution type-system) and all other v3.4.7 work merges, so the release tag reflects the final commit set.

Refs #464 (release tracker), #472 (overnight prep).