### PR TITLE
docs(release): v3.4.7 release notes + format guide (#469)

### DIFF
--- a/RELEASE_NOTES_v3.4.7.md
+++ b/RELEASE_NOTES_v3.4.7.md
@@ -1,0 +1,628 @@
+# v3.4.7 - Streaming Ceiling, WiFi Resilience & Long-Run Stability
+
+## Highlights
+
+This release is the result of two months of focused work on the three
+subsystems that customers rely on most: the streaming pipeline, the WiFi
+stack, and the boot/init path. Nearly 100 PRs landed against `main`
+between v3.4.6b1 and v3.4.7. The headline outcomes:
+
+**Streaming ceilings raised across every interface.** Hardware ADC trigger
+synchronization (#282), batched Type-1 ISRs (#277), per-task FPU
+correctness, smaller and better-shaped circular buffers, and a new
+multi-in-flight WiFi send path (#370) combine to push USB, WiFi, and SD
+ceilings higher than v3.4.6b1 at every channel count. Pipeline jitter at
+≥10 kHz is effectively eliminated by the new WINC idle-gate (#335) — CV
+at 10 kHz drops from 9.44% to 0.5%, peak-to-peak from 326 µs to 8.8 µs
+(measured via Saleae, Session 21).
+
+**WiFi survives the failure modes that used to wedge it.** Bad-password
+APPLY now backs off cleanly (#416), APPLY-during-active-TCP closes the
+listening and connected sockets in the right order (#435/#438/#440), the
+stuck-`isConnected` state-machine wedge that required a power cycle is
+recovered by a single SCPI APPLY (#467/#468), and rapid APPLY-during-
+REINIT is gated rather than deadlocked (#425/#434). A new in-firmware
+iperf2 module (#381/#393/#403) gives us wire-rate truth on the WINC1500
+path and the diagnostics to debug remaining state leaks.
+
+**Long-run reliability hardened from boot to last sample.** Defensive
+zero-init for BSS regions kseg0 best-fit alignment (#412/#409/#410),
+configLIST_VOLATILE in `FreeRTOSConfig.h` drops the FreeRTOS_tasks.c -O1
+workaround (#426/#432) — the kernel now builds at the global -O3, and
+USB silent-loss accounting (#372/#448) plus self-heal + auto-stop on
+dead transports (#397/#457) close the last gaps where streaming could
+drift away from its counters. NVM auto-power-up (#454/#462) eliminates
+the manual `SYST:POW:STAT 1` step for field-deployed loggers that
+reboot under USB power.
+
+## Added
+
+### NVM auto-power-up on USB connect (#454/#462)
+
+New opt-in SCPI surface; default off so existing behavior is preserved:
+
+```
+SYSTem:POWer:AUTOOn 0|1       # runtime
+SYSTem:POWer:AUTOOn?
+SYSTem:POWer:AUTOOn:SAVE      # persist to NVM
+SYSTem:POWer:AUTOOn:LOAD
+```
+
+When enabled, the device auto-transitions `STANDBY → POWERED_UP`
+whenever VBUS is present — at boot or on cable insertion mid-session.
+Battery-only operation is unaffected. A per-session latch prevents
+re-promote after a manual `SYST:POW:STAT 0` while USB stays plugged in.
+
+### In-firmware iperf2 client + server (#381/#393/#403)
+
+TCP and UDP iperf2 module embedded in firmware, exposing wire-rate
+truth on the WINC1500 path independent of MCU encode/decode pipeline:
+
+```
+IPERF:CLIENT:TCP <host>,<port>,<dur>[,<tx_mode>]
+IPERF:CLIENT:UDP <host>,<port>,<dur>,<rate_kbps>
+IPERF:SERVER:TCP <port>,<dur>
+IPERF:SERVER:UDP <port>,<dur>
+IPERF:STATs?
+IPERF:STOP
+IPERF:DIAG?                   # WINC HIF + send-pipeline diagnostics
+```
+
+`TXBlast` tx-mode (#403) bypasses the iperf2 framing for maximum-rate
+write testing. Auto-HRESet between trials probabilistically clears
+stuck WINC SDK state — see Known Limitations for the underlying iperf2
+HIF state leak (#399, mitigated, not root-caused).
+
+### Self-healing streaming with auto-stop on dead transports (#397/#457)
+
+The streaming engine now monitors per-interface health. If all
+configured transports report unhealthy continuously beyond a grace
+window, streaming auto-stops with a `LOG_E` capture instead of
+silently producing zero bytes forever:
+
+```
+SYST:STR:CONSumer:GRACe <sec>      # 5..300, default 60
+SYST:STR:CONSumer:GRACe?
+```
+
+QUES bit 12 (Transport Down) latches the auto-stop event for clients
+polling status registers. Cleared on next `SYST:STR:START`.
+
+### Capability rollup schema V1 (#343)
+
+Forward-looking single-source-of-truth capability discovery:
+
+```
+CONFigure:CAPabilities:JSON?       # full schema rollup (~11 KB JSON)
+CONFigure:CAPabilities:APIVersion? # fast pre-parse compat probe (now: 2)
+```
+
+Per-channel `signal_type` (extensible: `voltage`, `temperature`,
+`pressure`, ...), UCUM units, enumerated ranges, scaling and calibration
+models. Streaming block carries supported encodings, transports, cap
+formula constants, and buffer-size ranges. Storage, power, transports,
+and triggers blocks complete the first-phase scope.
+
+Three redundant subset queries removed: `CONFigure:ADC:MAXFreq?`,
+`CONFigure:CAPabilities:AIN?`, `CONFigure:CAPabilities:DIO?` — their
+data is now exclusive to the JSON rollup. Schema version bumped 1 → 2.
+
+### Hardware ADC trigger synchronization (#282/#286)
+
+Timer4/5 hardware-match triggering for ADC conversions, replacing the
+previous deferred software trigger. Throughput improvement
++12-39% on streaming configs vs the pre-#286 baseline (PR #286 body;
+exact channel-count sweep in Session 20 characterization).
+
+### Batched Type-1 ADC ISRs (#277/#278)
+
+Single CH3 trigger reads all enabled Type-1 (dedicated module) channels
+in one ISR entry. Eliminates N-1 redundant interrupts per sample.
+Measured +15-18% on 16-channel configurations (PR #278 body).
+
+### Per-module ADC acquisition-time tuning (#329)
+
+```
+CONFigure:ADC:SAMC <ticks>       # runtime SAMC override
+CONFigure:ADC:SAMC?
+```
+
+For users who need to trade ADC settling time against sample rate at
+the edge of the cap envelope.
+
+### Onboard-diagnostics gating (#287)
+
+```
+CONFigure:ADC:OBDiag 0|1         # skip rail-monitoring scans during
+                                 # streaming (default 1 = enabled)
+```
+
+OBDiag=0 yields measurably higher ceilings on single-channel configs
+(USB CSV 1×T1: 16,200 Hz → 20,000 Hz, +24%; SD CSV 1×T1: 9k → 10k);
+trade-off is loss of live rail-voltage updates. Stale rail values
+remain visible with age indicators per the SCPI data-visibility
+principle.
+
+### Configurable voltage precision (#210)
+
+Systemwide voltage decimal-precision control affecting CSV streaming,
+JSON streaming, and SCPI voltage queries:
+
+```
+CONFigure:VOLTage:PRECision <0-10>
+CONFigure:VOLTage:PRECision?
+CONFigure:VOLTage:SAVE | LOAD
+```
+
+Board-specific defaults: NQ1=4 decimals, NQ3=6, NQ2=7. Precision 0
+emits raw integer millivolts via fast `int_to_str` path. NVM-persisted.
+
+### Runtime per-module log levels (#240)
+
+```
+SYSTem:LOG:LEVel <module>,<level>     # POWER, WIFI, SD, USB, SCPI,
+                                      # ADC, DAC, STREAM, ENCODER,
+                                      # GENERAL × 0..3
+SYSTem:LOG:LEVel:ALL <level>
+SYSTem:LOG:LEVel?
+```
+
+All modules ship at compile-time DEBUG ceiling and runtime default of
+ERROR. INFO/DEBUG can be enabled on-demand without a rebuild. Runtime-
+only — resets to ERROR on reboot.
+
+### Streaming test patterns + benchmark modes (#216/#234/#257/#264)
+
+```
+SYSTem:STReam:TEST:PATtern <0-6>     # 0=off, 1=counter, 2=midscale,
+                                     # 3=fullscale, 4=walking,
+                                     # 5=triangle, 6=sine
+SYSTem:STReam:BENCHmark <0|1|2>      # OFF / NoCap / Pipeline
+SYSTem:STReam:THRoughput <freq>,<dur>
+```
+
+Deterministic regression and benchmarking. Pattern values override only
+the sample `Value` field — real ISR timing, ADC triggering, pool
+allocation, and the full encoding pipeline are preserved. PIPELINE mode
+bypasses ADC reads to isolate encoder + output cost. See CLAUDE.md
+"Streaming Throughput Benchmarking" for the full decision tree.
+
+### Streaming statistics and ISR overrun tracking (#266/#319)
+
+`SYSTem:STReam:STATS?` extended with `TimerISRCalls`, per-stage drop
+counters (USB / WiFi / SD), and a `WindowLossPercent` field from the
+sliding-window flow-health tracker. `STATS:CLEar` resets all counters.
+Every SCPI execution error is now also captured to the log buffer.
+
+### Stream control SCPI alias series (#311/#322/#323/#324)
+
+Canonical `SYST:STR:*` namespace consolidates all streaming control.
+Legacy aliases remain — existing client libraries continue to work
+unchanged. See Upgrade notes.
+
+### DIO debug probe framework (#301/#307)
+
+Compile-time and runtime debug probes for pipeline timing measurements
+via Saleae. Ten standard pipeline probes (ISR entry, encoder enter/
+exit, transport writes, etc) plus six ad-hoc compile-time slots.
+Caps-only SCPI: `SYST:DIOP:MODE`, `SYST:DIOP:ASSIGN`, etc. Probe-to-DIO
+routing is now runtime-flexible (#408). Living measurement record:
+`docs/PIPELINE_TIMING.md`.
+
+### SD card abort + format-status (#211/#212)
+
+```
+SYSTem:STORage:SD:ABORT
+SYSTem:STORage:SD:FORMat:STATus?
+```
+
+Long file transfers can now be cancelled without power-cycling. Format
+progress query lets clients poll long-running format operations.
+
+### SD write metrics in streaming stats (#225)
+
+Per-session SD write byte counters and drop counters now surfaced in
+`SYST:STR:STATS?`, completing the per-transport observability picture
+alongside USB and WiFi counters.
+
+### iperf2 diagnostics SCPI (#393/#403)
+
+`IPERF:DIAG?` exposes WINC HIF chip-wake/sleep refcounts, send-pipeline
+in-flight counts, and last-completion timing — instrumentation that
+backed the multi-in-flight Step C work and the auto-HRESet decision.
+
+## Changed
+
+### WiFi auto-balance circular buffer 32 KB → 64 KB (#364)
+
+When WiFi is the active streaming interface, the auto-balanced
+circular buffer size doubles. Measured Session 22 single-channel WiFi
+PB ceilings reflect this baseline; the buffer is a burst absorber, not
+a wire-rate raiser. 64 KB is empirically the sweet spot — 128 KB
+regresses 4-5 sentinel configs.
+
+### Multi-in-flight WINC sends (#370)
+
+WINC SPI send queue depth N=1 → N=4 (Step C of the #362 program).
+Measured +109% wire rate on Tesla-saturated 16-channel CSV at 2 kHz
+(see PR #370). USB and SD paths are unaffected.
+
+### Dynamic WINC idle-gate (#335)
+
+`lWDRV_WINC_Tasks` is paced only when streaming is active on a
+non-WiFi interface, eliminating the 22 Hz / 270 µs preemption that
+showed up as jitter on USB/SD streaming. CV at 10 kHz USB CSV drops
+9.44% → 0.5% (Session 21, Saleae-verified).
+
+### Streaming timer prescaler 1:256 → 1:8 (#303) + off-by-one (#302)
+
+Higher timer resolution at low rates plus a one-tick correction in the
+period calculation. Together these tighten timer jitter at all rates
+and remove a small (sub-microsecond) systematic phase offset.
+
+### USB CDC behavior on stop (#264)
+
+Streaming task now issues a USB CDC flush on `SYST:STR:STOP` so
+client-side reads complete cleanly without waiting for the next
+unrelated SCPI command to flush the pipeline.
+
+### Streaming engine `Running` flag semantics (#379/#458)
+
+`Running=1` now reflects "timer actually firing" rather than "start
+requested" — pre-existing race where SCPI clients could see Running=1
+during the brief gap before the timer hardware actually fired is
+closed.
+
+### `*IDN?` SN field populated (#436/#441)
+
+The `*IDN?` response now includes the real per-unit silicon serial in
+the SN field. Generic `DAQiFi,Nq1,0,01-02` previously carried no
+per-unit identifier — `*IDN?` is now sufficient for board ID where it
+wasn't before.
+
+### Stream control SCPI namespace consolidation (#311/#322/#323/#324)
+
+Canonical and legacy forms (both work — see Upgrade notes):
+
+| Canonical              | Legacy alias              |
+|------------------------|---------------------------|
+| `SYST:STR:START`       | `SYST:StartStreamData`    |
+| `SYST:STR:STOP`        | `SYST:StopStreamData`     |
+| `SYST:STR:DATA?`       | `SYST:StreamData?`        |
+| `SYST:USB:TRANSparent:MODE` | `SYST:USB:SetTransparentMode` |
+
+STATS-family renamed to eliminate single-letter short forms; TESTpattern
+and LOGging similarly normalized. Legacy aliases will not be removed
+without a scheduled deprecation cycle (months out, with explicit
+client-maintainer comms).
+
+### SCPI input buffer 256 → 512 bytes (#263)
+
+Larger commands no longer truncate mid-parse. Notably matters for the
+new capability JSON rollup and longer batched command sequences.
+
+## Fixed
+
+### WiFi reconnect resilience after bad-password APPLY (#416/#446)
+
+Bad-password APPLY used to leave WiFi in an unrecoverable state when
+followed by a good-password APPLY — only a power-cycle recovered.
+Reconnect backoff now applies to initial-association failures, not
+just runtime disconnects, so the retry path doesn't accumulate
+state.
+
+### Stuck `isConnected` WiFi wedge (#467/#468)
+
+After rapid auth-fail cycles, the WINC driver's internal
+`pCtrl->isConnected` could remain `true` despite the firmware's
+`STA_CONNECTED` flag being 0. Subsequent `IPUseDHCPSet` returned
+`REQUEST_ERROR` → "Error setting DHCP" → ERROR → REINIT loop forever.
+Fix: broaden `BSSDisconnect` gate in REINIT path B from `STA_CONNECTED`
+to `STA_CONNECTED || STA_STARTED` so the chip-level disconnect runs
+unconditionally when stale state may exist. Same widening applied to
+STA→AP mode-switch path.
+
+### APPLY-during-REINIT gated (#425/#434)
+
+Rapid back-to-back APPLY calls — or APPLY-during-active-TCP — could
+race the WiFi state machine into a deadlock at `wifi_manager.c:761`
+recoverable only by power-cycle. APPLY now refuses (with SCPI error +
+LOG_E) while a previous REINIT is still in flight.
+
+### TCP/UDP socket teardown on STA reconfigure (#435/#438/#440)
+
+Closing TCP server, TCP client, and UDP discovery sockets before
+issuing a `BSSReconnect` for STA reconfigure. The follow-up (#440)
+broadens the HardReset divert to bound listening sockets so the
+divert fires for the actual socket count rather than just the
+expected primary. Mutex-safe `CloseClientSocket` (#439) protects
+against cross-task socket-state races.
+
+### STA_CONNECTED flag drift reconciliation (#382/#451)
+
+When the WINC driver and our state machine disagreed about connection
+state (one of the two #382 sub-bugs), the firmware now reconciles
+toward the driver's view rather than getting stuck on its own flag.
+
+### One-client-per-port TCP policy (#452/#453)
+
+Previously a second connecting client could displace a working
+connection mid-stream. New policy: the listening socket politely
+rejects a new connect attempt while an existing client is active on
+the same port.
+
+### Auth-fail false-positive log suppressed during APPLY teardown (#423/#447)
+
+The intermediate disconnect event fired during APPLY teardown used to
+log as `Auth-Failed`, polluting `SYST:LOG?` output during routine
+reconfiguration. Suppressed when the disconnect is part of an active
+teardown.
+
+### USB silent-loss accounting (#372/#448)
+
+Streaming `hasUsb` predicate replaced with `ActiveInterface` gate.
+Previous predicate could silently skip USB writes when conditions
+briefly degraded, accounting for zero in `UsbDroppedBytes`. Now every
+skipped write is counted.
+
+### Streaming timer ISR off-by-one (#302) and prescaler resolution (#303)
+
+See Changed section.
+
+### Type-2 channel scan registration (#406/#421/#422)
+
+`TRGSRC=3` now enrolls Type-2 channels in the MODULE7 scan list. The
+original symptom (#406) was a Type-2 channel missing samples after a
+specific reconfigure sequence; #421 audited the broader set-once
+pointer hazard class but landed as a documentation/audit conclusion
+(see `docs/SET_ONCE_POINTER_AUDIT.md`), not a code change.
+
+### NQ3 ADC union safety + T2 muxed-cap SCPI error (#139/#232/#449)
+
+NQ3's union storage for ADC channel state could be accessed via the
+wrong arm in rare reconfigure paths; explicit per-arm initialization
+added. Muxed-cap configurations on Type-2 channels now return a proper
+SCPI error instead of silently capping.
+
+### ADC rail monitoring with `IsDataValid` gate removed (#460/#461)
+
+The gate was rejecting valid samples during a short transient window
+after enable, leaving rail-voltage queries stale longer than necessary.
+Gate removed; staleness now bounded by the ADC's own ready signal.
+
+### Streaming `Running` flag race (#379/#458)
+
+See Changed section.
+
+### Circular buffer producer/consumer counter split (#122/#276/#325)
+
+Split single uint32 head/tail into separate producer and consumer
+counters to eliminate a sub-microsecond race on the wrap boundary
+where a partial RMW could expose a stale length to the consumer.
+NULL-guards added to defensive call sites.
+
+### Defensive zero-init for BSS / kseg0 best-fit (#406/#409/#410/#412)
+
+Some BSS regions placed in kseg0 best-fit by the linker were not
+covered by the standard `_bss_start..._bss_end` zero loop on cold
+boot. Added explicit zero-init for the affected regions in `main`
+before `SYS_Initialize`. Mitigates a rare crash class observed in
+post-reset boot loops; the underlying issue is well-bounded but the
+zero-init defense is permanent.
+
+### Capabilities query — board configuration `Resolution` type (#466)
+
+`MC12bModuleConfig.Resolution` and `AD7609ModuleConfig.Resolution`
+changed from `double` to `uint32_t` in `AInConfig.h`. A pure-integer
+task reading a `double` field could pick up garbage FPU state from
+whatever was last in the FPU registers. Exposure was the UDP
+discovery announce packet's `analog_in_res` field. PR #369's
+hardcoded constants in the streaming hot path remain as defense in
+depth.
+
+### SCPI input buffer overflow (#100/#263) and UDP discovery sprintf overflow (#41/#46/#260)
+
+Buffer size + sprintf-format hardening. See PR bodies for symptom
+specifics.
+
+### WiFi power guard + CONF queries + DHCP values (#93/#97/#261)
+
+WiFi configuration SCPI now refuses operations that require power-up
+when the device is in STANDBY, returning a SCPI error rather than
+silently doing nothing. New CONF queries expose DHCP-assigned values.
+
+### SD file open race before streaming (#222)
+
+`SYST:STR:START` to SD now waits for the file-open completion before
+arming the timer, eliminating a small window where the first samples
+could be written to a not-yet-open handle.
+
+### SD graceful shutdown on power-down + WiFi SPI contention (#218)
+
+When the device transitions to standby with an SD file open and a
+WiFi transfer in flight, the shutdown order now serializes correctly
+so neither subsystem sees a half-finished SPI transaction.
+
+### Encoder hot-path O(N) channel lookup (#268/#269/#272)
+
+Replaced per-sample linear channel-config lookup with index-based
+access. Measurable in the per-tick budget at high channel counts.
+
+### CoherentPool quiesce before resize (#255/#256)
+
+Buffer resize now stops all DMA consumers before re-partitioning the
+coherent pool, eliminating a race where a partial DMA could corrupt
+post-resize buffers.
+
+### #353 SCPI-over-TCP / WINC stack-overflow chain (#347/#348/#350/#354/#356)
+
+The compounding root cause behind the v3.4.6b1 SCPI-over-TCP wedge:
+
+- #347/#348: `SCPI_SysInfoPB` 4 KB stack-local exceeded the WifiTask
+  1024-word stack
+- #350: shared SCPI response buffer (2 KB static, mutex-guarded) so
+  no callback needs a large stack-local
+- #354 root cause: `ADC_WriteChannelStateAll` 5 KB stack-locals (two
+  of them) overflowed the WINC task's 4 KB stack via SCPI-over-TCP
+- #356 Option 2: SCPI dispatch decoupled from WDRV_WINC_Tasks onto
+  app_WifiTask, restoring WINC to its 1024-word baseline (peak 316)
+
+Post-merge: SCPI-over-TCP runs on its own task stack with measured
+peak well below ceiling. WINC stack untouched. Throughput unchanged
+to +1k on five USB configs (Session 22 vs Session 20).
+
+### Streaming pipeline jitter and throughput (#308/#309/#310)
+
+Five firmware interventions across 19 PIPELINE_TIMING sessions: SD
+priority elevation, encoder retry yield strategy (#312/#314 follow-up),
+prescaler tightening, and ISR-deferred-task scheduling tuning. USB
+CSV +11-32% / USB PB T1 +8-20% in Session 17 vs Session 1 baseline.
+
+### Streaming task encoder retry uses `vTaskDelay(1)` (#312/#314)
+
+Replaces `taskYIELD()` so lower-priority SD task actually gets CPU to
+drain its circular buffer. SD CSV 16ch ceiling fully recovered;
+SD PB 1×T1 +10%.
+
+### MCU SD circular-buffer + DMA balance (#247)
+
+SD circular buffer moved into the streaming pool; DMA buffers (SD
+write, USB write, WiFi SPI staging) auto-balanced from the 124 KB
+coherent pool based on active interfaces.
+
+### CSV writer raw-counts path + JSON field-name compaction (already in v3.4.3, refined in #210)
+
+Voltage-precision = 0 in #210 routes CSV through the fast integer
+path. JSON field names normalized at proto3 migration time (#237).
+
+### Sample pool compaction (#264)
+
+Per-sample memory footprint reduced from fixed 208 bytes to a
+channel-count-dependent stride (1ch=14 B, 4ch=26 B, 8ch=42 B, 16ch=74 B).
+Pool depth at fixed budget scales accordingly.
+
+## Internal
+
+**Build / CI / kernel:** #275 enables global `-O3` with FreeRTOS@O1 override
+(now obsolete — see #426/#432) · #298 BUSL-1.1 license + NOTICE · #352
+MPLAB X project metadata sync (DioProbe + Util headers) · #414 cppcheck
+static-analysis CI gate · #426/#432 `configLIST_VOLATILE` in
+`FreeRTOSConfig.h`, drop FreeRTOS_tasks.c -O1 clamp — kernel now builds
+at global -O3 alongside the rest of the firmware · #459 parallelize
+cppcheck (`-j nproc`, 10m → 23s).
+
+**Refactors and renames (behavior-preserving):** #316 (BQ:FAULTCLear →
+BQ:FAULT:CLEar) · #320 audit `taskENTER_CRITICAL_FROM_ISR` + remove
+dead HeapList infrastructure (#294) · #337 DIO HAL + probe delegation
+pair · #339 `StreamingInterface_All` → `StreamingInterface_UsbAndSd`
+(name reflects actual semantics).
+
+**Observability and instrumentation:** #226 clear `lastSendSize` after
+callback reads it (eliminates false-positive double-count) · #223
+WiFi TCP send-delivery tracking · #237 proto3 migration + encoder
+optimization · #242 per-error one-shot LOG suppression macros · #244
+add `LOG_E` / `LOG_I` / `LOG_D` to silent failure paths across SD,
+USB, WiFi, ADC · #259 callback-driven WiFi sends + optimized flush
+threshold (#253) · #265/#266 timer-ISR overrun counters · #290 stale
+data indicators + EOS interrupt control (#288) · #293 move T1 result
+reads from ADC_DATA3 ISR to EOS task (#292) · #295/#296/#297/#299
+silent-loss instrumentation pass (queue, encoder, transport) · #319
+log every SCPI execution error via central helper (#262) · #369
+WiFi-pipeline diagnostics (alongside the (uint32_t)double cast fix).
+
+**Documentation and audits:** #321 Session 20 refresh · #338 Session 21
+refresh · #357 Session 22 refresh · #424 rip out #421 diag
+instrumentation post-merge · #431 atomicity rules + bench protocol +
+Makefile caveat added to CLAUDE.md · #433/#444 set-once pointer
+volatile audit conclusions (see `docs/SET_ONCE_POINTER_AUDIT.md` —
+audit found the qualifier is observable in codegen but not load-
+bearing for correctness on this XC32 v4.60 build).
+
+**Test infrastructure:** #408 runtime-flexible DIO probe routing ·
+in-tree iperf2 module (#381/#393/#403, listed under Added; the
+client+server harness pieces are internal scaffolding).
+
+**Chores:** #442 commit `checkpoint_remote` in project settings ·
+#473 bump `FIRMWARE_REVISION` to `3.4.7b1`.
+
+## Test coverage
+
+- **Bench characterization Session 22** (2026-04-24 overnight, post-#354
+  ADC stack fix + #356 SCPI-dispatch Option 2 decouple) — full USB and
+  SD ceiling sweep at 60 s endurance. Five USB configs picked up +1 k
+  ceilings vs Session 20; SD CSV 8×T2 picked up +2 k. No regressions.
+  Detailed tables in CLAUDE.md.
+- **WiFi characterization Session 23** (2026-04-25) — single-trial
+  ceiling sweep, no endurance. Captured pre-#371 silent-loss accounting
+  fix and reflects measurement artifact, not true ceilings. CLAUDE.md
+  flags this explicitly with a strikethrough advisory; Session 24
+  numbers (post-#372/#448) will replace.
+- **Manual MED-tier functional tests** per release tracker #464: SCPI
+  alias smoke (`SYST:StartStreamData` and `SYST:STR:START` both work),
+  #454 NVM auto-on toggle + save + reboot, #416 bad-pw backoff timing,
+  #425 rapid APPLY refusal, #467 reproducer recovery in <5 s.
+- **#467 reproducer** verified post-merge on NQ1 `7E2898F46200E8A7`:
+  pre-fix wedged at 192.168.1.1 with `Error setting DHCP` storm,
+  post-fix recovered cleanly within 5 s on first restore APPLY.
+- **cppcheck baseline:** 2 style findings, unchanged from v3.4.6b1.
+  Both in `wifi_serial_bridge.c` (ergonomic, not bugs).
+
+## Known limitations
+
+- **#463 — USB streaming ceilings 3-5 kHz below Session 22 baseline on
+  current main.** Hypothesis split between firmware regression and test
+  harness drift; cheap A/B planned. Documented as the only release-
+  blocker candidate in #464.
+- **#399 / #401 — iperf2 HIF state leaks and WINC1500 wedging.** WINC
+  send path can stall after a defined sequence of connection-setup
+  failures; auto-HRESet between trials probabilistically clears the
+  stuck state (#403). Root cause is plausibly a WINC SDK chip-wake /
+  sleep refcount asymmetry — hypothesized, not proven; tracked for the
+  v3.4.8+ window.
+- **WiFi optimization items deferred to v3.4.8+:** #361 (WINC SPI
+  staging), #362 (multi-in-flight further steps beyond #370's Step C),
+  #376 (decouple drain into dedicated task — needs DMA SPI to ship a
+  net win, not just shift the bottleneck), #378 (related WINC-side
+  diagnostics).
+- **SD-focused overnight sweep not run this release cycle.** Last
+  night's overnight (`20260515_2318`) was USB+WiFi only; SD path was
+  validated via characterization Session 22 and the targeted MED-tier
+  tests but no fresh endurance pass exists post-#449.
+
+---
+
+## Upgrade notes
+
+- **Client libraries continue to work unchanged.** All legacy SCPI
+  command forms remain as aliases (#311/#322/#323/#324). Canonical
+  `SYST:STR:*` namespace is documented in the wiki SCPI reference
+  (`01-SCPI-Interface.md`); migrate on your own schedule.
+- **NVM auto-power-up is off by default.** Existing devices upgrading
+  from v3.4.6b1 see no behavior change unless `SYST:POW:AUTOOn 1` is
+  explicitly set and `SYST:POW:AUTOOn:SAVE` issued. To opt in:
+
+  ```
+  SYST:POW:AUTOOn 1
+  SYST:POW:AUTOOn:SAVE
+  ```
+
+- **NVM is wiped on every IPE flash.** WiFi credentials, voltage-
+  precision, calibration, and the new `AUTOOn` setting all live in
+  program flash on the PIC32MZ. Restore via your usual configuration
+  batch after each flash.
+- **If you encountered the #467 wedge symptom on v3.4.6b1 in the field**
+  (`Error setting DHCP` log floods, requires `SYST:POW:STAT 0/1` to
+  recover), upgrade to v3.4.7 — a single SCPI APPLY now recovers
+  cleanly without a power cycle.
+- **Schema version 2 capability rollup is a breaking change for clients
+  that depended on the removed subset queries** (`CONF:ADC:MAXFreq?`,
+  `CONF:CAP:AIN?`, `CONF:CAP:DIO?`). Use `CONF:CAP:JSON?` and parse
+  the corresponding fields. The `CONF:CAP:APIVersion?` probe returns
+  `2` post-upgrade.
+- **`*IDN?` SN field is now populated.** Clients that previously
+  identified boards by streaming-metadata-header `# Serial` line can
+  continue to do so, but `*IDN?` is now sufficient on its own.
+
+---
+
+**Full Changelog:** https://github.com/daqifi/daqifi-nyquist-firmware/compare/v3.4.6b1...v3.4.7

--- a/RELEASE_NOTES_v3.4.7b1.md
+++ b/RELEASE_NOTES_v3.4.7b1.md
@@ -237,9 +237,16 @@ alongside USB and WiFi counters.
 WINC send-pipeline state.  Fields: `Mode`, `DataSock`, `ListenSock`,
 `PendingTx`, `AbortPending`, `BytesConfirmed`, `LastSendRc`,
 `SendErrCount`, `WincState`, `FreeTcpSockets`, `FreeUdpSockets`
-(see `SCPI_Iperf2_Diag` for the canonical field list).  This is the
-instrumentation that backed the multi-in-flight Step C work and the
-auto-HRESet decision.
+(see `SCPI_Iperf2_Diag` for the canonical field list).
+
+**Client-parsing note:** `FreeTcpSockets` and `FreeUdpSockets` emit
+the literal string `skipped` (not an integer) when iperf2 is not
+IDLE — the WINC socket counts are unsafe to read while a session
+is in flight.  Parsers should tolerate `key=skipped` for these two
+fields.
+
+This is the instrumentation that backed the multi-in-flight Step C
+work and the auto-HRESet decision.
 
 ## Changed
 

--- a/RELEASE_NOTES_v3.4.7b1.md
+++ b/RELEASE_NOTES_v3.4.7b1.md
@@ -1,11 +1,11 @@
-# v3.4.7 - Streaming Ceiling, WiFi Resilience & Long-Run Stability
+# v3.4.7b1 - Streaming Ceiling, WiFi Resilience & Long-Run Stability
 
 ## Highlights
 
 This release is the result of two months of focused work on the three
 subsystems that customers rely on most: the streaming pipeline, the WiFi
 stack, and the boot/init path. Nearly 100 PRs landed against `main`
-between v3.4.6b1 and v3.4.7. The headline outcomes:
+between v3.4.6b1 and v3.4.7b1. The headline outcomes:
 
 **Streaming ceilings raised across every interface.** Hardware ADC trigger
 synchronization (#282), batched Type-1 ISRs (#277), per-task FPU
@@ -59,13 +59,16 @@ TCP and UDP iperf2 module embedded in firmware, exposing wire-rate
 truth on the WINC1500 path independent of MCU encode/decode pipeline:
 
 ```
-IPERF:CLIENT:TCP <host>,<port>,<dur>[,<tx_mode>]
-IPERF:CLIENT:UDP <host>,<port>,<dur>,<rate_kbps>
-IPERF:SERVER:TCP <port>,<dur>
-IPERF:SERVER:UDP <port>,<dur>
-IPERF:STATs?
-IPERF:STOP
-IPERF:DIAG?                   # WINC HIF + send-pipeline diagnostics
+SYST:WIFI:IPERF:TCPClient <ip>[,<port=5001>][,<dur_s=10>]
+SYST:WIFI:IPERF:UDPClient <ip>[,<port=5001>][,<dur_s=10>]
+SYST:WIFI:IPERF:TCPServer [<port=5001>]
+SYST:WIFI:IPERF:UDPServer [<port=5001>]
+SYST:WIFI:IPERF:TXBLast <port>,<duration_s>      # #399 raw-rate workaround
+SYST:WIFI:IPERF:STATs?
+SYST:WIFI:IPERF:STOP
+SYST:WIFI:IPERF:DIAGnostics?                     # WINC HIF + send-pipeline diagnostics
+SYST:WIFI:IPERF:MAXPending [0..4]                # #399 throttle
+SYST:WIFI:IPERF:AUTOReset [0|1]                  # #399 auto-HRESet on stop
 ```
 
 `TXBlast` tx-mode (#403) bypasses the iperf2 framing for maximum-rate
@@ -123,8 +126,10 @@ Measured +15-18% on 16-channel configurations (PR #278 body).
 ### Per-module ADC acquisition-time tuning (#329)
 
 ```
-CONFigure:ADC:SAMC <ticks>       # runtime SAMC override
-CONFigure:ADC:SAMC?
+CONFigure:ADC:SAMC:DEDicated <ticks>     # Type-1 dedicated modules
+CONFigure:ADC:SAMC:DEDicated?
+CONFigure:ADC:SAMC:SHARed <ticks>        # Type-2 shared MODULE7 mux
+CONFigure:ADC:SAMC:SHARed?
 ```
 
 For users who need to trade ADC settling time against sample rate at
@@ -205,19 +210,20 @@ unchanged. See Upgrade notes.
 Compile-time and runtime debug probes for pipeline timing measurements
 via Saleae. Ten standard pipeline probes (ISR entry, encoder enter/
 exit, transport writes, etc) plus six ad-hoc compile-time slots.
-Caps-only SCPI: `SYST:DIOP:MODE`, `SYST:DIOP:ASSIGN`, etc. Probe-to-DIO
-routing is now runtime-flexible (#408). Living measurement record:
+Caps-only SCPI under `SYST:DIOProbe:*` — `MODE`, `ROUTe`, `CLEar`,
+`CLEar:ALL`, `PIPELine`, `LIST?`.  Probe-to-DIO routing is now
+runtime-flexible (#408). Living measurement record:
 `docs/PIPELINE_TIMING.md`.
 
 ### SD card abort + format-status (#211/#212)
 
 ```
 SYSTem:STORage:SD:ABORT
-SYSTem:STORage:SD:FORMat:STATus?
+SYSTem:STORage:SD:FORmat?     # query format state/progress
 ```
 
-Long file transfers can now be cancelled without power-cycling. Format
-progress query lets clients poll long-running format operations.
+Long file transfers can now be cancelled without power-cycling.
+`FORmat?` lets clients poll long-running format operations.
 
 ### SD write metrics in streaming stats (#225)
 
@@ -227,7 +233,7 @@ alongside USB and WiFi counters.
 
 ### iperf2 diagnostics SCPI (#393/#403)
 
-`IPERF:DIAG?` exposes WINC HIF chip-wake/sleep refcounts, send-pipeline
+`SYST:WIFI:IPERF:DIAGnostics?` exposes WINC HIF chip-wake/sleep refcounts, send-pipeline
 in-flight counts, and last-completion timing — instrumentation that
 backed the multi-in-flight Step C work and the auto-HRESet decision.
 
@@ -612,7 +618,7 @@ client+server harness pieces are internal scaffolding).
   batch after each flash.
 - **If you encountered the #467 wedge symptom on v3.4.6b1 in the field**
   (`Error setting DHCP` log floods, requires `SYST:POW:STAT 0/1` to
-  recover), upgrade to v3.4.7 — a single SCPI APPLY now recovers
+  recover), upgrade to v3.4.7b1 — a single SCPI APPLY now recovers
   cleanly without a power cycle.
 - **Schema version 2 capability rollup is a breaking change for clients
   that depended on the removed subset queries** (`CONF:ADC:MAXFreq?`,
@@ -625,4 +631,4 @@ client+server harness pieces are internal scaffolding).
 
 ---
 
-**Full Changelog:** https://github.com/daqifi/daqifi-nyquist-firmware/compare/v3.4.6b1...v3.4.7
+**Full Changelog:** https://github.com/daqifi/daqifi-nyquist-firmware/compare/v3.4.6b1...v3.4.7b1

--- a/RELEASE_NOTES_v3.4.7b1.md
+++ b/RELEASE_NOTES_v3.4.7b1.md
@@ -418,14 +418,16 @@ counters to eliminate a sub-microsecond race on the wrap boundary
 where a partial RMW could expose a stale length to the consumer.
 NULL-guards added to defensive call sites.
 
-### Defensive zero-init for BSS / kseg0 best-fit (#406/#409/#410/#412)
+### Defensive zero-init for BSS / kseg0 best-fit (#406/#409/#412)
 
 Some BSS regions placed in kseg0 best-fit by the linker were not
 covered by the standard `_bss_start..._bss_end` zero loop on cold
 boot. Added explicit zero-init for the affected regions in `main`
-before `SYS_Initialize`. Mitigates a rare crash class observed in
-post-reset boot loops; the underlying issue is well-bounded but the
-zero-init defense is permanent.
+before `SYS_Initialize`. Fixes the rare crash class observed in
+post-reset boot loops (#406 — auto-power-up + LED-off symptom under
+-O3 + IPE flash).  The underlying issue is well-bounded but the
+zero-init defense is permanent.  #410 (volatile-qualifier audit) is
+related defensive correctness and is listed under `Internal`.
 
 ### Capabilities query — board configuration `Resolution` type (#466)
 
@@ -554,6 +556,15 @@ Makefile caveat added to CLAUDE.md · #433/#444 set-once pointer
 volatile audit conclusions (see `docs/SET_ONCE_POINTER_AUDIT.md` —
 audit found the qualifier is observable in codegen but not load-
 bearing for correctness on this XC32 v4.60 build).
+
+**Defensive correctness (no observed-in-the-wild bug; hardens internal
+hazard):** #410 volatile-qualifier audit on `tPowerData.powerState` /
+`requestedPowerState` (#412) — fields written by app_PowerAndUITask
+(pri 7) and read across loop iterations by app_WifiTask (pri 2) and
+app_SDCardTask (pri 5).  Current consumer loops contain external
+function calls that act as compiler barriers (force re-load at -O3),
+so this is not a current bug — defense-in-depth against future
+inlining / refactor that removes a barrier.
 
 **Test infrastructure:** #408 runtime-flexible DIO probe routing ·
 in-tree iperf2 module (#381/#393/#403, listed under Added; the

--- a/RELEASE_NOTES_v3.4.7b1.md
+++ b/RELEASE_NOTES_v3.4.7b1.md
@@ -586,10 +586,33 @@ client+server harness pieces are internal scaffolding).
 
 ## Known limitations
 
-- **#463 — USB streaming ceilings 3-5 kHz below Session 22 baseline on
-  current main.** Hypothesis split between firmware regression and test
-  harness drift; cheap A/B planned. Documented as the only release-
-  blocker candidate in #464.
+### Newly observed during v3.4.7b1 validation
+
+- **#475 — WiFi TCP server (port 9760) silent after long USB streaming
+  while SCPI reports healthy STA state.** After a 5h+ USB streaming
+  session (overnight characterization), the device's TCP listen
+  socket stops accepting connections. `SYST:COMM:LAN:ADDR?` continues
+  to report the DHCP-assigned IP and RSSI 100%. Heap-free dropped to
+  ~7 KB during the long run, which is the suspected mechanism (silent
+  listen-socket allocation failure). **Workaround**: bounce WiFi via
+  `SYST:COMM:LAN:ENAbled 0 → APPLY → wait 5s → ENAbled 1 → APPLY`. TCP
+  comes back on first attempt. Full investigation including suggested
+  observability + heap-pressure audit deferred to v3.4.8.
+- **#476 — Single-channel WiFi PB throughput degrades with session
+  history; multi-channel does not.** First honest characterization
+  post-#371 silent-loss-counter fix. WiFi PB 1×T1 sustains 7000 Hz
+  immediately after a fresh `LAN:APPLY`, but drops to ~4000 Hz after
+  one neighboring config run and to ~3000 Hz after a 17-config
+  overnight sweep. WiFi PB 3×T1 holds 8000 Hz across all three
+  measurements — stable. Mechanism is small-PB-payload specific;
+  candidates include WINC SPI staging fragmentation, HIF refcount
+  drift, or asymmetric circular-buffer hysteresis (#475 may be the
+  same underlying state-pressure issue at a different symptom).
+  Reported numbers below are conservative "after typical session
+  activity" values, not fresh-cold-boot peaks.
+
+### Pre-existing, ongoing
+
 - **#399 / #401 — iperf2 HIF state leaks and WINC1500 wedging.** WINC
   send path can stall after a defined sequence of connection-setup
   failures; auto-HRESet between trials probabilistically clears the
@@ -601,10 +624,24 @@ client+server harness pieces are internal scaffolding).
   #376 (decouple drain into dedicated task — needs DMA SPI to ship a
   net win, not just shift the bottleneck), #378 (related WINC-side
   diagnostics).
-- **SD-focused overnight sweep not run this release cycle.** Last
-  night's overnight (`20260515_2318`) was USB+WiFi only; SD path was
-  validated via characterization Session 22 and the targeted MED-tier
-  tests but no fresh endurance pass exists post-#449.
+- **SD-focused overnight sweep not yet completed for v3.4.7b1.** The
+  v3.4.7b1 overnight run (`overnight_20260518_035928`) was USB+WiFi
+  only — the runner's `--sd` flag was omitted by the wrapper. SD path
+  validated via Session 22 characterization data and targeted
+  MED-tier tests; a fresh endurance pass post-#449 / post-#467 is
+  scheduled but not in this release.
+- **WiFi characterization tables in this release reflect post-#371
+  honest counters** — Session 23 numbers in earlier CLAUDE.md were
+  inflated by the pre-#371 silent-loss accounting bug. Some
+  single-channel numbers appear lower than v3.4.6b1's published
+  figures because the counter is now truthful, not because the
+  pipeline regressed. Multi-channel and 16-channel WiFi throughput
+  shows substantial honest improvements (e.g. WiFi PB 5T1+11T2 from
+  ~85 KB/s in v3.4.6b1 to 164 KB/s on v3.4.7b1).
+- **#463 (USB ceilings vs Session 22 baseline) — resolved during this
+  release cycle.** The apparent regression was test-harness drift,
+  not firmware. Honest ceilings reconfirmed in the v3.4.7b1 overnight
+  (`overnight_20260518_0319`).
 
 ---
 

--- a/RELEASE_NOTES_v3.4.7b1.md
+++ b/RELEASE_NOTES_v3.4.7b1.md
@@ -609,18 +609,23 @@ client+server harness pieces are internal scaffolding).
   `SYST:COMM:LAN:ENAbled 0 → APPLY → wait 5s → ENAbled 1 → APPLY`. TCP
   comes back on first attempt. Full investigation including suggested
   observability + heap-pressure audit deferred to v3.4.8.
-- **#476 — Single-channel WiFi PB throughput degrades with session
-  history; multi-channel does not.** First honest characterization
-  post-#371 silent-loss-counter fix. WiFi PB 1×T1 sustains 7000 Hz
-  immediately after a fresh `LAN:APPLY`, but drops to ~4000 Hz after
-  one neighboring config run and to ~3000 Hz after a 17-config
-  overnight sweep. WiFi PB 3×T1 holds 8000 Hz across all three
-  measurements — stable. Mechanism is small-PB-payload specific;
-  candidates include WINC SPI staging fragmentation, HIF refcount
-  drift, or asymmetric circular-buffer hysteresis (#475 may be the
-  same underlying state-pressure issue at a different symptom).
-  Reported numbers below are conservative "after typical session
-  activity" values, not fresh-cold-boot peaks.
+- **#476 — Single-channel WiFi PB throughput is stateful; multi-
+  channel is stable.** First honest characterization post-#371 silent-
+  loss-counter fix.  Observed range for WiFi PB 1×T1 across this
+  release validation window: **3000 Hz to 9000 Hz**, depending on
+  prior WiFi activity.  Specifically: 7000 Hz right after a fresh
+  `LAN:APPLY`, ~4000 Hz after one neighboring config sweep, ~3000 Hz
+  17-config deep into a continuous overnight, and **self-recovers to
+  9000 Hz after ~30 minutes of WiFi idle time**.  WiFi PB 3×T1 holds
+  8000 Hz across every measurement in the same window — small-PB-
+  payload-specific behavior confirmed.  Mechanism candidates: TCP
+  congestion-window state, WINC firmware background-housekeeping,
+  WINC SPI staging fragmentation.  #475 may be the same state-
+  pressure issue at a different symptom (#475 doesn't self-heal in
+  30 min, #476 does).  **Published numbers below quote the
+  conservative-after-activity values, not the fresh / recovered
+  peaks** — customers running a steady single-channel WiFi capture
+  should expect 3-5 kHz sustained, not the 7-9 kHz peak.
 
 ### Pre-existing, ongoing
 

--- a/RELEASE_NOTES_v3.4.7b1.md
+++ b/RELEASE_NOTES_v3.4.7b1.md
@@ -606,7 +606,8 @@ client+server harness pieces are internal scaffolding).
   to report the DHCP-assigned IP and RSSI 100%. Heap-free dropped to
   ~7 KB during the long run, which is the suspected mechanism (silent
   listen-socket allocation failure). **Workaround**: bounce WiFi via
-  `SYST:COMM:LAN:ENAbled 0 → APPLY → wait 5s → ENAbled 1 → APPLY`. TCP
+  send `SYST:COMM:LAN:ENAbled 0` → `SYST:COMM:LAN:APPLY` → wait 5s →
+  `SYST:COMM:LAN:ENAbled 1` → `SYST:COMM:LAN:APPLY`. TCP
   comes back on first attempt. Full investigation including suggested
   observability + heap-pressure audit deferred to v3.4.8.
 - **#476 — Single-channel WiFi PB throughput is stateful; multi-
@@ -614,7 +615,8 @@ client+server harness pieces are internal scaffolding).
   loss-counter fix.  Observed range for WiFi PB 1×T1 across this
   release validation window: **3000 Hz to 9000 Hz**, depending on
   prior WiFi activity.  Specifically: 7000 Hz right after a fresh
-  `LAN:APPLY`, ~4000 Hz after one neighboring config sweep, ~3000 Hz
+  `SYST:COMM:LAN:APPLY`, ~4000 Hz after one neighboring config sweep,
+  ~3000 Hz
   17-config deep into a continuous overnight, and **self-recovers to
   9000 Hz after ~30 minutes of WiFi idle time**.  WiFi PB 3×T1 holds
   8000 Hz across every measurement in the same window — small-PB-

--- a/RELEASE_NOTES_v3.4.7b1.md
+++ b/RELEASE_NOTES_v3.4.7b1.md
@@ -67,8 +67,8 @@ SYST:WIFI:IPERF:TXBLast <port>,<duration_s>      # #399 raw-rate workaround
 SYST:WIFI:IPERF:STATs?
 SYST:WIFI:IPERF:STOP
 SYST:WIFI:IPERF:DIAGnostics?                     # WINC HIF + send-pipeline diagnostics
-SYST:WIFI:IPERF:MAXPending [0..4]                # #399 throttle
-SYST:WIFI:IPERF:AUTOReset [0|1]                  # #399 auto-HRESet on stop
+SYST:WIFI:IPERF:MAXPending <0..4>                # #399 throttle (0=default, required)
+SYST:WIFI:IPERF:AUTOReset <0|1>                  # #399 auto-HRESet on stop (required)
 ```
 
 `TXBlast` tx-mode (#403) bypasses the iperf2 framing for maximum-rate
@@ -233,9 +233,13 @@ alongside USB and WiFi counters.
 
 ### iperf2 diagnostics SCPI (#393/#403)
 
-`SYST:WIFI:IPERF:DIAGnostics?` exposes WINC HIF chip-wake/sleep refcounts, send-pipeline
-in-flight counts, and last-completion timing — instrumentation that
-backed the multi-in-flight Step C work and the auto-HRESet decision.
+`SYST:WIFI:IPERF:DIAGnostics?` exposes the iperf2 state machine and
+WINC send-pipeline state.  Fields: `Mode`, `DataSock`, `ListenSock`,
+`PendingTx`, `AbortPending`, `BytesConfirmed`, `LastSendRc`,
+`SendErrCount`, `WincState`, `FreeTcpSockets`, `FreeUdpSockets`
+(see `SCPI_Iperf2_Diag` for the canonical field list).  This is the
+instrumentation that backed the multi-in-flight Step C work and the
+auto-HRESet decision.
 
 ## Changed
 

--- a/RELEASE_NOTES_v3.4.7b1.md
+++ b/RELEASE_NOTES_v3.4.7b1.md
@@ -422,8 +422,10 @@ NULL-guards added to defensive call sites.
 
 Some BSS regions placed in kseg0 best-fit by the linker were not
 covered by the standard `_bss_start..._bss_end` zero loop on cold
-boot. Added explicit zero-init for the affected regions in `main`
-before `SYS_Initialize`. Fixes the rare crash class observed in
+boot. Added explicit zero-init for the affected regions early in
+`APP_FREERTOS_Tasks()` / `app_SystemInit()` — after `SYS_Initialize()`
+but before any FreeRTOS task is created (see `app_freertos.c:547`).
+Fixes the rare crash class observed in
 post-reset boot loops (#406 — auto-power-up + LED-off symptom under
 -O3 + IPE flash).  The underlying issue is well-bounded but the
 zero-init defense is permanent.  #410 (volatile-qualifier audit) is
@@ -603,7 +605,8 @@ client+server harness pieces are internal scaffolding).
   while SCPI reports healthy STA state.** After a 5h+ USB streaming
   session (overnight characterization), the device's TCP listen
   socket stops accepting connections. `SYST:COMM:LAN:ADDR?` continues
-  to report the DHCP-assigned IP and RSSI 100%. Heap-free dropped to
+  to report the DHCP-assigned IP and `SYST:COMM:LAN:SSIDSTR?` continues
+  to report RSSI 100%. Heap-free dropped to
   ~7 KB during the long run, which is the suspected mechanism (silent
   listen-socket allocation failure). **Workaround**: bounce WiFi via
   send `SYST:COMM:LAN:ENAbled 0` → `SYST:COMM:LAN:APPLY` → wait 5s →

--- a/docs/RELEASE_NOTES_GUIDE.md
+++ b/docs/RELEASE_NOTES_GUIDE.md
@@ -106,11 +106,15 @@ A PR earns Highlights billing when **all three** of these are true:
    to know about it specifically. Not "we cleaned up volatile usage" —
    that's a means, not an end.
 
-If a change is internal correctness (#410 volatile audit, #347 stack
-overflow fix, #354 ADC stack overflow, #421 set-once pointer audit), it
-goes in `Internal`, NOT `Highlights`, even if it required heroic work.
-Highlights describe what the product does better, not how cleanly the
-code got there.
+**Highlights vs Fixed vs Internal — the distinction that trips writers**:
+internal *correctness* changes that *fixed an observed-in-the-wild bug*
+(e.g. v3.4.7b1's #347/#354 stack-overflow chain — they fixed a real
+WINC wedge customers hit) go in `Fixed`, not `Internal`.  Internal
+correctness changes that *hardened an internal hazard without fixing
+an observed bug* (#410 volatile audit, #421 set-once pointer audit) go
+in `Internal`.  Neither belongs in `Highlights` unless the user-visible
+impact is unambiguous and substantial.  Highlights describe what the
+product does better, not how cleanly the code got there.
 
 ### Added — new features
 
@@ -157,9 +161,11 @@ bulleted list, one line per PR, grouped by theme. Categories:
 - **Documentation and audits** (#321, #338, #357, #431, #433, #442,
   #444)
 - **Test infrastructure** (#308's DIO probes, etc)
-- **Defensive correctness** (#347 stack, #354 stack, #410 volatile —
-  these are the hard ones that *look* like fixes but didn't fix an
-  observed-in-the-wild bug; they hardened an internal hazard)
+- **Defensive correctness** (#410 volatile audit, #421 set-once
+  pointer audit — these are the hard ones that *look* like fixes but
+  didn't fix an observed-in-the-wild bug; they hardened an internal
+  hazard.  Contrast with #347/#354 stack-overflow fixes, which DID
+  fix real-world wedges and belong in `Fixed`.)
 
 ### Tie-break: when in doubt, demote
 
@@ -362,8 +368,8 @@ extrapolate. Quote what was actually measured ("PR #278: +15-18% on
 
 ### Hyping internal correctness as headline news
 
-The temptation is real for things like #354 (ADC stack overflow), #410
-(volatile audit), #421 (set-once pointer audit). They feel important —
+The temptation is real for things like #410 (volatile audit), #421
+(set-once pointer audit). They feel important —
 they took weeks of investigation. But the customer-visible win is "no
 more SCPI-over-WiFi crashes when running diagnostic commands during
 streaming", not "fixed a 5 KB stack-local in ADC_WriteChannelStateAll".

--- a/docs/RELEASE_NOTES_GUIDE.md
+++ b/docs/RELEASE_NOTES_GUIDE.md
@@ -1,0 +1,411 @@
+# Release Notes Guide
+
+This guide defines the format and process for drafting firmware release notes
+for the DAQiFi Nyquist project. It exists so every release reads the same way
+and so that future maintainers (human or AI) can produce notes from a PR list
+without reinventing structure each time.
+
+Past releases (v3.4.3, v3.4.4, v3.4.6b1) used a simple prose-only template.
+The v3.4.7 template extends that with explicit `Added / Changed / Fixed /
+Internal` buckets. New releases should follow this extended format.
+
+## When to draft
+
+Open a release-notes draft when:
+
+1. The release tracking issue (e.g. `Release vX.Y.Z tracking — validate N
+   commits since vP.Q.R`) is close to "ready to cut" status.
+2. The release tracker has a categorized PR list — that list is the
+   primary input. Don't try to categorize 100 PRs from scratch when the
+   tracker already did the work.
+3. `FIRMWARE_REVISION` in `firmware/src/version.h` has been bumped (or is
+   about to be).
+
+## File layout
+
+Draft both files in this order:
+
+1. **`RELEASE_NOTES_<version>.md` at repo root** — the actual notes for this
+   release. One file per release. The root location keeps it visible and
+   easy for the release tagger to find. Past examples (only at GitHub
+   release time, not committed): `RELEASE_NOTES_v3.4.7.md`.
+2. **`docs/RELEASE_NOTES_GUIDE.md`** — this guide. Update only when the
+   format itself changes, not for each release.
+
+After the release ships, the `RELEASE_NOTES_<version>.md` body becomes the
+GitHub Release description (`gh release create vX.Y.Z --notes-file
+RELEASE_NOTES_vX.Y.Z.md`). The file stays in the repo as a historical
+record.
+
+## The template
+
+```markdown
+# vX.Y.Z - <SHORT THEME>
+
+## Highlights
+
+1-3 paragraphs of marketing-grade prose. Write it so a customer reading
+the release page understands what changed about the product. Not a commit
+log — a story. Pick the 3-5 biggest customer-visible arcs and tell them.
+
+## Added
+### <Feature title> (PR #N)
+- User-visible SCPI commands or behavior
+- Measured impact, citing CLAUDE.md tables or PR bodies — never invented
+
+## Changed
+### <Behavioral change> (PR #N)
+- What changed
+- Client-library migration notes if applicable
+
+## Fixed
+### <Bug fix title> (PR #N)
+- Symptom, scope, one-line root cause
+
+## Internal
+PRs #N #N #N — build/CI/refactor/docs/observability/test. One line each,
+grouped by theme. Do NOT give each chore PR its own sub-section.
+
+## Test coverage
+- Bench characterization sessions (see CLAUDE.md)
+- Overnight ceiling + endurance sweeps
+- Manual functional tests (per release-tracker MED-tier checklist)
+- cppcheck baseline status
+
+## Known limitations
+- Open issues that aren't blocking the release
+- Features deferred to next release
+- WIP investigations
+
+---
+
+## Upgrade notes
+- Client-library compatibility (SCPI alias notes)
+- New default behaviors that change UX
+- NVM-persisted settings that may need re-saving
+```
+
+## Categorization rules
+
+Every merged PR lands in exactly one bucket. Use these decision rules in
+order — apply the first one that matches.
+
+### Highlights
+
+A PR earns Highlights billing when **all three** of these are true:
+
+1. **Customer-visible.** A user running the firmware notices the change
+   in normal operation. Examples: new SCPI command, throughput jump,
+   fewer crashes, new auto-recovery behavior.
+2. **Substantial.** It changes a top-line capability or eliminates a
+   long-running pain point. "Fixed a typo in a log message" does not
+   count, even if the log is customer-visible.
+3. **Stand-alone interesting.** A bench operator or library author wants
+   to know about it specifically. Not "we cleaned up volatile usage" —
+   that's a means, not an end.
+
+If a change is internal correctness (#410 volatile audit, #347 stack
+overflow fix, #354 ADC stack overflow, #421 set-once pointer audit), it
+goes in `Internal`, NOT `Highlights`, even if it required heroic work.
+Highlights describe what the product does better, not how cleanly the
+code got there.
+
+### Added — new features
+
+A `feat()` commit that gives users a new capability or SCPI command they
+didn't have before. Example shape: "Added the `SYST:STR:THRoughput`
+command for self-contained throughput benchmarks."
+
+Sub-section per feature. Inline the PR number in parentheses in the
+heading. List the SCPI surface area and the measured impact if there is
+one (cite CLAUDE.md or the PR body — don't invent numbers).
+
+### Changed — behavior changes that aren't bug fixes
+
+- SCPI command rename (with legacy alias retained → `Changed`, no alias →
+  this is a breaking change, mention in Upgrade notes)
+- Default value changes (e.g. WiFi buffer 32 KB → 64 KB auto-balance)
+- New default behaviors that existing customers might notice (e.g. #335
+  WINC idle-gate — silent under the hood but changes observed timing)
+- Performance characteristic changes (e.g. cap formula updates)
+
+Each gets a sub-section with PR number, what changed, and migration notes
+for clients if any.
+
+### Fixed — bug fixes
+
+A `fix()` commit that resolves observable wrong behavior. Each gets a
+sub-section. Format: symptom (what users saw), scope (which configs were
+affected), one-line root cause. Don't write a PR-body-length narrative —
+link to the PR for that.
+
+Group very-similar fixes if they're the same root cause across PRs (e.g.
+"WiFi reconnect resilience" can cover #416 + #423 + #425 in one sub-
+section).
+
+### Internal — everything else
+
+PRs that don't change observable behavior. Lump these into a single
+bulleted list, one line per PR, grouped by theme. Categories:
+
+- **Build / CI / kernel tuning** (#414, #426, #432, #459)
+- **Refactors and renames without behavior change** (#316, #319, #320,
+  #339)
+- **Observability and instrumentation** (#244, #265, #266, #295-#297)
+- **Documentation and audits** (#321, #338, #357, #431, #433, #442,
+  #444)
+- **Test infrastructure** (#308's DIO probes, etc)
+- **Defensive correctness** (#347 stack, #354 stack, #410 volatile —
+  these are the hard ones that *look* like fixes but didn't fix an
+  observed-in-the-wild bug; they hardened an internal hazard)
+
+### Tie-break: when in doubt, demote
+
+If you can't decide between `Highlights` and `Added`, choose `Added`.
+If you can't decide between `Added` and `Internal`, choose `Internal`.
+The customer reading the page benefits from short, focused Highlights
+and Added sections; nobody is harmed by an extra line in Internal.
+
+## Examples from past releases
+
+### v3.4.6b1 (March 2026)
+
+Simple two-bucket format (`New Features` + `Bug Fixes`), no
+Added/Changed/Fixed split. Worked at small scale (4 PRs total). Useful
+as a Highlights template:
+
+> This prerelease adds SCPI status register support, streaming
+> diagnostics improvements, and automatic device hostname/SSID
+> differentiation for multi-device setups.
+
+The PRs were then listed under "New Features" and "Bug Fixes" as
+sub-sections. v3.4.7's scale (~100 PRs) breaks this format — too much
+prose, hard to scan. Hence the Added/Changed/Fixed/Internal split.
+
+### v3.4.4 (March 2026)
+
+Single-theme release (USB power fix). Highlights wrote the story:
+
+> This release fixes a critical USB power issue where the device would
+> not draw current from USB when a battery was present. The root cause
+> was the BQ24297 charger IC classifying the USB host as a 100 mA
+> source...
+
+Used "Bug Fixes" sub-sections per PR, plus an explicit "Known Issues"
+section pointing at the deferred ticket. This is the model for `Fixed`
+sub-sections in the extended template.
+
+### v3.4.3 (Pre-v3.4 release)
+
+Multi-theme release, used "New Features / Stability Fixes / Breaking
+Changes / Commits Since v3.2.0" sections. The "Breaking Changes: None"
+explicit-zero pattern is useful — call out backward compatibility
+explicitly when it's a feature.
+
+## Process
+
+### 1. Set up the branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b docs/release-notes-vX.Y.Z
+```
+
+### 2. Source the PR list
+
+The release tracker (e.g. issue #464 for v3.4.7) is the canonical
+categorization. Read it first:
+
+```bash
+gh issue view <TRACKER_NUM> --repo daqifi/daqifi-nyquist-firmware \
+  --json body --jq .body
+```
+
+The tracker already groups PRs by risk/coverage area:
+
+- Hardware-touching streaming / ADC (HIGH)
+- WiFi state machine / WINC interface (HIGH)
+- Power / boot / init (MED)
+- SCPI surface (MED)
+- Memory / pool / buffer management (MED)
+- SD card path (MED)
+- Logging / observability / diagnostics (LOW)
+- Build / CI / kernel / docs / chores (LOW)
+
+Map that risk grouping to the release-notes bucket:
+
+- HIGH groups → mostly `Highlights` + `Added`/`Fixed`
+- MED groups → split between `Added`, `Changed`, `Fixed`, `Internal`
+- LOW groups → almost all `Internal`
+
+Then cross-check with the raw PR list to catch anything the tracker
+missed (often late-arriving PRs after the tracker was authored):
+
+```bash
+gh pr list --repo daqifi/daqifi-nyquist-firmware \
+  --base main --state merged --limit 200 \
+  --json number,title,labels,mergedAt \
+  --jq '[.[] | select(.mergedAt > "<PREV_RELEASE_DATE>T00:00:00Z")] |
+        sort_by(.mergedAt) |
+        .[] | "\(.number)\t\(.mergedAt[:10])\t\(.title)"'
+```
+
+Filter `mergedAt` by the previous release date.
+
+### 3. Source measured-impact numbers
+
+Bench characterization numbers come from **CLAUDE.md** — search for
+`Session 22`, `Session 23`, `Session 24` tables and quote conservatively.
+Never invent numbers. If the PR body has a measurement, cite it (e.g.
+"PR #335: USB CSV 16ch CV at 10 kHz: 9.44% → 0.5%, p-p 326 µs → 8.8
+µs"). If no measurement is documented, write "see PR #N for details" and
+don't make one up.
+
+### 4. Read past releases for tone
+
+```bash
+gh release view v3.4.6b1 --repo daqifi/daqifi-nyquist-firmware \
+  --json body --jq .body
+```
+
+Match the conversational-marketing tone in `Highlights`. Match the
+terse-bullet style in `Fixed` / `Internal`.
+
+### 5. Draft both files
+
+- `RELEASE_NOTES_<version>.md` at repo root
+- Update `docs/RELEASE_NOTES_GUIDE.md` only if the template itself
+  changes
+
+Target sizes:
+
+- Highlights: 200-400 words
+- Added: ~1 sub-section per substantive feat PR (typically 3-8 features)
+- Changed: only if there is real behavior change (often empty or short)
+- Fixed: ~1 sub-section per fix PR or per fix-group (typically 5-12)
+- Internal: 30-40 PRs in a single bulleted list — DO NOT split per PR
+- Known limitations + Upgrade notes: 5-10 bullets total
+
+Aim for the full file to be 400-600 lines for a 100-PR release. Shorter
+for smaller releases.
+
+### 6. Commit and PR
+
+```bash
+git add docs/RELEASE_NOTES_GUIDE.md RELEASE_NOTES_<version>.md
+git commit -m "$(cat <<'EOF'
+docs(release): vX.Y.Z release notes + format guide (#<TRACKER>)
+
+<one-paragraph context — what release this is for, what changed in the
+format guide if anything>
+EOF
+)"
+git push -u origin docs/release-notes-vX.Y.Z
+gh pr create --title "docs(release): vX.Y.Z release notes + format guide (#<TRACKER>)" \
+  --body "..."
+```
+
+The PR should request a human review of the Highlights prose and the
+Known Limitations wording specifically — those are the parts most likely
+to need user input.
+
+### 7. After merge: tag and zip
+
+Per CLAUDE.md's "Packaging Release Artifacts" recipe:
+
+```bash
+zip -j "daqifi-nyquist-firmware-<version>.zip" \
+  firmware/daqifi.X/dist/default/production/daqifi.X.production.hex
+```
+
+The version string is the value of `FIRMWARE_REVISION` in
+`firmware/src/version.h` (e.g. `3.4.7b1` → `daqifi-nyquist-firmware-3.4.7b1.zip`).
+
+Tag the release and upload the zip + hex:
+
+```bash
+git tag -a v<version> -m "v<version>"
+git push origin v<version>
+gh release create v<version> \
+  --repo daqifi/daqifi-nyquist-firmware \
+  --title "v<version> - <SHORT THEME>" \
+  --notes-file RELEASE_NOTES_v<version>.md \
+  daqifi-nyquist-firmware-<version>.zip \
+  firmware/daqifi.X/dist/default/production/daqifi.X.production.hex
+```
+
+For `b1`/`b2` prereleases, add `--prerelease` to the `gh release
+create` invocation.
+
+### 8. Update wiki SCPI page
+
+If the release adds, renames, or removes SCPI commands, update the wiki
+SCPI reference per CLAUDE.md's "SCPI Wiki Maintenance" section:
+
+```bash
+git clone https://github.com/daqifi/daqifi-nyquist-firmware.wiki.git \
+  /tmp/daqifi-wiki
+# edit 01-SCPI-Interface.md
+# commit + push
+```
+
+## Common pitfalls
+
+### Inventing numbers
+
+If a PR body says "+15% throughput" but doesn't specify config, do not
+extrapolate. Quote what was actually measured ("PR #278: +15-18% on
+16ch in benchmark") or just link to the PR.
+
+### Hyping internal correctness as headline news
+
+The temptation is real for things like #354 (ADC stack overflow), #410
+(volatile audit), #421 (set-once pointer audit). They feel important —
+they took weeks of investigation. But the customer-visible win is "no
+more SCPI-over-WiFi crashes when running diagnostic commands during
+streaming", not "fixed a 5 KB stack-local in ADC_WriteChannelStateAll".
+Lead with the customer outcome; the deep root-cause discussion belongs
+in the PR body and the engineering memory files.
+
+### Letting Internal sprawl
+
+If `Internal` exceeds ~40 items, sub-categorize but DO NOT add per-PR
+headings. Use bullet groups:
+
+```markdown
+## Internal
+
+**Build / CI / kernel:** #414 cppcheck gate · #426 configLIST_VOLATILE
+(drops FreeRTOS_tasks.c -O1 clamp) · #432 kernel build hygiene ·
+#459 parallelize cppcheck (10m → 23s).
+
+**Refactors and renames:** #316, #319, #320, #322, #323, #339 — SCPI
+command surface renames (legacy aliases retained — see Upgrade notes).
+
+**Observability:** #244 add LOG_E to silent failure paths · #265/#266
+streaming ISR overrun counters · #295-#297 silent-loss instrumentation ·
+#319 SCPI execution-error logging.
+
+**Documentation and audits:** #321, #338, #357 (Session 20/21/22
+characterization refreshes) · #431, #433, #444 (atomicity rules, set-
+once pointer audits) · #298 BUSL-1.1 license.
+```
+
+### Treating prereleases as throwaway
+
+Even `b1`/`b2` prereleases get full release notes. They're the only
+record of what was in that build, and customers may pin to a prerelease
+for months waiting for a `.0` cut.
+
+## Updating this guide
+
+If a release introduces a format change (new section, removed section,
+renamed bucket, new categorization rule):
+
+1. Make the change in `docs/RELEASE_NOTES_GUIDE.md` in the same PR as
+   the first `RELEASE_NOTES_<version>.md` that uses it.
+2. Update the "examples from past releases" section if the change
+   meaningfully alters how the previous releases would have looked.
+3. Mention the format change in the release notes themselves (so
+   readers know this release's notes look different from prior ones).

--- a/docs/RELEASE_NOTES_GUIDE.md
+++ b/docs/RELEASE_NOTES_GUIDE.md
@@ -27,8 +27,10 @@ Draft both files in this order:
 
 1. **`RELEASE_NOTES_<version>.md` at repo root** — the actual notes for this
    release. One file per release. The root location keeps it visible and
-   easy for the release tagger to find. Past examples (only at GitHub
-   release time, not committed): `RELEASE_NOTES_v3.4.7.md`.
+   easy for the release tagger to find. Committed alongside the release
+   PR and kept in the repo as a historical record (this convention starts
+   with v3.4.7b1; pre-v3.4.7b1 releases lived only in the GitHub release
+   body and are not in the tree). Example: `RELEASE_NOTES_v3.4.7b1.md`.
 2. **`docs/RELEASE_NOTES_GUIDE.md`** — this guide. Update only when the
    format itself changes, not for each release.
 


### PR DESCRIPTION
## Summary

Two deliverables for the v3.4.7 release tracked in #469:

1. **`docs/RELEASE_NOTES_GUIDE.md`** — permanent format reference for future releases. Defines the `Highlights / Added / Changed / Fixed / Internal` template, categorization decision rules (with explicit tie-break: when in doubt, demote), examples from past releases (v3.4.6b1, v3.4.4, v3.4.3), and the draft → commit → tag → zip workflow cross-referenced to CLAUDE.md's packaging recipe. ~410 lines.

2. **`RELEASE_NOTES_v3.4.7.md`** — draft notes for v3.4.7 itself, sourced from #464's PR matrix + `gh pr list --merged --base main` filtered by mergedAt > 2026-03-12 (98 PRs). ~630 lines.

## Format choice

Past releases (v3.4.4, v3.4.6b1) used a simple two-bucket structure (`New Features` + `Bug Fixes`). That worked for 4-10 PR releases. v3.4.7's scale (~100 PRs) breaks the format — too much prose, hard to scan — hence the explicit Added/Changed/Fixed/Internal split with a single bulleted "Internal" list for the ~30 chore/build/CI/observability PRs. Highlights stays prose, set up as marketing-grade narrative (3 customer-visible arcs: streaming ceilings, WiFi resilience, long-run stability).

For reference:
- [v3.4.6b1 release](https://github.com/daqifi/daqifi-nyquist-firmware/releases/tag/v3.4.6b1) — small scale, two-bucket
- [v3.4.4 release](https://github.com/daqifi/daqifi-nyquist-firmware/releases/tag/v3.4.4) — single-theme USB power fix
- [v3.4.3 release](https://github.com/daqifi/daqifi-nyquist-firmware/releases/tag/v3.4.3) — multi-theme, the closest precedent

## Categorization breakdown (98 PRs)

| Bucket | Count |
|---|---|
| Added (new SCPI / features) | 14 sub-sections |
| Changed (behavior + namespace) | 9 sub-sections |
| Fixed (bugs + correctness chains) | 18 sub-sections |
| Internal (build/CI/refactor/observability/docs) | ~32 PRs in themed bullet groups |

Total file: ~630 lines / ~3 630 words — within the guide's 400-600 line / 100-PR-release target.

## Source data

- Release tracker #464 — categorized PR matrix used as primary input
- `gh pr list --repo daqifi/daqifi-nyquist-firmware --base main --state merged --limit 200` filtered by `mergedAt > 2026-03-12`
- CLAUDE.md Session 22 (USB+SD characterization) and Session 23 (WiFi, advisory-flagged)
- Selected PR bodies (#467/#468, #462/#454, #466, #343) for accuracy of root-cause one-liners

## Review request — please look at

1. **Highlights prose** ("Streaming Ceiling, WiFi Resilience & Long-Run Stability" theme + the 3 paragraphs). Theme title and customer-facing tone are the calls most worth a human pass.
2. **Known Limitations wording** for #463, #399/#401, and the deferred WiFi optimization tickets — I summarized them conservatively but the framing should match your read of how close those fixes are.
3. **Categorization edge calls** — particularly #347/#350/#354/#356 (grouped under Fixed as the "#353 stack-overflow chain" rather than Internal — feels customer-relevant given v3.4.6b1 wedge symptoms, but defensible either way), #406/#409/#410/#412 (defensive zero-init under Fixed for the same reason), and #421 (audit conclusion, put in Internal).
4. **Anything I may have missed.** Late-arriving PRs since 2026-05-14 (#466, #468, #473) are covered. If there are unmerged PRs you expect to land before tagging, they need to be added.

## What I did NOT do

- Did NOT read every PR body individually — I read ~6 critical ones (#467/#468, #466, #343, #462/#454) and trusted #464's tracker categorization for the rest. If specific PRs need re-verification (e.g. someone questions a root-cause one-liner), I can pull the body in a follow-up.
- Did NOT update the wiki SCPI page (`01-SCPI-Interface.md`). Per the guide, that's a step-8 task after merge.
- Did NOT bump FIRMWARE_REVISION beyond what's already on main (`3.4.7b1`). Whether to cut as `3.4.7b1` prerelease or promote to `3.4.7` final is the release-tagger's call.

## Test plan

- [x] Both files render correctly as markdown (verified via cat + visual inspection)
- [x] Word counts within guide target (guide: 410 lines / 2.1k words; notes: 628 lines / 3.6k words)
- [x] All PR numbers cited from #464 + the gh pr list — spot-checked 6 for accuracy
- [ ] Human review of Highlights theme + prose
- [ ] Human review of categorization tie-break calls

Refs #469.

Generated with [Claude Code](https://claude.com/claude-code)