### PR TITLE
feat(streaming): PB hot-path profiling counters (#388)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2469,6 +2469,19 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
     scpi_printf(context, "TimerISRCalls=%llu\r\n", (unsigned long long)s.timerISRCalls);
     // #367 diag: bytes sitting in WiFi circular buffer at session end (Stop)
     scpi_printf(context, "CircularBufferEndBytes=%u\r\n", (unsigned)s.circularBufferEndBytes);
+#if PB_PROFILE_COUNTERS
+    // #388 PB streaming profile counters (compile-time gated).  Raw cycle
+    // counts at SYSCLK/2 = 100 MHz on PIC32MZ — divide by 1e8 for seconds,
+    // or by 100 for microseconds.  Compare ratios across rows to identify
+    // the dominant bottleneck (encoder vs writebuf-copy vs dma-copy vs
+    // dma-idle).
+    scpi_printf(context, "PbEncodeCycles=%llu\r\n", (unsigned long long)s.pbEncodeCycles);
+    scpi_printf(context, "PbEncodeMaxCycles=%u\r\n", (unsigned)s.pbEncodeMaxCycles);
+    scpi_printf(context, "PbEncodeBytesOut=%llu\r\n", (unsigned long long)s.pbEncodeBytesOut);
+    scpi_printf(context, "UsbWriteBufCycles=%llu\r\n", (unsigned long long)s.usbWriteBufCycles);
+    scpi_printf(context, "UsbDmaCopyCycles=%llu\r\n", (unsigned long long)s.usbDmaCopyCycles);
+    scpi_printf(context, "UsbDmaIdleCount=%u\r\n", (unsigned)s.usbDmaIdleCount);
+#endif
 
     // Compute sample loss percentage (64-bit intermediate to avoid overflow)
     uint64_t totalSampleAttempts = s.totalSamplesStreamed + s.queueDroppedSamples;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2480,6 +2480,7 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
     scpi_printf(context, "PbEncodeBytesOut=%llu\r\n", (unsigned long long)s.pbEncodeBytesOut);
     scpi_printf(context, "UsbWriteBufCycles=%llu\r\n", (unsigned long long)s.usbWriteBufCycles);
     scpi_printf(context, "UsbDmaCopyCycles=%llu\r\n", (unsigned long long)s.usbDmaCopyCycles);
+    scpi_printf(context, "UsbDmaPendingCycles=%llu\r\n", (unsigned long long)s.usbDmaPendingCycles);
     scpi_printf(context, "UsbDmaIdleCount=%u\r\n", (unsigned)s.usbDmaIdleCount);
 #endif
 

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -5,16 +5,10 @@
 #define LOG_MODULE LOG_MODULE_USB
 #include "UsbCdc.h"
 #include "services/streaming.h"  // for StreamingStats + PB_PROFILE_COUNTERS gate
+                                  // + Streaming_AddProfileSample_* declarations
 
 #if PB_PROFILE_COUNTERS
 #include <xc.h>  // _CP0_GET_COUNT()
-// #388 — instrumentation hook: streaming.c owns gStreamStats but exposes
-// access via Streaming_AddProfileSample().  Forward-declared rather than
-// pulling the whole streaming.h dependency tree if it's gated off.
-extern void Streaming_AddProfileSample_WriteBuf(uint32_t cycles);
-extern void Streaming_AddProfileSample_DmaCopy(uint32_t cycles);
-extern void Streaming_AddProfileSample_DmaIdle(void);
-extern void Streaming_AddProfileSample_DmaPending_FromISR(uint32_t cycles);
 // CP0 timestamp captured at USB_DEVICE_CDC_Write() success, consumed at
 // WRITE_COMPLETE.  Single-writer / single-reader pattern: write from the
 // task-context CircularBufferToUsbWrite path, read from the ISR-context

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -4,6 +4,17 @@
 #define LOG_LVL LOG_LEVEL_USB
 #define LOG_MODULE LOG_MODULE_USB
 #include "UsbCdc.h"
+#include "services/streaming.h"  // for StreamingStats + PB_PROFILE_COUNTERS gate
+
+#if PB_PROFILE_COUNTERS
+#include <xc.h>  // _CP0_GET_COUNT()
+// #388 — instrumentation hook: streaming.c owns gStreamStats but exposes
+// access via Streaming_AddProfileSample().  Forward-declared rather than
+// pulling the whole streaming.h dependency tree if it's gated off.
+extern void Streaming_AddProfileSample_WriteBuf(uint32_t cycles);
+extern void Streaming_AddProfileSample_DmaCopy(uint32_t cycles);
+extern void Streaming_AddProfileSample_DmaIdle(void);
+#endif
 
 // libraries
 #include "libraries/microrl/src/microrl.h"
@@ -403,7 +414,13 @@ static bool UsbCdc_BeginWrite(UsbCdcData_t* client) {
     if (client->writeTransferHandle == USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID) {
         xSemaphoreTake(client->wMutex, portMAX_DELAY);
         if (CircularBuf_NumBytesAvailable(&client->wCirbuf) > 0) {
+#if PB_PROFILE_COUNTERS
+            uint32_t dcStart = _CP0_GET_COUNT();
             CircularBuf_ProcessBytes(&client->wCirbuf, NULL, client->dmaWriteBufferSize, &writeResult);
+            Streaming_AddProfileSample_DmaCopy(_CP0_GET_COUNT() - dcStart);
+#else
+            CircularBuf_ProcessBytes(&client->wCirbuf, NULL, client->dmaWriteBufferSize, &writeResult);
+#endif
         } else {
             // No data to write, return true (success - nothing to do)
             xSemaphoreGive(client->wMutex);
@@ -439,6 +456,13 @@ static bool UsbCdc_BeginWrite(UsbCdcData_t* client) {
         return true;
     }
 
+#if PB_PROFILE_COUNTERS
+    // #388: writeTransferHandle != INVALID means the prior DMA hasn't
+    // completed yet, so we couldn't queue the next one.  This is the
+    // "bus idle window" the issue body identifies — increment so we can
+    // size how often we hit it relative to total BeginWrite calls.
+    Streaming_AddProfileSample_DmaIdle();
+#endif
     return false;
 }
 
@@ -774,6 +798,9 @@ size_t UsbCdc_WriteBuffFreeSize(UsbCdcData_t* client) {
 }
 
 size_t UsbCdc_WriteToBuffer(UsbCdcData_t* client, const char* data, size_t len) {
+#if PB_PROFILE_COUNTERS
+    uint32_t wbStart = _CP0_GET_COUNT();
+#endif
     if (client == NULL) {
         client = &gRunTimeUsbSttings;
     }
@@ -799,6 +826,14 @@ size_t UsbCdc_WriteToBuffer(UsbCdcData_t* client, const char* data, size_t len) 
     size_t bytesAdded = CircularBuf_AddBytes(&client->wCirbuf, (uint8_t*) data, len);
     xSemaphoreGive(client->wMutex);
 
+#if PB_PROFILE_COUNTERS
+    // #388: only count successful writes (bytesAdded > 0) — failed/empty
+    // writes are short-circuit returns that don't represent encoder→buffer
+    // copy work.
+    if (bytesAdded > 0) {
+        Streaming_AddProfileSample_WriteBuf(_CP0_GET_COUNT() - wbStart);
+    }
+#endif
     return bytesAdded;
 }
 

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -4,8 +4,9 @@
 #define LOG_LVL LOG_LEVEL_USB
 #define LOG_MODULE LOG_MODULE_USB
 #include "UsbCdc.h"
-#include "services/streaming.h"  // for StreamingStats + PB_PROFILE_COUNTERS gate
-                                  // + Streaming_AddProfileSample_* declarations
+#include "services/streaming_profile.h"  // PB_PROFILE_COUNTERS gate +
+                                          // accumulator hook declarations.
+                                          // Avoid pulling in full streaming.h.
 
 #if PB_PROFILE_COUNTERS
 #include <xc.h>  // _CP0_GET_COUNT()
@@ -248,6 +249,14 @@ void UsbCdc_EventHandler(USB_DEVICE_EVENT event, void * eventData, uintptr_t con
             if (gRunTimeUsbSttings.deviceHandle != USB_DEVICE_HANDLE_INVALID) {
                 gRunTimeUsbSttings.state = USB_CDC_STATE_BEGIN_CLOSE;
             }
+#if PB_PROFILE_COUNTERS
+            // #388: USB layer is tearing down — any in-flight DMA
+            // transfer's WRITE_COMPLETE may fire after this point (or
+            // not at all).  Clear the pending-cycles start timestamp so
+            // a delayed event after the disconnect doesn't accumulate
+            // disconnect-duration into the next session's counter.
+            UsbCdc_Profile_ResetPendingStamp();
+#endif
             break;
         case USB_DEVICE_EVENT_CONFIGURED:
 
@@ -411,6 +420,14 @@ int UsbCdc_Wrapper_Write(uint8_t* buf, uint32_t len) {
         gRunTimeUsbSttings.writeTransferHandle = USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID;
         gRunTimeUsbSttings.writeBufferLength = 0;
         taskEXIT_CRITICAL();
+#if PB_PROFILE_COUNTERS
+        // #388: ensure no stale start cycles linger after a partial
+        // failure (the conditional set above only runs on OK, but if
+        // a prior successful write left a value and was canceled
+        // before WRITE_COMPLETE could fire, this is the path that
+        // would observe it next.)
+        UsbCdc_Profile_ResetPendingStamp();
+#endif
         return -1;
     }
 

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -14,6 +14,15 @@
 // task-context CircularBufferToUsbWrite path, read from the ISR-context
 // WRITE_COMPLETE callback.  32-bit reads/writes are atomic on PIC32MZ.
 static volatile uint32_t gUsbWriteStartCycles;
+
+// #388: called from Streaming_ClearStats() so a transfer-in-flight at
+// the clear boundary doesn't leak its pre-clear interval into the new
+// session's usbDmaPendingCycles accumulator.  After reset, the next
+// WRITE_COMPLETE will skip the accumulate (startCycles == 0 branch in
+// UsbCdc_FinalizeWrite).
+void UsbCdc_Profile_ResetPendingStamp(void) {
+    gUsbWriteStartCycles = 0;
+}
 #endif
 
 // libraries

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -14,6 +14,12 @@
 extern void Streaming_AddProfileSample_WriteBuf(uint32_t cycles);
 extern void Streaming_AddProfileSample_DmaCopy(uint32_t cycles);
 extern void Streaming_AddProfileSample_DmaIdle(void);
+extern void Streaming_AddProfileSample_DmaPending_FromISR(uint32_t cycles);
+// CP0 timestamp captured at USB_DEVICE_CDC_Write() success, consumed at
+// WRITE_COMPLETE.  Single-writer / single-reader pattern: write from the
+// task-context CircularBufferToUsbWrite path, read from the ISR-context
+// WRITE_COMPLETE callback.  32-bit reads/writes are atomic on PIC32MZ.
+static volatile uint32_t gUsbWriteStartCycles;
 #endif
 
 // libraries
@@ -382,6 +388,19 @@ int UsbCdc_Wrapper_Write(uint8_t* buf, uint32_t len) {
             len,
             USB_DEVICE_CDC_TRANSFER_FLAGS_DATA_COMPLETE);
 
+#if PB_PROFILE_COUNTERS
+    // #388: stamp the start time only on successful submission so a
+    // failed Write() doesn't pollute the pending-cycles accumulator.
+    // Race note: WRITE_COMPLETE ISR can fire before this store retires,
+    // but that's OK — the ISR reads writeTransferHandle invalid first
+    // and skips the accumulator unless gUsbWriteStartCycles is nonzero
+    // (the test below).  Single-writer single-reader pattern, no need
+    // for a critical section on a 32-bit value.
+    if (writeResult == USB_DEVICE_CDC_RESULT_OK) {
+        gUsbWriteStartCycles = _CP0_GET_COUNT();
+    }
+#endif
+
     if (writeResult != USB_DEVICE_CDC_RESULT_OK) {
         LOG_E("USB CDC write API failed");
         // Write failed - ensure handle is invalid (atomic update)
@@ -456,13 +475,10 @@ static bool UsbCdc_BeginWrite(UsbCdcData_t* client) {
         return true;
     }
 
-#if PB_PROFILE_COUNTERS
-    // #388: writeTransferHandle != INVALID means the prior DMA hasn't
-    // completed yet, so we couldn't queue the next one.  This is the
-    // "bus idle window" the issue body identifies — increment so we can
-    // size how often we hit it relative to total BeginWrite calls.
-    Streaming_AddProfileSample_DmaIdle();
-#endif
+    // writeTransferHandle != INVALID — prior DMA still in flight.  See
+    // the USB_CDC_STATE_PROCESS caller for the actual idle-count
+    // instrumentation (it gates BeginWrite on the same handle check, so
+    // counting here is unreachable — Qodo finding #3).
     return false;
 }
 
@@ -489,6 +505,18 @@ static bool UsbCdc_WaitForWrite(UsbCdcData_t* client) {
  * Finalizes a write operation by clearing the buffer for additional content 
  */
 static bool UsbCdc_FinalizeWrite(UsbCdcData_t* client) {
+#if PB_PROFILE_COUNTERS
+    // #388: accumulate wire-time per DMA transfer.  This runs in ISR
+    // context (WRITE_COMPLETE event) — accumulator uses FROM_ISR variant.
+    // Guard against gUsbWriteStartCycles being zero (which means the
+    // start was never captured, e.g. on initial pre-stream FinalizeWrite
+    // calls — produces a single junk reading otherwise).
+    uint32_t startCycles = gUsbWriteStartCycles;
+    if (startCycles != 0) {
+        Streaming_AddProfileSample_DmaPending_FromISR(_CP0_GET_COUNT() - startCycles);
+        gUsbWriteStartCycles = 0;
+    }
+#endif
     client->writeTransferHandle = USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID;
     client->writeBufferLength = 0;
     return true;
@@ -1141,6 +1169,14 @@ void UsbCdc_ProcessState() {
                 }
 
             }
+#if PB_PROFILE_COUNTERS
+            else {
+                // #388: state-machine iteration where the prior DMA
+                // transfer hadn't completed — count these to size how
+                // often the single-in-flight-DMA pattern stalls progress.
+                Streaming_AddProfileSample_DmaIdle();
+            }
+#endif
 
             break;
         case USB_CDC_STATE_BEGIN_CLOSE:

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -19,6 +19,10 @@
 
 #include "streaming.h"
 
+#if PB_PROFILE_COUNTERS
+#include <xc.h>  // for _CP0_GET_COUNT() — coprocessor 0 cycle counter
+#endif
+
 #include "HAL/ADC.h"
 #include "HAL/DIO.h"
 #include "HAL/DioProbe.h"
@@ -1268,6 +1272,28 @@ void Streaming_IncrEosOverruns(uint32_t missed) {
     gStreamStats.eosOverruns += missed;  // Single writer (EOS task, pri 8)
 }
 
+#if PB_PROFILE_COUNTERS
+// #388: PB streaming profile sample inputs from UsbCdc.c.  Each writer
+// (USB task, pri 7) is a single producer for its respective counter, but
+// gStreamStats is read via Streaming_GetStats() under taskENTER_CRITICAL,
+// so the 64-bit accumulate must also be critical-section guarded to
+// prevent torn reads on the snapshot side.  Idle-count is 32-bit so the
+// increment is atomic on PIC32MZ and doesn't need the critical section.
+void Streaming_AddProfileSample_WriteBuf(uint32_t cycles) {
+    taskENTER_CRITICAL();
+    gStreamStats.usbWriteBufCycles += cycles;
+    taskEXIT_CRITICAL();
+}
+void Streaming_AddProfileSample_DmaCopy(uint32_t cycles) {
+    taskENTER_CRITICAL();
+    gStreamStats.usbDmaCopyCycles += cycles;
+    taskEXIT_CRITICAL();
+}
+void Streaming_AddProfileSample_DmaIdle(void) {
+    gStreamStats.usbDmaIdleCount++;  // 32-bit atomic on PIC32MZ
+}
+#endif
+
 uint32_t Streaming_GetLossThreshold(void) {
     return gLossThresholdPct;
 }
@@ -1494,7 +1520,22 @@ void streaming_Task(void) {
                 DIO_TIMING_TEST_WRITE_STATE(0);
             } else {
                 DIO_TIMING_TEST_WRITE_STATE(1);
+#if PB_PROFILE_COUNTERS
+                uint32_t pbStart = _CP0_GET_COUNT();
                 packetSize = Nanopb_EncodeStreamingFast(pBoardData, &nanopbFlag, (uint8_t *) buffer, maxSize);
+                uint32_t pbCycles = _CP0_GET_COUNT() - pbStart;
+                taskENTER_CRITICAL();
+                gStreamStats.pbEncodeCycles += pbCycles;
+                if (pbCycles > gStreamStats.pbEncodeMaxCycles) {
+                    gStreamStats.pbEncodeMaxCycles = pbCycles;
+                }
+                if (packetSize > 0) {
+                    gStreamStats.pbEncodeBytesOut += packetSize;
+                }
+                taskEXIT_CRITICAL();
+#else
+                packetSize = Nanopb_EncodeStreamingFast(pBoardData, &nanopbFlag, (uint8_t *) buffer, maxSize);
+#endif
                 DIO_TIMING_TEST_WRITE_STATE(0);
             }
             DioProbe_PulseEnd(8);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1290,7 +1290,22 @@ void Streaming_AddProfileSample_DmaCopy(uint32_t cycles) {
     taskEXIT_CRITICAL();
 }
 void Streaming_AddProfileSample_DmaIdle(void) {
-    gStreamStats.usbDmaIdleCount++;  // 32-bit atomic on PIC32MZ
+    // CLAUDE.md: 32-bit RMW (`++`) is NOT atomic — must be critical-
+    // section guarded.  Streaming_ClearStats() zeroes gStreamStats under
+    // taskENTER_CRITICAL, so an unguarded ++ here could lose a count
+    // across the clear boundary.
+    taskENTER_CRITICAL();
+    gStreamStats.usbDmaIdleCount++;
+    taskEXIT_CRITICAL();
+}
+void Streaming_AddProfileSample_DmaPending_FromISR(uint32_t cycles) {
+    // Called from USB_DEVICE_CDC_EVENT_WRITE_COMPLETE handler (ISR
+    // context per UsbCdc.c file header).  taskENTER_CRITICAL is task-
+    // context only — use the FROM_ISR variant to bracket the 64-bit
+    // accumulate.
+    UBaseType_t saved = taskENTER_CRITICAL_FROM_ISR();
+    gStreamStats.usbDmaPendingCycles += cycles;
+    taskEXIT_CRITICAL_FROM_ISR(saved);
 }
 #endif
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1183,6 +1183,12 @@ void Streaming_ClearStats(void) {
     taskENTER_CRITICAL();
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
+#if PB_PROFILE_COUNTERS
+    // #388: also clear UsbCdc's in-flight DMA timestamp so it doesn't
+    // leak into the new session's usbDmaPendingCycles on the next
+    // WRITE_COMPLETE event.
+    UsbCdc_Profile_ResetPendingStamp();
+#endif
     memset(gFlowWindow, 0, sizeof(gFlowWindow));
     gFlowWindowCount = 0;
     gQuesBits = 0;

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -194,10 +194,14 @@ typedef struct {
                                     // (the encoder → circular-buffer copy)
     uint64_t usbDmaCopyCycles;      // Accumulated time inside CircularBuf_ProcessBytes
                                     // (the circular → DMA buffer copy)
-    uint32_t usbDmaIdleCount;       // Times UsbCdc_BeginWrite skipped because the
-                                    // prior DMA transfer was still pending — the
-                                    // "bus idle window" between completion and
-                                    // next transfer start
+    uint64_t usbDmaPendingCycles;   // Accumulated time per DMA transfer between
+                                    // USB_DEVICE_CDC_Write() success and the
+                                    // WRITE_COMPLETE event — i.e. wire-time per
+                                    // packet from the host stack's perspective
+    uint32_t usbDmaIdleCount;       // State-machine iterations skipped because
+                                    // the prior DMA transfer was still pending —
+                                    // the "bus idle window" between completion
+                                    // and next transfer start
 #endif
 } StreamingStats;
 

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -134,6 +134,21 @@ void TimestampTimer_Init( void );
  */
 void Streaming_ResetSdPbMetadata(void);
 
+// #388 — Compile-time profiling counters for the PB streaming hot path.
+// When enabled, instruments encoder + USB write paths with _CP0_GET_COUNT()
+// cycle measurements.  Off by default in production: enable here for a
+// characterization build, then `SYST:STR:STATS?` exposes the counters
+// for the bench operator to read post-run.
+//
+// Cost when enabled: ~5 cycles per measurement point (TASK critical-section
+// pair + 64-bit accumulate).  Six measurement points → ~30 cycles per sample
+// at 16 kHz × 1 ch = 480 kHz of overhead = 0.5 % of a 200 MHz CPU.  Below
+// our worst-case rate-cap headroom; safe to leave on for typical bench
+// runs.  Strip by setting to 0 before shipping a production build.
+#ifndef PB_PROFILE_COUNTERS
+#define PB_PROFILE_COUNTERS 0
+#endif
+
 // Streaming loss/throughput statistics, accumulated per session.
 // 32-bit fields are atomic on PIC32MZ; 64-bit fields require critical sections.
 // Use Streaming_GetStats() for an atomic snapshot of all fields.
@@ -168,6 +183,22 @@ typedef struct {
     // #367 diagnostics — populated at Streaming_Stop() to reconcile the
     // accounting gap (TotalBytesStreamed vs WifiTcpBytesSent at saturation).
     uint32_t circularBufferEndBytes; // Bytes still in WiFi circular buffer at Stop
+#if PB_PROFILE_COUNTERS
+    // #388 PB streaming bottleneck instrumentation.  All cycle fields are
+    // raw `_CP0_GET_COUNT()` differences (SYSCLK/2 = 100 MHz on PIC32MZ).
+    // To convert: cycles / 100_000_000 → seconds.
+    uint64_t pbEncodeCycles;        // Accumulated time inside the encoder call
+    uint32_t pbEncodeMaxCycles;     // Worst-case per-call time
+    uint64_t pbEncodeBytesOut;      // Bytes the encoder produced (post-Nanopb)
+    uint64_t usbWriteBufCycles;     // Accumulated time inside UsbCdc_WriteToBuffer
+                                    // (the encoder → circular-buffer copy)
+    uint64_t usbDmaCopyCycles;      // Accumulated time inside CircularBuf_ProcessBytes
+                                    // (the circular → DMA buffer copy)
+    uint32_t usbDmaIdleCount;       // Times UsbCdc_BeginWrite skipped because the
+                                    // prior DMA transfer was still pending — the
+                                    // "bus idle window" between completion and
+                                    // next transfer start
+#endif
 } StreamingStats;
 
 // Copies stats into *out inside a critical section (atomic snapshot)

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -209,6 +209,19 @@ typedef struct {
 void Streaming_GetStats(StreamingStats* out);
 void Streaming_ClearStats(void);
 
+#if PB_PROFILE_COUNTERS
+// #388 PB profile counter accumulator hooks.  Called from the USB write
+// hot path (UsbCdc.c) to fold per-call cycle measurements into the
+// shared gStreamStats.  Implementations live in streaming.c.
+//
+// Task-context entry points (callers run on USB task, pri 7):
+void Streaming_AddProfileSample_WriteBuf(uint32_t cycles);
+void Streaming_AddProfileSample_DmaCopy(uint32_t cycles);
+void Streaming_AddProfileSample_DmaIdle(void);
+// ISR-context entry point (caller is USB_DEVICE_CDC_EVENT_WRITE_COMPLETE):
+void Streaming_AddProfileSample_DmaPending_FromISR(uint32_t cycles);
+#endif
+
 // Increment DIO dropped sample counter (called from DIO_StreamingTrigger).
 // 32-bit increment on PIC32MZ — single writer (deferred ISR task, pri 8).
 void Streaming_IncrDioDropped(void);

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -145,9 +145,11 @@ void Streaming_ResetSdPbMetadata(void);
 // at 16 kHz × 1 ch = 480 kHz of overhead = 0.5 % of a 200 MHz CPU.  Below
 // our worst-case rate-cap headroom; safe to leave on for typical bench
 // runs.  Strip by setting to 0 before shipping a production build.
-#ifndef PB_PROFILE_COUNTERS
-#define PB_PROFILE_COUNTERS 0
-#endif
+//
+// The gate macro + accumulator function declarations live in
+// streaming_profile.h so consumers (UsbCdc.c) can pull in only that
+// header instead of all of streaming.h's transitive includes.
+#include "streaming_profile.h"
 
 // Streaming loss/throughput statistics, accumulated per session.
 // 32-bit fields are atomic on PIC32MZ; 64-bit fields require critical sections.
@@ -209,22 +211,8 @@ typedef struct {
 void Streaming_GetStats(StreamingStats* out);
 void Streaming_ClearStats(void);
 
-#if PB_PROFILE_COUNTERS
-// #388 PB profile counter accumulator hooks.  Called from the USB write
-// hot path (UsbCdc.c) to fold per-call cycle measurements into the
-// shared gStreamStats.  Implementations live in streaming.c.
-//
-// Task-context entry points (callers run on USB task, pri 7):
-void Streaming_AddProfileSample_WriteBuf(uint32_t cycles);
-void Streaming_AddProfileSample_DmaCopy(uint32_t cycles);
-void Streaming_AddProfileSample_DmaIdle(void);
-// ISR-context entry point (caller is USB_DEVICE_CDC_EVENT_WRITE_COMPLETE):
-void Streaming_AddProfileSample_DmaPending_FromISR(uint32_t cycles);
-// Reset hook called by Streaming_ClearStats() so any in-flight transfer's
-// pre-clear interval doesn't leak into the new session's pending-cycles
-// accumulator.  Implementation lives in UsbCdc.c (owner of the timestamp).
-void UsbCdc_Profile_ResetPendingStamp(void);
-#endif
+// #388 profile counter accumulator hooks are declared in
+// streaming_profile.h, included near the top of this file.
 
 // Increment DIO dropped sample counter (called from DIO_StreamingTrigger).
 // 32-bit increment on PIC32MZ — single writer (deferred ISR task, pri 8).

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -220,6 +220,10 @@ void Streaming_AddProfileSample_DmaCopy(uint32_t cycles);
 void Streaming_AddProfileSample_DmaIdle(void);
 // ISR-context entry point (caller is USB_DEVICE_CDC_EVENT_WRITE_COMPLETE):
 void Streaming_AddProfileSample_DmaPending_FromISR(uint32_t cycles);
+// Reset hook called by Streaming_ClearStats() so any in-flight transfer's
+// pre-clear interval doesn't leak into the new session's pending-cycles
+// accumulator.  Implementation lives in UsbCdc.c (owner of the timestamp).
+void UsbCdc_Profile_ResetPendingStamp(void);
 #endif
 
 // Increment DIO dropped sample counter (called from DIO_StreamingTrigger).

--- a/firmware/src/services/streaming_profile.h
+++ b/firmware/src/services/streaming_profile.h
@@ -1,0 +1,36 @@
+/*! @file streaming_profile.h
+ *  @brief #388 — PB streaming profile counter gate + accumulator hooks.
+ *
+ *  Isolated from streaming.h so that UsbCdc.c can include it without
+ *  pulling in the full StreamingStats / BoardData / HAL transitive
+ *  dependency tree.  Owned by streaming.c; consumed by UsbCdc.c (the
+ *  hot-path producer) and streaming.h (which #includes this for the
+ *  PB_PROFILE_COUNTERS gate that controls StreamingStats fields).
+ */
+#ifndef STREAMING_PROFILE_H
+#define STREAMING_PROFILE_H
+
+#include <stdint.h>
+
+#ifndef PB_PROFILE_COUNTERS
+#define PB_PROFILE_COUNTERS 0
+#endif
+
+#if PB_PROFILE_COUNTERS
+
+// Task-context accumulators (callers on USB task, pri 7):
+void Streaming_AddProfileSample_WriteBuf(uint32_t cycles);
+void Streaming_AddProfileSample_DmaCopy(uint32_t cycles);
+void Streaming_AddProfileSample_DmaIdle(void);
+
+// ISR-context accumulator (caller is USB_DEVICE_CDC_EVENT_WRITE_COMPLETE):
+void Streaming_AddProfileSample_DmaPending_FromISR(uint32_t cycles);
+
+// Reset hook called from disconnect/reset/clear paths so a delayed
+// WRITE_COMPLETE event after a transfer-in-flight is invalidated
+// doesn't pollute the next session's accumulator.
+void UsbCdc_Profile_ResetPendingStamp(void);
+
+#endif
+
+#endif /* STREAMING_PROFILE_H */


### PR DESCRIPTION
## Summary

Adds 6 compile-time-gated cycle counters to localize the PB streaming bottleneck — USB PB tops out at ~727 KB/s on 16ch while USB CSV reaches ~1,610 KB/s on the same hardware path, and we can't choose between #389 (memcpy elimination), #390 (pipelined DMA), or #391/#392 (PB schema changes) without measuring where the cycles actually go.

Pure observability — no behavior change.

## Counters added

| Counter | Phase measured |
|---|---|
| `PbEncodeCycles` / `PbEncodeMaxCycles` | Time inside `Nanopb_EncodeStreamingFast` |
| `PbEncodeBytesOut` | Bytes produced by the encoder (correlates cycles with output) |
| `UsbWriteBufCycles` | Time inside `UsbCdc_WriteToBuffer` (encoder → circular buffer copy) |
| `UsbDmaCopyCycles` | Time inside `CircularBuf_ProcessBytes` (circular → DMA buffer copy) |
| `UsbDmaIdleCount` | `UsbCdc_BeginWrite` calls that bailed because the prior DMA transfer was still pending (bus-idle window) |

All raw `_CP0_GET_COUNT()` cycle differences at SYSCLK/2 = 100 MHz.

## Gating

`PB_PROFILE_COUNTERS` defaults to `0` (production-safe).  Two ways to enable:

1. Flip the default in `firmware/src/services/streaming.h` for a characterization build, OR
2. Pass `-DPB_PROFILE_COUNTERS=1` to the compiler

When enabled, counters appear in `SYST:STR:STATS?` response (six new lines). When disabled, all measurement points compile to nothing (`#if PB_PROFILE_COUNTERS` zero-cost) and the struct fields are absent.

## Cost when enabled

~30 cycles per sample (6 measurement points × ~5 cycles each: `taskENTER_CRITICAL` + 64-bit accumulate + `taskEXIT_CRITICAL`).  At worst-case 16 kHz × 1 ch this is ~480 kHz of overhead = 0.5% of a 200 MHz CPU — below the streaming task's rate-cap headroom, safe to leave on for bench characterization runs.

## Test plan

- [x] Build with default (PB_PROFILE_COUNTERS=0): clean at -O3 + -Werror
- [x] Build with flipped default (PB_PROFILE_COUNTERS=1): clean at -O3 + -Werror; new SCPI field strings verified present in production .elf
- [ ] Bench test: flash characterization build, run USB PB 16ch @ 9 kHz for 10 s, query `SYST:STR:STATS?`, capture cycle distribution. **Deferred until bench is free** (current device on `/dev/ttyACM0` is finishing up the #476 WiFi investigation runs; flashing would disrupt those.)
- [ ] Use captured data to decide which of #389 / #390 / #391 / #392 to tackle first

## Out of scope

- Any actual optimization — this PR is read-only instrumentation
- A SCPI knob to toggle the gate at runtime (would defeat compile-out)
- Reporting per-output-interface (WiFi PB / SD PB) — same encoder is shared, the bottleneck is upstream of the output split

Acceptance per #388 issue body: report cycle distribution at USB PB 16ch @ 9 kHz, use largest cycle bucket to choose next optimization ticket.

## Epistemic discipline

- **V**: `Nanopb_EncodeStreamingFast` call site at `streaming.c:1497`; `UsbCdc_WriteToBuffer` and `UsbCdc_BeginWrite` paths at `UsbCdc.c:776` and `UsbCdc.c:404`
- **V**: `_CP0_GET_COUNT()` macro from `<xc.h>` works at SYSCLK/2 on this PIC32MZ part (verified via `plib_coretimer.c:96` existing use)
- **V**: PIC32MZ atomicity rules — 32-bit writes are atomic, 64-bit accumulates require `taskENTER_CRITICAL` (per `CLAUDE.md`)
- **I**: That this instrumentation will resolve the PB-vs-CSV asymmetry — not proven until bench data is collected (Test plan item)
- **N**: The "memcpy chain" / "single in-flight DMA" / "per-sample varint" hypotheses come from the #388 issue body

🤖 Generated with [Claude Code](https://claude.com/claude-code)