### PR TITLE
fix(streaming): heap-floor enforcement at session start (#475 step 4)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2596,6 +2596,27 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
+    // #475 step 4 — heap-floor enforcement.  Refuse the start if the
+    // FreeRTOS heap is below the configured floor.  Rationale: in #475
+    // the symptom (TCP 9760 unreachable) appeared after heap had drifted
+    // down to ~7 KB across hours of streaming.  WINC SDK accept() and
+    // wifi_manager event paths allocate from this heap.  Starting a new
+    // session when heap is already pinched accelerates the slide.  The
+    // floor (15 KB default — about 20% of the 75 KB heap budget) leaves
+    // breathing room for callback/queue allocations during the session.
+    //
+    // Boot-time `HeapFree` after current ports/queues is ~13 KB, so this
+    // floor is just above steady-state idle — it bites only when there's
+    // unrecovered prior pressure.
+    size_t heapFreeAtStart = xPortGetFreeHeapSize();
+    if (heapFreeAtStart < MIN_HEAP_FREE_FOR_STREAM_START_BYTES) {
+        LOG_E("Streaming command rejected: free heap %u < floor %u (#475 — bounce LAN:APPLY or reboot)",
+              (unsigned)heapFreeAtStart,
+              (unsigned)MIN_HEAP_FREE_FOR_STREAM_START_BYTES);
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+
     volatile AInRuntimeArray * pRuntimeAInChannels = BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_AIN_CHANNELS);
     volatile AInArray *pBoardConfigADC = BoardConfig_Get(BOARDCONFIG_AIN_CHANNELS, 0);
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2596,27 +2596,6 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
-    // #475 step 4 — heap-floor enforcement.  Refuse the start if the
-    // FreeRTOS heap is below the configured floor.  Rationale: in #475
-    // the symptom (TCP 9760 unreachable) appeared after heap had drifted
-    // down to ~7 KB across hours of streaming.  WINC SDK accept() and
-    // wifi_manager event paths allocate from this heap.  Starting a new
-    // session when heap is already pinched accelerates the slide.  The
-    // floor (15 KB default — about 20% of the 75 KB heap budget) leaves
-    // breathing room for callback/queue allocations during the session.
-    //
-    // Boot-time `HeapFree` after current ports/queues is ~13 KB, so this
-    // floor is just above steady-state idle — it bites only when there's
-    // unrecovered prior pressure.
-    size_t heapFreeAtStart = xPortGetFreeHeapSize();
-    if (heapFreeAtStart < MIN_HEAP_FREE_FOR_STREAM_START_BYTES) {
-        LOG_E("Streaming command rejected: free heap %u < floor %u (#475 — bounce LAN:APPLY or reboot)",
-              (unsigned)heapFreeAtStart,
-              (unsigned)MIN_HEAP_FREE_FOR_STREAM_START_BYTES);
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        return SCPI_RES_ERR;
-    }
-
     volatile AInRuntimeArray * pRuntimeAInChannels = BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_AIN_CHANNELS);
     volatile AInArray *pBoardConfigADC = BoardConfig_Get(BOARDCONFIG_AIN_CHANNELS, 0);
 
@@ -2670,6 +2649,31 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
             Streaming_UpdateState();
             UsbCdc_FlushWriteBuffer();
             return SCPI_RES_OK;
+        }
+
+        // #475 step 4 — heap-floor enforcement.  Refuse a new session
+        // start (freq > 0) when FreeRTOS heap is below the configured
+        // floor.  Rationale: in #475 the symptom (TCP 9760 unreachable)
+        // appeared after heap had drifted down to ~7 KB across hours of
+        // streaming; WINC SDK accept() + wifi_manager event paths
+        // allocate from this heap, and starting a new session when
+        // already pinched accelerates the slide.
+        //
+        // Floor is 10 KB (see MIN_HEAP_FREE_FOR_STREAM_START_BYTES in
+        // SCPIInterface.h for the choice).  Boot-idle HeapFree is
+        // ~13 KB per CLAUDE.md, so cold-boot first-starts pass; the
+        // guard only bites under accumulated pressure.
+        //
+        // Placed AFTER the freq==0 disable branch — the disable path
+        // is always allowed, even (especially) under heap pressure, so
+        // users can stop streaming as a recovery action.
+        size_t heapFreeAtStart = xPortGetFreeHeapSize();
+        if (heapFreeAtStart < MIN_HEAP_FREE_FOR_STREAM_START_BYTES) {
+            LOG_E("Streaming start rejected: free heap %u < floor %u (#475 — bounce LAN:APPLY or reboot)",
+                  (unsigned)heapFreeAtStart,
+                  (unsigned)MIN_HEAP_FREE_FOR_STREAM_START_BYTES);
+            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+            return SCPI_RES_ERR;
         }
 
         // NQ3 Smart Frequency Management:

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2641,41 +2641,57 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
-    if (SCPI_ParamInt32(context, &freq, FALSE)) {
-        // Frequency = 0 is valid and means "disable streaming"
-        // (In future may support per-channel frequency where 0 disables that channel)
-        if (freq == 0) {
-            pRunTimeStreamConfig->IsEnabled = false;
-            Streaming_UpdateState();
-            UsbCdc_FlushWriteBuffer();
-            return SCPI_RES_OK;
-        }
+    bool freqProvided = SCPI_ParamInt32(context, &freq, FALSE);
+    if (freqProvided && freq == 0) {
+        // Frequency = 0 is the explicit disable form.  Always allowed,
+        // including under heap pressure (the user may be trying to
+        // stop streaming as a recovery action).
+        pRunTimeStreamConfig->IsEnabled = false;
+        Streaming_UpdateState();
+        UsbCdc_FlushWriteBuffer();
+        return SCPI_RES_OK;
+    }
 
-        // #475 step 4 — heap-floor enforcement.  Refuse a new session
-        // start (freq > 0) when FreeRTOS heap is below the configured
-        // floor.  Rationale: in #475 the symptom (TCP 9760 unreachable)
-        // appeared after heap had drifted down to ~7 KB across hours of
-        // streaming; WINC SDK accept() + wifi_manager event paths
-        // allocate from this heap, and starting a new session when
-        // already pinched accelerates the slide.
-        //
-        // Floor is 10 KB (see MIN_HEAP_FREE_FOR_STREAM_START_BYTES in
-        // SCPIInterface.h for the choice).  Boot-idle HeapFree is
-        // ~13 KB per CLAUDE.md, so cold-boot first-starts pass; the
-        // guard only bites under accumulated pressure.
-        //
-        // Placed AFTER the freq==0 disable branch — the disable path
-        // is always allowed, even (especially) under heap pressure, so
-        // users can stop streaming as a recovery action.
+    // #475 step 4 — heap-floor enforcement applied to every new-start
+    // path (freq > 0 explicit, or no-argument re-start with current
+    // freq).  Rationale: in #475 the symptom (TCP 9760 unreachable)
+    // appeared after heap had drifted down to ~7 KB across hours of
+    // streaming; WINC SDK accept() + wifi_manager event paths allocate
+    // from this heap, and starting a new session when already pinched
+    // accelerates the slide.
+    //
+    // Floor is 10 KB (see MIN_HEAP_FREE_FOR_STREAM_START_BYTES in
+    // SCPIInterface.h for the choice).  Boot-idle HeapFree is ~13 KB
+    // per CLAUDE.md, so cold-boot first-starts pass; the guard only
+    // bites under accumulated pressure.
+    //
+    // Placed AFTER the freq==0 disable branch, but BEFORE the freq-
+    // parameter branch — covers both the explicit-freq and no-argument
+    // start forms.  Disable path remains always-allowed above.
+    //
+    // Scope-gated to WiFi-relevant interfaces: pure USB or SD streams
+    // don't allocate from the FreeRTOS heap during operation (their
+    // DMA + circular buffers live in the static StreamingBufferPool +
+    // CoherentPool, not heap), so the #475 failure mode doesn't apply
+    // to them.  ActiveInterface is checked here; the interface may not
+    // yet be auto-detected at this point in the flow, but if the user
+    // explicitly set WiFi via SYST:STR:INTerface (or it's already the
+    // default from a prior session), we gate.  The auto-detect later
+    // in this function may pick WiFi anyway — false negatives here are
+    // acceptable since the floor is purely defensive.
+    StreamingInterface currentInterfaceAtCheck = pRunTimeStreamConfig->ActiveInterface;
+    if (currentInterfaceAtCheck == StreamingInterface_WiFi) {
         size_t heapFreeAtStart = xPortGetFreeHeapSize();
         if (heapFreeAtStart < MIN_HEAP_FREE_FOR_STREAM_START_BYTES) {
-            LOG_E("Streaming start rejected: free heap %u < floor %u (#475 — bounce LAN:APPLY or reboot)",
+            LOG_E("WiFi streaming start rejected: free heap %u < floor %u (#475 — bounce LAN:APPLY or reboot)",
                   (unsigned)heapFreeAtStart,
                   (unsigned)MIN_HEAP_FREE_FOR_STREAM_START_BYTES);
             SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
             return SCPI_RES_ERR;
         }
+    }
 
+    if (freqProvided) {
         // NQ3 Smart Frequency Management:
         // When external AD7609 channels are active WITHOUT any Type 1 MC12bADC channels,
         // force internal monitoring to 1Hz (since only monitoring channels would be streaming)

--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -58,6 +58,24 @@ extern "C" {
     #define SCPI_RESPONSE_BUF_SIZE 2048U
 
     /**
+     * #475 step 4 — minimum free heap (bytes) required to accept a new
+     * streaming session start.  Refuses SYST:STR:START when
+     * xPortGetFreeHeapSize() is below this threshold.  Designed to keep
+     * the WiFi accept() and event-callback allocation path from
+     * starving when prior pressure left the heap pinched.
+     *
+     * **10 KB chosen carefully:** boot-idle HeapFree settles around
+     * 13 KB per CLAUDE.md "Heap Allocation Map" — going above that
+     * would refuse cold-boot first-starts.  10 KB is ~3 KB above the
+     * observed #475 pinch point (~7 KB) and ~3 KB below typical idle,
+     * so it bites only when accumulated pressure has eaten meaningfully
+     * into post-boot headroom.  Not a hard guarantee that 10 KB is
+     * always enough for the WINC accept() path (we don't have its
+     * allocation profile measured); first defensive cut.
+     */
+    #define MIN_HEAP_FREE_FOR_STREAM_START_BYTES 10000U
+
+    /**
      * Acquire the shared SCPI response scratch buffer.
      * Blocks until the buffer mutex is available (portMAX_DELAY). Caller
      * MUST pair every successful Take with exactly one Give.


### PR DESCRIPTION
## Summary

Refuses `SYST:STR:START` when `xPortGetFreeHeapSize()` is below 10 KB (≈13% of the 75 KB `configTOTAL_HEAP_SIZE`). Defensive guard for the heap-pressure mechanism hypothesized in #475.

This is step 4 from the #475 issue body's "Suggested next steps". Steps 1 (observability) and 2 (heap audit) preceded; step 3 (defensive listen-socket re-open) remains.

## Why 10 KB

Tuned carefully against the heap budget documented in CLAUDE.md "Heap Allocation Map":

| State | HeapFree |
|---|---:|
| Cold-boot idle (per CLAUDE.md) | ~13 KB |
| #475 observed pinch point | ~7 KB |
| **Threshold (this PR)** | **10 KB** |

- 13 KB cold-boot idle means the floor must be **below** 13 KB or the very first stream after reboot would be refused
- 7 KB was the #475 symptom — the threshold needs to bite before the slide reaches there
- 10 KB sits between, providing a ~3 KB cushion above the pinch point while leaving ~3 KB headroom for natural post-boot heap settling

## Doesn't fix the root cause

Per #475 body: the mid-session heap drift is a separate problem. Step 3 (detect dead listen socket + self-heal) addresses the in-session case. This PR (step 4) only prevents starting a new session under pre-existing pressure — breaks the "accumulating pressure across sessions" path.

## Test plan

- [x] Build clean at -O3 + -Werror
- [ ] Bench verify: cold-boot `SYST:STR:START 1000` succeeds (heap should be ~13 KB, above floor)
- [ ] Bench verify: artificially pinch heap below 10 KB → `SYST:STR:START` returns error with diagnostic log via `SYST:LOG?`

Bench verification deferred — `/dev/ttyACM0` is in active use for the #476 v3 wireshark investigation (next).

## Epistemic discipline

- **V**: heap numbers (13 KB boot-idle, 75 KB total) from CLAUDE.md "Heap Allocation Map" section
- **V**: 7 KB pinch from #475 issue body, captured 2026-05-18
- **I**: That 10 KB is enough headroom for the WINC accept() path under typical churn — not proven, we don't have its allocation profile measured. First defensive cut; tune if it produces false-refusal noise.

Refs #475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)