### PR TITLE
feat(wifi): TCP listen-socket uptime observable (#475 step 3 prep)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2482,6 +2482,13 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
         scpi_printf(context, "WifiCirbufProduced=%u\r\n", (unsigned)cirbufProduced);
         scpi_printf(context, "WifiCirbufConsumed=%u\r\n", (unsigned)cirbufConsumed);
         scpi_printf(context, "WifiCirbufBufSize=%u\r\n", (unsigned)cirbufBufSize);
+        // #475 step 3: how long the TCP listen socket has been continuously
+        // open.  0 = currently closed.  Long values combined with the
+        // silent-failure log lines from #477 give operators a way to spot
+        // stuck listen sockets.  See #475 for the eventual periodic-recycle
+        // watchdog this enables.
+        scpi_printf(context, "WifiListenUptimeSec=%u\r\n",
+                    (unsigned)wifi_manager_GetListenSocketUptimeSec());
     }
     scpi_printf(context, "SdDroppedBytes=%u\r\n", (unsigned)s.sdDroppedBytes);
     scpi_printf(context, "SdDroppedBytesSteady=%u\r\n", (unsigned)s.sdDroppedBytesSteady);

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -126,6 +126,18 @@ static volatile TickType_t gListenSocketOpenTick = 0;
         gListenSocketOpenTick = 0;                                          \
     } while (0)
 
+// #475 step 3 — anchor the tick to xTaskGetTickCount(), coercing 0 → 1
+// so the "closed" sentinel doesn't collide on the rare wrap event.
+// At 1 kHz tick rate the 32-bit counter wraps every ~50 days; if a
+// listen socket opens exactly when the tick is 0, returning "closed" is
+// a false negative.  Same coercion pattern used elsewhere in the file
+// for other tick sentinels.
+#define ANCHOR_LISTEN_SOCKET_OPEN_TICK()                                    \
+    do {                                                                    \
+        TickType_t _t = xTaskGetTickCount();                                \
+        gListenSocketOpenTick = (_t == 0) ? 1 : _t;                         \
+    } while (0)
+
 // #353 Option 2: decouple SCPI dispatch from WINC callback context.
 // SOCKET_MSG_RECV fires on WDRV_WINC_Tasks (the WINC driver's task). Prior
 // to this change, the handler ran the whole microrl + libscpi + SCPI handler
@@ -836,6 +848,10 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
             bool wifiFwUpdateRequested = GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_REQUESTED);
 
             ResetAllEventFlags(&pInstance->eventFlags);
+            // #475 step 3 — bulk-clear includes TCP_SOCKET_OPEN flag, so
+            // pair it with the matching tick clear to keep observable in
+            // sync.
+            gListenSocketOpenTick = 0;
             pInstance->udpServerSocket = -1;
             pInstance->wdrvHandle = DRV_HANDLE_INVALID;
             pInstance->assocHandle = WDRV_WINC_ASSOC_HANDLE_INVALID;
@@ -1085,7 +1101,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     } else {
                         SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
                         // #475 step 3: anchor open-time for uptime tracking
-                        gListenSocketOpenTick = xTaskGetTickCount();
+                        ANCHOR_LISTEN_SOCKET_OPEN_TICK();
                         LOG_D("TCP server socket opened in AP mode on port %d\r\n", pInstance->pWifiSettings->tcpPort);
                     }
                 }
@@ -1129,10 +1145,14 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     LOG_E("[%s:%d]Error WiFi init", __FILE__, __LINE__);
                     break;
                 }
+                // #475 step 3: anchor open-time ONLY when we actually open
+                // the socket.  This event fires both for STA-mode connect
+                // and for AP-mode client station connect (ApEventCallback);
+                // unconditional anchoring outside the if-block would reset
+                // the uptime every time an AP client associated.
+                ANCHOR_LISTEN_SOCKET_OPEN_TICK();
             }
             SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
-            // #475 step 3: anchor open-time for uptime tracking (STA mode)
-            gListenSocketOpenTick = xTaskGetTickCount();
             SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
             break;
         case WIFI_MANAGER_EVENT_STA_DISCONNECTED:
@@ -1675,8 +1695,14 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
             pInstance->nextState = MainState;            
             if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN))
                 CloseUdpSocket(&pInstance->udpServerSocket);
-            if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN))
+            if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN)) {
                 wifi_tcp_server_CloseSocket();
+                // #475 step 3 — flag is reset by the downstream MainState
+                // ENTRY path (via ResetAllEventFlags), but clear the tick
+                // here too so the observable doesn't lag behind the actual
+                // close.
+                gListenSocketOpenTick = 0;
+            }
             if (WDRV_WINC_Status(sysObj.drvWifiWinc) != SYS_STATUS_UNINITIALIZED) {
                 WDRV_WINC_Close(pInstance->wdrvHandle);
                 pInstance->wdrvHandle = DRV_HANDLE_INVALID;
@@ -1843,6 +1869,7 @@ void wifi_manager_BootInit(void) {
     gApplyInProgress = false;
     gApplyInProgressDeadlineTick = 0;
     gApplyTeardownStartTick = 0;
+    gListenSocketOpenTick = 0;  // #475 step 3 — retained-RAM scrub
 }
 
 bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -104,6 +104,28 @@ static wifi_tcp_server_context_t gTcpServerContext;
 // Volatile flags for on-demand RSSI queries
 static volatile bool gRssiUpdatePending = false;
 
+// #475 step 3 — tracks when the TCP listen socket transitioned to OPEN.
+// Set when WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN is asserted (STA-mode
+// or AP-mode connect path); cleared to 0 at every site that resets the
+// flag.  Exposed via wifi_manager_GetListenSocketUptimeSec() for the
+// SCPI STATS response — gives observers a measurable for "how long has
+// this listen socket been continuously open?", which is the prerequisite
+// for the eventual periodic-recycle policy (#475 step 3 next iteration).
+//
+// 32-bit volatile read/write is atomic on PIC32MZ — no critical section
+// needed.  Single writer (wifi_manager_ProcessState on app_WifiTask pri 2).
+static volatile TickType_t gListenSocketOpenTick = 0;
+
+// #475 step 3 — paired reset of the TCP_SOCKET_OPEN flag + the open-tick
+// tracker.  Wrapping the 5 reset sites in a helper keeps them in sync if
+// future code adds another reset path.
+#define RESET_TCP_SOCKET_OPEN(pInstance)                                    \
+    do {                                                                    \
+        ResetEventFlag(&(pInstance)->eventFlags,                            \
+                       WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);            \
+        gListenSocketOpenTick = 0;                                          \
+    } while (0)
+
 // #353 Option 2: decouple SCPI dispatch from WINC callback context.
 // SOCKET_MSG_RECV fires on WDRV_WINC_Tasks (the WINC driver's task). Prior
 // to this change, the handler ran the whole microrl + libscpi + SCPI handler
@@ -1062,6 +1084,8 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                         LOG_E("Failed to open TCP server socket in AP mode\r\n");
                     } else {
                         SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
+                        // #475 step 3: anchor open-time for uptime tracking
+                        gListenSocketOpenTick = xTaskGetTickCount();
                         LOG_D("TCP server socket opened in AP mode on port %d\r\n", pInstance->pWifiSettings->tcpPort);
                     }
                 }
@@ -1107,6 +1131,8 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 }
             }
             SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
+            // #475 step 3: anchor open-time for uptime tracking (STA mode)
+            gListenSocketOpenTick = xTaskGetTickCount();
             SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
             break;
         case WIFI_MANAGER_EVENT_STA_DISCONNECTED:
@@ -1114,7 +1140,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
             ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
             CloseUdpSocket(&pInstance->udpServerSocket);
             wifi_tcp_server_CloseSocket();
-            ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
+            RESET_TCP_SOCKET_OPEN(pInstance);
             ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
             
             // Clear signal strength on disconnect
@@ -1196,7 +1222,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // Close sockets before stopping AP
                     CloseUdpSocket(&pInstance->udpServerSocket);
                     wifi_tcp_server_CloseSocket();
-                    ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
+                    RESET_TCP_SOCKET_OPEN(pInstance);
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
                     
                     WDRV_WINC_APStop(pInstance->wdrvHandle);
@@ -1317,7 +1343,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     // Close sockets before stopping AP
                     CloseUdpSocket(&pInstance->udpServerSocket);
                     wifi_tcp_server_CloseSocket();
-                    ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
+                    RESET_TCP_SOCKET_OPEN(pInstance);
                     ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
                     
                     WDRV_WINC_APStop(pInstance->wdrvHandle);
@@ -1346,7 +1372,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 // Close sockets before stopping AP
                 CloseUdpSocket(&pInstance->udpServerSocket);
                 wifi_tcp_server_CloseSocket();
-                ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
+                RESET_TCP_SOCKET_OPEN(pInstance);
                 ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
                 
                 // Stop current AP
@@ -1503,7 +1529,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                         // earlier speculative wrap was inappropriate.  Also
                         // clear UDP_SOCKET_CONNECTED so it doesn't outlast
                         // UDP_SOCKET_OPEN.
-                        ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN);
+                        RESET_TCP_SOCKET_OPEN(pInstance);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_CONNECTED);
                         ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
@@ -2335,6 +2361,16 @@ void wifi_manager_ProcessStateNoTcpRx(void) {
 
 wifi_tcp_server_context_t* wifi_manager_GetTcpServerContext() {
     return gStateMachineContext.pTcpServerContext;
+}
+
+uint32_t wifi_manager_GetListenSocketUptimeSec(void) {
+    // #475 step 3: report seconds the TCP listen socket has been
+    // continuously open.  Returns 0 when not open.  The prerequisite
+    // observable for an eventual periodic-recycle watchdog (next iter).
+    TickType_t openTick = gListenSocketOpenTick;
+    if (openTick == 0) return 0;
+    TickType_t elapsed = xTaskGetTickCount() - openTick;
+    return (uint32_t)(elapsed / configTICK_RATE_HZ);
 }
 
 void wifi_manager_RequestWifiFirmwareUpdate(void) {

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -307,6 +307,19 @@ extern "C" {
     wifi_tcp_server_context_t* wifi_manager_GetTcpServerContext();
 
     /**
+     * Returns the number of seconds the TCP listen socket has been
+     * continuously open, or 0 if it is currently closed.  Set when
+     * WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN is asserted; cleared via
+     * the internal RESET_TCP_SOCKET_OPEN helper at every site that
+     * resets the flag.
+     *
+     * Observable prerequisite for the eventual #475 step 3 periodic-
+     * recycle watchdog — lets operators spot a stuck listen socket
+     * even when other SCPI fields report healthy state.
+     */
+    uint32_t wifi_manager_GetListenSocketUptimeSec(void);
+
+    /**
      * @brief Formats a UDP announcement packet with the provided WiFi settings.
      * 
      * This callback function prepares a UDP packet containing relevant network information, such as IP address,


### PR DESCRIPTION
Adds WifiListenUptimeSec to SYST:STR:STATS? — seconds the TCP listen socket has been continuously open (0 = closed). Observability prerequisite for the eventual #475 step 3 periodic-recycle watchdog.

Pure observability, no behavior change. Build clean at -O3 + -Werror. Wiki updated (c1d2ca1).

Refs #475.