### PR TITLE
feat(sd): iterative directory listing with bounded depth (#351)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -880,7 +880,7 @@ The PIC32MZ2048**EF**M144 has a hardware 64-bit double-precision FPU (Coprocesso
 
 Stack sizes profiled under stress: 16ch@5kHz PB/CSV/JSON + SD file ops + WiFi TCP + power cycles. Sized at 2-3x measured peak. Query at runtime: `SYST:MEM:STACk?`
 
-**WARNING**: If recursive SD directory listing is enabled, `app_SDCardTask` needs 10KB+ (~550 bytes per nesting level).
+**Note**: SD directory listing uses iterative traversal with a bounded BSS-backed stack (`SD_CARD_MANAGER_MAX_LIST_DEPTH = 16`, ~4.3 KB total). Task stack usage is O(1) regardless of FAT32 tree depth. Trees deeper than 16 levels emit a diagnostic and skip the subtree.
 
 **SCPI shared response buffer**: Any SCPI callback needing ≥256 B of scratch MUST use `SCPI_ResponseBuf_Take()` / `SCPI_ResponseBuf_Give()` rather than a stack local. The shared buffer is a single 2048-byte static in BSS guarded by a statically-allocated mutex (`configSUPPORT_STATIC_ALLOCATION=1`). Rationale: WifiTask's stack is only 1024 words; the TCP → microrl → libscpi path consumes ~808 words before the callback runs, so a large stack-local buffer inside a SCPI callback can overflow (issue #347). Callers that use the shared pattern keep SCPI stack depth below the measured 372-word WifiTask peak. Current users: `SCPI_SysInfoGet`, `SCPI_SysInfoTextGet`, `SCPI_GetCommandHistory`, `SCPI_Help`, `SCPI_StorageSDBenchmark`.
 

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -310,8 +310,11 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
             SYS_FS_ERROR err = SYS_FS_Error();
             LOG_E("[SD] ListFiles: Failed to read directory '%s', error=%d",
                   gListDirStack[sp].path, err);
-            strBuffIndex += snprintf((char *) pStrBuff + strBuffIndex, strBuffSize - strBuffIndex,
+            int errN = snprintf((char *) pStrBuff + strBuffIndex, strBuffSize - strBuffIndex,
                     "\r\n[Error:%d]Failed to read directory\r\n", err);
+            if (errN > 0 && (size_t)errN < strBuffSize - strBuffIndex) {
+                strBuffIndex += (size_t)errN;
+            }
             SYS_FS_DirClose(gListDirStack[sp].handle);
             sp--;
             continue;
@@ -337,12 +340,15 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
 
         if (stat.fattrib & SYS_FS_ATTR_DIR) {
             if (sp + 1 >= SD_CARD_MANAGER_MAX_LIST_DEPTH) {
-                LOG_E("[SD] ListFiles: max depth %d reached at '%s', skipping subtree",
+                LOG_E("[SD] ListFiles: max depth %d reached at '%s', listing truncated",
                       SD_CARD_MANAGER_MAX_LIST_DEPTH, newPath);
-                strBuffIndex += snprintf((char *) pStrBuff + strBuffIndex,
+                int depthN = snprintf((char *) pStrBuff + strBuffIndex,
                         strBuffSize - strBuffIndex,
-                        "\r\n[Warn]Max depth %d reached, skipping [%s]\r\n",
+                        "\r\n[Error]Listing truncated: max depth %d reached at [%s]\r\n",
                         SD_CARD_MANAGER_MAX_LIST_DEPTH, newPath);
+                if (depthN > 0 && (size_t)depthN < strBuffSize - strBuffIndex) {
+                    strBuffIndex += (size_t)depthN;
+                }
                 continue;
             }
             LOG_D("[SD] ListFiles: Descending into '%s'\r\n", newPath);

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -310,12 +310,23 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
             SYS_FS_ERROR err = SYS_FS_Error();
             LOG_E("[SD] ListFiles: Failed to read directory '%s', error=%d",
                   gListDirStack[sp].path, err);
+            // Pre-flush if the diagnostic won't fit, so it's never silently dropped.
+            int needed = snprintf(NULL, 0, "\r\n[Error:%d]Failed to read directory\r\n", err);
+            if (needed > 0 && sendChunk && strBuffIndex > 0
+                    && (size_t)needed >= strBuffSize - strBuffIndex) {
+                pStrBuff[strBuffIndex] = '\0';
+                sendChunk(pStrBuff, strBuffIndex);
+                strBuffIndex = 0;
+            }
             int errN = snprintf((char *) pStrBuff + strBuffIndex, strBuffSize - strBuffIndex,
                     "\r\n[Error:%d]Failed to read directory\r\n", err);
             if (errN > 0 && (size_t)errN < strBuffSize - strBuffIndex) {
                 strBuffIndex += (size_t)errN;
             }
-            SYS_FS_DirClose(gListDirStack[sp].handle);
+            if (SYS_FS_DirClose(gListDirStack[sp].handle) == SYS_FS_RES_FAILURE) {
+                LOG_E("[SD] ListFiles: Failed to close directory '%s', error=%d",
+                      gListDirStack[sp].path, SYS_FS_Error());
+            }
             sp--;
             continue;
         }
@@ -342,6 +353,16 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
             if (sp + 1 >= SD_CARD_MANAGER_MAX_LIST_DEPTH) {
                 LOG_E("[SD] ListFiles: max depth %d reached at '%s', listing truncated",
                       SD_CARD_MANAGER_MAX_LIST_DEPTH, newPath);
+                // Pre-flush if the diagnostic won't fit, so it's never silently dropped.
+                int needed = snprintf(NULL, 0,
+                        "\r\n[Error]Listing truncated: max depth %d reached at [%s]\r\n",
+                        SD_CARD_MANAGER_MAX_LIST_DEPTH, newPath);
+                if (needed > 0 && sendChunk && strBuffIndex > 0
+                        && (size_t)needed >= strBuffSize - strBuffIndex) {
+                    pStrBuff[strBuffIndex] = '\0';
+                    sendChunk(pStrBuff, strBuffIndex);
+                    strBuffIndex = 0;
+                }
                 int depthN = snprintf((char *) pStrBuff + strBuffIndex,
                         strBuffSize - strBuffIndex,
                         "\r\n[Error]Listing truncated: max depth %d reached at [%s]\r\n",

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -346,8 +346,13 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
             continue;
         }
 
-        snprintf(newPath, SD_CARD_MANAGER_FILE_PATH_LEN_MAX, "%s/%s",
-                 gListDirStack[sp].path, stat.fname);
+        int pn = snprintf(newPath, sizeof(newPath), "%s/%s",
+                          gListDirStack[sp].path, stat.fname);
+        if (pn < 0 || (size_t)pn >= sizeof(newPath)) {
+            LOG_E("[SD] ListFiles: Path too long, skipping '%s/%s'",
+                  gListDirStack[sp].path, stat.fname);
+            continue;
+        }
 
         if (stat.fattrib & SYS_FS_ATTR_DIR) {
             if (sp + 1 >= SD_CARD_MANAGER_MAX_LIST_DEPTH) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -303,7 +303,19 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
 
     sp = 0;
     gListDirStack[sp].handle = rootHandle;
-    snprintf(gListDirStack[sp].path, sizeof(gListDirStack[sp].path), "%s", dirPath);
+    int rootPn = snprintf(gListDirStack[sp].path, sizeof(gListDirStack[sp].path), "%s", dirPath);
+    if (rootPn < 0 || (size_t)rootPn >= sizeof(gListDirStack[sp].path)) {
+        LOG_E("[SD] ListFiles: Root path too long, aborting list");
+        if (SYS_FS_DirClose(rootHandle) == SYS_FS_RES_FAILURE) {
+            LOG_E("[SD] ListFiles: Failed to close directory, error=%d", SYS_FS_Error());
+        }
+        strBuffIndex += snprintf((char *)pStrBuff + strBuffIndex, strBuffSize - strBuffIndex,
+                "\r\n[Error]Directory path too long\r\n");
+        if (sendChunk && strBuffIndex > 0) {
+            sendChunk(pStrBuff, strBuffIndex);
+        }
+        return;
+    }
 
     while (sp >= 0) {
         if (SYS_FS_DirRead(gListDirStack[sp].handle, &stat) == SYS_FS_RES_FAILURE) {
@@ -311,9 +323,9 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
             LOG_E("[SD] ListFiles: Failed to read directory '%s', error=%d",
                   gListDirStack[sp].path, err);
             // Pre-flush if the diagnostic won't fit, so it's never silently dropped.
-            int needed = snprintf(NULL, 0, "\r\n[Error:%d]Failed to read directory\r\n", err);
-            if (needed > 0 && sendChunk && strBuffIndex > 0
-                    && (size_t)needed >= strBuffSize - strBuffIndex) {
+            // Worst-case length: constant text + up to 10 digits (err) + CRLF.
+            size_t needed = sizeof("\r\n[Error:]Failed to read directory\r\n") - 1U + 10U + 2U;
+            if (sendChunk && strBuffIndex > 0 && needed >= (strBuffSize - strBuffIndex)) {
                 pStrBuff[strBuffIndex] = '\0';
                 sendChunk(pStrBuff, strBuffIndex);
                 strBuffIndex = 0;
@@ -359,11 +371,10 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
                 LOG_E("[SD] ListFiles: max depth %d reached at '%s', listing truncated",
                       SD_CARD_MANAGER_MAX_LIST_DEPTH, newPath);
                 // Pre-flush if the diagnostic won't fit, so it's never silently dropped.
-                int needed = snprintf(NULL, 0,
-                        "\r\n[Error]Listing truncated: max depth %d reached at [%s]\r\n",
-                        SD_CARD_MANAGER_MAX_LIST_DEPTH, newPath);
-                if (needed > 0 && sendChunk && strBuffIndex > 0
-                        && (size_t)needed >= strBuffSize - strBuffIndex) {
+                // Worst-case length: constant text + 10 digits (depth) + path + CRLF.
+                size_t needed = sizeof("\r\n[Error]Listing truncated: max depth  reached at []\r\n")
+                              - 1U + 10U + strlen(newPath) + 2U;
+                if (sendChunk && strBuffIndex > 0 && needed >= (strBuffSize - strBuffIndex)) {
                     pStrBuff[strBuffIndex] = '\0';
                     sendChunk(pStrBuff, strBuffIndex);
                     strBuffIndex = 0;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -391,10 +391,13 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
         }
 
         LOG_D("[SD] ListFiles: Found file '%s'\r\n", newPath);
-        int n = snprintf(NULL, 0, "%s\r\n", newPath);  // Calculate length needed
+        // Conservative length estimate for the entry "<path> <size>\r\n":
+        // path + ' ' + up to 10 digits (UINT32 max) + \r\n
+        size_t estLen = strlen(newPath) + 1U + 10U + 2U;
+        int n;
 
         // Check if buffer is getting full - need space for this entry
-        if (n > 0 && (strBuffIndex + n) >= (strBuffSize - 4)) {
+        if ((strBuffIndex + estLen) >= (strBuffSize - 4)) {
             // Send current chunk before adding this entry
             if (sendChunk && strBuffIndex > 0) {
                 pStrBuff[strBuffIndex] = '\0';

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -323,8 +323,8 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
             LOG_E("[SD] ListFiles: Failed to read directory '%s', error=%d",
                   gListDirStack[sp].path, err);
             // Pre-flush if the diagnostic won't fit, so it's never silently dropped.
-            // Worst-case length: constant text + up to 10 digits (err) + CRLF.
-            size_t needed = sizeof("\r\n[Error:]Failed to read directory\r\n") - 1U + 10U + 2U;
+            // Worst-case length: sizeof literal (already includes both CRLFs and NUL) - 1 + 10 digits (err).
+            const size_t needed = sizeof("\r\n[Error:]Failed to read directory\r\n") - 1U + 10U;
             if (sendChunk && strBuffIndex > 0 && needed >= (strBuffSize - strBuffIndex)) {
                 pStrBuff[strBuffIndex] = '\0';
                 sendChunk(pStrBuff, strBuffIndex);
@@ -371,9 +371,9 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
                 LOG_E("[SD] ListFiles: max depth %d reached at '%s', listing truncated",
                       SD_CARD_MANAGER_MAX_LIST_DEPTH, newPath);
                 // Pre-flush if the diagnostic won't fit, so it's never silently dropped.
-                // Worst-case length: constant text + 10 digits (depth) + path + CRLF.
-                size_t needed = sizeof("\r\n[Error]Listing truncated: max depth  reached at []\r\n")
-                              - 1U + 10U + strlen(newPath) + 2U;
+                // Worst-case length: sizeof literal (already includes both CRLFs and NUL) - 1 + 10 digits + path.
+                const size_t needed = sizeof("\r\n[Error]Listing truncated: max depth  reached at []\r\n")
+                                    - 1U + 10U + strlen(newPath);
                 if (sendChunk && strBuffIndex > 0 && needed >= (strBuffSize - strBuffIndex)) {
                     pStrBuff[strBuffIndex] = '\0';
                     sendChunk(pStrBuff, strBuffIndex);

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -15,6 +15,10 @@
 // SD_CARD_MANAGER_DISK_DEV_NAME is now in header for external use
 #define SD_CARD_MANAGER_MAX_SPLIT_FILES    9999
 
+// Iterative directory listing — bounded BSS-backed stack instead of recursion.
+// 16 levels covers any realistic FAT32 tree without growing the task stack.
+#define SD_CARD_MANAGER_MAX_LIST_DEPTH     16
+
 // File read transfer constants
 #define SD_READ_MAX_CHUNK_SIZE      16384U  // Maximum read size (16KB) - tested maximum for stability
 #define SD_READ_ALIGNMENT_SIZE      4096U   // Chunk alignment (4KB) - matches USB transfer granularity
@@ -264,17 +268,29 @@ static void sd_listdir_send_chunk(const uint8_t* data, size_t len) {
     }
 }
 
+// Iterative directory listing — explicit stack instead of function recursion.
+// Each frame holds the open directory handle plus the path string used to
+// build child paths during enumeration.  The stack lives in BSS so deep
+// trees don't grow the SD task stack (see #351).
+typedef struct {
+    SYS_FS_HANDLE handle;
+    char path[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
+} ListDirFrame;
+
+static ListDirFrame gListDirStack[SD_CARD_MANAGER_MAX_LIST_DEPTH];
+
 static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, size_t strBuffSize, ListChunkCallback sendChunk) {
     SYS_FS_FSTAT stat;
     size_t strBuffIndex = 0;
-    SYS_FS_HANDLE dirHandle;
     char newPath[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
+    int sp = -1;  // Stack pointer: -1 = empty, 0..MAX-1 = current frame
 
     memset(newPath, 0, sizeof (newPath));
     memset(&stat, 0, sizeof (stat));
     LOG_D("[SD] ListFiles: Opening directory '%s'\r\n", dirPath);
-    dirHandle = SYS_FS_DirOpen(dirPath);
-    if (dirHandle == SYS_FS_HANDLE_INVALID) {
+
+    SYS_FS_HANDLE rootHandle = SYS_FS_DirOpen(dirPath);
+    if (rootHandle == SYS_FS_HANDLE_INVALID) {
         SYS_FS_ERROR err = SYS_FS_Error();
         LOG_E("[SD] ListFiles: Failed to open directory '%s', error=%d\r\n", dirPath, err);
         strBuffIndex += snprintf((char *) pStrBuff + strBuffIndex, strBuffSize - strBuffIndex,
@@ -285,18 +301,29 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
         return;
     }
 
-    while (true) {
-        if (SYS_FS_DirRead(dirHandle, &stat) == SYS_FS_RES_FAILURE) {
+    sp = 0;
+    gListDirStack[sp].handle = rootHandle;
+    snprintf(gListDirStack[sp].path, sizeof(gListDirStack[sp].path), "%s", dirPath);
+
+    while (sp >= 0) {
+        if (SYS_FS_DirRead(gListDirStack[sp].handle, &stat) == SYS_FS_RES_FAILURE) {
             SYS_FS_ERROR err = SYS_FS_Error();
-            LOG_E("[SD] ListFiles: Failed to read directory, error=%d", err);
+            LOG_E("[SD] ListFiles: Failed to read directory '%s', error=%d",
+                  gListDirStack[sp].path, err);
             strBuffIndex += snprintf((char *) pStrBuff + strBuffIndex, strBuffSize - strBuffIndex,
                     "\r\n[Error:%d]Failed to read directory\r\n", err);
-            break;
+            SYS_FS_DirClose(gListDirStack[sp].handle);
+            sp--;
+            continue;
         }
 
         if (stat.fname[0] == '\0') {
-            LOG_D("[SD] ListFiles: End of directory\r\n");
-            break;
+            LOG_D("[SD] ListFiles: End of directory '%s'\r\n", gListDirStack[sp].path);
+            if (SYS_FS_DirClose(gListDirStack[sp].handle) == SYS_FS_RES_FAILURE) {
+                LOG_E("[SD] ListFiles: Failed to close directory, error=%d", SYS_FS_Error());
+            }
+            sp--;
+            continue;
         }
 
         LOG_D("[SD] ListFiles: Read entry '%s'\r\n", stat.fname);
@@ -305,45 +332,64 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
             continue;
         }
 
-        snprintf(newPath, SD_CARD_MANAGER_FILE_PATH_LEN_MAX, "%s/%s", dirPath, stat.fname);
+        snprintf(newPath, SD_CARD_MANAGER_FILE_PATH_LEN_MAX, "%s/%s",
+                 gListDirStack[sp].path, stat.fname);
 
         if (stat.fattrib & SYS_FS_ATTR_DIR) {
-            // For subdirectories, recursively list (skip for now to keep simple)
-            LOG_D("[SD] ListFiles: Skipping subdirectory '%s'\r\n", newPath);
-        } else {
-            LOG_D("[SD] ListFiles: Found file '%s'\r\n", newPath);
-            int n = snprintf(NULL, 0, "%s\r\n", newPath);  // Calculate length needed
-
-            // Check if buffer is getting full - need space for this entry
-            if (n > 0 && (strBuffIndex + n) >= (strBuffSize - 4)) {
-                // Send current chunk before adding this entry
-                if (sendChunk && strBuffIndex > 0) {
-                    pStrBuff[strBuffIndex] = '\0';
-                    sendChunk(pStrBuff, strBuffIndex);
-                    strBuffIndex = 0;  // Reset buffer for next chunk
-                }
+            if (sp + 1 >= SD_CARD_MANAGER_MAX_LIST_DEPTH) {
+                LOG_E("[SD] ListFiles: max depth %d reached at '%s', skipping subtree",
+                      SD_CARD_MANAGER_MAX_LIST_DEPTH, newPath);
+                strBuffIndex += snprintf((char *) pStrBuff + strBuffIndex,
+                        strBuffSize - strBuffIndex,
+                        "\r\n[Warn]Max depth %d reached, skipping [%s]\r\n",
+                        SD_CARD_MANAGER_MAX_LIST_DEPTH, newPath);
+                continue;
             }
+            LOG_D("[SD] ListFiles: Descending into '%s'\r\n", newPath);
+            SYS_FS_HANDLE childHandle = SYS_FS_DirOpen(newPath);
+            if (childHandle == SYS_FS_HANDLE_INVALID) {
+                SYS_FS_ERROR err = SYS_FS_Error();
+                LOG_E("[SD] ListFiles: Failed to open subdir '%s', error=%d", newPath, err);
+                continue;
+            }
+            sp++;
+            gListDirStack[sp].handle = childHandle;
+            snprintf(gListDirStack[sp].path, sizeof(gListDirStack[sp].path), "%s", newPath);
+            continue;
+        }
 
-            // Now add the filename and size to buffer (space-separated)
-            n = snprintf((char *) pStrBuff + strBuffIndex, strBuffSize - strBuffIndex,
-                    "%s %u\r\n", newPath, (unsigned)stat.fsize);
-            if (n > 0 && (size_t)n < strBuffSize - strBuffIndex) {
-                strBuffIndex += (size_t)n;
-            } else {
-                // Entry doesn't fit - flush buffer and retry with fresh buffer
-                if (sendChunk && strBuffIndex > 0) {
-                    pStrBuff[strBuffIndex] = '\0';
-                    sendChunk(pStrBuff, strBuffIndex);
-                    strBuffIndex = 0;
+        LOG_D("[SD] ListFiles: Found file '%s'\r\n", newPath);
+        int n = snprintf(NULL, 0, "%s\r\n", newPath);  // Calculate length needed
 
-                    // Retry with fresh buffer
-                    n = snprintf((char *) pStrBuff, strBuffSize,
-                                "%s %u\r\n", newPath, (unsigned)stat.fsize);
-                    if (n > 0 && (size_t)n < strBuffSize) {
-                        strBuffIndex = (size_t)n;
-                    }
-                    // If still doesn't fit, entry is too large for buffer (skip it)
+        // Check if buffer is getting full - need space for this entry
+        if (n > 0 && (strBuffIndex + n) >= (strBuffSize - 4)) {
+            // Send current chunk before adding this entry
+            if (sendChunk && strBuffIndex > 0) {
+                pStrBuff[strBuffIndex] = '\0';
+                sendChunk(pStrBuff, strBuffIndex);
+                strBuffIndex = 0;  // Reset buffer for next chunk
+            }
+        }
+
+        // Now add the filename and size to buffer (space-separated)
+        n = snprintf((char *) pStrBuff + strBuffIndex, strBuffSize - strBuffIndex,
+                "%s %u\r\n", newPath, (unsigned)stat.fsize);
+        if (n > 0 && (size_t)n < strBuffSize - strBuffIndex) {
+            strBuffIndex += (size_t)n;
+        } else {
+            // Entry doesn't fit - flush buffer and retry with fresh buffer
+            if (sendChunk && strBuffIndex > 0) {
+                pStrBuff[strBuffIndex] = '\0';
+                sendChunk(pStrBuff, strBuffIndex);
+                strBuffIndex = 0;
+
+                // Retry with fresh buffer
+                n = snprintf((char *) pStrBuff, strBuffSize,
+                            "%s %u\r\n", newPath, (unsigned)stat.fsize);
+                if (n > 0 && (size_t)n < strBuffSize) {
+                    strBuffIndex = (size_t)n;
                 }
+                // If still doesn't fit, entry is too large for buffer (skip it)
             }
         }
     }
@@ -358,10 +404,6 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
             pStrBuff[strBuffIndex] = '\0';
             sendChunk(pStrBuff, strBuffIndex);
         }
-    }
-
-    if (SYS_FS_DirClose(dirHandle) == SYS_FS_RES_FAILURE) {
-        LOG_E("[SD] ListFiles: Failed to close directory, error=%d", SYS_FS_Error());
     }
 }
 


### PR DESCRIPTION
## Summary

- Convert `ListFilesInDirectoryChunked` to iterative traversal with a bounded BSS-backed stack instead of function recursion.
- Enable the previously-disabled subdirectory descent (closes #351).
- Update `CLAUDE.md` to replace the "10 KB+ recursive stack" warning with the iterative-design note.

## Why

The recursive descent was disabled because each level consumed ~550 B of task stack and `app_SDCardTask` is only 1024 words. Bumping the stack was the wrong fix — it scales with FAT32 depth and we can't bound it. The iterative version uses a fixed BSS frame array (`gListDirStack[16]`, ~4.2 KB) so task-stack usage is O(1) regardless of tree depth.

## What changed

- New `SD_CARD_MANAGER_MAX_LIST_DEPTH = 16` constant.
- New `ListDirFrame` struct + static `gListDirStack[]` array (handle + path per frame).
- Function rewritten as a `while (sp >= 0)` loop with explicit push/pop on `SYS_FS_ATTR_DIR` entries.
- Trees deeper than 16 levels emit a `[Warn]Max depth N reached, skipping [path]` line and continue with the next sibling rather than overflowing.
- Existing chunked-output flush logic (sendChunk + index reset) ports over unchanged.

## Test plan
- [x] Build clean at `-O3 -Werror` (XC32 v4.60).
- [x] Flash to bench primary (PIC32MZ2048EFM144, serial `7E2898F46200E8A7`).
- [x] `SYST:STORage:SD:LISt?` returns full file listing now traversing into `DAQiFi/` subdirectory — 22 entries enumerated where pre-change the directory was silently skipped.
- [x] `SYST:MEM:STACk?` post-listing: `SDCardTask hwm=560 words`, 2240 bytes free — comfortably under the 1024-word allocation.
- [ ] Functional test against a deeper tree (≥3 levels) if available — not exercised on the bench's current SD card content.
