### PR TITLE
feat(streaming): extend 3 s startup grace to all drop counters (#450 follow-up)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2442,6 +2442,7 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
     scpi_printf(context, "TotalSamplesStreamed=%llu\r\n", (unsigned long long)s.totalSamplesStreamed);
     scpi_printf(context, "TotalBytesStreamed=%llu\r\n", (unsigned long long)s.totalBytesStreamed);
     scpi_printf(context, "QueueDroppedSamples=%u\r\n", (unsigned)s.queueDroppedSamples);
+    scpi_printf(context, "QueueDroppedSamplesSteady=%u\r\n", (unsigned)s.queueDroppedSamplesSteady);
     scpi_printf(context, "UsbDroppedBytes=%u\r\n", (unsigned)s.usbDroppedBytes);
     scpi_printf(context, "UsbDroppedBytesSteady=%u\r\n", (unsigned)s.usbDroppedBytesSteady);
     scpi_printf(context, "WifiDroppedBytes=%u\r\n", (unsigned)s.wifiDroppedBytes);
@@ -2503,8 +2504,11 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
         scpi_printf(context, "SdWriteAlignedCopies=%u\r\n", (unsigned)sdm.writeAlignedCopies);
     }
     scpi_printf(context, "EncoderFailures=%u\r\n", (unsigned)s.encoderFailures);
+    scpi_printf(context, "EncoderFailuresSteady=%u\r\n", (unsigned)s.encoderFailuresSteady);
     scpi_printf(context, "EncoderDroppedSamples=%u\r\n", (unsigned)s.encoderDroppedSamples);
+    scpi_printf(context, "EncoderDroppedSamplesSteady=%u\r\n", (unsigned)s.encoderDroppedSamplesSteady);
     scpi_printf(context, "DioDroppedSamples=%u\r\n", (unsigned)s.dioDroppedSamples);
+    scpi_printf(context, "DioDroppedSamplesSteady=%u\r\n", (unsigned)s.dioDroppedSamplesSteady);
     scpi_printf(context, "EosOverruns=%u\r\n", (unsigned)s.eosOverruns);
     // Timer ISR tracking (#265): actual ISR entry count this session (64-bit
     // so it never wraps in practice). Compare against (TotalSamplesStreamed

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1080,14 +1080,18 @@ static void Streaming_Stop(void) {
                 (unsigned)gStreamStats.circularBufferEndBytes);
         }
 
-        // Log session summary if any data was lost
-        bool hadDrops = gStreamStats.queueDroppedSamples > 0 ||
-                        gStreamStats.usbDroppedBytes > 0 ||
-                        gStreamStats.wifiDroppedBytes > 0 ||
-                        gStreamStats.sdDroppedBytes > 0 ||
-                        gStreamStats.encoderFailures > 0 ||
-                        gStreamStats.dioDroppedSamples > 0 ||
-                        gStreamStats.eosOverruns > 0;
+        // Log session summary if any data was lost.
+        // Gate on STEADY counters so startup-window transients (within
+        // gLossGraceSec, default 3 s) don't produce misleading end-of-
+        // session error logs.  Total counters are still available via
+        // SYST:STR:STATS? for forensic diagnostic.
+        bool hadDrops = gStreamStats.queueDroppedSamplesSteady > 0 ||
+                        gStreamStats.usbDroppedBytesSteady > 0 ||
+                        gStreamStats.wifiDroppedBytesSteady > 0 ||
+                        gStreamStats.sdDroppedBytesSteady > 0 ||
+                        gStreamStats.encoderFailuresSteady > 0 ||
+                        gStreamStats.dioDroppedSamplesSteady > 0 ||
+                        gStreamStats.eosOverruns > 0;  // no Steady variant — hw staleness, not a grace-window false flag
         // Clear runtime overflow / data-loss condition bits — they refer to
         // the live session that just ended.  Preserve QUES_BIT_TRANSPORT_DOWN
         // (#397) because it captures the REASON streaming stopped; clearing
@@ -1107,22 +1111,24 @@ static void Streaming_Stop(void) {
                                      gStreamStats.queueDroppedSamples;
             // EOS coalescing is data staleness (ADC register overwrite),
             // not a dropped sample — exclude from loss total/percentage.
-            uint32_t totalSampleLoss = gStreamStats.queueDroppedSamples +
-                                      gStreamStats.encoderDroppedSamples +
-                                      gStreamStats.dioDroppedSamples;
+            // Steady counters for the loss math: startup-window transients
+            // shouldn't inflate the reported loss percent.
+            uint32_t totalSampleLoss = gStreamStats.queueDroppedSamplesSteady +
+                                      gStreamStats.encoderDroppedSamplesSteady +
+                                      gStreamStats.dioDroppedSamplesSteady;
             uint32_t lossPercent = totalAttempted > 0
                 ? (uint32_t)((totalSampleLoss * 100ULL) / totalAttempted)
                 : 0;
-            LOG_E("Stream end: lost %u/%llu samples (%u%%), USB=%u WiFi=%u SD=%u bytes, encFail=%u encDrop=%u dioDrop=%u eos=%u",
+            LOG_E("Stream end: lost %u/%llu samples (%u%%), USB=%u WiFi=%u SD=%u bytes, encFail=%u encDrop=%u dioDrop=%u eos=%u (all post-grace)",
                   (unsigned)totalSampleLoss,
                   (unsigned long long)totalAttempted,
                   (unsigned)lossPercent,
-                  (unsigned)gStreamStats.usbDroppedBytes,
-                  (unsigned)gStreamStats.wifiDroppedBytes,
-                  (unsigned)gStreamStats.sdDroppedBytes,
-                  (unsigned)gStreamStats.encoderFailures,
-                  (unsigned)gStreamStats.encoderDroppedSamples,
-                  (unsigned)gStreamStats.dioDroppedSamples,
+                  (unsigned)gStreamStats.usbDroppedBytesSteady,
+                  (unsigned)gStreamStats.wifiDroppedBytesSteady,
+                  (unsigned)gStreamStats.sdDroppedBytesSteady,
+                  (unsigned)gStreamStats.encoderFailuresSteady,
+                  (unsigned)gStreamStats.encoderDroppedSamplesSteady,
+                  (unsigned)gStreamStats.dioDroppedSamplesSteady,
                   (unsigned)gStreamStats.eosOverruns);
         }
     }

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -452,7 +452,13 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             // No heap check needed - pool uses pre-allocated static memory
             pPublicSampleList = AInSampleList_AllocateFromPool();
             if(pPublicSampleList==NULL) {
+                bool pastGrace = Streaming_PastStartupGrace();
+                taskENTER_CRITICAL();
                 gStreamStats.queueDroppedSamples++;
+                if (pastGrace) {
+                    gStreamStats.queueDroppedSamplesSteady++;
+                }
+                taskEXIT_CRITICAL();
                 LOG_E_SESSION(LOG_SESSION_POOL_EXHAUST, "Streaming: Sample pool exhausted");
                 Streaming_UpdateFlowWindow(true);
                 // Still increment test pattern counter to stay in sync
@@ -556,7 +562,13 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                 }
             }
             if(!AInSampleList_PushBack(pPublicSampleList)){//failed pushing to Q
+                bool pastGrace = Streaming_PastStartupGrace();
+                taskENTER_CRITICAL();
                 gStreamStats.queueDroppedSamples++;
+                if (pastGrace) {
+                    gStreamStats.queueDroppedSamplesSteady++;
+                }
+                taskEXIT_CRITICAL();
                 LOG_E_SESSION(LOG_SESSION_QUEUE_OVERFLOW, "Streaming: Sample queue overflow detected");
                 AInSampleList_FreeToPool(pPublicSampleList);  // Use pool!
                 Streaming_UpdateFlowWindow(true);
@@ -1321,7 +1333,13 @@ uint32_t Streaming_GetQuesBits(void) {
 }
 
 void Streaming_IncrDioDropped(void) {
+    bool pastGrace = Streaming_PastStartupGrace();
+    taskENTER_CRITICAL();
     gStreamStats.dioDroppedSamples++;  // Single writer (deferred ISR task, pri 8)
+    if (pastGrace) {
+        gStreamStats.dioDroppedSamplesSteady++;
+    }
+    taskEXIT_CRITICAL();
 }
 
 void Streaming_IncrEosOverruns(uint32_t missed) {
@@ -1612,7 +1630,7 @@ void streaming_Task(void) {
             DioProbe_PulseEnd(8);
         }
         if (packetSize == 0 && nanopbFlag.Size > 0 && (AINDataAvailable || DIODataAvailable)) {
-            gStreamStats.encoderFailures++;
+            bool pastGrace = Streaming_PastStartupGrace();
             // Each encoder pops exactly 1 sample per call. On failure that
             // sample is freed back to the pool but its data is lost (#297).
             // Counting 1 per failure avoids the race condition where the
@@ -1620,13 +1638,19 @@ void streaming_Task(void) {
             // queue depth reads, making a delta approach inaccurate.
             // Count for both AIN and DIO encoder failures — any sample type
             // consumed by a failed encode is lost.
-            gStreamStats.encoderDroppedSamples++;
-            LOG_E_SESSION(LOG_SESSION_ENCODER_SAMPLE_LOSS,
-                "Streaming: encoder failure lost 1 sample");
-            // Critical section: gQuesBits is also RMW'd by deferred ISR task
+            // Single critical section covers the counter pair and QUES bit
+            // so a concurrent Streaming_GetStats snapshot sees them coherently.
             taskENTER_CRITICAL();
+            gStreamStats.encoderFailures++;
+            gStreamStats.encoderDroppedSamples++;
+            if (pastGrace) {
+                gStreamStats.encoderFailuresSteady++;
+                gStreamStats.encoderDroppedSamplesSteady++;
+            }
             gQuesBits |= QUES_BIT_ENCODER_FAIL;
             taskEXIT_CRITICAL();
+            LOG_E_SESSION(LOG_SESSION_ENCODER_SAMPLE_LOSS,
+                "Streaming: encoder failure lost 1 sample");
             LOG_E_SESSION(LOG_SESSION_ENCODER_FAIL, "Streaming: Encoder failure detected");
         }
         if (packetSize > 0) {

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -159,17 +159,21 @@ typedef struct {
     uint32_t usbDroppedBytes;       // USB circular buffer full (total — incl. startup transients)
     uint32_t wifiDroppedBytes;      // WiFi circular buffer full (total — incl. startup transients)
     uint32_t sdDroppedBytes;        // SD write timeout/partial (total — incl. startup transients)
-    // #450: post-grace subsets of the above.  Drops that occur within
-    // the first `gLossGraceSec` of a session increment only the Total
-    // above; drops after the grace expires also increment these Steady
-    // counters.  Steady == real-data-loss after the pipeline stabilizes.
-    // Total − Steady == startup-window drops.
+    // #450 + follow-up: post-grace subsets of the above. Drops that
+    // occur within the first `gLossGraceSec` of a session increment
+    // only the Total above; drops after the grace expires also
+    // increment these Steady counters. Steady == real-data-loss after
+    // the pipeline stabilizes. Total − Steady == startup-window drops.
     uint32_t usbDroppedBytesSteady;
     uint32_t wifiDroppedBytesSteady;
     uint32_t sdDroppedBytesSteady;
     uint32_t encoderFailures;       // Encoder returned 0 with data available
+    uint32_t encoderFailuresSteady;
     uint32_t encoderDroppedSamples; // AIn samples consumed by failed encode calls (#297)
+    uint32_t encoderDroppedSamplesSteady;
     uint32_t dioDroppedSamples;     // DIO queue full — PushBack returned false (#296)
+    uint32_t dioDroppedSamplesSteady;
+    uint32_t queueDroppedSamplesSteady;  // post-grace subset of queueDroppedSamples
     uint32_t eosOverruns;      // EOS notifications coalesced (>1 per wake) (#295)
     uint64_t totalSamplesStreamed;   // Samples successfully queued (64-bit for week-long sessions)
     uint64_t totalBytesStreamed;     // Total bytes encoded (64-bit for week-long sessions)


### PR DESCRIPTION
## Summary

Extends the 3 s startup-grace pattern from PR #479 (USB/WiFi/SD transport drops) to the remaining drop counters: encoder failures, encoder dropped samples, queue dropped samples, DIO dropped samples.

Addresses the #476 follow-up observation today: the `EncoderFailures=1` per-trial transient was firing in 45-100% of trials at every rate from 2 to 7 kHz — always exactly 1 sample, classic startup-window false-flag pattern.

## Wire format

`SYST:STR:STATS?` adds 4 new fields:

- `QueueDroppedSamplesSteady`
- `EncoderFailuresSteady`
- `EncoderDroppedSamplesSteady`
- `DioDroppedSamplesSteady`

Existing `*Steady` fields (Usb/Wifi/Sd) unchanged. Total counters unchanged. Wire-compatible additive change.

## Implementation pattern

For each increment site, mirror PR #479:

```c
bool pastGrace = Streaming_PastStartupGrace();
taskENTER_CRITICAL();
gStreamStats.<counter>++;
if (pastGrace) gStreamStats.<counter>Steady++;
// + ques bit if applicable
taskEXIT_CRITICAL();
```

`pastGrace` captured BEFORE the critical section to avoid `xTaskGetTickCount()` inside.

## Test plan
- [x] Build clean at `-O3 -Werror` (XC32 v4.60).
- [x] Flash + smoke test (3 kHz × 30 s, fullscale pattern, BENCH 2 PIPELINE).
- [x] All 4 new fields present in `SYST:STR:STATS?` output.
- [x] Grace math verified: `WifiDroppedBytes` Total=1115145, Steady=1020481 → 94664 bytes filtered into the 3 s grace window.
- [ ] Multi-trial sweep with new firmware to confirm `EncoderFailuresSteady=0` across 20 trials at 3 kHz (where Total had the startup-1-sample hiccup) — verifies the user-visible "false flag" is gone from the Steady counter.
