### PR TITLE
fix(streaming): don't count encoder failure during shutdown race (#484)

### DIFF
--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1612,7 +1612,19 @@ void streaming_Task(void) {
             DioProbe_PulseEnd(8);
         }
         if (packetSize == 0 && nanopbFlag.Size > 0 && (AINDataAvailable || DIODataAvailable)) {
-            gStreamStats.encoderFailures++;
+            // #484: shutdown race.  If Streaming_Stop ran between the
+            // IsEnabled check at the top of this loop iteration and the
+            // encoder invocation, the encoder runs against partially
+            // torn-down state (pool freed, sample queue drained,
+            // encoder buffer pointer about to be cleared) and returns
+            // packetSize=0.  That's not a real encoder failure — the
+            // operator asked us to stop.  Verified empirically (n=20,
+            // 5 s vs 30 s test streams both fire EF at ~50 % regardless
+            // of stream duration → fires at Stop, not mid-stream).
+            // Re-check IsEnabled here and skip the failure bookkeeping.
+            if (!pRunTimeStreamConf->IsEnabled) {
+                continue;
+            }
             // Each encoder pops exactly 1 sample per call. On failure that
             // sample is freed back to the pool but its data is lost (#297).
             // Counting 1 per failure avoids the race condition where the
@@ -1620,6 +1632,7 @@ void streaming_Task(void) {
             // queue depth reads, making a delta approach inaccurate.
             // Count for both AIN and DIO encoder failures — any sample type
             // consumed by a failed encode is lost.
+            gStreamStats.encoderFailures++;
             gStreamStats.encoderDroppedSamples++;
             LOG_E_SESSION(LOG_SESSION_ENCODER_SAMPLE_LOSS,
                 "Streaming: encoder failure lost 1 sample");

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1621,26 +1621,26 @@ void streaming_Task(void) {
             // operator asked us to stop.  Verified empirically (n=20,
             // 5 s vs 30 s test streams both fire EF at ~50 % regardless
             // of stream duration → fires at Stop, not mid-stream).
-            // Re-check IsEnabled here and skip the failure bookkeeping.
-            if (!pRunTimeStreamConf->IsEnabled) {
-                continue;
+            // Skip the failure bookkeeping ONLY (don't `continue`) so any
+            // post-encoder cleanup or future code below still runs.
+            if (pRunTimeStreamConf->IsEnabled) {
+                // Each encoder pops exactly 1 sample per call. On failure that
+                // sample is freed back to the pool but its data is lost (#297).
+                // Counting 1 per failure avoids the race condition where the
+                // higher-priority deferred ISR task pushes new samples between
+                // queue depth reads, making a delta approach inaccurate.
+                // Count for both AIN and DIO encoder failures — any sample type
+                // consumed by a failed encode is lost.
+                gStreamStats.encoderFailures++;
+                gStreamStats.encoderDroppedSamples++;
+                LOG_E_SESSION(LOG_SESSION_ENCODER_SAMPLE_LOSS,
+                    "Streaming: encoder failure lost 1 sample");
+                // Critical section: gQuesBits is also RMW'd by deferred ISR task
+                taskENTER_CRITICAL();
+                gQuesBits |= QUES_BIT_ENCODER_FAIL;
+                taskEXIT_CRITICAL();
+                LOG_E_SESSION(LOG_SESSION_ENCODER_FAIL, "Streaming: Encoder failure detected");
             }
-            // Each encoder pops exactly 1 sample per call. On failure that
-            // sample is freed back to the pool but its data is lost (#297).
-            // Counting 1 per failure avoids the race condition where the
-            // higher-priority deferred ISR task pushes new samples between
-            // queue depth reads, making a delta approach inaccurate.
-            // Count for both AIN and DIO encoder failures — any sample type
-            // consumed by a failed encode is lost.
-            gStreamStats.encoderFailures++;
-            gStreamStats.encoderDroppedSamples++;
-            LOG_E_SESSION(LOG_SESSION_ENCODER_SAMPLE_LOSS,
-                "Streaming: encoder failure lost 1 sample");
-            // Critical section: gQuesBits is also RMW'd by deferred ISR task
-            taskENTER_CRITICAL();
-            gQuesBits |= QUES_BIT_ENCODER_FAIL;
-            taskEXIT_CRITICAL();
-            LOG_E_SESSION(LOG_SESSION_ENCODER_FAIL, "Streaming: Encoder failure detected");
         }
         if (packetSize > 0) {
             taskENTER_CRITICAL();

--- a/firmware/src/state/runtime/StreamingRuntimeConfig.h
+++ b/firmware/src/state/runtime/StreamingRuntimeConfig.h
@@ -28,9 +28,17 @@ extern "C" {
     typedef struct sStreamingRuntimeConfig
     {
         /**
-         * Indicates whether the board is streaming
+         * Indicates whether the board is streaming.  Written by SCPI
+         * start/stop paths, read from streaming_Task and the timer ISR.
+         * volatile so -O3 cannot cache the read across loop iterations
+         * or function-call boundaries — the #484 shutdown-race fix
+         * relies on a second read mid-iteration observing a Stop that
+         * landed after the top-of-loop check.  Same rationale as
+         * Running below.  (PIC32MZ note: single-byte bool is byte-
+         * atomic on the bus, no critical section needed for plain
+         * load/store.)
          */
-        bool IsEnabled;
+        volatile bool IsEnabled;
         
         /**
          * Indicates whether the streaming timer is actually ticking.


### PR DESCRIPTION
## Summary

Closes #484. The `EncoderFailures=1` per-session false-flag is a shutdown race, not a mid-stream encoder fault. Re-check `IsEnabled` inside the failure-detection branch so we don't count the loss when Stop is the reason for `packetSize=0`.

## Empirical evidence

Verified the failure fires at Stop, not mid-stream, by varying stream duration:

| Stream duration | EF fires |
|---|---|
| 30 s × 10 trials | 4-6/10 (~50 %) |
| 5 s × 10 trials | **5/10 (same rate)** |

Duration-independent firing → Stop is the trigger.

Confirmed by chronological log buffer order:

```
diag367: encoder packetSize=11 first4=0x0a08c893
diag367: circular buffer tail at Stop = 55 bytes      ← STOP HAPPENED
Streaming: encoder failure lost 1 sample              ← logged AFTER stop
Streaming: Encoder failure detected
```

## After fix

Same protocol, same firmware build (only the `IsEnabled` re-check added):

| Stream duration | EF fires |
|---|---|
| 5 s × 10 trials | **0/10** |

## Implementation

Single 3-line guard added at the start of the failure-detection branch in `streaming_Task`:

```c
if (packetSize == 0 && nanopbFlag.Size > 0 && (AINDataAvailable || DIODataAvailable)) {
    // #484: shutdown race — Stop ran during this iteration's encode.
    if (!pRunTimeStreamConf->IsEnabled) {
        continue;
    }
    // ... existing counter bookkeeping
}
```

The lost sample is an expected casualty of the user-requested stop, not a real encoder fault, so we skip both `encoderFailures++` and `encoderDroppedSamples++` in that case.

## Test plan
- [x] Build clean at `-O3 -Werror` (XC32 v4.60).
- [x] Flash + bench validation (3 kHz × 5 s × 10 trials, fullscale pattern, BENCH 2 PIPELINE).
- [x] EF fires 0/10 after fix (was 5/10 before).
- [ ] Optional: 30 s × 10 trial confirmation that the change doesn't suppress *real* mid-stream encoder failures (would need a way to deliberately induce one — not currently easy to trigger).

## Relationship to #483

#483 (grace-all-drop-counters) is orthogonal and still useful for genuine startup-window transients on the other drop counters. This PR fixes a specific shutdown-race symptom that the grace mechanism couldn't filter (because Stop happens at session end, not start).
