### PR TITLE
perf(winc): pace WINC idle gate at 1ms during WiFi streaming

### DIFF
--- a/firmware/src/config/default/tasks.c
+++ b/firmware/src/config/default/tasks.c
@@ -148,7 +148,20 @@ uint32_t WincIdleGate_ComputeDelay(SYS_STATUS status)
         !wifi_tcp_server_HasActiveClient()) {
         return 50U;
     }
-    return 0U;
+    // WiFi-streaming-with-client case: previously tight loop (0 ms).
+    // A/B testing (2026-05-19, 16ch @ 1 kHz × 1 trial each):
+    //   - 0 ms tight loop: pc_kbps 37.7, WifiDroppedBytes 8733
+    //   - 1 ms pace:       pc_kbps 38.0, WifiDroppedBytes 0
+    // Same wire delivery, drops eliminated.  Mechanism: tight loop
+    // was CPU-stealing the streaming task at high channel counts;
+    // 1 ms = one FreeRTOS tick lets streaming_Task encode + hand
+    // off without WINC SPI staging starvation.
+    //
+    // Single-trial A/B (n=1 per condition) — needs multi-trial
+    // confirmation, but the contrast plus the consistent mechanism
+    // model justifies shipping.  Reverts cleanly to 0 if regressions
+    // surface.
+    return 1U;
 }
 
 // Debug accessor for SCPI verification of #55: reports the live gate state


### PR DESCRIPTION
## Summary

- `WincIdleGate_ComputeDelay()` returned `0U` (tight loop) for the WiFi-streaming-with-active-client case
- At high channel counts the tight loop CPU-stole `streaming_Task` and caused `WifiDroppedBytes` even at modest rates
- Pace at 1 ms (one FreeRTOS tick) so the streaming task gets CPU to encode + hand off without WINC SPI staging starvation

## A/B (2026-05-19, 16ch @ 1 kHz × 1 trial each)

| Variant | pc_kbps | WifiDroppedBytes |
|---|---:|---:|
| 0 ms (tight loop, main) | 37.7 | 8733 |
| **1 ms (this PR)** | **38.0** | **0** |

Same wire delivery. Drops eliminated.

## Mechanism (V/E/I labels)

- **V**: `lWDRV_WINC_Tasks` runs at FreeRTOS priority 2. With `vTaskDelay(0)` it never yields voluntarily and time-slices only against `streaming_Task` (priority 6) when preempted by higher-priority work.
- **E**: 16ch encoder + WINC SPI staging interact such that streaming_Task can't make progress fast enough → WINC circular buffer fills → drops.
- **E**: With 1 ms gate, streaming_Task gets ≥1 tick per WINC iteration and the buffer never fills.
- **I**: Wire rate unchanged (37.7 → 38.0) confirms WINC SPI throughput was not the bottleneck — drops were upstream, in encoder → WiFi handoff.

## Honest disclosure on evidence strength

**Single-trial A/B (n=1 per condition).** Multi-trial confirmation blocked on a separate streaming-restart wedge bug (see #490).

Shipping anyway because:
1. The downside is trivial (1 ms slower task pacing in one case; reverts cleanly to `0U`)
2. The mechanism is consistent with prior WINC/streaming interaction characterizations
3. The 8.7 KB → 0 contrast in one trial is decisive enough to warrant the change

## Follow-ups (separate tickets)

- #490 — streaming-restart wedge (blocks multi-trial 16ch benchmarks)
- #489 — priority-tuning exploration (broader A/B matrix once #490 is fixed)

## Test plan

- [x] Builds clean at -O3
- [x] A/B verified on bench: 16ch @ 1 kHz, control 8733 dropped → treatment 0 dropped
- [ ] Multi-trial confirmation (deferred — see restart-wedge ticket)
- [ ] Regression check: USB-only streaming with TCP control client should be unaffected (gate path unchanged for non-WiFi-streaming case)