### PR TITLE
perf(winc): drop WDRV_WINC_Tasks pri 2→1 to eliminate bimodal WiFi drops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -872,8 +872,8 @@ The PIC32MZ2048**EF**M144 has a hardware 64-bit double-precision FPU (Coprocesso
 | 6 | `streaming_Task` | 1392 | 692 | Encodes PB/CSV/JSON + outputs, FPU (CSV/JSON at precision>0) |
 | 5 | `app_SDCardTask` | 1024 | 468 | SD mount/write/read/list/delete |
 | 2 | `app_WifiTask` | 1500 | 780 | WiFi state machine + TCP + SCPI-over-TCP dispatch (post-#353 Opt 2: microrl + libscpi + handlers all run here instead of on WDRV_WINC_Tasks) |
-| 2 | `lWDRV_WINC_Tasks` | 1024 | 320 | WINC1500 driver only. SCPI dispatch moved to app_WifiTask per #353 Option 2 |
 | 2 | `fwUpdateTask` | 128 | 62 | WiFi FW update (dynamic) |
+| 1 | `lWDRV_WINC_Tasks` | 1024 | 320 | WINC1500 driver. PR #492 (#489 variant B): dropped 2→1 so `streaming_Task` (pri 6) preempts WINC by 5 levels and OSAL semaphores inside `WDRV_WINC_Tasks` do the yielding (Microchip reference pattern). Eliminated #491 BIMODAL catastrophic WiFi drops. |
 | 1 | `lAPP_FREERTOS_Tasks` | 1500 | 1156 | Boot init (77% used) |
 | 1 | `F_USB_DEVICE_Tasks` | 144 | 72 | USB device stack |
 | 1 | `F_DRV_USBHS_Tasks` | 144 | 72 | USB hardware driver |

--- a/firmware/daqifi.X/daqifi_default/components/drvWifiWinc.yml
+++ b/firmware/daqifi.X/daqifi_default/components/drvWifiWinc.yml
@@ -98,7 +98,11 @@ data:
       children:
       - children:
         - attributes:
-            value: '2'
+            # #489 variant B (PR #492): 2 -> 1 so streaming_Task (pri 6)
+            # preempts WINC by 5 levels and OSAL semaphores inside
+            # WDRV_WINC_Tasks do the yielding (Microchip reference pattern).
+            # MCC regen must preserve this value.
+            value: '1'
           type: User
         type: Values
       type: Integer

--- a/firmware/src/config/default/configuration.h
+++ b/firmware/src/config/default/configuration.h
@@ -178,7 +178,7 @@ extern "C" {
 #define WDRV_WINC_DEBUG_LEVEL               WDRV_WINC_DEBUG_TYPE_ERROR
 /*** WiFi WINC Driver RTOS Configuration ***/
 #define DRV_WIFI_WINC_RTOS_STACK_SIZE           3000
-#define DRV_WIFI_WINC_RTOS_TASK_PRIORITY        2
+#define DRV_WIFI_WINC_RTOS_TASK_PRIORITY        1  // #489 variant B: 2->1 — streaming_Task (pri 6) preempts WINC by 5 levels so OSAL semaphores inside WDRV_WINC_Tasks do the yielding (Microchip pattern).
 
 /* SPI Driver Instance 0 Configuration Options */
 #define DRV_SPI_INDEX_0                       0

--- a/firmware/src/services/wifi_services/wifi_tcp_server.h
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.h
@@ -64,7 +64,9 @@ typedef struct s_tcpClientContext
      *  callback.  Caps at WIFI_TCP_MAX_IN_FLIGHT.  Replaces the prior
      *  `bool tcpSendPending` (which capped at 1).  Updated under
      *  taskENTER_CRITICAL — concurrent writers are streaming_Task (priority 6)
-     *  and WDRV_WINC_Tasks (priority 2). */
+     *  and WDRV_WINC_Tasks (DRV_WIFI_WINC_RTOS_TASK_PRIORITY, currently 1 per
+     *  PR #492 — formerly 2).  Reference the macro rather than hard-coding to
+     *  avoid stale comment drift if priority changes again. */
     volatile uint8_t tcpInFlight;
 
     /** #437: pending CircularBuf_Reset deferred from a context that


### PR DESCRIPTION
## Summary

Drops `DRV_WIFI_WINC_RTOS_TASK_PRIORITY` from 2 to 1 so `streaming_Task` (priority 6) preempts `WDRV_WINC_Tasks` by 5 levels.  The OSAL semaphores inside the WINC driver body do the yielding — matching Microchip's reference RTOS pattern instead of host-side wall-clock pacing.

## Why

#491 documented BIMODAL catastrophic WiFi drops: at otherwise-stable rates (CV 0.5 %), ~1 trial in 15 dropped 800 KB – 1.4 MB while ISR/timer kept firing normally.  Cross-firmware data confirms this is independent of any WINC idle-gate value (PR #488's 1 ms gate did not fix it).

## A/B comparison — 3 historically-bimodal cells × 15 trials × 30 s each

Bench: NQ1 / WiFi STA / Tesla AP / RSSI 100, PB encoding, fullscale test pattern, BENCH 2 PIPELINE.

| Cell | main (BIMODAL baseline) | A: stream pri 7 | **B: WINC pri 1 (THIS PR)** | C: both |
|---|---|---|---|---|
| 1×T1 @ 3000 | 10/15, CV 27 %, **Wmax 930 KB** | 13/15, CV 0.7 %, Wmax 0 | **10/15, CV 0.7 %, Wmax 0** | 11/15, CV 0.6 %, Wmax 0 |
| 5×T1 @ 2500 | 9/15, CV 27 %, **Wmax 1.35 MB** | 3/15, CV 27 %, **Wmax 1.34 MB (still BIMODAL)** | **3/15, CV 0.6 %, Wmax 12.6 KB** | 4/15, CV 0.6 %, Wmax 25.6 KB (10 Wst fires) |
| 5×T1 @ 1500 | 7/15, CV 27 %, **Wmax 797 KB** | 10/15, CV 0.5 %, Wmax 0 | **7/15, CV 0.5 %, Wmax 0** | 11/15, CV 0.4 %, Wmax 0 |

**Variant A (streaming pri 6 → 7 alone) does NOT fix the 5×T1 @ 2500 case** — catastrophic 1.34 MB spike persists.  **WINC 2 → 1 is the load-bearing change.**

Variant C (both moves combined) re-introduces round-robin contention with USB SCPI which pulls 5×T1 @ 2500 back toward A's pattern (10 small Wst fires vs B's 5).  C wins by a hair on easy cells (11/15 vs B's 10/15 and 7/15) but loses on the hard cell.  Simplicity + the near-saturation win make B the right choice.

## Mechanism (V-labeled)

- **V**: `WDRV_WINC_Tasks` (`firmware/src/config/default/driver/winc/wdrv_winc.c:2181`) is a pure switch state-machine with no internal `vTaskDelay`.  Designed for back-to-back invocation.
- **V**: The driver body blocks on OSAL semaphores (`drvEventSemaphore`, etc.) — those are the designed yield points.
- **V**: Harmony RTOS reference demos (`MPLAB_Harmony_v3_Synchronous_Drivers_DS90003290A`, `HarmonyHelpAppsRTOSDemonstrations`) follow the pattern of each driver getting its own task that calls its `_Tasks()` back-to-back with no delay.
- **I**: At WINC priority 2 and streaming priority 6, the 4-level gap is enough that streaming preempts WINC most of the time, but the residual contention manifests as catastrophic-but-rare drops at near-saturation rates.  Dropping WINC to 1 removes that residual and lets the OSAL semaphores arbitrate.

## Honest disclosure

- A/B is from a single 30-trial bench session.  Multi-session reproducibility not yet verified.
- #491 (BIMODAL drops) describes the symptom we measured against; this PR's fix correlates strongly but root-cause investigation (TCP socket / WINC SPI staging state during the spike) wasn't completed before this change.  The drops just stop, mechanism untouched.
- 16ch validation **not done** — blocked by #490 (heap leak on streaming session start, exposed by #475 floor).  Single-session 16ch is the workaround; multi-session waits on #490 fix.

## Tradeoffs

- **WINC priority 1** is the FreeRTOS minimum non-idle level.  `lAPP_FREERTOS_Tasks`, `F_USB_DEVICE_Tasks`, `F_DRV_USBHS_Tasks`, and `fwUpdateTask` are also at priority 1.  WINC time-slices round-robin with these.
- WINC connection establishment / keepalive may be marginally slower under heavy preemption from streaming.  Bench observation: STA reassociation after `LAN:APPLy` still completes in <3 s (no change).
- USB CDC behavior unchanged (we did not touch streaming priority or USB SCPI priority).

## Test plan

- [x] Builds clean at -O3
- [x] BIMODAL probe on 3 cells reproduces variant B advantage
- [x] STA reassociation still works post-`LAN:APPLy`
- [ ] USB-only streaming regression (PB and CSV at known clean rates)
- [ ] SD streaming regression
- [ ] 16ch single-trial regression (multi-trial blocked on #490)
- [ ] CLAUDE.md Task Priority Map updated to reflect new WINC priority

## Files changed

- `firmware/src/config/default/configuration.h` — `DRV_WIFI_WINC_RTOS_TASK_PRIORITY 2 → 1` (single line)

## Related

- #488 (closed) — 1 ms WINC gate; superseded by this priority restructuring
- #489 — priorities exploration ticket (this is variant B from its matrix)
- #491 — BIMODAL catastrophic drops, the symptom this PR addresses
- #490 — heap leak on WiFi streaming session start; blocks 16ch multi-trial validation