### PR TITLE
perf(streaming): WiFi-only mode claims unused 64 KB of pool for WiFi circular

### DIFF
--- a/firmware/src/Util/StreamingBufferPool.h
+++ b/firmware/src/Util/StreamingBufferPool.h
@@ -36,20 +36,20 @@ extern "C" {
 
 /** Active-interface defaults used by Streaming_ComputeAutoBuffers */
 #define STREAMING_USB_DEFAULT       (64U * 1024U)  /* USB circular when active */
-/* WiFi circular when active.  PR #364 bumped this 32→64 KB and was originally
- * reported as +5x ceiling — but #371 retrospective A/B (with truthful drop
- * counter) showed the 64KB had ZERO effect on wire rate vs 32KB at any
- * tested rate.  The original "win" was a measurement artifact of the
- * silent-loss bug.  Reverting to 32 KB to free 32 KB of streaming pool
- * memory for the sample pool / encoder.  See #373. */
-#define STREAMING_WIFI_DEFAULT      (32U * 1024U)
-/* WiFi circular when WiFi is the SOLE active interface.  In WiFi-only
- * mode auto-balance previously left ~118 KB of the 194 KB streaming
- * pool idle (sample pool caps at MAX_AIN_SAMPLE_COUNT=1100 ≈ 33 KB,
- * inactive USB/SD reduce to minimums).  Issue #497 documented the
- * waste and proposed reallocating to the WiFi circular — the layer
- * that overflows on WINC SPI back-pressure.  96 KB triples the burst-
- * absorption window without touching encoder or sample pool. */
+/* WiFi circular when WiFi is the active interface.  WiFi is always
+ * single-interface — the StreamingInterface enum has no USB+WiFi or
+ * WiFi+SD value, and the SCPIInterface.c runtime guard refuses WiFi
+ * while SD logging is active due to the SPI bus conflict.  So
+ * auto-balance has nothing to choose between: hasWifi -> WIFI_ONLY
+ * else MIN.
+ *
+ * Sized to claim the ~118 KB of streaming pool that previously sat
+ * idle in WiFi-only sessions (sample pool caps at
+ * MAX_AIN_SAMPLE_COUNT=1100 ≈ 33 KB; inactive USB/SD reduce to
+ * minimums; old fixed 32 KB WiFi circular carved ~76 KB total leaving
+ * the rest unused).  Issue #497.  96 KB triples the burst-absorption
+ * window before WINC SPI back-pressure cascades to wst, without
+ * touching encoder or sample pool. */
 #define STREAMING_WIFI_WIFI_ONLY    (96U * 1024U)
 
 /**

--- a/firmware/src/Util/StreamingBufferPool.h
+++ b/firmware/src/Util/StreamingBufferPool.h
@@ -44,12 +44,18 @@ extern "C" {
  * else MIN.
  *
  * Sized to claim the ~118 KB of streaming pool that previously sat
- * idle in WiFi-only sessions (sample pool caps at
- * MAX_AIN_SAMPLE_COUNT=1100 ≈ 33 KB; inactive USB/SD reduce to
- * minimums; old fixed 32 KB WiFi circular carved ~76 KB total leaving
- * the rest unused).  Issue #497.  96 KB triples the burst-absorption
- * window before WINC SPI back-pressure cascades to wst, without
- * touching encoder or sample pool. */
+ * unused in WiFi-only sessions (old fixed 32 KB WiFi circular carved
+ * only ~76 KB total with the boot-default sample pool of 1100
+ * elements; the rest was unused).  Issue #497.
+ *
+ * Tradeoff (Qodo PR #501 pass 2): when SamplePoolCount is auto (0),
+ * Partition() sets the pool depth from remaining pool bytes — so
+ * bumping this constant shrinks the auto-sized sample pool and
+ * indirectly shrinks the FreeRTOS heap used by AInSample's queue.
+ * MAX_AIN_SAMPLE_COUNT is 10000 (not 1100 — that's the DEFAULT).
+ * Acceptable because SamplePoolMaxUsed on actual workloads stays
+ * ≤16 (per #497 evidence), so the post-shrink pool still has 100×
+ * headroom. */
 #define STREAMING_WIFI_WIFI_ONLY    (96U * 1024U)
 
 /**

--- a/firmware/src/Util/StreamingBufferPool.h
+++ b/firmware/src/Util/StreamingBufferPool.h
@@ -43,6 +43,14 @@ extern "C" {
  * silent-loss bug.  Reverting to 32 KB to free 32 KB of streaming pool
  * memory for the sample pool / encoder.  See #373. */
 #define STREAMING_WIFI_DEFAULT      (32U * 1024U)
+/* WiFi circular when WiFi is the SOLE active interface.  In WiFi-only
+ * mode auto-balance previously left ~118 KB of the 194 KB streaming
+ * pool idle (sample pool caps at MAX_AIN_SAMPLE_COUNT=1100 ≈ 33 KB,
+ * inactive USB/SD reduce to minimums).  Issue #497 documented the
+ * waste and proposed reallocating to the WiFi circular — the layer
+ * that overflows on WINC SPI back-pressure.  96 KB triples the burst-
+ * absorption window without touching encoder or sample pool. */
+#define STREAMING_WIFI_WIFI_ONLY    (96U * 1024U)
 
 /**
  * Initialize the pool and set default partition.

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -844,12 +844,24 @@ void Streaming_ComputeAutoBuffers(uint32_t* outUsbSize, uint32_t* outWifiSize,
     // StreamingRuntimeConfig.h:17-22 and the runtime guard at
     // SCPIInterface.c:2823 that refuses WiFi while SD is logging due
     // to the SPI bus conflict).  So `hasWifi` always means "WiFi is
-    // the SOLE active interface", which makes the previous fixed
-    // 32 KB partition leave ~118 KB of the 194 KB pool idle
-    // (sample-pool capped at MAX_AIN_SAMPLE_COUNT, inactive USB/SD
-    // at minimums = ~76 KB total carved).  Bump to
-    // STREAMING_WIFI_WIFI_ONLY (96 KB) to triple the burst-
-    // absorption window before WINC SPI back-pressure cascades to wst.
+    // the SOLE active interface".  Bump to STREAMING_WIFI_WIFI_ONLY
+    // (96 KB) — triples the burst-absorption window vs the prior
+    // fixed 32 KB before WINC SPI back-pressure cascades to wst.
+    //
+    // Sample-pool tradeoff (Qodo PR #501 pass 2): the pool is NOT
+    // capped here at 1100; that's only the DEFAULT_AIN_SAMPLE_COUNT.
+    // MAX_AIN_SAMPLE_COUNT is 10000, and Partition() in auto mode
+    // (sampleCount == 0) sets sampleCount = remaining_pool_bytes /
+    // per_sample_bytes (capped at MAX).  So bumping WiFi 32→96 KB
+    // shrinks the auto-sized sample pool by ~64 KB / per-sample
+    // (≈ 2000 fewer samples at 5×T1's 30 B/sample stride).  That in
+    // turn shrinks the FreeRTOS heap used by the AInSample queue —
+    // observable as the heap delta in #501 validation (13272 → 4344
+    // during wifi_5xT1 @ 2 kHz).  Acceptable tradeoff because
+    // SamplePoolMaxUsed measurements on actual workloads are tiny
+    // (≤16 across all probed rates per #497 evidence), so even the
+    // post-shrink sample pool has 100× burst-absorption headroom for
+    // streaming use.
     *outWifiSize = hasWifi ? STREAMING_WIFI_WIFI_ONLY : STREAMING_WIFI_MIN;
     *outUsbSize  = hasUsb  ? STREAMING_USB_DEFAULT    : STREAMING_USB_MIN;
 }

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -838,27 +838,20 @@ void Streaming_ComputeAutoBuffers(uint32_t* outUsbSize, uint32_t* outWifiSize,
 
     // Circular buffers: larger buffers reduce retry frequency for
     // all-or-nothing writes, but must leave enough pool for samples.
-    // WiFi at 32 KB absorbs ~600 ms of encoder lead at 5×T1 @ 3 kHz
-    // (52 KB/s) before WINC's per-packet callback-paced drain catches
-    // up.  Sample-pool floor with USB+WiFi active is ~520 samples
-    // (well above MIN_AIN_SAMPLE_COUNT=100).
     //
-    // #497: in WiFi-only mode the previous fixed 32 KB left ~118 KB of
-    // the 194 KB pool idle (sample-pool cap of MAX_AIN_SAMPLE_COUNT +
-    // inactive USB/SD at minimums = 76 KB total carved).  Bump to
-    // STREAMING_WIFI_WIFI_ONLY (96 KB) when WiFi is the sole active
-    // interface — triples the burst-absorption window before WINC SPI
-    // back-pressure cascades to wst.  USB+WiFi sessions keep the 32 KB
-    // default to preserve sample-pool headroom for the dual-interface
-    // case where it actually matters.
-    if (hasWifi && !hasUsb && !hasSd) {
-        *outWifiSize = STREAMING_WIFI_WIFI_ONLY;
-    } else if (hasWifi) {
-        *outWifiSize = STREAMING_WIFI_DEFAULT;
-    } else {
-        *outWifiSize = STREAMING_WIFI_MIN;
-    }
-    *outUsbSize  = hasUsb  ? STREAMING_USB_DEFAULT  : STREAMING_USB_MIN;
+    // #497: the StreamingInterface enum has no USB+WiFi or WiFi+SD
+    // combination — WiFi is always single-interface (see
+    // StreamingRuntimeConfig.h:17-22 and the runtime guard at
+    // SCPIInterface.c:2823 that refuses WiFi while SD is logging due
+    // to the SPI bus conflict).  So `hasWifi` always means "WiFi is
+    // the SOLE active interface", which makes the previous fixed
+    // 32 KB partition leave ~118 KB of the 194 KB pool idle
+    // (sample-pool capped at MAX_AIN_SAMPLE_COUNT, inactive USB/SD
+    // at minimums = ~76 KB total carved).  Bump to
+    // STREAMING_WIFI_WIFI_ONLY (96 KB) to triple the burst-
+    // absorption window before WINC SPI back-pressure cascades to wst.
+    *outWifiSize = hasWifi ? STREAMING_WIFI_WIFI_ONLY : STREAMING_WIFI_MIN;
+    *outUsbSize  = hasUsb  ? STREAMING_USB_DEFAULT    : STREAMING_USB_MIN;
 }
 
 /*!

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -838,11 +838,26 @@ void Streaming_ComputeAutoBuffers(uint32_t* outUsbSize, uint32_t* outWifiSize,
 
     // Circular buffers: larger buffers reduce retry frequency for
     // all-or-nothing writes, but must leave enough pool for samples.
-    // WiFi at 64KB absorbs ~44ms of encoder lead at 1kHz×1400B before
-    // WINC's per-packet callback-paced drain catches up. Sample-pool
-    // floor with USB+WiFi active is ~520 samples (well above
-    // MIN_AIN_SAMPLE_COUNT=100).
-    *outWifiSize = hasWifi ? STREAMING_WIFI_DEFAULT : STREAMING_WIFI_MIN;
+    // WiFi at 32 KB absorbs ~600 ms of encoder lead at 5×T1 @ 3 kHz
+    // (52 KB/s) before WINC's per-packet callback-paced drain catches
+    // up.  Sample-pool floor with USB+WiFi active is ~520 samples
+    // (well above MIN_AIN_SAMPLE_COUNT=100).
+    //
+    // #497: in WiFi-only mode the previous fixed 32 KB left ~118 KB of
+    // the 194 KB pool idle (sample-pool cap of MAX_AIN_SAMPLE_COUNT +
+    // inactive USB/SD at minimums = 76 KB total carved).  Bump to
+    // STREAMING_WIFI_WIFI_ONLY (96 KB) when WiFi is the sole active
+    // interface — triples the burst-absorption window before WINC SPI
+    // back-pressure cascades to wst.  USB+WiFi sessions keep the 32 KB
+    // default to preserve sample-pool headroom for the dual-interface
+    // case where it actually matters.
+    if (hasWifi && !hasUsb && !hasSd) {
+        *outWifiSize = STREAMING_WIFI_WIFI_ONLY;
+    } else if (hasWifi) {
+        *outWifiSize = STREAMING_WIFI_DEFAULT;
+    } else {
+        *outWifiSize = STREAMING_WIFI_MIN;
+    }
     *outUsbSize  = hasUsb  ? STREAMING_USB_DEFAULT  : STREAMING_USB_MIN;
 }
 


### PR DESCRIPTION
Closes #497.  In WiFi-only mode the streaming-pool auto-balancer previously gave WiFi circular 32 KB and left ~118 KB of the 194 KB pool idle.  Bump WiFi circular to 96 KB when WiFi is the sole active interface.  USB+WiFi and SD-involving sessions keep the 32 KB default to preserve sample-pool headroom there.

## Validation (2026-05-26)

10-minute endurance probe at wifi_5xT1 @ 2 kHz — the same workload that DEGRADED in yesterday's 9-hour stress at the same rate (60,267 B wst_steady over 1 hr).

|  | Pre-fix (32 KB) | Post-fix (96 KB) |
|---|---|---|
| Verdict | DEGRADED | **CLEAN** |
| pc_kbps | 37.0 | 36.9 |
| wst_steady | 60,267 B | **0** |
| ISR | 7,200,987 (exact) | 1,201,183 (exact, 10-min trial) |
| partial_sends | 1,661 / hr | 113 / 10 min (rate-scaled) |
| Heap free post | 11,888 | 4,344 (still above 1 KB floor) |

Drops go to zero, throughput unchanged.

## Auto-balance behavior after this change

| Active interface | WiFi circular |
|---|---:|
| WiFi only | **98,304** (was 32,768) |
| USB+WiFi | 32,768 (unchanged) |
| WiFi+SD | 32,768 (unchanged) |
| USB only | 1,400 (min, unchanged) |
| SD only | 1,400 (min, unchanged) |

## Caveats

- Heap dropped from 13,272 → 4,344 (-8,928 B) during the test cell.  Origin downstream of this change (sample queue allocation scales with the new partition?).  Still well above MIN_HEAP_FREE_FOR_STREAM_START_BYTES (1 KB), but worth watching at 60-min endurance.  Next overnight will validate.
- 10-min validation only.  Full 9-hr endurance validation pending the next overnight run.

## Test plan

- [x] Build clean (XC32 v4.60, default config)
- [x] SYST:MEM:AUTO returns WIFI_BUF=98304 in WiFi-only mode
- [x] SYST:MEM:WIFI:BUF? confirms active partition (#494 was already merged)
- [x] 10-min endurance at wifi_5xT1 @ 2 kHz: CLEAN, 0 drops, throughput unchanged
- [ ] 60-min endurance validation (pending next overnight)
- [ ] Full 9-hr endurance + derated rates re-verification