### PR TITLE
feat(sd): pre-start disk-full gate (SYST:STOR:SD:MINFree) — #498 v1

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2842,11 +2842,12 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         // catches "customer started a long run on a card with ~10 MB free"
         // BEFORE 30 minutes of streaming silently fails.
         //
-        // Qodo PR #502 pass 1 bug 1: snapshot the 64-bit minFreeBytes
-        // under critical section once at function entry — matches the
-        // CRITICAL guard on the SCPI setter side.  Reusing the local
-        // for the LOG_E + comparison also guarantees consistent value
-        // even if a concurrent setter mutates the config mid-function.
+        // Snapshot the 64-bit minFreeBytes under critical section once
+        // at function entry — pairs with the CRITICAL guard on the
+        // SCPI setter side (PIC32MZ 32-bit bus tears 64-bit accesses
+        // under preemption).  Reusing the local for the LOG_E +
+        // comparison guarantees a consistent value even if a concurrent
+        // setter mutates the config mid-function.
         uint64_t minFreeFloor;
         taskENTER_CRITICAL();
         minFreeFloor = pSDCardSettings->minFreeBytes;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2836,6 +2836,38 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
             SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
             return SCPI_RES_ERR;
         }
+        // #498: pre-start disk-full gate.  If minFreeBytes > 0, query the
+        // card via SYS_FS_DriveSectorGet (synchronous through the SD task)
+        // and refuse the start if free space is below the floor.  This
+        // catches "customer started a long run on a card with ~10 MB free"
+        // BEFORE 30 minutes of streaming silently fails.
+        if (pSDCardSettings->minFreeBytes > 0) {
+            pSDCardSettings->mode = SD_CARD_MANAGER_MODE_GET_SPACE;
+            sd_card_manager_UpdateSettings(pSDCardSettings);
+            if (!sd_card_manager_WaitForCompletion(5000)) {
+                LOG_E("[SD] STR:START disk-full check timed out");
+                pSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
+                sd_card_manager_UpdateSettings(pSDCardSettings);
+                SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+                return SCPI_RES_ERR;
+            }
+            uint64_t freeBytes = 0, totalBytes = 0;
+            if (sd_card_manager_GetLastOperationResult() &&
+                sd_card_manager_GetSpaceInfo(&freeBytes, &totalBytes) &&
+                freeBytes < pSDCardSettings->minFreeBytes) {
+                LOG_E("[SD] STR:START refused: %llu B free < %llu B floor",
+                      (unsigned long long)freeBytes,
+                      (unsigned long long)pSDCardSettings->minFreeBytes);
+                pSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
+                sd_card_manager_UpdateSettings(pSDCardSettings);
+                SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+                return SCPI_RES_ERR;
+            }
+            // If the query itself failed (mount/SDIO error), fall through
+            // and let the existing WRITE-mode path surface the error.
+            // We've already done the user-friendly "you're out of space"
+            // rejection above when the query SUCCEEDED but the floor was hit.
+        }
         pSDCardSettings->mode = SD_CARD_MANAGER_MODE_WRITE;
         sd_card_manager_UpdateSettings(pSDCardSettings);
 
@@ -4596,6 +4628,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:STORage:SD:BENCHmark?", .callback = SCPI_StorageSDBenchmarkQuery},
     {.pattern = "SYSTem:STORage:SD:MAXSize", .callback = SCPI_StorageSDMaxSizeSet},
     {.pattern = "SYSTem:STORage:SD:MAXSize?", .callback = SCPI_StorageSDMaxSizeGet},
+    {.pattern = "SYSTem:STORage:SD:MINFree", .callback = SCPI_StorageSDMinFreeSet},   // #498
+    {.pattern = "SYSTem:STORage:SD:MINFree?", .callback = SCPI_StorageSDMinFreeGet},  // #498
     {.pattern = "SYSTem:STORage:SD:SPACe?", .callback = SCPI_StorageSDSpaceGet},
     {.pattern = "SYSTem:STORage:SD:ABORt", .callback = SCPI_StorageSDAbort},
     {.pattern = "SYSTem:STORage:SD:INFO?", .callback = SCPI_StorageSDInfo},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2842,12 +2842,12 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         // catches "customer started a long run on a card with ~10 MB free"
         // BEFORE 30 minutes of streaming silently fails.
         //
-        // Snapshot the 64-bit minFreeBytes under critical section once
-        // at function entry — pairs with the CRITICAL guard on the
+        // Snapshot the 64-bit minFreeBytes under critical section before
+        // the disk-full check — pairs with the CRITICAL guard on the
         // SCPI setter side (PIC32MZ 32-bit bus tears 64-bit accesses
         // under preemption).  Reusing the local for the LOG_E +
         // comparison guarantees a consistent value even if a concurrent
-        // setter mutates the config mid-function.
+        // setter mutates the config while this block runs.
         uint64_t minFreeFloor;
         taskENTER_CRITICAL();
         minFreeFloor = pSDCardSettings->minFreeBytes;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2841,7 +2841,17 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         // and refuse the start if free space is below the floor.  This
         // catches "customer started a long run on a card with ~10 MB free"
         // BEFORE 30 minutes of streaming silently fails.
-        if (pSDCardSettings->minFreeBytes > 0) {
+        //
+        // Qodo PR #502 pass 1 bug 1: snapshot the 64-bit minFreeBytes
+        // under critical section once at function entry — matches the
+        // CRITICAL guard on the SCPI setter side.  Reusing the local
+        // for the LOG_E + comparison also guarantees consistent value
+        // even if a concurrent setter mutates the config mid-function.
+        uint64_t minFreeFloor;
+        taskENTER_CRITICAL();
+        minFreeFloor = pSDCardSettings->minFreeBytes;
+        taskEXIT_CRITICAL();
+        if (minFreeFloor > 0) {
             pSDCardSettings->mode = SD_CARD_MANAGER_MODE_GET_SPACE;
             sd_card_manager_UpdateSettings(pSDCardSettings);
             if (!sd_card_manager_WaitForCompletion(5000)) {
@@ -2854,10 +2864,10 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
             uint64_t freeBytes = 0, totalBytes = 0;
             if (sd_card_manager_GetLastOperationResult() &&
                 sd_card_manager_GetSpaceInfo(&freeBytes, &totalBytes) &&
-                freeBytes < pSDCardSettings->minFreeBytes) {
+                freeBytes < minFreeFloor) {
                 LOG_E("[SD] STR:START refused: %llu B free < %llu B floor",
                       (unsigned long long)freeBytes,
-                      (unsigned long long)pSDCardSettings->minFreeBytes);
+                      (unsigned long long)minFreeFloor);
                 pSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
                 sd_card_manager_UpdateSettings(pSDCardSettings);
                 SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -747,31 +747,29 @@ scpi_result_t SCPI_StorageSDMaxSizeGet(scpi_t * context) {
 scpi_result_t SCPI_StorageSDMinFreeSet(scpi_t * context) {
     sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
 
-    // Qodo PR #502 pass 1 bug 3: parse as uint64 directly (storage is
-    // uint64; using SCPI_ParamInt64 rejected values above INT64_MAX).
+    // Parse as uint64 directly — storage is uint64; SCPI_ParamInt64
+    // would reject values above INT64_MAX.
     uint64_t minFreeBytes;
     if (!SCPI_ParamUInt64(context, &minFreeBytes, TRUE)) {
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         return SCPI_RES_ERR;
     }
-    // Qodo PR #502 pass 1 bug 1: 64-bit shared write needs critical
-    // section per CLAUDE.md atomicity rules — PIC32MZ's 32-bit data
-    // bus tears 64-bit stores under task preemption.  The runtime
-    // config is read by SCPI_StartStreaming from a different task
-    // and by the SCPI getter from this task; without critical
-    // section guarding the 64-bit store, a concurrent STR:START
-    // could read a torn intermediate value.
+    // 64-bit shared write needs critical section per CLAUDE.md
+    // atomicity rules — PIC32MZ's 32-bit data bus tears 64-bit
+    // stores under task preemption.  The runtime config is read
+    // by SCPI_StartStreaming from a different task and by the
+    // SCPI getter from this task; without the critical section,
+    // a concurrent reader could see a torn intermediate value.
     taskENTER_CRITICAL();
     pSDCardRuntimeConfig->minFreeBytes = minFreeBytes;
     taskEXIT_CRITICAL();
-    // Qodo PR #502 pass 1 bug 2: do NOT call
-    // sd_card_manager_UpdateSettings() here.  UpdateSettings()
-    // unconditionally forces SD state to DEINIT → UNMOUNT_DISK,
-    // which closes any active WRITE file and on next open
-    // truncates with WRITE_PLUS.  MINFree is consulted only at
-    // SYST:STR:START, so a config-only write is correct — no need
-    // to bounce the SD state machine.  Doing so during an active
-    // logging session would cause silent data loss.
+    // Config-only write — do NOT call sd_card_manager_UpdateSettings()
+    // here.  UpdateSettings() unconditionally forces SD state to
+    // DEINIT → UNMOUNT_DISK, which closes any active WRITE file and
+    // on next open truncates with WRITE_PLUS.  MINFree is consulted
+    // only at SYST:STR:START, so a config-only write is correct;
+    // bouncing the SD state machine during an active logging session
+    // would cause silent data loss.
     return SCPI_RES_OK;
 }
 
@@ -784,8 +782,8 @@ scpi_result_t SCPI_StorageSDMinFreeSet(scpi_t * context) {
 scpi_result_t SCPI_StorageSDMinFreeGet(scpi_t * context) {
     sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
 
-    // Qodo PR #502 pass 1 bug 1: 64-bit shared read also under
-    // critical section.
+    // 64-bit shared read also under critical section — pairs with the
+    // setter (same field, same PIC32MZ tearing risk under preemption).
     uint64_t minFreeBytes;
     taskENTER_CRITICAL();
     minFreeBytes = pSDCardRuntimeConfig->minFreeBytes;

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -731,6 +731,51 @@ scpi_result_t SCPI_StorageSDMaxSizeGet(scpi_t * context) {
 }
 
 /**
+ * @brief Set minimum free space floor for SYST:STR:START (#498)
+ *
+ * Command: SYST:STOR:SD:MINFree <bytes>
+ *   Default: 0 (no pre-start check; legacy behavior)
+ *   Typical: 52428800 (50 MB) — refuses to start a long log run on a
+ *            card with less than 50 MB headroom.
+ *
+ * When > 0, SYST:STR:START for SD-output sessions runs
+ * SYS_FS_DriveSectorGet() before arming the streaming timer and
+ * returns SCPI -200 if the free space is below this floor.  Catches
+ * the "started a 4-hour log on a near-full card" failure mode that
+ * otherwise drops samples silently after disk-full mid-run.
+ */
+scpi_result_t SCPI_StorageSDMinFreeSet(scpi_t * context) {
+    sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
+
+    int64_t minFreeBytes;
+    if (!SCPI_ParamInt64(context, &minFreeBytes, TRUE)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    if (minFreeBytes < 0) {
+        LOG_E("SD:MINFree - Invalid floor: %lld (must be >= 0)", (long long)minFreeBytes);
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    pSDCardRuntimeConfig->minFreeBytes = (uint64_t)minFreeBytes;
+    sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
+    return SCPI_RES_OK;
+}
+
+/**
+ * @brief Query minimum free space floor
+ *
+ * Command: SYST:STOR:SD:MINFree?
+ * Returns: <bytes> (0 = no pre-start check)
+ */
+scpi_result_t SCPI_StorageSDMinFreeGet(scpi_t * context) {
+    sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
+
+    SCPI_ResultUInt64(context, pSDCardRuntimeConfig->minFreeBytes);
+    return SCPI_RES_OK;
+}
+
+/**
  * @brief Query SD card free and total space
  *
  * Command: SYST:STOR:SD:SPACe?

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -747,18 +747,31 @@ scpi_result_t SCPI_StorageSDMaxSizeGet(scpi_t * context) {
 scpi_result_t SCPI_StorageSDMinFreeSet(scpi_t * context) {
     sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
 
-    int64_t minFreeBytes;
-    if (!SCPI_ParamInt64(context, &minFreeBytes, TRUE)) {
+    // Qodo PR #502 pass 1 bug 3: parse as uint64 directly (storage is
+    // uint64; using SCPI_ParamInt64 rejected values above INT64_MAX).
+    uint64_t minFreeBytes;
+    if (!SCPI_ParamUInt64(context, &minFreeBytes, TRUE)) {
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         return SCPI_RES_ERR;
     }
-    if (minFreeBytes < 0) {
-        LOG_E("SD:MINFree - Invalid floor: %lld (must be >= 0)", (long long)minFreeBytes);
-        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
-        return SCPI_RES_ERR;
-    }
-    pSDCardRuntimeConfig->minFreeBytes = (uint64_t)minFreeBytes;
-    sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
+    // Qodo PR #502 pass 1 bug 1: 64-bit shared write needs critical
+    // section per CLAUDE.md atomicity rules — PIC32MZ's 32-bit data
+    // bus tears 64-bit stores under task preemption.  The runtime
+    // config is read by SCPI_StartStreaming from a different task
+    // and by the SCPI getter from this task; without critical
+    // section guarding the 64-bit store, a concurrent STR:START
+    // could read a torn intermediate value.
+    taskENTER_CRITICAL();
+    pSDCardRuntimeConfig->minFreeBytes = minFreeBytes;
+    taskEXIT_CRITICAL();
+    // Qodo PR #502 pass 1 bug 2: do NOT call
+    // sd_card_manager_UpdateSettings() here.  UpdateSettings()
+    // unconditionally forces SD state to DEINIT → UNMOUNT_DISK,
+    // which closes any active WRITE file and on next open
+    // truncates with WRITE_PLUS.  MINFree is consulted only at
+    // SYST:STR:START, so a config-only write is correct — no need
+    // to bounce the SD state machine.  Doing so during an active
+    // logging session would cause silent data loss.
     return SCPI_RES_OK;
 }
 
@@ -771,7 +784,13 @@ scpi_result_t SCPI_StorageSDMinFreeSet(scpi_t * context) {
 scpi_result_t SCPI_StorageSDMinFreeGet(scpi_t * context) {
     sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
 
-    SCPI_ResultUInt64(context, pSDCardRuntimeConfig->minFreeBytes);
+    // Qodo PR #502 pass 1 bug 1: 64-bit shared read also under
+    // critical section.
+    uint64_t minFreeBytes;
+    taskENTER_CRITICAL();
+    minFreeBytes = pSDCardRuntimeConfig->minFreeBytes;
+    taskEXIT_CRITICAL();
+    SCPI_ResultUInt64(context, minFreeBytes);
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/SCPI/SCPIStorageSD.h
+++ b/firmware/src/services/SCPI/SCPIStorageSD.h
@@ -47,6 +47,10 @@ scpi_result_t SCPI_StorageSDFormat(scpi_t * context);
 scpi_result_t SCPI_StorageSDMaxSizeSet(scpi_t * context);
 scpi_result_t SCPI_StorageSDMaxSizeGet(scpi_t * context);
 
+// SD Disk-Full Pre-Start Gate (#498)
+scpi_result_t SCPI_StorageSDMinFreeSet(scpi_t * context);
+scpi_result_t SCPI_StorageSDMinFreeGet(scpi_t * context);
+
 // SD Card Space Query
 scpi_result_t SCPI_StorageSDSpaceGet(scpi_t * context);
 

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -55,6 +55,11 @@ extern "C" {
         char directory[SD_CARD_MANAGER_CONF_DIR_NAME_LEN_MAX + 1];
         char file[SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX + 1];
         uint64_t maxFileSizeBytes;  // Max file size before auto-split (0 = unlimited)
+        // Pre-start free-space floor (#498).  When > 0, SYST:STR:START
+        // for SD-output sessions runs a SYS_FS_DriveSectorGet() check
+        // and rejects with SCPI -200 if the card has fewer than this
+        // many bytes free.  0 = no pre-start check (legacy behavior).
+        uint64_t minFreeBytes;
     } sd_card_manager_settings_t;
 
 

--- a/firmware/src/state/runtime/CommonRuntimeDefaults.h
+++ b/firmware/src/state/runtime/CommonRuntimeDefaults.h
@@ -135,6 +135,7 @@ _Static_assert(sizeof(DEFAULT_NETWORK_HOST_NAME) <= WIFI_MANAGER_DNS_CLIENT_MAX_
         .file = "default.bin", \
         .mode = SD_CARD_MANAGER_MODE_NONE, \
         .maxFileSizeBytes = SD_CARD_MANAGER_FAT32_SAFE_MAX_FILE_SIZE, \
+        .minFreeBytes = 0,  /* #498: 0 = pre-start disk-full gate disabled */ \
     }
 
 /**


### PR DESCRIPTION
Closes #498 v1.  Adds SYST:STOR:SD:MINFree.  When set > 0, SYST:STR:START for SD-output sessions runs SYS_FS_DriveSectorGet() before arming the streaming timer and returns -200 if free space is below the floor.  **Default 0 = no pre-start check (firmware policy: mechanism only, no opinionated defaults).**

## Architectural split (2026-05-26 decision)

| Layer | Responsibility |
|---|---|
| **Firmware** | Provides the mechanism (`SYST:STOR:SD:MINFree`).  Default 0.  Never surprises existing users. |
| **Client software** | Owns the UX warning.  Query `SYST:STOR:SD:SPACe?` before long captures and warn the user if free space is low.  Filed as daqifi/daqifi-python-core#151. |

If a client wants to enforce a floor without re-checking each start, it can set `SYST:STOR:SD:MINFree 52428800` (50 MB) once per session and let the firmware -200 the bad starts.  The mechanism supports both patterns.

## Why

Pre-fix: customer starts a 4-hour log on a card with ~10 MB free.  Streaming arms cleanly, fills in ~5 minutes, then every write fails silently.  Customer sees 5 minutes of data where they expected 4 hours.

Post-fix with `SYST:STOR:SD:MINFree 52428800` (50 MB):

    > SYST:STR:START 1000
    **ERROR: -200, "Execution error"
    LOG_E [SD] STR:START refused: 8 MB free < 50 MB floor

## Surface

- `SYST:STOR:SD:MINFree <bytes>` — set the floor (uint64; 0 = disabled, the default)
- `SYST:STOR:SD:MINFree?` — query

Setting lives in `sd_card_manager_settings_t` alongside `maxFileSizeBytes`.  Runtime-only (NVM persistence is separate work).

## Validation (2026-05-26 bench)

```
> SYST:STOR:SD:MINFree?                       → 0
> SYST:STOR:SD:MINFree 107374182400           (set 100 GB — intentionally absurd to prove the gate fires)
> SYST:STOR:SD:MINFree?                       → 107374182400
> SYST:STOR:SD:FILE "498test.pb"
> SYST:STOR:SD:ENAble 1
> SYST:STR:INT 2
> ENA:VOLT:DC 4,1
> SYST:STR:START 1000                         → **ERROR: -200
> SYST:ERR?                                   → -200,"Execution error"
> SYST:STOR:SD:MINFree 0                      (disable gate)
> SYST:STR:START 1000                         → proceeds normally
```

## Deferred to v2

Per the original #498 plan:

- In-flight detection: consecutive `FR_DENIED` / `FR_DISK_ERR` counter from `SDCardWrite` return value
- New QUES bit 13 `SD_DISK_FULL`
- Auto-stop via the #397 transport-down machinery
- `SdDiskFull` field in `SYST:STR:STATS?`
- NVM persistence of `MINFree`

## Test plan

- [x] Build clean (XC32 v4.60, default config)
- [x] `SYST:STOR:SD:MINFree?` returns 0 at boot
- [x] set/get round-trip
- [x] `STR:START` rejected with -200 when free < floor
- [x] `STR:START` proceeds when MINFree=0
- [ ] Bench validation on a physically-near-full card
- [ ] v2: in-flight detection + auto-stop
- [ ] Client integration: daqifi/daqifi-python-core#151

Refs #498 #397
