### PR TITLE
feat(streaming): split QueueDroppedSamples into pool vs queue (#499)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2088,6 +2088,11 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
     scpi_printf(context, "SamplesPerSec=%u\r\n", (unsigned)samplesPerSec);
     scpi_printf(context, "BytesPerSec=%u\r\n", (unsigned)bytesPerSec);
     scpi_printf(context, "QueueDropped=%u\r\n", (unsigned)s.queueDroppedSamples);
+    // #499: split sub-counters — QueueDropped is their sum (kept for back-compat).
+    //   PoolExhausted = sample pool depth too shallow for the rate.
+    //   QueueOverflow = streaming_Task drain too slow (queue full while pool has slots).
+    scpi_printf(context, "PoolExhausted=%u\r\n", (unsigned)s.poolExhaustedSamples);
+    scpi_printf(context, "QueueOverflow=%u\r\n", (unsigned)s.queueOverflowSamples);
     scpi_printf(context, "UsbDropped=%u\r\n", (unsigned)s.usbDroppedBytes);
     scpi_printf(context, "WifiDropped=%u\r\n", (unsigned)s.wifiDroppedBytes);
     scpi_printf(context, "SdDropped=%u\r\n", (unsigned)s.sdDroppedBytes);
@@ -2442,6 +2447,11 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
     scpi_printf(context, "TotalSamplesStreamed=%llu\r\n", (unsigned long long)s.totalSamplesStreamed);
     scpi_printf(context, "TotalBytesStreamed=%llu\r\n", (unsigned long long)s.totalBytesStreamed);
     scpi_printf(context, "QueueDroppedSamples=%u\r\n", (unsigned)s.queueDroppedSamples);
+    // #499: split sub-counters — QueueDroppedSamples is their sum (kept for back-compat).
+    //   PoolExhaustedSamples = sample pool depth too shallow for the rate.
+    //   QueueOverflowSamples = streaming_Task drain too slow (queue full while pool has slots).
+    scpi_printf(context, "PoolExhaustedSamples=%u\r\n", (unsigned)s.poolExhaustedSamples);
+    scpi_printf(context, "QueueOverflowSamples=%u\r\n", (unsigned)s.queueOverflowSamples);
     scpi_printf(context, "UsbDroppedBytes=%u\r\n", (unsigned)s.usbDroppedBytes);
     scpi_printf(context, "UsbDroppedBytesSteady=%u\r\n", (unsigned)s.usbDroppedBytesSteady);
     scpi_printf(context, "WifiDroppedBytes=%u\r\n", (unsigned)s.wifiDroppedBytes);

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2524,6 +2524,13 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
     scpi_printf(context, "TimerISRCalls=%llu\r\n", (unsigned long long)s.timerISRCalls);
     // #367 diag: bytes sitting in WiFi circular buffer at session end (Stop)
     scpi_printf(context, "CircularBufferEndBytes=%u\r\n", (unsigned)s.circularBufferEndBytes);
+    // #499 diag: sample-pool peak utilization this session.  Compare with
+    // SamplePoolCount (MEM:FREE?) — if Used == Count, the pool was saturated
+    // and PoolExhaustedSamples > 0 makes sense.  If Used << Count but
+    // QueueOverflowSamples > 0, the queue is the bottleneck (streaming_Task
+    // drain too slow), not the pool.
+    scpi_printf(context, "SamplePoolMaxUsed=%u\r\n",
+                (unsigned)AInSampleList_PoolMaxUsed());
 #if PB_PROFILE_COUNTERS
     // #388 PB streaming profile counters (compile-time gated).  Raw cycle
     // counts at SYSCLK/2 = 100 MHz on PIC32MZ — divide by 1e8 for seconds,

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -67,7 +67,8 @@ static volatile bool gSdPbMetadataSent = false;
 static volatile bool gSdFileWasReady = false;
 
 // Per-session streaming statistics.
-// Written by: deferred ISR task (queueDroppedSamples, totalSamplesStreamed)
+// Written by: deferred ISR task (queueDroppedSamples, poolExhaustedSamples,
+//             queueOverflowSamples, totalSamplesStreamed)
 //             streaming task (all other fields)
 // Read by:    SCPI handler via Streaming_GetStats() atomic snapshot
 static StreamingStats gStreamStats = {0};
@@ -1660,7 +1661,9 @@ void streaming_Task(void) {
             DioProbe_PulseStart(9);  /* probe 9: output write duration */
             // All-or-nothing output writes. On timeout (10s), the interface
             // is assumed dead. Backpressure propagates to sample queue —
-            // QueueDroppedSamples is the ONLY data loss mechanism.
+            // PoolExhaustedSamples (deferred task can't allocate) and
+            // QueueOverflowSamples (deferred task can't enqueue) are the only
+            // input-side data loss mechanisms.  Their sum is QueueDroppedSamples.
             // USB/WiFi: all-or-nothing without retry. Full packet written
             // or cleanly dropped (no garbled partial data). No retry because
             // the ISR→encoder feedback loop causes sample queue overflow.
@@ -1737,9 +1740,10 @@ void streaming_Task(void) {
 
             // Track packets discarded due to output buffer backpressure.
             // The streaming task always encodes to drain the sample queue
-            // (preventing queueDroppedSamples), but when an output buffer
-            // is too full (< 128 bytes free), the encoded packet is silently
-            // discarded. Count these drops so SYST:STR:STATS? is accurate.
+            // (preventing queueOverflowSamples from rising further), but
+            // when an output buffer is too full (< 128 bytes free), the
+            // encoded packet is silently discarded.  Count these drops so
+            // SYST:STR:STATS? is accurate.
             {
                 bool sdExpected = hasSD || (
                     pRunTimeStreamConf->ActiveInterface == StreamingInterface_SD ||

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -452,7 +452,11 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             // No heap check needed - pool uses pre-allocated static memory
             pPublicSampleList = AInSampleList_AllocateFromPool();
             if(pPublicSampleList==NULL) {
+                // #499: split counter — this path = pool depth too shallow for
+                // the configured rate. Distinct from the PushBack-fail path
+                // below, which is "queue full / streaming_Task too slow."
                 gStreamStats.queueDroppedSamples++;
+                gStreamStats.poolExhaustedSamples++;
                 LOG_E_SESSION(LOG_SESSION_POOL_EXHAUST, "Streaming: Sample pool exhausted");
                 Streaming_UpdateFlowWindow(true);
                 // Still increment test pattern counter to stay in sync
@@ -556,7 +560,11 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                 }
             }
             if(!AInSampleList_PushBack(pPublicSampleList)){//failed pushing to Q
+                // #499: split counter — this path = FreeRTOS queue full,
+                // i.e. streaming_Task can't drain fast enough. Distinct from
+                // the AllocateFromPool-NULL path above (pool depth shallow).
                 gStreamStats.queueDroppedSamples++;
+                gStreamStats.queueOverflowSamples++;
                 LOG_E_SESSION(LOG_SESSION_QUEUE_OVERFLOW, "Streaming: Sample queue overflow detected");
                 AInSampleList_FreeToPool(pPublicSampleList);  // Use pool!
                 Streaming_UpdateFlowWindow(true);

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -155,7 +155,15 @@ void Streaming_ResetSdPbMetadata(void);
 // 32-bit fields are atomic on PIC32MZ; 64-bit fields require critical sections.
 // Use Streaming_GetStats() for an atomic snapshot of all fields.
 typedef struct {
-    uint32_t queueDroppedSamples;   // Pool exhaustion or queue full (deferred ISR task)
+    uint32_t queueDroppedSamples;   // Aggregate: poolExhaustedSamples + queueOverflowSamples
+    // #499 split — two distinct mechanisms previously combined in queueDroppedSamples:
+    //   poolExhaustedSamples: AInSampleList_AllocateFromPool() returned NULL
+    //                         (no free slot — pool depth too shallow for rate)
+    //   queueOverflowSamples: AInSampleList_PushBack() failed
+    //                         (FreeRTOS queue full — streaming_Task not draining fast enough)
+    // Sum equals queueDroppedSamples (kept for backward compat with existing parsers).
+    uint32_t poolExhaustedSamples;
+    uint32_t queueOverflowSamples;
     uint32_t usbDroppedBytes;       // USB circular buffer full (total — incl. startup transients)
     uint32_t wifiDroppedBytes;      // WiFi circular buffer full (total — incl. startup transients)
     uint32_t sdDroppedBytes;        // SD write timeout/partial (total — incl. startup transients)


### PR DESCRIPTION
## Summary

Splits `queueDroppedSamples` into two distinct sub-counters so the next overnight run distinguishes "increase pool depth" from "speed up encoder/output drain" without firmware re-instrumentation.

- `poolExhaustedSamples`: `AInSampleList_AllocateFromPool()` returned NULL — pool depth too shallow for the rate.
- `queueOverflowSamples`: `AInSampleList_PushBack()` returned false — FreeRTOS queue full, streaming_Task too slow.

Both still increment `queueDroppedSamples` (their sum), so existing parsers — test-suite endurance runner, `MEM:FREE` output, session-end log line, the `TimerISRCalls == TotalSamples + QueueDropped` invariant — keep working unchanged.

## Why

Issue #499 — `usb_1xT1 @ 25 kHz` lost 43,382/90,005,809 samples (0.048%) in the 2026-05-26 9 h endurance run. The current counter can't tell us whether to bump pool depth (path 1 dominant) or speed up the encoder / shorten USB drain latency (path 2 dominant).

Observability-only — no behavior change on the wire. Diagnosis costs one overnight run instead of A/B pool-depth sweeps.

## Changes

| File | Change |
|---|---|
| `streaming.h` | Add `poolExhaustedSamples` + `queueOverflowSamples` to `StreamingStats`. Document as sub-counters of the existing aggregate. |
| `streaming.c` | Increment the new sub-counter alongside `queueDroppedSamples` at each of the two existing drop sites. |
| `SCPIInterface.c` | Surface as `PoolExhausted=`/`QueueOverflow=` (in `STR:STATS:THR?`) and `PoolExhaustedSamples=`/`QueueOverflowSamples=` (in `STR:STATS?`). |

## Test plan

- [x] Build clean at -O3 (hex 1.7 MB).
- [x] cppcheck baseline unchanged.
- [ ] Flash device and confirm `SYST:STR:STATS?` includes the two new fields with sane values (`PoolExhausted + QueueOverflow == QueueDroppedSamples`).
- [ ] Reproduce the `usb_1xT1 @ 25 kHz` workload from #499 and confirm the breakdown points to a specific mechanism.

## References

- Closes part of #499 (diagnostic instrumentation; pool-depth tuning follows once we know which mechanism dominates).
- Atomicity is unchanged — both counters are single-writer (deferred ISR task), 32-bit RMW. Reader (`Streaming_GetStats`) already runs under `taskENTER_CRITICAL` which transitively blocks the timer ISR and the deferred task notification, so reads remain coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)