### PR TITLE
perf(streaming): coherent pool distributes 100% across active interfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1041,18 +1041,20 @@ All USB, WiFi, encoder, and sample pool memory comes from the unified Streaming 
 
 **Auto-Balance Buffer Sizing by Active Interface:**
 
-| Buffer | USB only | WiFi only | SD only | USB+WiFi | USB+SD | WiFi+SD | All |
-|--------|---:|---:|---:|---:|---:|---:|---:|
-| USB circular (stream pool) | 65,536 | 2,048 | 2,048 | 65,536 | 65,536 | 2,048 | 65,536 |
-| WiFi circular (stream pool) | 1,400 | 32,768 | 1,400 | 32,768 | 1,400 | 32,768 | 32,768 |
-| SD circular (stream pool) | 512 | 512 | 32,768 | 512 | 32,768 | 32,768 | 32,768 |
-| Encoder (stream pool) | 8,192 | 8,192 | 16,384 | 8,192 | 16,384 | 16,384 | 16,384 |
-| SD DMA write (coherent) | 512 | 512 | ~124,000 | 512 | ~62,000 | ~63,000 | ~63,000 |
-| USB DMA write (coherent) | ~124,000 | 512 | 512 | ~37,000 | ~37,000 | 512 | ~38,000 |
-| WiFi SPI staging (coherent) | 2,048 | ~125,000 | 2,048 | ~88,000 | 2,048 | ~63,000 | ~25,000 |
-| Sample pool | ~585 | ~738 | ~695 | ~436 | ~393 | ~546 | ~243 |
+The `StreamingInterface` enum exposes four combinations: `USB`, `WiFi`, `SD`, and `UsbAndSd`.  USB+WiFi and WiFi+SD are not selectable — WiFi is always solo (SPI bus is shared with SD; USB+WiFi was never wired into the interface enum).  Values below are for 16-channel `AInSampleList_ElementSize` (74 B + 2 B free-list = 76 B/sample).
 
-All DMA buffers (SD write, USB write, WiFi SPI staging) are auto-balanced from the 124KB coherent pool.
+| Buffer | USB only | WiFi only | SD only | USB+SD |
+|--------|---:|---:|---:|---:|
+| USB circular (stream pool) | 65,536 | 2,048 | 2,048 | 65,536 |
+| WiFi circular (stream pool) | 1,400 | 98,304 | 1,400 | 1,400 |
+| SD circular (stream pool) | 512 | 512 | 32,768 | 32,768 |
+| Encoder (stream pool) | 8,192 | 8,192 | 16,384 | 16,384 |
+| SD DMA write (coherent) | 512 | 512 | 124,368 | 77,922 |
+| USB DMA write (coherent) | 124,368 | 512 | 512 | 46,958 |
+| WiFi SPI staging (coherent) | 2,048 | 125,904 | 2,048 | 2,048 |
+| Sample pool (slots @16ch) | ~1,618 | ~1,178 | ~1,921 | ~1,086 |
+
+All DMA buffers (SD write, USB write, WiFi SPI staging) are auto-balanced from the 124KB coherent pool — `Streaming_ComputeAutoBuffers` distributes the remaining pool space across active interfaces using weighted shares (SD=5, USB=3, WiFi=2), so the full pool is allocated regardless of which interfaces are active.  Single-active gets the whole pool; multi-active splits proportionally.
 
 **Implementation:** `firmware/src/Util/StreamingBufferPool.c` (unified pool), `firmware/src/Util/CoherentPool.c` (DMA pool), `firmware/src/services/streaming.c` (`ComputeAutoBuffers`), `firmware/src/state/data/AInSample.c` (`InitializeExternal`), `firmware/src/services/SCPI/SCPIInterface.c` (SCPI callbacks), `firmware/src/state/runtime/StreamingRuntimeConfig.h` (MemoryConfig struct), `firmware/src/config/default/driver/winc/dev/spi/wdrv_winc_spi.c` (WiFi SPI staging)
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -822,22 +822,47 @@ void Streaming_ComputeAutoBuffers(uint32_t* outUsbSize, uint32_t* outWifiSize,
         uint32_t totalMin = sdMin + usbMin + wifiMin + overhead;
         if (pool > totalMin) {
             uint32_t avail = pool - totalMin;
-            uint32_t activeCount = (hasSd ? 1 : 0) + (hasUsb ? 1 : 0) + (hasWifi ? 1 : 0);
 
-            if (activeCount == 1) {
-                // Single active gets all remaining
-                if (hasSd)   *outSdDmaSize   += avail;
-                if (hasUsb)  *outUsbDmaSize  += avail;
-                if (hasWifi) *outWifiDmaSize += avail;
-            } else if (activeCount >= 2) {
-                // Split: SD 50%, USB 30%, WiFi 20%
-                uint32_t sdShare   = hasSd   ? (avail / 2) : 0;
-                uint32_t usbShare  = hasUsb  ? (avail * 3 / 10) : 0;
-                uint32_t wifiShare = hasWifi ? (avail - sdShare - usbShare) : 0;
-                *outSdDmaSize   += sdShare;
-                *outUsbDmaSize  += usbShare;
-                *outWifiDmaSize += wifiShare;
+            // Weighted distribution across active interfaces — weights only
+            // count for interfaces that are actually active, so `avail` is
+            // always fully allocated (no inactive-interface "share" wasted).
+            // Ratios (when multiple active): SD=5, USB=3, WiFi=2.  Single-
+            // active is the degenerate weighted case (all weight on one).
+            //
+            // Prior bug (#502 follow-up audit): the activeCount==2 branch
+            // wrote `wifiShare = hasWifi ? (avail - sdShare - usbShare) : 0`,
+            // which dropped 20% (~24.7 KB) of the coherent pool on the
+            // floor for USB+SD streaming.
+            uint32_t sdW   = hasSd   ? 5u : 0u;
+            uint32_t usbW  = hasUsb  ? 3u : 0u;
+            uint32_t wifiW = hasWifi ? 2u : 0u;
+            uint32_t totW  = sdW + usbW + wifiW;
+            if (totW > 0) {
+                uint32_t sdShare   = (avail * sdW)  / totW;
+                uint32_t usbShare  = (avail * usbW) / totW;
+                // The remainder (integer-division rounding + any unused
+                // weight) goes to the highest-priority active interface so
+                // the full `avail` lands somewhere — SD first, then USB,
+                // then WiFi.
+                uint32_t accounted = sdShare + usbShare;
+                uint32_t wifiShare = (avail > accounted) ? (avail - accounted) : 0;
+                if (hasSd)   *outSdDmaSize   += sdShare;
+                if (hasUsb)  *outUsbDmaSize  += usbShare;
+                if (hasWifi) {
+                    *outWifiDmaSize += wifiShare;
+                } else if (hasSd) {
+                    *outSdDmaSize   += wifiShare;
+                } else if (hasUsb) {
+                    *outUsbDmaSize  += wifiShare;
+                }
+                // If totW > 0 then at least one of hasSd/hasUsb/hasWifi is
+                // true, so the remainder is always absorbed above.
             }
+            // totW == 0 (degenerate: no active interface — possible if
+            // ActiveInterface=SD but sd->enable=false) leaves all three
+            // buffers at minimum.  No streaming consumer exists, so the
+            // unused RAM doesn't actively hurt — partition will be
+            // recomputed when the user re-enables a consumer.
         }
     }
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -838,25 +838,26 @@ void Streaming_ComputeAutoBuffers(uint32_t* outUsbSize, uint32_t* outWifiSize,
             uint32_t wifiW = hasWifi ? 2u : 0u;
             uint32_t totW  = sdW + usbW + wifiW;
             if (totW > 0) {
-                uint32_t sdShare   = (avail * sdW)  / totW;
-                uint32_t usbShare  = (avail * usbW) / totW;
-                // The remainder (integer-division rounding + any unused
-                // weight) goes to the highest-priority active interface so
-                // the full `avail` lands somewhere — SD first, then USB,
-                // then WiFi.
-                uint32_t accounted = sdShare + usbShare;
-                uint32_t wifiShare = (avail > accounted) ? (avail - accounted) : 0;
+                uint32_t sdShare   = (avail * sdW)   / totW;
+                uint32_t usbShare  = (avail * usbW)  / totW;
+                uint32_t wifiShare = (avail * wifiW) / totW;
+
+                // Route the integer-division remainder to the highest-
+                // priority active interface (SD > USB > WiFi) so the full
+                // `avail` lands somewhere.  totW > 0 guarantees at least
+                // one of the three is active, so one of the branches will
+                // always absorb the remainder.
+                uint32_t accounted = sdShare + usbShare + wifiShare;
+                uint32_t rem = (avail > accounted) ? (avail - accounted) : 0u;
+                if (rem > 0u) {
+                    if (hasSd)        sdShare   += rem;
+                    else if (hasUsb)  usbShare  += rem;
+                    else              wifiShare += rem;  /* hasWifi true */
+                }
+
                 if (hasSd)   *outSdDmaSize   += sdShare;
                 if (hasUsb)  *outUsbDmaSize  += usbShare;
-                if (hasWifi) {
-                    *outWifiDmaSize += wifiShare;
-                } else if (hasSd) {
-                    *outSdDmaSize   += wifiShare;
-                } else if (hasUsb) {
-                    *outUsbDmaSize  += wifiShare;
-                }
-                // If totW > 0 then at least one of hasSd/hasUsb/hasWifi is
-                // true, so the remainder is always absorbed above.
+                if (hasWifi) *outWifiDmaSize += wifiShare;
             }
             // totW == 0 (degenerate: no active interface — possible if
             // ActiveInterface=SD but sd->enable=false) leaves all three


### PR DESCRIPTION
## Summary

Fixes 24.7 KB of coherent-pool waste in USB+SD streaming, and 123.8 KB waste in the degenerate "SD interface selected but `sd->enable=false`" state.

## What the audit found

Walking `Streaming_ComputeAutoBuffers` for every `StreamingInterface` combo (USB / WiFi / SD / UsbAndSd):

| Combo | Old coherent waste | New |
|---|---:|---:|
| USB only | 0 | 0 |
| WiFi only | 0 | 0 |
| SD only | 0 | 0 |
| **USB+SD** | **24,772 B** | **0** |
| **iface=SD, sd disabled** | **123,856 B** | unchanged (no consumer to feed) |

The `activeCount == 2` branch wrote `wifiShare = hasWifi ? (avail - sdShare - usbShare) : 0` — so when USB+SD was active and WiFi was not, the 20% remainder (24.7 KB) was assigned to a variable that was then ignored.

## Fix

Replace `activeCount == 1` / `activeCount >= 2` branches with a single weighted-share computation that only counts weights for active interfaces (SD=5, USB=3, WiFi=2). The integer-division remainder is routed to the highest-priority active interface (SD > USB > WiFi).

Per-combo allocation table (16-channel element size):

| Combo | SD-DMA | USB-DMA | WiFi-DMA |
|---|---:|---:|---:|
| USB only | 512 | 124,368 | 2,048 |
| WiFi only | 512 | 512 | 125,904 |
| SD only | 124,368 | 512 | 2,048 |
| **USB+SD (new)** | **77,922** | **46,958** | 2,048 |
| USB+SD (old) | 62,440 | 37,668 | 2,048 (24,772 B dropped) |

## Other changes

`CLAUDE.md` auto-balance table updated:
- Removed fictional `USB+WiFi` / `WiFi+SD` / `All` columns — these combos are not selectable via the `StreamingInterface` enum (WiFi is always solo by design — SPI bus conflict with SD; USB+WiFi was never wired).
- Updated USB+SD coherent values to match the fix.
- Updated WiFi-only `WiFi circular` from 32 KB → 96 KB (PR #501 from earlier today).

## Test plan

- [x] Build clean at -O3 (hex 1.71 MB)
- [x] cppcheck baseline unchanged
- [ ] Flash device, run `SYST:STR:INT 3` (UsbAndSd) then `SYST:STR:START`, query `SYST:MEM:FREE?` to confirm `SdDma`, `UsbDma`, `WifiDma` sum to 124,288 B (pool minus alignment overhead).
- [ ] Re-run the wifi_5xT1 / usb_5xT1 endurance cells to confirm no regression on the WiFi-only or USB-only paths.

## References

- Audit reasoning in the chat session 2026-05-26.
- Companion to recently-merged #501 (WiFi-only pool) / #502 (#498 SD disk-full gate) / #504 (#499 counter split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)