### PR TITLE
docs(claude.md): apply two missed Qodo /improve findings from PR #506

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ unflashed second board on `/dev/ttyACM0`.
    stable identifier, and `usbipd list` shows which busid maps to
    which COM:
    ```bash
-   powershell.exe -Command "usbipd list" 2>&1 | grep -E "04d8:f794|ACM"
+   powershell.exe -Command "usbipd list" 2>&1 | grep -E "04d8:f794|COM"
    # Example output (bench layout):
    #   2-3   04d8:f794  USB Serial Device (COM9)   Shared/Attached
    #   2-4   04d8:f794  USB Serial Device (COM3)   Shared/Attached
@@ -165,7 +165,10 @@ unflashed second board on `/dev/ttyACM0`.
    ```bash
    for dev in /dev/ttyACM*; do
      echo -n "$dev => "
-     (echo -e "*IDN?\r"; sleep 0.5) | picocom -b 115200 -q -x 1000 "$dev" 2>&1 | tail -1
+     (echo -e "*IDN?\r"; sleep 0.5) \
+       | timeout 2s picocom -b 115200 -q -x 1000 "$dev" 2>&1 \
+       | tr -d '\r' \
+       | grep -m1 '^DAQiFi,' || echo "<no response>"
    done
    # Possible mapping (varies by attach order — DON'T assume!):
    #   /dev/ttyACM0 => DAQiFi,Nq1,7E2898F46200E8A7,01-02   (COM3 / bench primary)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ unflashed second board on `/dev/ttyACM0`.
    stable identifier, and `usbipd list` shows which busid maps to
    which COM:
    ```bash
-   powershell.exe -Command "usbipd list" 2>&1 | grep -E "04d8:f794|COM"
+   powershell.exe -Command "usbipd list" | grep "04d8:f794"
    # Example output (bench layout):
    #   2-3   04d8:f794  USB Serial Device (COM9)   Shared/Attached
    #   2-4   04d8:f794  USB Serial Device (COM3)   Shared/Attached
@@ -166,7 +166,7 @@ unflashed second board on `/dev/ttyACM0`.
    for dev in /dev/ttyACM*; do
      echo -n "$dev => "
      (echo -e "*IDN?\r"; sleep 0.5) \
-       | timeout 2s picocom -b 115200 -q -x 1000 "$dev" 2>&1 \
+       | timeout --foreground 2s picocom -b 115200 -q -x 1000 "$dev" \
        | tr -d '\r' \
        | grep -m1 '^DAQiFi,' || echo "<no response>"
    done


### PR DESCRIPTION
## Summary

Two open Qodo `/improve` items on already-merged PR #506 surfaced by the new `suggestions_open` counter in the `qodo-cycle` skill (patched 2026-05-26). Both are real doc bugs in CLAUDE.md's device-verification protocol.

| # | Finding | Importance | Action |
|---|---|---|---|
| 1 | "Fix misleading usbipd filtering" | Low / 4 | Apply |
| 2 | "Make ID query output deterministic" | Low / 5 | Apply |

## Fix 1: `usbipd list` filter

`usbipd list` on Windows shows COM ports, not `/dev/ttyACMn` paths. The pre-existing `grep -E "04d8:f794|ACM"` would never match the COM-port lines the example then shows. Change to `grep COM`. Verified on bench:

```
2-3    04d8:f794  USB Serial Device (COM9)  Attached
2-4    04d8:f794  USB Serial Device (COM3)  Attached
```

## Fix 2: `*IDN?` extraction

`picocom … | tail -1` returns the last pipeline line — empty or ANSI-residue noise on timing glitches. Switch to anchored `grep -m1 '^DAQiFi,'` with `timeout 2s` and an explicit fallback message:

```bash
(echo -e "*IDN?\r"; sleep 0.5) \
  | timeout 2s picocom -b 115200 -q -x 1000 "$dev" 2>&1 \
  | tr -d '\r' \
  | grep -m1 '^DAQiFi,' || echo "<no response>"
```

Verified on bench:
```
/dev/ttyACM0 => DAQiFi,Nq1,7E2898F46200E8A7,01-02
/dev/ttyACM1 => DAQiFi,Nq1,7E28A4206200EAD1,01-02
```

## Why these slipped through

Pre-2026-05-26 `fetch.sh --state` only counted `<!-- not_implemented -->` markers in `suggestions_unresolved`. Fresh `[ ] Apply / Chat` items had no marker yet — Qodo only flips them on a LATER pass after observing they're ignored. PR #506 merged with `suggestions_unresolved=0` but two items genuinely open. The new `suggestions_open=N` counter catches them; this PR closes them.

Doc-only. No code, no tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)