### PR TITLE
docs(CLAUDE.md): how-we-test policy pointer to python-test-suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1896,7 +1896,7 @@ All **durable regression tests** — firmware regression, MCP integration, clien
 
 **Carve-out for ad-hoc bench exploration.** Quick interactive commands — `picocom` one-liners, single SCPI queries, a throwaway `/tmp/temp.sh` to validate a hunch before writing the real test — are fine and have their own conventions documented in the "Continuous Testing and Automation" section above. The policy here applies when the question is "will this break if I change X next month?" — that answer lives in a versioned script in `daqifi-python-test-suite`, not in your shell history.
 
-When you're touching the firmware in a way that needs a regression check, your first move is to find or write a script in `daqifi-python-test-suite` that exercises it. Don't put bench-validation logic in the firmware repo. Don't reproduce harness primitives.
+When you're touching the firmware in a way that needs a regression check, your first move is to find or write a script in `daqifi-python-test-suite` that exercises it. Don't put **regression** bench-validation logic in the firmware repo (the carve-out above is for one-off exploration only, not for tests that should keep running). Don't reproduce harness primitives.
 
 ### DAQiFi Test & API Repositories
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1886,15 +1886,17 @@ voltage, NTC status, and power-up readiness.
 
 ### How we test (policy)
 
-All testing — firmware regression, MCP integration, client SDK validation, throughput characterization — lives in **`daqifi-python-test-suite`**. The full policy is in [`docs/HOW_WE_TEST.md`](https://github.com/daqifi/daqifi-python-test-suite/blob/main/docs/HOW_WE_TEST.md) in that repo; the short version:
+All **durable regression tests** — firmware regression, MCP integration, client SDK validation, throughput characterization — live in **`daqifi-python-test-suite`**. The full policy is in [`docs/HOW_WE_TEST.md`](https://github.com/daqifi/daqifi-python-test-suite/blob/main/docs/HOW_WE_TEST.md) in that repo (private, see `docs/README.md` for access); the short version:
 
-1. **All host-observable tests live in `daqifi-python-test-suite`.** Firmware-internal unit tests (boot self-tests, cppcheck, `mdb`-driven device tests) stay in the firmware repo; everything you'd run from a PC against the device goes in the test suite.
+1. **Anything you'd run again** — regression checks, ceiling sweeps, endurance soaks, integration validation — lives in `daqifi-python-test-suite`. Firmware-internal unit tests (boot self-tests, cppcheck, `mdb`-driven device tests) stay in the firmware repo.
 2. **Build tests from modular pieces** in `test_harness.py` (`StreamingMeasurement`, `ReliableSCPI`, `FastReader`, `build_result_row`, `format_sd_card`, `derive_targets_from_csv`, etc.). New utilities go in the harness, not your script. New scripts that re-implement existing primitives get flagged in review.
 3. **A test run = a recipe.** Either YAML (`comprehensive_test.py` pattern) or Python script with CLI flags (`test_overnight_characterization.py` pattern). Both are valid.
 4. **Every run logs its complete recipe + version triplet** to a sidecar `<script>_<timestamp>.meta.json`: firmware `*IDN?` + firmware version + test-suite git SHA (`test_harness.collect_run_metadata`). Two runs with the same triplet should produce comparable CSVs; that's the **repeatability key**.
 5. **Every benchmark emits the canonical CSV shape** documented in [`docs/CSV_SCHEMA.md`](https://github.com/daqifi/daqifi-python-test-suite/blob/main/docs/CSV_SCHEMA.md). New `SYST:STR:STATS?` firmware fields flow through automatically — no script changes needed.
 
-When you're touching the firmware in a way that needs a regression check, your first move is to find or write a script in `daqifi-python-test-suite` that exercises it. Don't write throwaway scripts in `/tmp`. Don't put bench-validation logic in the firmware repo. Don't reproduce harness primitives.
+**Carve-out for ad-hoc bench exploration.** Quick interactive commands — `picocom` one-liners, single SCPI queries, a throwaway `/tmp/temp.sh` to validate a hunch before writing the real test — are fine and have their own conventions documented in the "Continuous Testing and Automation" section above. The policy here applies when the question is "will this break if I change X next month?" — that answer lives in a versioned script in `daqifi-python-test-suite`, not in your shell history.
+
+When you're touching the firmware in a way that needs a regression check, your first move is to find or write a script in `daqifi-python-test-suite` that exercises it. Don't put bench-validation logic in the firmware repo. Don't reproduce harness primitives.
 
 ### DAQiFi Test & API Repositories
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1884,6 +1884,18 @@ voltage, NTC status, and power-up readiness.
      test_feature && echo "PASS" || echo "FAIL"
      ```
 
+### How we test (policy)
+
+All testing — firmware regression, MCP integration, client SDK validation, throughput characterization — lives in **`daqifi-python-test-suite`**. The full policy is in [`docs/HOW_WE_TEST.md`](https://github.com/daqifi/daqifi-python-test-suite/blob/main/docs/HOW_WE_TEST.md) in that repo; the short version:
+
+1. **All host-observable tests live in `daqifi-python-test-suite`.** Firmware-internal unit tests (boot self-tests, cppcheck, `mdb`-driven device tests) stay in the firmware repo; everything you'd run from a PC against the device goes in the test suite.
+2. **Build tests from modular pieces** in `test_harness.py` (`StreamingMeasurement`, `ReliableSCPI`, `FastReader`, `build_result_row`, `format_sd_card`, `derive_targets_from_csv`, etc.). New utilities go in the harness, not your script. New scripts that re-implement existing primitives get flagged in review.
+3. **A test run = a recipe.** Either YAML (`comprehensive_test.py` pattern) or Python script with CLI flags (`test_overnight_characterization.py` pattern). Both are valid.
+4. **Every run logs its complete recipe + version triplet** to a sidecar `<script>_<timestamp>.meta.json`: firmware `*IDN?` + firmware version + test-suite git SHA (`test_harness.collect_run_metadata`). Two runs with the same triplet should produce comparable CSVs; that's the **repeatability key**.
+5. **Every benchmark emits the canonical CSV shape** documented in [`docs/CSV_SCHEMA.md`](https://github.com/daqifi/daqifi-python-test-suite/blob/main/docs/CSV_SCHEMA.md). New `SYST:STR:STATS?` firmware fields flow through automatically — no script changes needed.
+
+When you're touching the firmware in a way that needs a regression check, your first move is to find or write a script in `daqifi-python-test-suite` that exercises it. Don't write throwaway scripts in `/tmp`. Don't put bench-validation logic in the firmware repo. Don't reproduce harness primitives.
+
 ### DAQiFi Test & API Repositories
 
 The DAQiFi GitHub organization (https://github.com/daqifi) hosts companion libraries and test suites useful for firmware validation and regression testing:


### PR DESCRIPTION
Adds a 'How we test' policy section to CLAUDE.md (above the existing 'DAQiFi Test & API Repositories' section). Defers to the just-landed canonical docs in the test suite:

- [docs/HOW_WE_TEST.md](https://github.com/daqifi/daqifi-python-test-suite/blob/feat/full-stats-capture/docs/HOW_WE_TEST.md) — single-source-of-truth testing policy
- [docs/CSV_SCHEMA.md](https://github.com/daqifi/daqifi-python-test-suite/blob/feat/full-stats-capture/docs/CSV_SCHEMA.md) — canonical benchmark CSV + meta.json shape

Five-bullet summary in CLAUDE.md so firmware contributors don't write throwaway /tmp scripts or reproduce harness primitives in this repo when they should be using the suite.

The test-suite-side docs land in https://github.com/daqifi/daqifi-python-test-suite/pull/43 (currently open).