### PR TITLE
docs(CLAUDE.md): Session 24 characterization (400s endurance)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,6 +395,8 @@ The PIC32MZ ADCHS peripheral has two types of ADC channels with different ISR st
 
 Current table = **Session 24 (2026-05-28 overnight + 2× targeted retry, 400 s endurance).** Methodology change vs Session 22: where Session 22 used a fresh 10 s ceiling sweep + 60 s endurance soak, Session 24 uses 400 s endurance soaks with iterative haircut from prior-night ceilings (12.5 % per pass, repeated until zero drops). Result: **substantially more conservative** numbers than Session 22 in many cells — these are *verified-safe steady-state rates* the device sustains for 400 s+ without losing a single byte. Fresh 10 s sweeps will still find higher rates that hold short-term; treat Session 22 as "burst ceiling" and Session 24 as "soak ceiling." Source CSVs: `daqifi-python-test-suite/benchmarks/overnight_20260528_0642.csv` + `_0827_boardE8A7.csv` + `_1604_retry3.csv`. Test-suite SHA: `22302ba` on `feat/full-stats-capture`.
 
+> **This is descriptive endurance characterization, not the firmware cap.** These soak ceilings are an empirical record of what the device sustains across many configs (incl. OBDiag variants, OBDiag here = on-board diagnostics monitoring); the rate the firmware actually *enforces* is fitted separately — see **"Streaming Frequency Capping"** below, whose **"Fit basis — measured zero-loss ceilings"** table is the canonical 1/5/10/16-ch subset the `Streaming_TransportMaxFreq` coefficients derive from. The two use different methods (soak-with-haircut vs zero-loss sweep escalator) and so report different numbers by design. Authoritative dataset for both: `daqifi-python-test-suite/benchmarks/`.
+
 **USB** (400 s endurance soak, KB/s from `pc_kbps`):
 
 | Config | PB Hz | PB KB/s | CSV Hz | CSV KB/s |
@@ -600,6 +602,8 @@ The firmware computes a maximum safe streaming frequency — the `min()` of an *
 **Verified caps (hardware, 1 channel, #524):** USB 15000 · WiFi PB 11250 / CSV 9000 · SD PB 9000 / CSV 7500 · USB+SD 8000 — all match the equation and `current_max_rate_hz` (capabilities query reflects the full cap as of #524).
 
 **Fit basis — measured zero-loss ceilings (real ADC / PAT0) the F3 coefficients are fitted at-or-below (Hz):**
+
+> This is the **normative** basis for the enforced cap — the zero-loss sweep-escalator subset (1/5/10/16 ch, all four interfaces). It is distinct from the **Session 24 soak ceilings** in "Characterization results" above (ADC Architecture section), which are a broader *descriptive* endurance record across more configs and a different method (400 s soak + haircut). Different methods → different numbers by design; this table is what the firmware actually enforces.
 
 | interface/fmt | 1ch | 5ch | 10ch | 16ch |
 |---|--:|--:|--:|--:|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -743,7 +743,7 @@ SYSTem:STORage:SD:BENCHmark?                      # Query results: bytes,ms,bps
 >
 > **Do not use these numbers** for capacity planning. Spot-check with truthful counter (post-#371): 1×T1 PB real ceiling is ~3 kHz (not 7), 5×T1 PB is ~2 kHz (not 3), 16ch is ~2.5 kHz (not 1).
 >
-> Retrospective A/B planned in #373 to determine which prior throughput PRs actually moved firmware-path wire rate vs which were measurement artifacts. iperf demo A/B planned in #377 to establish the true wire-rate ceiling. A future WiFi characterization session will replace this table after both audits — Session 24 (USB/SD only, 2026-05-28, see line 396 above) does NOT include WiFi.
+> Retrospective A/B planned in #373 to determine which prior throughput PRs actually moved firmware-path wire rate vs which were measurement artifacts. iperf demo A/B planned in #377 to establish the true wire-rate ceiling. A future WiFi characterization session will replace this table after both audits — Session 24 (USB/SD only, 2026-05-28, see the **"Characterization results"** section earlier in this document) does NOT include WiFi.
 
 Single-trial ceiling sweep, no endurance. Best wire rate = **183 KB/s = 1.5 Mbps** (CSV 1×T1 OBD=OFF @ 8 kHz). WINC1500 spec is 5–10 Mbps real TCP — **~25 % of available bandwidth, 3-7× headroom**. WiFi-side bottleneck is `WifiDroppedBytes` in every leak (pipeline up to encoder is clean; WINC SPI staging is the bottleneck).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,52 +391,57 @@ The PIC32MZ ADCHS peripheral has two types of ADC channels with different ISR st
 - `HAL/ADC/MC12bADC.c` — `MC12b_TriggerConversion`, `MC12b_WriteStateAll` (batch interrupt setup)
 - `HAL/ADC.c` — `MC12bADC_EosInterruptTask`, `ADC_ReadADCSampleFromISR`
 
-**Characterization results (O3, USB, zero-loss ceiling sustained for 60s, fullscale test pattern, NoCap benchmark mode):**
+**Characterization results (O3, fullscale test pattern, NoCap benchmark mode):**
 
-Current table = Session 22 (2026-04-24 overnight, post-#354 ADC stack fix + #356 SCPI-dispatch Option 2 decouple). #354 moved two ~5 KB stack locals off the ADC write path; #356 moved the TCP-SCPI dispatch from WDRV_WINC_Tasks onto app_WifiTask so WINC stays at 1024 words. Throughput is unchanged to +1 k on five USB configs (likely run-to-run at the edge, confirmed by 60 s endurance). No regressions.
+Current table = **Session 24 (2026-05-28 overnight + 2× targeted retry, 400 s endurance).** Methodology change vs Session 22: where Session 22 used a fresh 10 s ceiling sweep + 60 s endurance soak, Session 24 uses 400 s endurance soaks with iterative haircut from prior-night ceilings (12.5 % per pass, repeated until zero drops). Result: **substantially more conservative** numbers than Session 22 in many cells — these are *verified-safe steady-state rates* the device sustains for 400 s+ without losing a single byte. Fresh 10 s sweeps will still find higher rates that hold short-term; treat Session 22 as "burst ceiling" and Session 24 as "soak ceiling." Source CSVs: `daqifi-python-test-suite/benchmarks/overnight_20260528_0642.csv` + `_0827_boardE8A7.csv` + `_1604_retry3.csv`. Test-suite SHA: `22302ba` on `feat/full-stats-capture`.
 
-**USB** (ceiling sweep 10s/step, endurance 60s at each ceiling):
+**USB** (400 s endurance soak, KB/s from `pc_kbps`):
 
-| Config | PB Ceiling | PB KB/s | CSV Ceiling | CSV KB/s |
-|--------|----------:|--------:|------------:|--------:|
-| 1×T1 | 19,000 Hz | 240 | 19,000 Hz | 276 |
-| 1×T1 OBDiag=OFF | **20,000 Hz** | 253 | **20,000 Hz** | 321 |
-| 1×T2 | 19,000 Hz | 240 | 19,000 Hz | 287 |
-| 3×T1 | 17,000 Hz | 364 | 15,000 Hz | 711 |
-| 3×T2 | 17,000 Hz | 363 | 15,000 Hz | 716 |
-| 5×T1 | 15,000 Hz | 457 | 13,000 Hz | 993 |
-| 5×T2 | 15,000 Hz | 456 | 13,000 Hz | 1,002 |
-| 5×T1 OBDiag=OFF | 17,000 Hz | 510 | 14,000 Hz | 1,102 |
-| 8×T2 | 13,000 Hz | 566 | 10,000 Hz | 1,256 |
-| 11×T2 | 11,000 Hz | 633 | 9,000 Hz† | 1,484† |
-| 5T1+3T2 (8ch) | 13,000 Hz | 567 | 10,000 Hz | 1,257 |
-| 5T1+5T2 (10ch) | 12,000 Hz† | 625† | 9,000 Hz | 1,349 |
-| 5T1+11T2 (16ch) | 9,000 Hz | 727 | 7,000 Hz | 1,610 |
+| Config | PB Hz | PB KB/s | CSV Hz | CSV KB/s |
+|--------|----------:|--------:|----------:|--------:|
+| 1×T1 OBDiag=OFF        | 16,500 | 182 | 17,000 | 256  |
+| 1×T1 OBDiag=ON         | 14,500 | 159 | 14,000 | 222  |
+| 1×T2                   | 14,500 | 159 | 16,000 | 250  |
+| 3×T1                   | 15,000 | 224 | 13,000 | 612  |
+| 3×T2                   | 15,000 | 224 | 13,000 | 613  |
+| 5×T1 OBDiag=OFF        | 16,000 | 303 | 13,000 | 968  |
+| 5×T1 OBDiag=ON         | 14,000 | 265 | 11,000 | 869  |
+| 5×T2                   | 14,000 | 266 | 11,000 | 868  |
+| 8×T2                   | 12,000 | 300 |  9,000 | 1,140 |
+| 11×T2                  | 11,000 | 341 |  8,000 | 1,386 |
+| 5T1+3T2 (8ch)          | 12,000 | 299 |  9,000 | 1,139 |
+| 5T1+5T2 (10ch)         | 11,000 | 315 |  8,000 | 1,266 |
+| 5T1+11T2 OBDiag=ON (16ch)  |  9,000 | 368 |  6,000 | 1,518 |
+| 5T1+11T2 OBDiag=OFF (16ch) | 11,000 | 449 |  7,000 | 1,798 |
 
-† Endurance leak at ceiling in Session 22 (PB 5T1+5T2 @ 12k: 3180 drops; CSV 11×T2 @ 9k: 1866 drops). Ceilings listed are highest clean in the 10s sweep; true sustainable endurance ceilings are 1 kHz lower for those configs.
+Best wire rate observed: **USB CSV 5T1+11T2 OBD=OFF @ 7 kHz → 1,798 KB/s**.
 
-**SD** (zero-drop over 60s, interface=2):
+**SD** (400 s endurance soak, interface=2, post-format clean card):
 
-| Config | PB Ceiling | CSV Ceiling |
-|--------|----------:|------------:|
-| 1×T1 | 10,000 Hz | 9,000 Hz |
-| 1×T1 OBDiag=OFF | **11,000 Hz** | 10,000 Hz |
-| 1×T2 | 10,000 Hz | 9,000 Hz |
-| 3×T1 | 8,000 Hz | 5,000 Hz |
-| 3×T2 | 8,000 Hz | 5,000 Hz |
-| 5×T1 | 7,000 Hz | 4,000 Hz |
-| 5×T2 | 7,000 Hz | 4,000 Hz |
-| 5×T1 OBDiag=OFF | 8,000 Hz | 4,000 Hz |
-| 5×T1 OBDiag=ON | 7,000 Hz | 4,000 Hz† |
-| 8×T2 | 6,000 Hz | 3,000 Hz |
-| 11×T2 | 5,000 Hz | 2,000 Hz |
-| 5T1+3T2 (8ch) | 6,000 Hz | 3,000 Hz |
-| 5T1+5T2 (10ch) | 5,000 Hz | 2,000 Hz† |
-| 5T1+11T2 (16ch) | 4,000 Hz | 2,000 Hz† |
+| Config | PB Hz | CSV Hz |
+|--------|----------:|----------:|
+| 1×T1 OBDiag=OFF        | 10,000 |  9,000 |
+| 1×T1 OBDiag=ON         |  9,000 |  8,000 |
+| 1×T2                   |  9,000 |  8,000 |
+| 3×T1                   |  8,000 |  5,000 |
+| 3×T2                   |  8,000 |  5,000 |
+| 5×T1 OBDiag=OFF        |  8,000 |  4,000 |
+| 5×T1 OBDiag=ON         |  7,000 |  3,000 |
+| 5×T2                   |  7,000 |  3,500 |
+| 8×T2                   |  6,000 |  2,500 |
+| 11×T2                  |  6,000 |  1,500 |
+| 5T1+3T2 (8ch)          |  6,000 |  2,000 |
+| 5T1+5T2 (10ch)         |  6,000 |  1,500 |
+| 5T1+11T2 OBDiag=ON (16ch)  |  5,000 |  1,000 |
+| 5T1+11T2 OBDiag=OFF (16ch) |  5,000 |  1,500 |
 
-† Endurance leak at ceiling in Session 22 (CSV 5×T1 OBD=ON @ 4k, 5T1+5T2 @ 2k, 5T1+11T2 @ 2k all leaked during the 60 s endurance). True sustainable ceilings are 1 kHz lower for those three configs.
+**Session 24 vs Session 22 (notable deltas):**
+- **SD CSV got tighter at high channel counts.** SD CSV 11×T2: 2,000 → 1,500 Hz (Session 22's 2,000 was a † endurance-leaker). SD CSV 5T1+5T2: 2,000† → 1,500 Hz. SD CSV 5T1+11T2: 2,000† → 1,000 Hz. The new numbers are zero-leak over 400 s, not "best 60-s candidate."
+- **SD PB 11×T2 +1 k** (5,000 → 6,000 Hz) and SD PB 8×T2 +0 (held at 6,000). One genuine improvement.
+- **OBD=ON now explicit everywhere** for 1×T1, 5×T1, 5T1+11T2. Previously the "default" rows inherited whatever OBDiag state lingered from the prior test — fixed in test-suite commit `22302ba`.
+- **USB cells look much lower** because Session 22 was a 10 s + 60 s methodology; running those same configs under 400 s endurance with iterative haircut converges several k below the burst ceiling. No firmware regression — methodology shift.
 
-**Session 22 highlights vs Sessions 20/21:**
+**Session 22 highlights vs Sessions 20/21 (historical):**
 - **#354/#356 throughput-safe.** 5 USB configs pick up +1 k ceilings post-merge (USB PB 3×T1, USB PB 5×T1 OBD=OFF, USB CSV 1×T1, USB CSV 1×T2, USB CSV 5×T1) — confirmed clean at 60 s endurance. Likely run-to-run at the edge rather than a real speedup.
 - **SD CSV 8×T2 real +2 k gain** (3 k clean vs Session 20's 1 k). Biggest SD surprise; SD CSV 5T1+11T2 ceiling sweep also finds 2 k (was 1 k) but leaks endurance, so sustainable ceiling stays at 1 k.
 - **SD single-channel PB -1 k** (10k/11k vs 11k/12k in Session 20). Session 20 numbers were run-to-run optimistic per own note; Session 22 figures are the reliable endurance values.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,7 @@ Best wire rate observed: **USB CSV 5T1+11T2 OBD=OFF @ 7 kHz → 1,798 KB/s**.
 **Session 24 vs Session 22 (notable deltas):**
 - **SD CSV got tighter at high channel counts.** SD CSV 11×T2: 2,000 → 1,500 Hz (Session 22's 2,000 was a † endurance-leaker). SD CSV 5T1+5T2: 2,000† → 1,500 Hz. SD CSV 5T1+11T2: 2,000† → 1,000 Hz. The new numbers are zero-leak over 400 s, not "best 60-s candidate."
 - **SD PB 11×T2 +1 k** (5,000 → 6,000 Hz) and SD PB 8×T2 +0 (held at 6,000). One genuine improvement.
-- **OBD=ON now explicit everywhere** for 1×T1, 5×T1, 5T1+11T2. Previously the "default" rows inherited whatever OBDiag state lingered from the prior test — fixed in test-suite commit `22302ba`.
+- **OBDiag=ON now explicit everywhere** for 1×T1, 5×T1, 5T1+11T2. Previously the "default" rows inherited whatever OBDiag state lingered from the prior test — fixed in test-suite commit `22302ba`.
 - **USB cells look much lower** because Session 22 was a 10 s + 60 s methodology; running those same configs under 400 s endurance with iterative haircut converges several k below the burst ceiling. No firmware regression — methodology shift.
 
 **Session 22 highlights vs Sessions 20/21 (historical):**
@@ -743,7 +743,7 @@ SYSTem:STORage:SD:BENCHmark?                      # Query results: bytes,ms,bps
 >
 > **Do not use these numbers** for capacity planning. Spot-check with truthful counter (post-#371): 1×T1 PB real ceiling is ~3 kHz (not 7), 5×T1 PB is ~2 kHz (not 3), 16ch is ~2.5 kHz (not 1).
 >
-> Retrospective A/B planned in #373 to determine which prior throughput PRs actually moved firmware-path wire rate vs which were measurement artifacts. iperf demo A/B planned in #377 to establish the true wire-rate ceiling. Session 24 numbers will replace this table after both audits.
+> Retrospective A/B planned in #373 to determine which prior throughput PRs actually moved firmware-path wire rate vs which were measurement artifacts. iperf demo A/B planned in #377 to establish the true wire-rate ceiling. A future WiFi characterization session will replace this table after both audits — Session 24 (USB/SD only, 2026-05-28, see line 396 above) does NOT include WiFi.
 
 Single-trial ceiling sweep, no endurance. Best wire rate = **183 KB/s = 1.5 Mbps** (CSV 1×T1 OBD=OFF @ 8 kHz). WINC1500 spec is 5–10 Mbps real TCP — **~25 % of available bandwidth, 3-7× headroom**. WiFi-side bottleneck is `WifiDroppedBytes` in every leak (pipeline up to encoder is clean; WINC SPI staging is the bottleneck).
 


### PR DESCRIPTION
## Summary

Refresh the streaming-throughput characterization tables in `CLAUDE.md` to Session 24 numbers (replaces Session 22, 2026-04-24).

**Methodology shift:** Session 22 was a 10 s ceiling sweep + 60 s endurance verify. Session 24 is **400 s endurance soak with iterative haircut** until every config holds zero drops. Numbers are more conservative — these are *verified-safe steady-state rates* (sustains 400 s+ without losing a byte), not burst ceilings. Session 22 numbers remain valid as "burst ceiling good for short runs."

Source CSVs (test-suite SHA `22302ba` on `feat/full-stats-capture`):
- `benchmarks/overnight_20260528_0642.csv` — full overnight, 14 configs × 4 interfaces × 400 s = 7 h 40 min
- `benchmarks/overnight_20260528_0827_boardE8A7.csv` — retry 1: 8 leakers @ −10 %
- `benchmarks/overnight_20260528_1604_retry3.csv` — retry 2: 3 remaining @ another −10 %

## Notable deltas vs Session 22

| Cell | Session 22 | Session 24 | Why |
|---|---:|---:|---|
| SD CSV 11×T2 | 2,000† | 1,500 | † was an endurance-leaker — now resolved into a real zero-drop number |
| SD CSV 5T1+5T2 | 2,000† | 1,500 | same |
| SD CSV 5T1+11T2 | 2,000† | 1,000 | same — 400 s soak needed two haircuts to converge |
| SD PB 11×T2 | 5,000 | 6,000 | one genuine improvement |
| USB cells (broadly) | higher | lower | methodology shift; not a regression |

OBD=ON is now an explicit row everywhere (1×T1 / 5×T1 / 5T1+11T2) — previously some configs had a "default" row that inherited whatever OBDiag state lingered from the prior test. Fixed in test-suite commit 22302ba.

## Test plan

- [ ] Tables render correctly in GitHub markdown (preview)
- [ ] CSV references resolve in `daqifi-python-test-suite/benchmarks/`
- [ ] No firmware code changes — docs-only PR

## Notes

- `daqifi-python-test-suite#43` (the test-harness changes that produced these numbers) is still open; this firmware PR can merge ahead of it.
- Session 22 highlights / Sessions 20/21 callouts retained below the new tables as historical context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)