### PR TITLE
fix(wifi): invalidate STA link state on teardown (#517)

### DIFF
--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -389,14 +389,26 @@ static void InvalidateStaLinkState(void) {
     //     networkMode to AP synchronously while STA is still tearing down; a
     //     networkMode-only gate would skip and leak the stale STA assocHandle.
     // (Qodo /agentic_review pass 1 + /improve passes 2-3.)
-    if (gStateMachineContext.pWifiSettings == NULL ||
-        GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED)) {
+    if (gStateMachineContext.pWifiSettings == NULL) {
+        return;
+    }
+    // Take a SINGLE coherent snapshot of the state flags and mode, then make
+    // all gate decisions against the snapshot.  This helper can run on the USB
+    // task (Deinit/HardReset) while the WifiTask mutates eventFlags, so reading
+    // gStateMachineContext.eventFlags separately for each of the three checks
+    // below could straddle a concurrent flag flip and observe an inconsistent
+    // AP/STA combination.  One atomic load each is sufficient on PIC32MZ — a
+    // critical section isn't needed for a single ≤32-bit read (Qodo
+    // /agentic_review pass 4 / "single flags snapshot").
+    const wifi_manager_stateFlag_t flags = gStateMachineContext.eventFlags;
+    const wifi_manager_networkMode_t mode = gStateMachineContext.pWifiSettings->networkMode;
+    if (GetEventFlagStatus(flags, WIFI_MANAGER_STATE_FLAG_AP_STARTED)) {
         return;
     }
     const bool staContext =
-        (gStateMachineContext.pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA) ||
-        GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED) ||
-        GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+        (mode == WIFI_MANAGER_NETWORK_MODE_STA) ||
+        GetEventFlagStatus(flags, WIFI_MANAGER_STATE_FLAG_STA_STARTED) ||
+        GetEventFlagStatus(flags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
     if (!staContext) {
         return;
     }

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -372,13 +372,23 @@ static void DhcpEventCallback(DRV_HANDLE handle, uint32_t ipAddress) {
 // from any task context (USB pri 7 or WifiTask pri 2).
 static void InvalidateStaLinkState(void) {
     gStateMachineContext.assocHandle = WDRV_WINC_ASSOC_HANDLE_INVALID;
-    // Only zero ipAddr in STA mode: there it holds the transient DHCP-assigned
-    // address.  In AP mode this SAME field is the AP's own IP (read at AP
-    // start, line ~1069) — zeroing it would silently drop a user-configured
-    // AP IP on the next AP start.  The STA_DISCONNECTED event also fires for
-    // AP-client disconnects, so this guard is load-bearing, not cosmetic.
+    // Only zero ipAddr when this is genuinely a STA link teardown: there the
+    // field holds the transient DHCP-assigned address.  In AP mode the SAME
+    // field is the AP's own IP (read at AP start, line ~1069) — zeroing it
+    // would silently drop a user-configured AP IP on the next AP start.
+    //
+    // Guard on BOTH the configured mode AND the running mode:
+    //   - networkMode is updated synchronously by UpdateNetworkSettings on
+    //     APPLY, but the AP it describes keeps running (AP_STARTED set) until
+    //     the queued REINIT executes.  In that window networkMode is already
+    //     STA while ipAddr still holds the live AP IP.
+    //   - STA_DISCONNECTED also fires for AP-client disconnects (ApEventCallback)
+    //     while AP_STARTED is set — so without the !AP_STARTED gate an AP
+    //     client dropping mid-transition would erase the AP IP (Qodo
+    //     /agentic_review pass 1).
     if (gStateMachineContext.pWifiSettings != NULL &&
-        gStateMachineContext.pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA) {
+        gStateMachineContext.pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA &&
+        !GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED)) {
         gStateMachineContext.pWifiSettings->ipAddr.Val = 0;
     }
     gRssiUpdatePending = false;

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -355,6 +355,43 @@ static void DhcpEventCallback(DRV_HANDLE handle, uint32_t ipAddress) {
     }
 }
 
+// Invalidate every STA link-derived cached value (#517).  Called from each
+// teardown path — disconnect, disable, Deinit (POW:STAT 0 / reboot), and
+// hard reset — so:
+//   1. SYST:COMM:LAN:RSSI / ADDRess? (and BSSID? once #516 lands) can't
+//      report a link that no longer exists.  assocHandle == INVALID is the
+//      first gate both wifi_manager_GetRSSI and #516's _GetBSSID check, so
+//      clearing it here is the load-bearing fix that makes those queries
+//      fail cleanly; ipAddr separately feeds ADDRess?.
+//   2. A stale assocHandle can't make a later WDRV_WINC_IPUseDHCPSet observe
+//      isConnected==true and return REQUEST_ERROR (the #467/#425 re-enable
+//      wedge class).
+// Previously assocHandle was cleared ONLY by the async StaEventCallback on a
+// WINC-reported disconnect — never on Deinit/power-down/disable, so the
+// cached values survived the radio going down.  Idempotent and safe to call
+// from any task context (USB pri 7 or WifiTask pri 2).
+static void InvalidateStaLinkState(void) {
+    gStateMachineContext.assocHandle = WDRV_WINC_ASSOC_HANDLE_INVALID;
+    // Only zero ipAddr in STA mode: there it holds the transient DHCP-assigned
+    // address.  In AP mode this SAME field is the AP's own IP (read at AP
+    // start, line ~1069) — zeroing it would silently drop a user-configured
+    // AP IP on the next AP start.  The STA_DISCONNECTED event also fires for
+    // AP-client disconnects, so this guard is load-bearing, not cosmetic.
+    if (gStateMachineContext.pWifiSettings != NULL &&
+        gStateMachineContext.pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA) {
+        gStateMachineContext.pWifiSettings->ipAddr.Val = 0;
+    }
+    gRssiUpdatePending = false;
+    // gLastRssiPercentage is paired with gRssiUpdateComplete by the query
+    // path (GetRSSI) under this same critical section — clear them together
+    // so a concurrent reader sees a coherent "no link" snapshot, never a
+    // half-cleared one.
+    taskENTER_CRITICAL();
+    gRssiUpdateComplete = false;
+    gLastRssiPercentage = 0;
+    taskEXIT_CRITICAL();
+}
+
 static void ApEventCallback(DRV_HANDLE handle, WDRV_WINC_ASSOC_HANDLE assocHandle, WDRV_WINC_CONN_STATE currentState, WDRV_WINC_CONN_ERROR errorCode) {
     // Validate this callback is for a valid association and we're in AP mode
     if (assocHandle == WDRV_WINC_ASSOC_HANDLE_INVALID) {
@@ -1158,6 +1195,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
         case WIFI_MANAGER_EVENT_STA_DISCONNECTED:
             returnStatus = WIFI_MANAGER_STATE_MACHINE_RETURN_STATUS_HANDLED;
             ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+            InvalidateStaLinkState();  // #517: clear cached RSSI/IP/assocHandle
             CloseUdpSocket(&pInstance->udpServerSocket);
             wifi_tcp_server_CloseSocket();
             RESET_TCP_SOCKET_OPEN(pInstance);
@@ -1288,6 +1326,11 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                         LOG_E("WiFi: BSS disconnect failed on disable (status=%d)", (int)discStatus);
                     }
                 }
+                // #517: invalidate synchronously here, not just via the async
+                // StaEventCallback — BSSDisconnect's disconnect callback can
+                // no-op when isConnected is stuck (#467), leaving the cached
+                // link state alive after the user disabled WiFi.
+                InvalidateStaLinkState();
 
                 // Close sockets
                 if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
@@ -2018,6 +2061,12 @@ bool wifi_manager_Deinit() {
     gApplyInProgressDeadlineTick = 0;
     gApplyInProgress = false;
     taskEXIT_CRITICAL();
+    // #517: clear cached link state immediately.  The DEINIT event's
+    // ResetAllEventFlags can be deferred (BUSY re-queue, or app_WifiTask not
+    // scheduled while the board powers down), so relying on it to clear
+    // STA_STARTED/assocHandle leaves BSSID?/RSSI/ADDR? reporting the dead
+    // link.  Doing it here makes the query gates trip the moment Deinit runs.
+    InvalidateStaLinkState();
     return SendEvent(WIFI_MANAGER_EVENT_DEINIT);
 }
 
@@ -2052,6 +2101,7 @@ bool wifi_manager_HardReset(void) {
     gApplyInProgressDeadlineTick = 0;
     gApplyInProgress = false;
     taskEXIT_CRITICAL();
+    InvalidateStaLinkState();  // #517: same rationale as wifi_manager_Deinit
     return SendEvent(WIFI_MANAGER_EVENT_DEINIT);
 }
 

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -371,27 +371,33 @@ static void DhcpEventCallback(DRV_HANDLE handle, uint32_t ipAddress) {
 // cached values survived the radio going down.  Idempotent and safe to call
 // from any task context (USB pri 7 or WifiTask pri 2).
 static void InvalidateStaLinkState(void) {
-    // Act only on a genuine STA-link teardown.  Gate on BOTH the configured
-    // mode AND the running mode:
-    //   - networkMode is updated synchronously by UpdateNetworkSettings on
-    //     APPLY, but the AP it describes keeps running (AP_STARTED set) until
-    //     the queued REINIT executes — so networkMode can read STA while AP
-    //     is still live.
-    //   - STA_DISCONNECTED also fires for AP-client disconnects
-    //     (ApEventCallback) while AP_STARTED is set.
-    // Without the !AP_STARTED gate, an AP client dropping mid-transition would
-    // zero ipAddr — which in AP mode is the AP's OWN IP (read at AP start,
-    // line ~1069), silently dropping a configured AP IP on the next AP start.
-    // assocHandle/RSSI are STA-only (assocHandle is set solely by
-    // StaEventCallback; GetRSSI gates on it) so clearing them in AP mode is
-    // currently harmless, but gating the whole helper keeps it unambiguous
-    // that it only touches STA link state (Qodo /agentic_review pass 1 +
-    // /improve pass 2).
-    const bool isStaLinkTeardown =
-        (gStateMachineContext.pWifiSettings != NULL) &&
-        (gStateMachineContext.pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA) &&
-        !GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED);
-    if (!isStaLinkTeardown) {
+    // Act only on a genuine STA-link teardown — never while an AP is up.
+    //
+    // !AP_STARTED is the hard guard: while an AP is actually running, ipAddr
+    // holds the AP's OWN IP (read at AP start, ~line 1069) and assocHandle is
+    // irrelevant, so we must not touch STA link state.  This matters because
+    // STA_DISCONNECTED also fires for AP-client disconnects (ApEventCallback).
+    //
+    // The STA-context predicate is an OR of the configured mode and the
+    // runtime flags, because each covers a blind spot of the other and BOTH
+    // are needed:
+    //   - networkMode==STA catches the disable path (and Deinit/HardReset from
+    //     STA): those reset STA_STARTED/STA_CONNECTED *before* calling this
+    //     helper (~line 1331), so a runtime-flag-only gate would early-return
+    //     and skip the clear — re-introducing the #467 re-enable wedge.
+    //   - STA_STARTED || STA_CONNECTED catches a STA->AP APPLY, which flips
+    //     networkMode to AP synchronously while STA is still tearing down; a
+    //     networkMode-only gate would skip and leak the stale STA assocHandle.
+    // (Qodo /agentic_review pass 1 + /improve passes 2-3.)
+    if (gStateMachineContext.pWifiSettings == NULL ||
+        GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED)) {
+        return;
+    }
+    const bool staContext =
+        (gStateMachineContext.pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA) ||
+        GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED) ||
+        GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+    if (!staContext) {
         return;
     }
     // assocHandle == INVALID is the load-bearing fix: both GetRSSI and #516's

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -419,7 +419,14 @@ static void InvalidateStaLinkState(void) {
     // stale isConnected==true (#467/#425 re-enable wedge class).
     gStateMachineContext.assocHandle = WDRV_WINC_ASSOC_HANDLE_INVALID;
     gStateMachineContext.pWifiSettings->ipAddr.Val = 0;
-    // Clear the whole RSSI state tuple (pending + complete + value) as one
+    // Also clear the USER-FACING RSSI cache: SCPI_LANSsidStrengthGet (SSIDSTR?)
+    // returns pWifiSettings->rssi_percent as a fallback when a fresh GetRSSI
+    // fails, so without this a stale RSSI survives a teardown where the
+    // STA_DISCONNECTED handler (which already zeroes rssi_percent) doesn't run
+    // — e.g. Deinit/HardReset/disable.  Matches the STA_DISCONNECTED handler
+    // (Qodo /agentic_review pass 6).
+    gStateMachineContext.pWifiSettings->rssi_percent = 0;
+    // Clear the internal RSSI state tuple (pending + complete + value) as one
     // coherent snapshot under the same critical section the query path
     // (GetRSSI) uses, so a concurrent reader never sees a mixed state.
     taskENTER_CRITICAL();

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -392,23 +392,25 @@ static void InvalidateStaLinkState(void) {
     if (gStateMachineContext.pWifiSettings == NULL) {
         return;
     }
-    // Take a SINGLE coherent snapshot of the state flags and mode, then make
-    // all gate decisions against the snapshot.  This helper can run on the USB
-    // task (Deinit/HardReset) while the WifiTask mutates eventFlags, so reading
-    // gStateMachineContext.eventFlags separately for each of the three checks
-    // below could straddle a concurrent flag flip and observe an inconsistent
-    // AP/STA combination.  One atomic load each is sufficient on PIC32MZ — a
-    // critical section isn't needed for a single ≤32-bit read (Qodo
-    // /agentic_review pass 4 / "single flags snapshot").
-    const wifi_manager_stateFlag_t flags = gStateMachineContext.eventFlags;
+    // Take a SINGLE coherent snapshot of the state-flag bitmask and mode, then
+    // make all gate decisions against the snapshot.  This helper can run on the
+    // USB task (Deinit/HardReset) while the WifiTask mutates the flags, so
+    // reading them separately for each of the three checks below could straddle
+    // a concurrent flip and observe an inconsistent AP/STA combination.
+    // Snapshot the uint16_t .value field specifically — that is the atomic unit
+    // (wifi_manager_stateFlag_t is a struct, so copying the whole struct would
+    // be a multi-word, non-atomic copy).  A single 16-bit load is atomic on
+    // PIC32MZ; no critical section needed (Qodo /agentic_review pass 4 +
+    // /improve pass 5).
+    const uint16_t flags = gStateMachineContext.eventFlags.value;
     const wifi_manager_networkMode_t mode = gStateMachineContext.pWifiSettings->networkMode;
-    if (GetEventFlagStatus(flags, WIFI_MANAGER_STATE_FLAG_AP_STARTED)) {
+    if (flags & WIFI_MANAGER_STATE_FLAG_AP_STARTED) {
         return;
     }
     const bool staContext =
         (mode == WIFI_MANAGER_NETWORK_MODE_STA) ||
-        GetEventFlagStatus(flags, WIFI_MANAGER_STATE_FLAG_STA_STARTED) ||
-        GetEventFlagStatus(flags, WIFI_MANAGER_STATE_FLAG_STA_CONNECTED);
+        (0u != (flags & WIFI_MANAGER_STATE_FLAG_STA_STARTED)) ||
+        (0u != (flags & WIFI_MANAGER_STATE_FLAG_STA_CONNECTED));
     if (!staContext) {
         return;
     }

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -371,32 +371,39 @@ static void DhcpEventCallback(DRV_HANDLE handle, uint32_t ipAddress) {
 // cached values survived the radio going down.  Idempotent and safe to call
 // from any task context (USB pri 7 or WifiTask pri 2).
 static void InvalidateStaLinkState(void) {
-    gStateMachineContext.assocHandle = WDRV_WINC_ASSOC_HANDLE_INVALID;
-    // Only zero ipAddr when this is genuinely a STA link teardown: there the
-    // field holds the transient DHCP-assigned address.  In AP mode the SAME
-    // field is the AP's own IP (read at AP start, line ~1069) — zeroing it
-    // would silently drop a user-configured AP IP on the next AP start.
-    //
-    // Guard on BOTH the configured mode AND the running mode:
+    // Act only on a genuine STA-link teardown.  Gate on BOTH the configured
+    // mode AND the running mode:
     //   - networkMode is updated synchronously by UpdateNetworkSettings on
     //     APPLY, but the AP it describes keeps running (AP_STARTED set) until
-    //     the queued REINIT executes.  In that window networkMode is already
-    //     STA while ipAddr still holds the live AP IP.
-    //   - STA_DISCONNECTED also fires for AP-client disconnects (ApEventCallback)
-    //     while AP_STARTED is set — so without the !AP_STARTED gate an AP
-    //     client dropping mid-transition would erase the AP IP (Qodo
-    //     /agentic_review pass 1).
-    if (gStateMachineContext.pWifiSettings != NULL &&
-        gStateMachineContext.pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA &&
-        !GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED)) {
-        gStateMachineContext.pWifiSettings->ipAddr.Val = 0;
+    //     the queued REINIT executes — so networkMode can read STA while AP
+    //     is still live.
+    //   - STA_DISCONNECTED also fires for AP-client disconnects
+    //     (ApEventCallback) while AP_STARTED is set.
+    // Without the !AP_STARTED gate, an AP client dropping mid-transition would
+    // zero ipAddr — which in AP mode is the AP's OWN IP (read at AP start,
+    // line ~1069), silently dropping a configured AP IP on the next AP start.
+    // assocHandle/RSSI are STA-only (assocHandle is set solely by
+    // StaEventCallback; GetRSSI gates on it) so clearing them in AP mode is
+    // currently harmless, but gating the whole helper keeps it unambiguous
+    // that it only touches STA link state (Qodo /agentic_review pass 1 +
+    // /improve pass 2).
+    const bool isStaLinkTeardown =
+        (gStateMachineContext.pWifiSettings != NULL) &&
+        (gStateMachineContext.pWifiSettings->networkMode == WIFI_MANAGER_NETWORK_MODE_STA) &&
+        !GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED);
+    if (!isStaLinkTeardown) {
+        return;
     }
-    gRssiUpdatePending = false;
-    // gLastRssiPercentage is paired with gRssiUpdateComplete by the query
-    // path (GetRSSI) under this same critical section — clear them together
-    // so a concurrent reader sees a coherent "no link" snapshot, never a
-    // half-cleared one.
+    // assocHandle == INVALID is the load-bearing fix: both GetRSSI and #516's
+    // GetBSSID gate on it, and it stops a later IPUseDHCPSet from observing a
+    // stale isConnected==true (#467/#425 re-enable wedge class).
+    gStateMachineContext.assocHandle = WDRV_WINC_ASSOC_HANDLE_INVALID;
+    gStateMachineContext.pWifiSettings->ipAddr.Val = 0;
+    // Clear the whole RSSI state tuple (pending + complete + value) as one
+    // coherent snapshot under the same critical section the query path
+    // (GetRSSI) uses, so a concurrent reader never sees a mixed state.
     taskENTER_CRITICAL();
+    gRssiUpdatePending = false;
     gRssiUpdateComplete = false;
     gLastRssiPercentage = 0;
     taskEXIT_CRITICAL();


### PR DESCRIPTION
## What

Closes the WINC stale-link-state class from #517. Adds
`InvalidateStaLinkState()` and calls it from every STA teardown
chokepoint so cached link state can't outlive the radio.

## Why

`assocHandle`, the DHCP-assigned `ipAddr`, and the cached RSSI were
cleared **only** by the async `StaEventCallback` on a WINC-reported
disconnect — never on:
- disable (`SYST:COMM:LAN:ENAbled 0` + APPLY),
- `wifi_manager_Deinit` (`SYST:POW:STAT 0`, reboot),
- `wifi_manager_HardReset`.

Consequences, both verified on the bench (2026-05-30):
1. **Stale queries.** After `POW:STAT 0`, `SYST:COMM:LAN:ADDRess?`
   still reported the last DHCP IP (`192.168.1.65`) and `BSSID?`
   (from #516) still returned the AP MAC — for a link a clean
   ARP-flush + re-ping proved was gone.
2. **Re-enable wedge risk.** A stale `assocHandle` can make a later
   `WDRV_WINC_IPUseDHCPSet` observe `isConnected==true` and return
   `REQUEST_ERROR` — the #467/#425 class.

## How

`assocHandle == WDRV_WINC_ASSOC_HANDLE_INVALID` is the **load-bearing**
fix: both `wifi_manager_GetRSSI` and #516's `GetBSSID` gate on it
first, so clearing it on teardown makes those queries fail cleanly.
`ipAddr` is zeroed **only in STA mode** — in AP mode the same field is
the AP's own IP (read at AP start with a `192.168.1.1` fallback), and
the `STA_DISCONNECTED` event also fires for AP-client disconnects.

## Scope note (#516 interaction)

The BSSID-cache globals (`gLastBssid`) live on the **open** PR #516
(`feat/scpi-lan-bssid`), not on `main`, so this PR doesn't touch them.
It doesn't need to: once #516 merges on top, its `GetBSSID` already
gates on `assocHandle`, which this PR now invalidates correctly.
Optional defense-in-depth (clearing `gLastBssid` in the helper) can be
added when #516 lands.

## Test

- **Build:** clean at `-O3 -Werror`.
- **Hardware smoke test:** power-cycle + `ENAbled 0/1` + APPLY +
  `POW:STAT 0/1` sequence — `*IDN?` answered through every transition,
  no #425-class wedge or SCPI hang.
- **Pending:** SCPI-visible proof of the stale-query fix is best shown
  via #516's `BSSID?` on a conflict-free network; the bench AP
  currently has a DHCP/static IP conflict (separate, network-side).

Closes #517.

Test environment: firmware `fix/517-winc-link-state-invalidation`
@ 25fd9a57; bench primary `7E2898F46200E8A7` (PICkit BUR184882598);
XC32 v4.60 / MPLAB X v6.30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
