### PR TITLE
fix(state): invalidate stale globals on reverse transitions (#517 audit follow-up)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -815,7 +815,9 @@ static scpi_result_t SCPI_SysInfoTextGet(scpi_t * context) {
     // BQ24297 status - get fresh data
     tBQ24297Data * pBQ24297Data = &pBoardData->PowerData.BQ24297Data;
     if (pBQ24297Data->initComplete) {
-        BQ24297_UpdateStatus();
+        // UpdateBatteryStatus (not bare UpdateStatus) so batPresent is
+        // recomputed live, not the boot-time value (stale-global audit).
+        BQ24297_UpdateBatteryStatus();
         
         // Battery detection and charging
         const char* chgStatStr[] = {"Not Charging", "Pre-charge", "Fast Charge", "Charge Done"};
@@ -1799,8 +1801,14 @@ static scpi_result_t SCPI_GetBQDiagnostics(scpi_t * context) {
     }
     tBQ24297Data* pBQ = &pPower->BQ24297Data;
 
-    // Refresh cached status from hardware
-    BQ24297_UpdateStatus();
+    // Refresh cached status from hardware. Use UpdateBatteryStatus (not the
+    // bare UpdateStatus) so batPresent/chargeAllowed are recomputed from live
+    // NTC+voltage — they are otherwise only computed once at boot, so this
+    // diagnostic would print a stale battery-presence after a runtime
+    // insert/remove (stale-global audit). The ChargeEnable re-enforce inside
+    // only fires when chargeAllowed actually changes, so steady-state polling
+    // has no side effect.
+    BQ24297_UpdateBatteryStatus();
 
     // --- [Battery] ---
     scpi_printf(context, "[Battery]\r\n");

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -246,6 +246,12 @@ void UsbCdc_EventHandler(USB_DEVICE_EVENT event, void * eventData, uintptr_t con
         case USB_DEVICE_EVENT_DECONFIGURED:
         case USB_DEVICE_EVENT_RESET:
             gRunTimeUsbSttings.isConfigured = false;
+            // Cable unplug / re-enumeration produces DECONFIGURED/RESET but NOT
+            // a DTR-deassert SET_CONTROL_LINE_STATE, so the host-connected flag
+            // would otherwise stay set after the host is gone — and
+            // NanoPB_Encoder reads it directly for the streaming device_status
+            // "USB connected" bit. Clear it on real teardown (stale-global audit).
+            gRunTimeUsbSttings.isCdcHostConnected = 0;
             if (gRunTimeUsbSttings.deviceHandle != USB_DEVICE_HANDLE_INVALID) {
                 gRunTimeUsbSttings.state = USB_CDC_STATE_BEGIN_CLOSE;
             }
@@ -329,6 +335,7 @@ void UsbCdc_EventHandler(USB_DEVICE_EVENT event, void * eventData, uintptr_t con
             /* VBUS truly removed */
             gRunTimeUsbSttings.isVbusDetected = false;
             gRunTimeUsbSttings.isConfigured = false;
+            gRunTimeUsbSttings.isCdcHostConnected = 0;  // host gone (stale-global audit)
             if (gRunTimeUsbSttings.deviceHandle != USB_DEVICE_HANDLE_INVALID) {
                 USB_DEVICE_Detach(gRunTimeUsbSttings.deviceHandle);
             }
@@ -350,6 +357,7 @@ void UsbCdc_EventHandler(USB_DEVICE_EVENT event, void * eventData, uintptr_t con
             // Some errors may be non-fatal (transient bus errors, CRC errors)
             // but conservative approach is to reset the interface
             gRunTimeUsbSttings.isConfigured = false;
+            gRunTimeUsbSttings.isCdcHostConnected = 0;  // host link reset (stale-global audit)
             gRunTimeUsbSttings.state = USB_CDC_STATE_BEGIN_CLOSE;
             break;
         default:

--- a/firmware/src/services/wifi_services/wifi_tcp_server.c
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.c
@@ -395,6 +395,23 @@ void wifi_tcp_server_OpenSocket(uint16_t port) {
     }
 }
 
+// #517-class fix (stale-global audit): reset the in-flight send-size ring so
+// inflightHead/inflightTail/inflightSizes never survive a client teardown
+// desynced.  Always paired with tcpInFlight=0 in the same wMutex-held region,
+// so the invariant "tcpInFlight==0 ⇒ head==tail" holds across every reverse
+// transition.  Without it, a disconnect mid-send (head advanced, SOCKET_MSG_SEND
+// not yet fired) leaves head!=tail, and the partial-send consumer then reads the
+// wrong inflightSizes[] slot on the next connection — mis-attributing
+// wifiTcpPartialSends / wifiPartialBytesMissing for the rest of the session.
+// Caller must hold client.wMutex.
+static inline void ResetInflightRing(void) {
+    gpServerData->client.inflightHead = 0;
+    gpServerData->client.inflightTail = 0;
+    for (uint8_t i = 0; i < WIFI_TCP_MAX_IN_FLIGHT; i++) {
+        gpServerData->client.inflightSizes[i] = 0;
+    }
+}
+
 void wifi_tcp_server_CloseSocket() {
     // The WINC driver's shutdown() automatically closes the socket
     if (gpServerData->client.clientSocket != -1) {
@@ -417,6 +434,7 @@ void wifi_tcp_server_CloseSocket() {
         xSemaphoreTake(gpServerData->client.wMutex, 0) == pdTRUE) {
         gpServerData->client.writeBufferLength = 0;
         gpServerData->client.tcpInFlight = 0;
+        ResetInflightRing();  // #517-class: keep send-size ring in sync with tcpInFlight on teardown
         CircularBuf_Reset(&gpServerData->client.wCirbuf);
         gpServerData->client.pendingBufferReset = false;
         xSemaphoreGive(gpServerData->client.wMutex);
@@ -444,6 +462,7 @@ void wifi_tcp_server_CloseClientSocket() {
         xSemaphoreTake(gpServerData->client.wMutex, 0) == pdTRUE) {
         gpServerData->client.writeBufferLength = 0;
         gpServerData->client.tcpInFlight = 0;
+        ResetInflightRing();  // #517-class: keep send-size ring in sync with tcpInFlight on teardown
         CircularBuf_Reset(&gpServerData->client.wCirbuf);
         gpServerData->client.pendingBufferReset = false;
         xSemaphoreGive(gpServerData->client.wMutex);
@@ -460,6 +479,7 @@ static inline void DrainPendingBufferReset(void) {
     if (gpServerData->client.pendingBufferReset) {
         gpServerData->client.writeBufferLength = 0;
         gpServerData->client.tcpInFlight = 0;
+        ResetInflightRing();  // #517-class: keep send-size ring in sync with tcpInFlight on teardown
         CircularBuf_Reset(&gpServerData->client.wCirbuf);
         gpServerData->client.pendingBufferReset = false;
     }


### PR DESCRIPTION
## What

Follow-up to #517/#518: a firmware-wide audit for the **same bug class** —
a global written on a state transition *X* but never invalidated on the
reverse transition *~X*, where a consumer reads it on a path the reverse
doesn't gate. A multi-agent audit examined **110 candidate globals across
6 subsystems**; **3 confirmed** (the other 7 flags were verified false
positives — config flags like `gTestPattern`/`gBenchmarkMode`, read-once
latches, and consumers that re-arm before reading).

## Fixes

**1. USB `isCdcHostConnected` not cleared on cable unplug (medium)**
Set on DTR-assert, cleared only on DTR-deassert. A cable unplug produces
`DECONFIGURED`/`RESET`/`POWER_REMOVED` but **not** a DTR-deassert, so the
flag stayed set after the host was gone — and `NanoPB_Encoder.c:485` reads
it *directly* for the streaming `device_status` "USB connected" bit. A
device streaming over WiFi/SD after a USB unplug therefore reported
USB-connected=true. → cleared on those three teardown events.

**2. WiFi TCP in-flight send-size ring not reset on disconnect (low, diagnostic)**
`inflightHead`/`inflightTail`/`inflightSizes[]` were reset only at
stream-START, not on client teardown. A disconnect mid-send (head
advanced, `SOCKET_MSG_SEND` not yet fired) left `head != tail`; on the
next connection the partial-send consumer read the wrong slot,
mis-attributing `wifiTcpPartialSends`/`wifiPartialBytesMissing` for the
rest of the session. → new `ResetInflightRing()` called at all three
teardown sites, paired with the existing `tcpInFlight=0`.

**3. BQ24297 `batPresent`/`chargeAllowed` computed only at boot (low, diagnostic)**
No periodic re-eval, so `SYST:POW:BQ:DIAG?` (and the other status block)
printed a stale battery-presence after a runtime insert/remove. → those
two read paths now call `BQ24297_UpdateBatteryStatus()` (recompute from
live NTC+voltage) instead of bare `UpdateStatus()`. The internal
`ChargeEnable` re-enforce fires only when `chargeAllowed` actually
changes, so steady-state polling has no side effect (and it closes a
latent gap: charging a removed battery).

## Why not the other "obvious" fixes

Read-side gating (make the getters consult association/connection state)
was rejected for the same reason as in #518 review: it contradicts the
firmware's "inform on stale data — show last-known rather than hide"
principle and changes SCPI semantics. Clearing at the reverse transition
keeps last-known visible during operation and reflects reality after
teardown.

## Test

- Build clean at `-O3 -Werror`.
- **Pending:** hardware regression smoke (boot + USB SCPI + WiFi associate
  + basic stream) once the in-progress multi-target WiFi ceiling probe
  releases the bench device; will confirm before merge.

Audit method + the 7 refuted candidates are in the workflow transcript.
Refs #517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
