### PR TITLE
feat(streaming)!: per-interface/format transport cap + hard-error over-cap (#524)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1818,6 +1818,42 @@ voltage, NTC status, and power-up readiness.
 
 ### Real-Time Testing Guidelines
 
+0. **Background Python: always `-u`, never wrap a long run in a tight `timeout`.**
+   When launching a test-suite probe / bench script in the background and
+   monitoring it from outside, **two failure modes bite repeatedly**:
+   - **Buffering:** plain `python3 script.py > log 2>&1 &` is block-buffered
+     when stdout isn't a TTY, so the log looks *empty* while the run is
+     actually progressing — and if the process is killed (SIGTERM/timeout),
+     the buffered output is **lost entirely**. Always run `python3 -u` (or
+     set `PYTHONUNBUFFERED=1`) so lines stream live and survive a kill.
+   - **Aggressive `timeout`:** wrapping a multi-trial/overnight run in
+     `timeout 200 ...` kills it mid-run (bench runs are slower than you
+     estimate — per-trial SCPI overhead alone is ~15-20s), and combined
+     with buffering you get *nothing* back. Don't cap a real run with a
+     short `timeout`. Instead launch with **no timeout** and watch via a
+     PID-exit waiter (`while kill -0 $PID; do sleep N; done`) or by polling
+     the live `-u` log / the CSV. Reserve `timeout` for genuinely-bounded
+     one-shot probes, and even then size it generously.
+   - The CSV/JSONL the probe fsyncs per row is the reliable progress
+     signal; the stdout log is secondary. (Lesson logged after repeatedly
+     tripping on buffering+timeout, 2026-06-02.)
+
+0b. **Sustained high-rate USB streaming: prefer Windows-native Python
+   over WSL.** The `ISR=-1` / unreadable-`STATS?` "wedge" seen under
+   sustained high-rate USB streaming is a **WSL/usbipd passthrough
+   artifact, not a device problem** (a single 12 kHz trial streams +
+   reads cleanly; the wedge is cumulative across many back-to-back
+   high-rate trials). Running `python.exe` (Windows) + pyserial against
+   the device's **COM port (COM3 = bench primary)** bypasses usbipd
+   entirely and avoids the wedge — no attach/detach, no recovery dance.
+   For multi-hour / high-rate runs (the #524 matrix, endurance), prefer
+   the Windows host; WSL `/dev/ttyACMn` is fine for low-rate /
+   control-plane SCPI. The test-suite framework is mostly portable
+   (pyserial; `fcntl`/SIOCINQ guarded; TcpDrain cross-platform) — pass
+   `--port COM3`; the repo must be on `C:\...` for Windows python to run
+   it. Distinct from the WSL-launched-python UDP-drop issue (that's UDP;
+   serial/TCP on native Windows is fine). (User guidance 2026-06-03.)
+
 1. **Avoid Echo Output to Windows**:
    - Don't echo test results - Claude should observe and report internally
    - Reduces prompting issues and improves test speed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -581,7 +581,7 @@ The firmware computes a maximum safe streaming frequency — the `min()` of an *
 | Type 1 aggregate | 55 kHz total | `55000 / type1ChannelCount` (batched ISR) |
 | Per-tick budget | Scales with channels | `110000 / (6 + totalEnabledChannels)` |
 
-**Transport constraint** (`Streaming_TransportMaxFreq`, streaming.h — #524): per-(interface, format) wire/storage ceiling, fitted to the 3-run real-ADC zero-loss characterization (matrix_524, conservative). Form is **single-channel special-cased + `A/(B+n)` for n≥2** ("F3"), because 1-channel (esp. CSV) sits far above the multi-channel curve. Every cap is ≤ the measured zero-loss ceiling (safe; tightness 86–100%). This generalized the former WiFi-only term (#520) to USB/SD/USB+SD and **closed a format-blind hole** where high-channel CSV was capped *above* its true ceiling (silent loss). JSON treated as CSV.
+**Transport constraint** (`Streaming_TransportMaxFreq`, streaming.h — #524): per-(interface, format) wire/storage ceiling, fitted to the 3-run real-ADC zero-loss characterization (matrix_524, conservative). Form is **single-channel special-cased + `A/(B+n)` for n≥2** ("F3"), because 1-channel (esp. CSV) sits far above the multi-channel curve. Every cap is ≤ the measured zero-loss ceiling (safe; tightness 86–100%). This generalized the former WiFi-only term (#520) to USB/SD/USB+SD and **closed a format-blind hole** where high-channel CSV was capped *above* its true ceiling (silent loss). JSON uses the CSV coefficients **derated ×0.5** (uncharacterized; conservative so it never over-caps — JSON emits ~2-3× CSV bytes/sample; #524 follow-up to measure it).
 
 | interface | single (n=1) PB / CSV | A/(B+n) PB | A/(B+n) CSV |
 |-----------|----:|----:|----:|
@@ -593,6 +593,23 @@ The firmware computes a maximum safe streaming frequency — the `min()` of an *
 **Effective limit:** `min(ISR_MAX, TYPE1_AGG/type1Count, TICK_BUDGET/(OVERHEAD+totalEnabled), TransportMax(interface, encoding, totalEnabled))`
 
 **Verified caps (hardware, 1 channel, #524):** USB 15000 · WiFi PB 11250 / CSV 9000 · SD PB 9000 / CSV 7500 · USB+SD 8000 — all match the equation and `current_max_rate_hz` (capabilities query reflects the full cap as of #524).
+
+**Fit basis — measured zero-loss ceilings (real ADC / PAT0) the F3 coefficients are fitted at-or-below (Hz):**
+
+| interface/fmt | 1ch | 5ch | 10ch | 16ch |
+|---|--:|--:|--:|--:|
+| USB PB | 15000 | 12000 | 9000 | 7000 |
+| USB CSV | 15000 | 6000 | 6000 | 2000 |
+| WiFi PB | 11250 | 6000 | 6000 | 5000 |
+| WiFi CSV | 9000 | 3500 | 2000 | 1250 |
+| SD PB | 9000 | 7500 | 6000 | 5000 |
+| SD CSV | 7500 | 2500 | 3000 | 1500 |
+| USB+SD PB | 8000 | 6000 | 5250 | 3000 |
+| USB+SD CSV | 8000 | 3000 | 1500 | 1000 |
+
+**ADC cost (synth PAT3 − real PAT0), representative:** USB PB 1ch 25000→15000 (−40%); USB PB 16ch 10000→7000 (−30%); WiFi PB 1ch 12500→11250 (−10%); SD PB 1ch 12000→9000 (−25%). Below each transport's wire ceiling the ADC is ~free; above it, ADC ISR/EOS load competes with the encoder.
+
+**Full data + traceability:** the complete matrix (USB/WiFi/SD/USB+SD × PB/CSV × {1,5,10,16}ch × synth PAT3 / real PAT0, run-1/2/3 corroboration + the F3 fit script) lives in `daqifi-python-test-suite` `benchmarks/524_streaming_characterization/` — the authoritative record the coefficients above derive from (USB-CSV 3/8/11ch fill in `matrix_524_usbfill.csv`).
 
 **Where capping is applied:**
 - `SYSTem:STReam:START <freq>` — caps frequency before starting the timer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -572,7 +572,7 @@ SYSTem:STReam:LOSS:WINDow?           # Query current override (0=auto)
 
 #### Streaming Frequency Capping
 
-The firmware automatically caps the requested streaming frequency. The cap is applied silently — no SCPI error is returned, but a `LOG_I` message is written to the log buffer (retrievable via `SYST:LOG?`). It is the `min()` of an **ADC/ISR** model and a **per-interface, per-format TRANSPORT** model.
+The firmware computes a maximum safe streaming frequency — the `min()` of an **ADC/ISR** model and a **per-interface, per-format TRANSPORT** model. As of #524 the cap is a **HARD limit**: `SYSTem:STReam:START <freq>` with `freq` above the cap is **rejected** with SCPI error `-222` (Data out of range) plus a `LOG_E` detail line (`SYST:LOG?`) stating the achievable max — streaming does **not** start, and the rate is never silently changed. (Earlier firmware silently capped + `LOG_I`'d; that was changed because a client would stream at a different rate than it requested, unaware.) Clients should pre-validate against `current_max_rate_hz` (`CONF:CAP:JSON?`, which now equals this cap) or handle the error. **Benchmark mode (`SYST:STR:BENCHmark`) bypasses the cap.** (The mid-stream `CONFigure:ADC:CHANnel` recompute still silently re-caps for now — making it error too needs a channel-state snapshot/restore so runtime config and hardware don't desync; tracked separately.)
 
 **ADC/ISR constraints** (`Streaming_ComputeMaxFreq`, streaming.h):
 | Constraint | Limit | Formula |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -572,25 +572,27 @@ SYSTem:STReam:LOSS:WINDow?           # Query current override (0=auto)
 
 #### Streaming Frequency Capping
 
-The firmware automatically caps the requested streaming frequency based on a three-constraint model validated against hardware benchmarks. The cap is applied silently — no SCPI error is returned, but a `LOG_I` message is written to the log buffer (retrievable via `SYST:LOG?`).
+The firmware automatically caps the requested streaming frequency. The cap is applied silently — no SCPI error is returned, but a `LOG_I` message is written to the log buffer (retrievable via `SYST:LOG?`). It is the `min()` of an **ADC/ISR** model and a **per-interface, per-format TRANSPORT** model.
 
-**Constraints (fitted to characterization data 2026-04-13):**
+**ADC/ISR constraints** (`Streaming_ComputeMaxFreq`, streaming.h):
 | Constraint | Limit | Formula |
 |-----------|-------|---------|
-| ISR ceiling | 13 kHz | Hard per-invocation overhead limit |
+| ISR ceiling | 16 kHz | Hard per-invocation overhead limit (raised 13→16k in #524 so single-channel isn't capped below the transport ceiling) |
 | Type 1 aggregate | 55 kHz total | `55000 / type1ChannelCount` (batched ISR) |
 | Per-tick budget | Scales with channels | `110000 / (6 + totalEnabledChannels)` |
 
-**Effective limit:** `min(ISR_MAX, TYPE1_AGG / type1Count, BUDGET / (OVERHEAD + totalEnabled))`
+**Transport constraint** (`Streaming_TransportMaxFreq`, streaming.h — #524): per-(interface, format) wire/storage ceiling, fitted to the 3-run real-ADC zero-loss characterization (matrix_524, conservative). Form is **single-channel special-cased + `A/(B+n)` for n≥2** ("F3"), because 1-channel (esp. CSV) sits far above the multi-channel curve. Every cap is ≤ the measured zero-loss ceiling (safe; tightness 86–100%). This generalized the former WiFi-only term (#520) to USB/SD/USB+SD and **closed a format-blind hole** where high-channel CSV was capped *above* its true ceiling (silent loss). JSON treated as CSV.
 
-**Example caps vs measured ceilings:**
-| Config | Cap | Measured | Utilization |
-|--------|----:|--------:|-----------:|
-| 1×T1 | 13,000 Hz | 13,800 Hz | 94% |
-| 5×T1 | 10,000 Hz | 11,000 Hz | 91% |
-| 1×T2 | 13,000 Hz | 16,200 Hz | 80% |
-| 5T1+4T2 (9ch) | 7,333 Hz | 10,000 Hz | 73% |
-| 16ch | 5,000 Hz | 6,400 Hz | 78% |
+| interface | single (n=1) PB / CSV | A/(B+n) PB | A/(B+n) CSV |
+|-----------|----:|----:|----:|
+| USB    | 15000 / 15000 | 180000/(10+n) | 34000/(1+n) |
+| WiFi   | 11250 / 9000  | 210000/(30+n) | 21000/(1+n) |
+| SD     | 9000 / 7500   | 150000/(15+n) | 42000/(12+n) |
+| USB+SD | 8000 / 8000   | 66000/(6+n)   | 15000/(0+n) |
+
+**Effective limit:** `min(ISR_MAX, TYPE1_AGG/type1Count, TICK_BUDGET/(OVERHEAD+totalEnabled), TransportMax(interface, encoding, totalEnabled))`
+
+**Verified caps (hardware, 1 channel, #524):** USB 15000 · WiFi PB 11250 / CSV 9000 · SD PB 9000 / CSV 7500 · USB+SD 8000 — all match the equation and `current_max_rate_hz` (capabilities query reflects the full cap as of #524).
 
 **Where capping is applied:**
 - `SYSTem:STReam:START <freq>` — caps frequency before starting the timer

--- a/firmware/src/services/Capabilities.c
+++ b/firmware/src/services/Capabilities.c
@@ -117,7 +117,12 @@ void Capabilities_GetStreamingSummary(CapabilitiesStreamingSummary* out) {
     /* 0 public channels → no valid streaming rate. Reporting the
      * ISR ceiling in that state would advertise rates that
      * StartStreamData would reject. */
-    out->maxFreqHz = (total > 0) ? Streaming_ComputeMaxFreq(type1, total) : 0;
+    /* Use ComputeMaxFreqForConfig (#524) so current_max_rate_hz matches the rate
+     * StartStreamData actually applies — it now includes the per-interface,
+     * per-format TRANSPORT cap, not just the channel-count/ADC terms. Without
+     * this the capability query would advertise a higher rate than the device
+     * delivers (clients pre-validate against current_max_rate_hz). */
+    out->maxFreqHz = (total > 0) ? Streaming_ComputeMaxFreqForConfig() : 0;
     out->isrMaxHz      = STREAMING_ISR_MAX_HZ;
     out->type1AggMaxHz = STREAMING_TYPE1_AGG_MAX_HZ;
     out->tickBudget    = STREAMING_TICK_BUDGET;

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -228,10 +228,10 @@ scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
     uint64_t freq = pRunTimeStreamConfig->Frequency;
     uint32_t clkFreq = TimerApi_FrequencyGet(pBoardConfig->StreamingConfig.TimerIndex);
 
-    // Three-constraint frequency capping (see streaming.h)
+    // Frequency capping (see streaming.h) — includes the WiFi wire-rate term
+    // when ActiveInterface==WiFi on top of the ADC/ISR/tick constraints (#522).
     {
-        uint32_t maxFreq = Streaming_ComputeMaxFreq(
-            activeType1ChannelCount, totalEnabledPublicChannels);
+        uint32_t maxFreq = Streaming_ComputeMaxFreqForConfig();
         if (freq > maxFreq) {
             LOG_I("Frequency capped: %u Hz -> %u Hz (%u ch, %u type1)",
                   (unsigned)freq, (unsigned)maxFreq,

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2579,7 +2579,10 @@ static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
     // arc ceiling (lastGoodHz/KBps) is reported unclamped for testing.
     bool benchClamped = false;
     if (soakClean && recommendedHz > 0) {
-        uint32_t capHz = Streaming_ComputeMaxFreqForConfig();
+        // WIFI:FIND probes the WiFi path, so clamp to the WiFi transport cap
+        // explicitly rather than the global ActiveInterface (which may still be
+        // USB if the interface hasn't been switched) — Qodo /improve pass-6.
+        uint32_t capHz = Streaming_ComputeMaxFreqForConfigIface(StreamingInterface_WiFi);
         if (capHz > 0 && recommendedHz > capHz) {
             uint32_t newKBps = (recommendedHz > 0)
                 ? (uint32_t)((uint64_t)recommendedKBps * capHz / recommendedHz) : 0;
@@ -3243,7 +3246,12 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     // the cap entirely and could start an over-cap stream after interface/format/
     // channel changes, contradicting the hard-limit behavior.
     if (!freqProvided) {
+        // 64-bit read needs a critical section on the 32-bit PIC32MZ bus to avoid
+        // a torn read if another SCPI task writes Frequency concurrently
+        // (CLAUDE.md atomicity rules; Qodo /agentic_review pass-6).
+        taskENTER_CRITICAL();
         uint64_t stored = pRunTimeStreamConfig->Frequency;
+        taskEXIT_CRITICAL();
         if (stored > (uint64_t)INT32_MAX) stored = (uint64_t)INT32_MAX;  // clamp before narrowing (Qodo)
         freq = (int32_t)stored;
     }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4619,21 +4619,21 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
     Capabilities_GetAinSummary(&ai);
     Capabilities_GetAoutSummary(&ao);
     Capabilities_GetDioSummary(&di);
-    /* current_max_rate_hz reflects the cap for ActiveInterface; if that's still the
-     * default USB (client hasn't streamed yet), temporarily adopt the detected
-     * connection interface so the advertised cap matches what START will enforce
-     * for THIS client (#524 Qodo — query-side of the interface-detect fix). Restored
-     * immediately; the SCPI query runs single-threaded on the connection's task. */
-    {
+    Capabilities_GetStreamingSummary(&st);
+    /* current_max_rate_hz must reflect the cap for the interface the client will
+     * actually stream on. When ActiveInterface is still the default USB (or already
+     * matches the detected connection), START will auto-detect this connection — so
+     * advertise the cap for the DETECTED interface, computed WITHOUT mutating the
+     * shared runtime config (#524 Qodo). Skip when no channels are enabled
+     * (st.maxFreqHz == 0). */
+    if (st.maxFreqHz > 0) {
         StreamingRuntimeConfig* scq =
             BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
-        StreamingInterface savedIf = scq->ActiveInterface;
         StreamingInterface detIf = SCPI_GetInterface(context);
-        if (savedIf == detIf || savedIf == StreamingInterface_USB) {
-            scq->ActiveInterface = detIf;
-        }
-        Capabilities_GetStreamingSummary(&st);
-        scq->ActiveInterface = savedIf;
+        StreamingInterface effIf =
+            (scq->ActiveInterface == detIf || scq->ActiveInterface == StreamingInterface_USB)
+                ? detIf : scq->ActiveInterface;
+        st.maxFreqHz = Streaming_ComputeMaxFreqForConfigIface(effIf);
     }
     Capabilities_GetStorageSummary(&stor);
     Capabilities_GetPowerSummary(&pw);

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2283,7 +2283,9 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
                             uint32_t wRingCap, uint32_t freq, uint32_t obsMs,
                             uint32_t* outKBps, bool* outStartFailed) {
     if (freq == 0u) { *outStartFailed = true; *outKBps = 0; return false; }  // guard div-by-zero (Qodo)
-    uint32_t periodCycles = (clkFreq + freq - 1) / freq;
+    // 64-bit intermediate so clkFreq + freq - 1 can't wrap uint32_t (Qodo pass-8
+    // hardening; the real values — ~100 MHz clk + <=100 kHz freq — never overflow).
+    uint32_t periodCycles = (uint32_t)(((uint64_t)clkFreq + freq - 1u) / freq);
     if (periodCycles < 2) periodCycles = 2;
 
     Streaming_ClearStats();

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2203,7 +2203,13 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
 // =====================================================================
 //
 // SYSTem:STReam:WIFI:FINd? [startHz][,maxHz]
-//   -> <recommendedHz>,<measuredKBps>,<reason>
+//   -> <recommendedHz>,<recommendedKBps>,<reason>,<ceilingHz>,<ceilingKBps>
+//   recommendedHz/KBps = soak-confirmed clean rate, clamped to the bench wire
+//                        ceiling (WIFI_BENCH_CEILING_KBPS) — the rate to stream.
+//   reason             = START_FAIL | NO_LINK | NO_CLEAN_SOAK | BENCH_CAP |
+//                        LINK_SATURATED | HIT_MAX
+//   ceilingHz/KBps     = raw arc/refine ceiling (the pre-soak, pre-clamp
+//                        overestimate) — kept unclamped for diagnostics/testing.
 //
 // Climbs the streaming rate from a conservative start and locks the ceiling
 // only when the buffer that actually fills is essentially FULL (high-water mark
@@ -2243,6 +2249,26 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
 #define FIND_BACKOFF_NUM        9u      // recommended = lastGood * 9/10 (-10% margin)
 #define FIND_BACKOFF_DEN        10u
 #define FIND_RESOLUTION_HZ      500u    // binary-refine stops when bracket <= this
+// Soak-confirm stage (#520, 2026-06-01): the 3 s arc dwell OVERESTIMATES — a rate
+// clean for 3 s can drop over a longer window, and the WiFi ceiling is a bimodal
+// CLIFF (a rate is 0% one run, catastrophic the next).  So after the −10% backoff,
+// SOAK 20 s and walk the rate down −2% per lossy soak until a soak is fully clean.
+// This is the acceptance gate that corrects the overestimate.
+#define FIND_SOAK_MS            60000u  // soak-confirm dwell — 60s (20s overestimated:
+                                        // 1481Hz passed a 20s soak but lost 4.8% over 60s,
+                                        // 2026-06-01). Long enough to expose slow/bimodal loss.
+#define FIND_SOAK_START_NUM     8u      // start soak at ceiling × 0.8 (−20%). The SOAK is the
+#define FIND_SOAK_START_DEN     10u     // correctness gate, not this factor — a fixed derate
+                                        // can't cover the link's drift (ceiling swung 1000↔1750
+                                        // this session) anyway; that's runtime AIMD's job. So
+                                        // this is just modest margin + fast soak convergence.
+                                        // 0.7 was needlessly conservative (962 vs a clean 1400).
+#define FIND_SOAK_CLEAN_STREAK  2u      // require N consecutive clean 60s soaks at the SAME rate
+                                        // before locking — one clean soak can be a bimodal fluke.
+#define FIND_SOAK_STEP_NUM      49u     // −2% walk-down per lossy soak (×49/50); resets the streak
+#define FIND_SOAK_STEP_DEN      50u
+#define FIND_SOAK_MAX_ITERS     12u     // bound total soaks (≤12 × 60s) so a flaky link can't spin
+#define FIND_SOAK_MIN_HZ        100u    // absolute floor — below this, report NO_CLEAN_SOAK
 
 // One measurement cycle for SCPI_WifiFindRate: start streaming at `freq`, dwell,
 // observe the sample-pool high-water mark (the last-to-fill buffer — see header),
@@ -2254,7 +2280,7 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
 // climb and the binary-search refinement share one code path.  wRingCap is used
 // only for the diagnostic log line.
 static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
-                            uint32_t wRingCap, uint32_t freq,
+                            uint32_t wRingCap, uint32_t freq, uint32_t obsMs,
                             uint32_t* outKBps, bool* outStartFailed) {
     uint32_t periodCycles = (clkFreq + freq - 1) / freq;
     if (periodCycles < 2) periodCycles = 2;
@@ -2280,7 +2306,7 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
     AInSampleList_PoolResetMaxUsed();
     uint32_t occMax = 0;   // WiFi-ring high-water mark across the dwell
     for (uint32_t i = 0; i < FIND_OCC_SAMPLES; i++) {
-        vTaskDelay(pdMS_TO_TICKS(FIND_DWELL_MS / FIND_OCC_SAMPLES));
+        vTaskDelay(pdMS_TO_TICKS(obsMs / FIND_OCC_SAMPLES));
         uint32_t occ = wifi_tcp_server_GetCircularBufferAvailable();
         if (occ > occMax) occMax = occ;
     }
@@ -2315,7 +2341,7 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
                  (s.wifiDroppedBytesSteady > 0) || (s.windowLossPercent > 0);
     bool tripped = poolFull || lossy;
 
-    uint32_t dwellMs = FIND_SETTLE_MS + FIND_DWELL_MS;
+    uint32_t dwellMs = FIND_SETTLE_MS + obsMs;
     *outKBps = (dwellMs > 0)
         ? (uint32_t)((s.totalBytesStreamed * 1000ULL) / dwellMs / 1024ULL) : 0;
 
@@ -2438,7 +2464,7 @@ static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
     while (freq <= hardMax) {
         uint32_t kbps = 0;
         bool sf = false;
-        bool sat = FindMeasureStep(cfg, clkFreq, wRingCap, freq, &kbps, &sf);
+        bool sat = FindMeasureStep(cfg, clkFreq, wRingCap, freq, FIND_DWELL_MS, &kbps, &sf);
         if (sf) { startFailed = true; break; }
 
         if (!sat) {
@@ -2479,7 +2505,7 @@ static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
             uint32_t mid = lo + (hi - lo) / 2;
             uint32_t kbps = 0;
             bool sf = false;
-            bool sat = FindMeasureStep(cfg, clkFreq, wRingCap, mid, &kbps, &sf);
+            bool sat = FindMeasureStep(cfg, clkFreq, wRingCap, mid, FIND_DWELL_MS, &kbps, &sf);
             if (sf) break;          // unexpected start failure — keep coarse lastGood
             if (sat) {
                 hi = mid;
@@ -2487,6 +2513,41 @@ static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
                 lo = mid;
                 lastGoodHz = mid;
                 lastGoodKBps = kbps;
+            }
+            vTaskDelay(pdMS_TO_TICKS(FIND_INTERSTEP_MS));
+        }
+    }
+
+    // ---- Soak-confirm stage (#520, 2026-06-01) ----------------------------
+    // The arc/refine above use a 3 s dwell, which OVERESTIMATES the sustainable
+    // rate (clean-for-3s != clean-for-20s; the WiFi ceiling is a bimodal cliff).
+    // Start at the −10% backoff and SOAK 20 s; on any loss (pool-full or drops)
+    // walk down −2% and re-soak; lock the first rate that soaks fully clean.
+    // Runs on the SAME persistent stream session (never reconnect mid-find).
+    uint32_t recommendedHz = 0;
+    uint32_t recommendedKBps = 0;
+    bool soakClean = false;
+    if (!startFailed && lastGoodHz > 0) {
+        uint32_t cand = (uint32_t)((uint64_t)lastGoodHz * FIND_SOAK_START_NUM / FIND_SOAK_START_DEN);
+        uint32_t streak = 0;   // consecutive clean 60 s soaks at the current cand
+        for (uint32_t it = 0; it < FIND_SOAK_MAX_ITERS && cand >= FIND_SOAK_MIN_HZ; it++) {
+            uint32_t kbps = 0; bool sf = false;
+            bool sat = FindMeasureStep(cfg, clkFreq, wRingCap, cand, FIND_SOAK_MS, &kbps, &sf);
+            if (sf) { startFailed = true; break; }
+            if (!sat) {                       // a clean 60 s soak
+                streak++;
+                recommendedKBps = kbps;       // track the clean rate's wire rate
+                LOG_I("WIFI:FIND soak %u Hz CLEAN (%u/%u)",
+                      (unsigned)cand, (unsigned)streak, (unsigned)FIND_SOAK_CLEAN_STREAK);
+                if (streak >= FIND_SOAK_CLEAN_STREAK) {   // N in a row → lock
+                    recommendedHz = cand; soakClean = true;
+                    break;
+                }
+                // else re-soak the SAME rate to build the streak
+            } else {                          // any loss → reset streak, walk down −2%
+                streak = 0;
+                LOG_I("WIFI:FIND soak %u Hz LOSSY -> -2%% (streak reset)", (unsigned)cand);
+                cand = (uint32_t)((uint64_t)cand * FIND_SOAK_STEP_NUM / FIND_SOAK_STEP_DEN);
             }
             vTaskDelay(pdMS_TO_TICKS(FIND_INTERSTEP_MS));
         }
@@ -2502,17 +2563,43 @@ static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
     cfg->ClockPeriod = savedClockPeriod;
     RestoreSdMode(savedSdMode);
 
+    // ---- Bench-fitted WiFi cap (#522) -------------------------------------
+    // Clamp the soak-confirmed recommendation to the bench-fitted WiFi cap from
+    // Streaming_ComputeMaxFreqForConfig() (which includes the per-format WiFi
+    // wire-rate term for the currently configured interface/format/channels).
+    // The live soak measures THIS environment; the equation is the empirical
+    // hard ceiling we never recommend above — this also hardens against a
+    // transient-high arc spike (the 2026-06-02 overnight's miss mode).  The raw
+    // arc ceiling (lastGoodHz/KBps) is reported unclamped for testing.
+    bool benchClamped = false;
+    if (soakClean && recommendedHz > 0) {
+        uint32_t capHz = Streaming_ComputeMaxFreqForConfig();
+        if (capHz > 0 && recommendedHz > capHz) {
+            uint32_t newKBps = (recommendedHz > 0)
+                ? (uint32_t)((uint64_t)recommendedKBps * capHz / recommendedHz) : 0;
+            LOG_I("WIFI:FIND bench-cap %u -> %u Hz (equation)",
+                  (unsigned)recommendedHz, (unsigned)capHz);
+            recommendedHz = capHz;
+            recommendedKBps = newKBps;
+            benchClamped = true;
+        }
+    }
+
     const char* reason;
     if (startFailed)            reason = "START_FAIL";
-    else if (lastGoodHz == 0)   reason = "NO_LINK";       // nothing sustainable, even the start freq
-    else if (saturated)         reason = "LINK_SATURATED";
-    else                        reason = "HIT_MAX";       // climbed to the backstop w/o saturating
+    else if (lastGoodHz == 0)   reason = "NO_LINK";        // nothing sustainable, even the start freq
+    else if (!soakClean)        reason = "NO_CLEAN_SOAK";  // walked to floor without a clean 20 s — link unstable
+    else if (benchClamped)      reason = "BENCH_CAP";      // soak clean but clamped to bench wire ceiling
+    else if (saturated)         reason = "LINK_SATURATED"; // confirmed ceiling + clean soak
+    else                        reason = "HIT_MAX";        // climbed to backstop w/o saturating
 
-    uint32_t recommendedHz = (lastGoodHz > 0)
-        ? (uint32_t)((uint64_t)lastGoodHz * FIND_BACKOFF_NUM / FIND_BACKOFF_DEN) : 0;
-
-    scpi_printf(context, "%u,%u,%s\r\n",
-                (unsigned)recommendedHz, (unsigned)lastGoodKBps, reason);
+    // Output: recommendedHz,recommendedKBps,reason,ceilingHz,ceilingKBps
+    //   recommendedHz/KBps = soak-confirmed clean rate + its wire rate (0 if none)
+    //   ceilingHz/KBps      = raw arc/refine ceiling (the pre-soak overestimate,
+    //                         kept for diagnostics so the soak correction is visible)
+    scpi_printf(context, "%u,%u,%s,%u,%u\r\n",
+                (unsigned)recommendedHz, (unsigned)recommendedKBps,
+                reason, (unsigned)lastGoodHz, (unsigned)lastGoodKBps);
     return SCPI_RES_OK;
 }
 
@@ -3186,8 +3273,9 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
                 }
             }
 
-            uint32_t maxFreq = Streaming_ComputeMaxFreq(
-                activeType1ChannelCount, totalEnabledPublicChannels);
+            // Includes the WiFi wire-rate term when ActiveInterface==WiFi
+            // (#522) on top of the ADC/ISR/tick constraints.
+            uint32_t maxFreq = Streaming_ComputeMaxFreqForConfig();
             if (freq > (int32_t)maxFreq) {
                 LOG_I("Frequency capped: %d Hz -> %u Hz (%u ch, %u type1)",
                       (int)freq, (unsigned)maxFreq,

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4727,9 +4727,10 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
      *   client that always picks this rate is never surprised.
      *
      * - current_max_rate_hz: device's authoritative cap for the
-     *   channel set enabled right now. Today only reflects channel
-     *   count/type; future work (#344 Phase 3) extends it to apply
-     *   interface / encoder / DIO caps too.
+     *   channel set enabled right now. Reflects channel count/type
+     *   AND the per-interface, per-format transport cap (#524), i.e.
+     *   it now matches the rate StartStreamData actually applies.
+     *   (DIO / OBDiag caps still not folded in — future work.)
      *
      * - rate_model: client-side formula for optimistic previews
      *   across hypothetical channel groupings. Channel-count only —

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3220,7 +3220,27 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         }
     }
 
-    if (freqProvided) {
+    // Auto-detect the streaming interface BEFORE the frequency cap (#524 Qodo
+    // fix): the per-interface/per-format transport cap depends on ActiveInterface,
+    // so it must be resolved first or the cap is computed for the wrong interface.
+    // If the current setting matches the detected interface (or is the default
+    // USB), adopt auto-detection; otherwise keep the user's explicit choice
+    // (e.g. SD or USB+SD).
+    {
+        StreamingInterface detectedInterface = SCPI_GetInterface(context);
+        StreamingInterface currentInterface = pRunTimeStreamConfig->ActiveInterface;
+        if (currentInterface == detectedInterface || currentInterface == StreamingInterface_USB) {
+            pRunTimeStreamConfig->ActiveInterface = detectedInterface;
+        }
+    }
+
+    // #524 (Qodo): a no-argument START reuses the stored frequency — resolve it
+    // here so the muxed + transport-cap validation below covers BOTH the
+    // explicit-freq and no-arg restart paths. The no-arg path previously skipped
+    // the cap entirely and could start an over-cap stream after interface/format/
+    // channel changes, contradicting the hard-limit behavior.
+    if (!freqProvided) freq = (int32_t)pRunTimeStreamConfig->Frequency;
+    {
         // NQ3 Smart Frequency Management:
         // When external AD7609 channels are active WITHOUT any Type 1 MC12bADC channels,
         // force internal monitoring to 1Hz (since only monitoring channels would be streaming)
@@ -3325,22 +3345,7 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         } else {
             return SCPI_RES_ERR;
         }
-    } else {
-        //No freq given just stream with the current value
     }
-
-    // Auto-detect interface only if user hasn't explicitly set it via SYSTem:STReam:INTerface
-    // If current interface matches what auto-detection would choose, allow override
-    // If different, user explicitly set it (e.g., SD or All) so preserve their choice
-    StreamingInterface detectedInterface = SCPI_GetInterface(context);
-    StreamingInterface currentInterface = pRunTimeStreamConfig->ActiveInterface;
-
-    // Only auto-detect if current setting matches the detected interface
-    // (meaning user hasn't changed it, or wants auto-detection)
-    if (currentInterface == detectedInterface || currentInterface == StreamingInterface_USB) {
-        pRunTimeStreamConfig->ActiveInterface = detectedInterface;
-    }
-    // Otherwise keep user's explicit setting (e.g., SD or All)
 
     /* Interface_All is USB+SD (WiFi excluded by SPI bus conflict). Any
      * interface other than WiFi-only can drive SD logging when the SD

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3277,11 +3277,19 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
             // (#522) on top of the ADC/ISR/tick constraints.
             uint32_t maxFreq = Streaming_ComputeMaxFreqForConfig();
             if (freq > (int32_t)maxFreq) {
-                LOG_I("Frequency capped: %d Hz -> %u Hz (%u ch, %u type1)",
+                /* #524: HARD cap — reject the over-ask with a SCPI error instead
+                 * of silently lowering the rate. Silent capping left the client
+                 * streaming at a different rate than it requested, unaware. The
+                 * achievable max is in the LOG_E (SYST:LOG?); clients should
+                 * pre-validate against current_max_rate_hz (CONF:CAP:JSON?).
+                 * Benchmark mode (SYST:STR:BENCHmark) bypasses the cap entirely. */
+                LOG_E("Streaming rejected: %d Hz exceeds max %u Hz for this config "
+                      "(%u ch, %u type1) - request <= %u Hz or use SYST:STR:BENCHmark",
                       (int)freq, (unsigned)maxFreq,
                       (unsigned)totalEnabledPublicChannels,
-                      (unsigned)activeType1ChannelCount);
-                freq = (int32_t)maxFreq;
+                      (unsigned)activeType1ChannelCount, (unsigned)maxFreq);
+                SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+                return SCPI_RES_ERR;
             }
         } else {
             // Benchmark: no frequency cap. Timer hardware limit is
@@ -4741,10 +4749,11 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
      *   do not factor (DIO is amortized in per_tick_overhead; AOut
      *   is not streamed).
      *
-     * rate_validation documents over-ask handling. Today: silent_cap
-     * (firmware lowers to current_max_rate_hz, logs LOG_I). Clients
-     * needing explicit feedback MUST pre-validate against
-     * current_max_rate_hz before SYSTem:StartStreamData. */
+     * rate_validation documents over-ask handling. As of #524: "error" —
+     * StartStreamData REJECTS freq > current_max_rate_hz with SCPI error
+     * -222 (+ LOG_E detail) and does NOT start; no silent rate change.
+     * Clients MUST pre-validate against current_max_rate_hz, or handle the
+     * error, before SYSTem:StartStreamData. (Benchmark mode bypasses.) */
     scpi_printf(context,
         "],\"sample_rate_range_hz\":{\"min\":1,\"max\":%u},"
         "\"conservative_envelope_hz\":%u,"
@@ -4767,7 +4776,7 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
         (unsigned)st.tickBudget,
         (unsigned)st.tickOverhead);
 
-    scpi_printf(context, "\"rate_validation\":\"silent_cap\",");
+    scpi_printf(context, "\"rate_validation\":\"error\",");
 
     scpi_printf(context,
         "\"buffer_ranges_bytes\":{"

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2306,7 +2306,7 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
     vTaskDelay(pdMS_TO_TICKS(FIND_SETTLE_MS));
     AInSampleList_PoolResetMaxUsed();
     uint32_t occMax = 0;   // WiFi-ring high-water mark across the dwell
-    TickType_t stepTicks = pdMS_TO_TICKS(obsMs / FIND_OCC_SAMPLES);
+    TickType_t stepTicks = pdMS_TO_TICKS(obsMs) / FIND_OCC_SAMPLES;  // convert then divide — less truncation (Qodo)
     if (stepTicks == 0) stepTicks = 1;   // never busy-spin on a zero-tick delay (Qodo)
     for (uint32_t i = 0; i < FIND_OCC_SAMPLES; i++) {
         vTaskDelay(stepTicks);
@@ -2344,7 +2344,10 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
                  (s.wifiDroppedBytesSteady > 0) || (s.windowLossPercent > 0);
     bool tripped = poolFull || lossy;
 
-    uint32_t dwellMs = FIND_SETTLE_MS + obsMs;
+    // Use the ACTUAL observed dwell (stepTicks may round up vs obsMs/N) so the
+    // KB/s denominator matches the real sleep time (Qodo).
+    uint32_t obsActualMs = (uint32_t)(FIND_OCC_SAMPLES * stepTicks * portTICK_PERIOD_MS);
+    uint32_t dwellMs = FIND_SETTLE_MS + obsActualMs;
     *outKBps = (dwellMs > 0)
         ? (uint32_t)((s.totalBytesStreamed * 1000ULL) / dwellMs / 1024ULL) : 0;
 
@@ -3239,7 +3242,11 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     // explicit-freq and no-arg restart paths. The no-arg path previously skipped
     // the cap entirely and could start an over-cap stream after interface/format/
     // channel changes, contradicting the hard-limit behavior.
-    if (!freqProvided) freq = (int32_t)pRunTimeStreamConfig->Frequency;
+    if (!freqProvided) {
+        uint64_t stored = pRunTimeStreamConfig->Frequency;
+        if (stored > (uint64_t)INT32_MAX) stored = (uint64_t)INT32_MAX;  // clamp before narrowing (Qodo)
+        freq = (int32_t)stored;
+    }
     {
         // NQ3 Smart Frequency Management:
         // When external AD7609 channels are active WITHOUT any Type 1 MC12bADC channels,

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2282,6 +2282,7 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
 static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
                             uint32_t wRingCap, uint32_t freq, uint32_t obsMs,
                             uint32_t* outKBps, bool* outStartFailed) {
+    if (freq == 0u) { *outStartFailed = true; *outKBps = 0; return false; }  // guard div-by-zero (Qodo)
     uint32_t periodCycles = (clkFreq + freq - 1) / freq;
     if (periodCycles < 2) periodCycles = 2;
 
@@ -2305,8 +2306,10 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
     vTaskDelay(pdMS_TO_TICKS(FIND_SETTLE_MS));
     AInSampleList_PoolResetMaxUsed();
     uint32_t occMax = 0;   // WiFi-ring high-water mark across the dwell
+    TickType_t stepTicks = pdMS_TO_TICKS(obsMs / FIND_OCC_SAMPLES);
+    if (stepTicks == 0) stepTicks = 1;   // never busy-spin on a zero-tick delay (Qodo)
     for (uint32_t i = 0; i < FIND_OCC_SAMPLES; i++) {
-        vTaskDelay(pdMS_TO_TICKS(obsMs / FIND_OCC_SAMPLES));
+        vTaskDelay(stepTicks);
         uint32_t occ = wifi_tcp_server_GetCircularBufferAvailable();
         if (occ > occMax) occMax = occ;
     }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3247,6 +3247,11 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         if (stored > (uint64_t)INT32_MAX) stored = (uint64_t)INT32_MAX;  // clamp before narrowing (Qodo)
         freq = (int32_t)stored;
     }
+    if (freq < 1) {  // reject zero/negative rate (e.g. no-arg with stored 0) before the period division (Qodo)
+        LOG_E("Streaming rejected: invalid frequency %d Hz (must be >= 1)", (int)freq);
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
     {
         // NQ3 Smart Frequency Management:
         // When external AD7609 channels are active WITHOUT any Type 1 MC12bADC channels,
@@ -4614,7 +4619,22 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
     Capabilities_GetAinSummary(&ai);
     Capabilities_GetAoutSummary(&ao);
     Capabilities_GetDioSummary(&di);
-    Capabilities_GetStreamingSummary(&st);
+    /* current_max_rate_hz reflects the cap for ActiveInterface; if that's still the
+     * default USB (client hasn't streamed yet), temporarily adopt the detected
+     * connection interface so the advertised cap matches what START will enforce
+     * for THIS client (#524 Qodo — query-side of the interface-detect fix). Restored
+     * immediately; the SCPI query runs single-threaded on the connection's task. */
+    {
+        StreamingRuntimeConfig* scq =
+            BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
+        StreamingInterface savedIf = scq->ActiveInterface;
+        StreamingInterface detIf = SCPI_GetInterface(context);
+        if (savedIf == detIf || savedIf == StreamingInterface_USB) {
+            scq->ActiveInterface = detIf;
+        }
+        Capabilities_GetStreamingSummary(&st);
+        scq->ActiveInterface = savedIf;
+    }
     Capabilities_GetStorageSummary(&stor);
     Capabilities_GetPowerSummary(&pw);
     Capabilities_GetTransportsSummary(&tr);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -437,8 +437,7 @@ uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
      * returns NULL (CLAUDE.md). */
     StreamingRuntimeConfig* sc =
         BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
-    uint32_t transportMax = Streaming_TransportMaxFreq((uint32_t)iface,
-                                                       (uint32_t)sc->Encoding, total);
+    uint32_t transportMax = Streaming_TransportMaxFreq(iface, sc->Encoding, total);
     if (transportMax < maxFreq) maxFreq = transportMax;
     return maxFreq;
 }

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -429,14 +429,14 @@ uint32_t Streaming_ComputeMaxFreqForConfig(void) {
     // when the last channel is disabled.
     uint32_t maxFreq = Streaming_ComputeMaxFreq(type1, total);
 
-    /* Add the WiFi wire-rate term only when the active streaming interface is
-     * WiFi.  BoardRunTimeConfig_Get never returns NULL (CLAUDE.md). */
+    /* Apply the per-interface, per-format TRANSPORT cap (#524), generalizing the
+     * former WiFi-only term to USB / SD / USB+SD.  min() with the ADC cap above.
+     * BoardRunTimeConfig_Get never returns NULL (CLAUDE.md). */
     StreamingRuntimeConfig* sc =
         BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
-    if (sc->ActiveInterface == StreamingInterface_WiFi) {
-        uint32_t wifiMax = Streaming_WifiMaxFreq((uint32_t)sc->Encoding, total);
-        if (wifiMax < maxFreq) maxFreq = wifiMax;
-    }
+    uint32_t transportMax = Streaming_TransportMaxFreq((uint32_t)sc->ActiveInterface,
+                                                       (uint32_t)sc->Encoding, total);
+    if (transportMax < maxFreq) maxFreq = transportMax;
     return maxFreq;
 }
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -420,7 +420,7 @@ void Streaming_CountActiveChannels(uint16_t* out_type1Count,
     if (out_hasAD7609   != NULL) *out_hasAD7609   = has7609;
 }
 
-uint32_t Streaming_ComputeMaxFreqForConfig(void) {
+uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
     uint16_t type1 = 0, total = 0;
     Streaming_CountActiveChannels(&type1, &total, NULL);
 
@@ -431,13 +431,22 @@ uint32_t Streaming_ComputeMaxFreqForConfig(void) {
 
     /* Apply the per-interface, per-format TRANSPORT cap (#524), generalizing the
      * former WiFi-only term to USB / SD / USB+SD.  min() with the ADC cap above.
-     * BoardRunTimeConfig_Get never returns NULL (CLAUDE.md). */
+     * The interface is a PARAMETER (not read from the global) so callers such as
+     * the capabilities query can compute for the client's detected interface
+     * without mutating shared state (#524 Qodo). BoardRunTimeConfig_Get never
+     * returns NULL (CLAUDE.md). */
     StreamingRuntimeConfig* sc =
         BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
-    uint32_t transportMax = Streaming_TransportMaxFreq((uint32_t)sc->ActiveInterface,
+    uint32_t transportMax = Streaming_TransportMaxFreq((uint32_t)iface,
                                                        (uint32_t)sc->Encoding, total);
     if (transportMax < maxFreq) maxFreq = transportMax;
     return maxFreq;
+}
+
+uint32_t Streaming_ComputeMaxFreqForConfig(void) {
+    StreamingRuntimeConfig* sc =
+        BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
+    return Streaming_ComputeMaxFreqForConfigIface(sc->ActiveInterface);
 }
 
 /**

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -420,6 +420,26 @@ void Streaming_CountActiveChannels(uint16_t* out_type1Count,
     if (out_hasAD7609   != NULL) *out_hasAD7609   = has7609;
 }
 
+uint32_t Streaming_ComputeMaxFreqForConfig(void) {
+    uint16_t type1 = 0, total = 0;
+    Streaming_CountActiveChannels(&type1, &total, NULL);
+
+    // Mirror Streaming_ComputeMaxFreq's behavior for 0 channels (returns
+    // ISR_MAX, not 0) so the channel-enable recompute path doesn't cap to 0
+    // when the last channel is disabled.
+    uint32_t maxFreq = Streaming_ComputeMaxFreq(type1, total);
+
+    /* Add the WiFi wire-rate term only when the active streaming interface is
+     * WiFi.  BoardRunTimeConfig_Get never returns NULL (CLAUDE.md). */
+    StreamingRuntimeConfig* sc =
+        BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
+    if (sc->ActiveInterface == StreamingInterface_WiFi) {
+        uint32_t wifiMax = Streaming_WifiMaxFreq((uint32_t)sc->Encoding, total);
+        if (wifiMax < maxFreq) maxFreq = wifiMax;
+    }
+    return maxFreq;
+}
+
 /**
  * @brief Deferred interrupt handler for sample collection.
  *

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -172,6 +172,14 @@ static inline uint32_t Streaming_TransportMaxFreq(uint32_t interface, uint32_t e
 uint32_t Streaming_ComputeMaxFreqForConfig(void);
 
 /**
+ * Same as Streaming_ComputeMaxFreqForConfig() but for an explicitly-supplied
+ * interface instead of the live ActiveInterface — lets the capabilities query
+ * advertise the cap for a client's detected interface without mutating the
+ * shared runtime config (#524). Encoding + channel counts still come from config.
+ */
+uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface);
+
+/**
  * Count enabled public ADC channels from current board + runtime config.
  * Used by SCPI_StartStreaming, the ADC channel-enable path, and the
  * capability rollup so they all agree on what counts toward the cap.

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -147,7 +147,7 @@ static inline uint32_t Streaming_TransportMaxFreq(uint32_t interface, uint32_t e
             else    { single =  8000u; A =  15000u; B =  0u; }
             break;
         default:
-            return STREAMING_ISR_MAX_HZ;  /* unknown interface -> no transport constraint */
+            return 1u;  /* unknown/corrupted interface -> fail-safe floor, never over-cap (Qodo) */
     }
     uint32_t hz = (totalChannels == 1u) ? single : A / (B + totalChannels);
     /* JSON emits ~2-3x CSV bytes/sample (object braces + per-sample field names),

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -122,7 +122,8 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
     if (totalChannels == 0) return STREAMING_ISR_MAX_HZ;
     /* Explicit encoding handling (Qodo): unknown encodings cap at 1 Hz so a
      * future/garbage value can never over-cap. */
-    uint32_t pb, json = 0u;
+    uint32_t pb = 0u, json = 0u;  /* init pb defensively (Qodo pass-7); every
+                                   * non-default case still assigns it explicitly */
     switch (encoding) {
         case Streaming_ProtoBuffer: pb = 1u; break;
         case Streaming_Csv:         pb = 0u; break;

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -119,7 +119,15 @@ static inline uint32_t Streaming_ComputeMaxFreq(uint32_t type1Count, uint32_t to
 static inline uint32_t Streaming_TransportMaxFreq(uint32_t interface, uint32_t encoding,
                                                   uint32_t totalChannels) {
     if (totalChannels == 0) return STREAMING_ISR_MAX_HZ;
-    uint32_t pb = (encoding == Streaming_ProtoBuffer);
+    /* Explicit encoding handling (Qodo): unknown encodings cap at 1 Hz so a
+     * future/garbage value can never over-cap. PB vs CSV; JSON treated as CSV. */
+    uint32_t pb;
+    switch ((StreamingEncoding)encoding) {
+        case Streaming_ProtoBuffer: pb = 1u; break;
+        case Streaming_Csv:
+        case Streaming_Json:        pb = 0u; break;
+        default:                    return 1u;
+    }
     uint32_t single, A, B;
     switch (interface) {
         case StreamingInterface_USB:

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -55,6 +55,29 @@ extern "C" {
 #define STREAMING_TICK_BUDGET       110000
 #define STREAMING_TICK_OVERHEAD     6
 
+// WiFi wire-rate constraint (#522/#520) — a 4th term in the cap model that only
+// binds when the active streaming interface is WiFi.  The WINC1500 firmware path
+// sustains a finite encoded BYTES/s on the air; expressed here in the same
+// per-channel budget form as the tick budget above (Hz falls as channels add
+// bytes/sample).  Each encoding gets its OWN budget AND overhead: PB packs
+// tighter than CSV, so its per-channel byte cost is small and the fixed framing
+// overhead dominates — i.e. a much larger effective OVERHEAD term (12 vs 2).
+// A single shared overhead (or a flat byte-rate) mispredicts SPS at low channel
+// counts, which is exactly the failure mode this per-format form avoids.  For
+// low channel counts the ADC terms above often bind first, making this a no-op.
+//
+// FITTED to the WiFi ceiling sweep (Tesla AP, NQ1, 2026-06-02, n=1, 10–12 s
+// dwells × 1/3/5/8/16 ch × CSV/PB).  Cap = measured raw ceiling × 0.80 (the
+// safe-rate derate); constants chosen so every predicted cap is ≤ the measured
+// safe rate for that config (conservative).  Anchor: 16ch CSV predicts 1000 Hz,
+// matching the independently 60 s-validated safe rate.  Refine with more trials
+// / APs / boards as collected (issue #520).  JSON is treated as CSV (slightly
+// optimistic — JSON is more verbose; refine if JSON-over-WiFi matters).
+#define STREAMING_WIFI_CSV_BUDGET    18000u  // CSV: BUDGET/(OVH+ch); 16ch→1000 Hz
+#define STREAMING_WIFI_CSV_OVERHEAD  2u
+#define STREAMING_WIFI_PB_BUDGET    103000u  // PB: tighter packing → higher ceiling
+#define STREAMING_WIFI_PB_OVERHEAD   12u     // larger fixed-framing fraction
+
 // Type 2 (shared MODULE7 mux) hard cap.  T2 channels are scanned via the
 // analog multiplexer sequentially; the firmware applies
 // ChannelScanFreqDiv = freq/1000 in SCPI_StartStreaming so the muxed scan
@@ -89,6 +112,41 @@ static inline uint32_t Streaming_ComputeMaxFreq(uint32_t type1Count, uint32_t to
     if (maxFreq == 0) maxFreq = 1;
     return maxFreq;
 }
+
+/**
+ * WiFi wire-rate cap (Hz) for a given encoding + channel count.  Pure function
+ * of the fitted per-format budget; only meaningful when the active interface is
+ * WiFi (callers gate on that).  Returns STREAMING_ISR_MAX_HZ for 0 channels
+ * (no WiFi constraint to apply).  See the SEED-value caveat above the budgets.
+ *
+ * @param encoding       StreamingEncoding (Streaming_ProtoBuffer / _Csv / _Json)
+ * @param totalChannels  Total enabled public ADC channels
+ * @return WiFi-limited max frequency in Hz
+ */
+static inline uint32_t Streaming_WifiMaxFreq(uint32_t encoding, uint32_t totalChannels) {
+    if (totalChannels == 0) return STREAMING_ISR_MAX_HZ;
+    uint32_t budget, overhead;
+    if (encoding == Streaming_ProtoBuffer) {
+        budget = STREAMING_WIFI_PB_BUDGET;  overhead = STREAMING_WIFI_PB_OVERHEAD;
+    } else {  // CSV (and JSON, treated as CSV — see budget comment)
+        budget = STREAMING_WIFI_CSV_BUDGET; overhead = STREAMING_WIFI_CSV_OVERHEAD;
+    }
+    uint32_t hz = budget / (overhead + totalChannels);
+    return (hz == 0) ? 1u : hz;
+}
+
+/**
+ * Max safe streaming frequency for the CURRENTLY configured interface + format
+ * + enabled channels.  Reads ActiveInterface / Encoding from the streaming
+ * runtime config and the enabled-channel counts, then returns
+ * min(Streaming_ComputeMaxFreq(...), WiFi term when ActiveInterface==WiFi).
+ * This is the single "what rate can this config stream?" entry point for the
+ * START cap, the channel-enable recompute, and the WiFi finder.
+ *
+ * @return Max safe frequency in Hz (STREAMING_ISR_MAX_HZ when no channels are
+ *         enabled, matching Streaming_ComputeMaxFreq(0,0))
+ */
+uint32_t Streaming_ComputeMaxFreqForConfig(void);
 
 /**
  * Count enabled public ADC channels from current board + runtime config.

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -50,33 +50,18 @@ extern "C" {
 
 // Frequency cap constants — fitted to characterization data (2026-04-13).
 // ISR batching (#277) reduced Type 1 overhead; refit with updated ceilings.
-#define STREAMING_ISR_MAX_HZ        13000
+// ISR_MAX raised 13000->16000 (#524): the per-interface TRANSPORT caps
+// (Streaming_TransportMaxFreq) now govern the real ceilings; ISR_MAX is the
+// ADC/ISR safety ceiling and must sit above the highest single-channel transport
+// cap (USB PB 1ch = 15000) so it does not override it.
+#define STREAMING_ISR_MAX_HZ        16000
 #define STREAMING_TYPE1_AGG_MAX_HZ  55000
 #define STREAMING_TICK_BUDGET       110000
 #define STREAMING_TICK_OVERHEAD     6
 
-// WiFi wire-rate constraint (#522/#520) — a 4th term in the cap model that only
-// binds when the active streaming interface is WiFi.  The WINC1500 firmware path
-// sustains a finite encoded BYTES/s on the air; expressed here in the same
-// per-channel budget form as the tick budget above (Hz falls as channels add
-// bytes/sample).  Each encoding gets its OWN budget AND overhead: PB packs
-// tighter than CSV, so its per-channel byte cost is small and the fixed framing
-// overhead dominates — i.e. a much larger effective OVERHEAD term (12 vs 2).
-// A single shared overhead (or a flat byte-rate) mispredicts SPS at low channel
-// counts, which is exactly the failure mode this per-format form avoids.  For
-// low channel counts the ADC terms above often bind first, making this a no-op.
-//
-// FITTED to the WiFi ceiling sweep (Tesla AP, NQ1, 2026-06-02, n=1, 10–12 s
-// dwells × 1/3/5/8/16 ch × CSV/PB).  Cap = measured raw ceiling × 0.80 (the
-// safe-rate derate); constants chosen so every predicted cap is ≤ the measured
-// safe rate for that config (conservative).  Anchor: 16ch CSV predicts 1000 Hz,
-// matching the independently 60 s-validated safe rate.  Refine with more trials
-// / APs / boards as collected (issue #520).  JSON is treated as CSV (slightly
-// optimistic — JSON is more verbose; refine if JSON-over-WiFi matters).
-#define STREAMING_WIFI_CSV_BUDGET    18000u  // CSV: BUDGET/(OVH+ch); 16ch→1000 Hz
-#define STREAMING_WIFI_CSV_OVERHEAD  2u
-#define STREAMING_WIFI_PB_BUDGET    103000u  // PB: tighter packing → higher ceiling
-#define STREAMING_WIFI_PB_OVERHEAD   12u     // larger fixed-framing fraction
+// Per-interface, per-format wire/storage transport caps live in
+// Streaming_TransportMaxFreq below (#524), which superseded the earlier
+// WiFi-only budget term (#520/#522) and generalized it to all interfaces.
 
 // Type 2 (shared MODULE7 mux) hard cap.  T2 channels are scanned via the
 // analog multiplexer sequentially; the firmware applies
@@ -114,25 +99,51 @@ static inline uint32_t Streaming_ComputeMaxFreq(uint32_t type1Count, uint32_t to
 }
 
 /**
- * WiFi wire-rate cap (Hz) for a given encoding + channel count.  Pure function
- * of the fitted per-format budget; only meaningful when the active interface is
- * WiFi (callers gate on that).  Returns STREAMING_ISR_MAX_HZ for 0 channels
- * (no WiFi constraint to apply).  See the SEED-value caveat above the budgets.
+ * Per-interface, per-format TRANSPORT wire-rate cap (Hz) — generalizes the
+ * WiFi-only term (#520) to USB / SD / USB+SD (#524).  Fitted to the 3-run
+ * real-ADC zero-loss characterization (matrix_524 run-1/2/3 + WiFi-v2,
+ * conservative min across runs).  Form: single-channel special-cased + A/(B+n)
+ * for n>=2 (the "F3" fit) — 1-channel (esp. CSV) sits far above the
+ * multi-channel curve, which a single A/(B+n) cannot hug.  Every predicted cap
+ * is <= the measured zero-loss ceiling at the tested channel counts (safe by
+ * construction; tightness 86-100%).  This closes the prior format-blind hole
+ * where high-channel CSV was capped well ABOVE its true ceiling (silent loss).
+ * JSON is treated as CSV (text; slightly optimistic — refine if it matters).
+ * Only meaningful for the ACTIVE interface; ComputeMaxFreqForConfig gates on it.
  *
- * @param encoding       StreamingEncoding (Streaming_ProtoBuffer / _Csv / _Json)
+ * @param interface      StreamingInterface (USB / WiFi / SD / UsbAndSd)
+ * @param encoding       StreamingEncoding (PB vs CSV/JSON)
  * @param totalChannels  Total enabled public ADC channels
- * @return WiFi-limited max frequency in Hz
+ * @return transport-limited max frequency in Hz
  */
-static inline uint32_t Streaming_WifiMaxFreq(uint32_t encoding, uint32_t totalChannels) {
+static inline uint32_t Streaming_TransportMaxFreq(uint32_t interface, uint32_t encoding,
+                                                  uint32_t totalChannels) {
     if (totalChannels == 0) return STREAMING_ISR_MAX_HZ;
-    uint32_t budget, overhead;
-    if (encoding == Streaming_ProtoBuffer) {
-        budget = STREAMING_WIFI_PB_BUDGET;  overhead = STREAMING_WIFI_PB_OVERHEAD;
-    } else {  // CSV (and JSON, treated as CSV — see budget comment)
-        budget = STREAMING_WIFI_CSV_BUDGET; overhead = STREAMING_WIFI_CSV_OVERHEAD;
+    uint32_t pb = (encoding == Streaming_ProtoBuffer);
+    uint32_t single, A, B;
+    switch (interface) {
+        case StreamingInterface_USB:
+            if (pb) { single = 15000u; A = 180000u; B = 10u; }
+            else    { single = 15000u; A =  34000u; B =  1u; }
+            break;
+        case StreamingInterface_WiFi:
+            if (pb) { single = 11250u; A = 210000u; B = 30u; }
+            else    { single =  9000u; A =  21000u; B =  1u; }
+            break;
+        case StreamingInterface_SD:
+            if (pb) { single =  9000u; A = 150000u; B = 15u; }
+            else    { single =  7500u; A =  42000u; B = 12u; }
+            break;
+        case StreamingInterface_UsbAndSd:
+            if (pb) { single =  8000u; A =  66000u; B =  6u; }
+            else    { single =  8000u; A =  15000u; B =  0u; }
+            break;
+        default:
+            return STREAMING_ISR_MAX_HZ;  /* unknown interface -> no transport constraint */
     }
-    uint32_t hz = budget / (overhead + totalChannels);
-    return (hz == 0) ? 1u : hz;
+    if (totalChannels == 1u) return single;
+    uint32_t hz = A / (B + totalChannels);
+    return (hz == 0u) ? 1u : hz;
 }
 
 /**

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -116,13 +116,14 @@ static inline uint32_t Streaming_ComputeMaxFreq(uint32_t type1Count, uint32_t to
  * @param totalChannels  Total enabled public ADC channels
  * @return transport-limited max frequency in Hz
  */
-static inline uint32_t Streaming_TransportMaxFreq(uint32_t interface, uint32_t encoding,
+static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
+                                                  StreamingEncoding encoding,
                                                   uint32_t totalChannels) {
     if (totalChannels == 0) return STREAMING_ISR_MAX_HZ;
     /* Explicit encoding handling (Qodo): unknown encodings cap at 1 Hz so a
      * future/garbage value can never over-cap. */
     uint32_t pb, json = 0u;
-    switch ((StreamingEncoding)encoding) {
+    switch (encoding) {
         case Streaming_ProtoBuffer: pb = 1u; break;
         case Streaming_Csv:         pb = 0u; break;
         case Streaming_Json:        pb = 0u; json = 1u; break;  /* CSV coefficients, derated below */

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -120,12 +120,12 @@ static inline uint32_t Streaming_TransportMaxFreq(uint32_t interface, uint32_t e
                                                   uint32_t totalChannels) {
     if (totalChannels == 0) return STREAMING_ISR_MAX_HZ;
     /* Explicit encoding handling (Qodo): unknown encodings cap at 1 Hz so a
-     * future/garbage value can never over-cap. PB vs CSV; JSON treated as CSV. */
-    uint32_t pb;
+     * future/garbage value can never over-cap. */
+    uint32_t pb, json = 0u;
     switch ((StreamingEncoding)encoding) {
         case Streaming_ProtoBuffer: pb = 1u; break;
-        case Streaming_Csv:
-        case Streaming_Json:        pb = 0u; break;
+        case Streaming_Csv:         pb = 0u; break;
+        case Streaming_Json:        pb = 0u; json = 1u; break;  /* CSV coefficients, derated below */
         default:                    return 1u;
     }
     uint32_t single, A, B;
@@ -149,8 +149,12 @@ static inline uint32_t Streaming_TransportMaxFreq(uint32_t interface, uint32_t e
         default:
             return STREAMING_ISR_MAX_HZ;  /* unknown interface -> no transport constraint */
     }
-    if (totalChannels == 1u) return single;
-    uint32_t hz = A / (B + totalChannels);
+    uint32_t hz = (totalChannels == 1u) ? single : A / (B + totalChannels);
+    /* JSON emits ~2-3x CSV bytes/sample (object braces + per-sample field names),
+     * so its true ceiling is below CSV's and it was not separately characterized.
+     * Derate the CSV-based cap by half to stay conservative (never over-cap JSON)
+     * until JSON is measured (#524 follow-up). */
+    if (json) hz /= 2u;
     return (hz == 0u) ? 1u : hz;
 }
 

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -151,7 +151,14 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
         default:
             return 1u;  /* unknown/corrupted interface -> fail-safe floor, never over-cap (Qodo) */
     }
-    uint32_t hz = (totalChannels == 1u) ? single : A / (B + totalChannels);
+    /* Widen the divide to 64-bit so a corrupted/huge channel count can never wrap
+     * the denominator (Qodo pass-8 hardening). denom is always >= 2 in this branch
+     * (totalChannels >= 2, B >= 0), so no div-by-zero guard is needed. */
+    uint32_t hz = single;
+    if (totalChannels != 1u) {
+        uint64_t denom = (uint64_t)B + (uint64_t)totalChannels;
+        hz = (uint32_t)((uint64_t)A / denom);
+    }
     /* JSON emits ~2-3x CSV bytes/sample (object braces + per-sample field names),
      * so its true ceiling is below CSV's and it was not separately characterized.
      * Derate the CSV-based cap by half to stay conservative (never over-cap JSON)


### PR DESCRIPTION
Overhauls the streaming frequency cap (#524): makes it **per-interface and per-format**, and turns it into a **hard limit that errors** instead of silently capping.

## 1. Per-interface / per-format cap
The old cap was interface/format-blind (except WiFi) — **74% mean error** vs the measured ceilings, with two opposite failures: too low single-channel (USB 1ch capped 13k vs 15k achievable), and dangerously too high for high-channel CSV (format-blind, allowed 16ch CSV at 5000 Hz vs ~2000 sustainable → silent data loss).

- `Streaming_TransportMaxFreq(interface, encoding, channels)` — F3 form (single-channel special-cased + `A/(B+n)` for n≥2), coefficients fitted **conservatively** so every cap ≤ the measured zero-loss ceiling (tightness 86–100%).
- `ComputeMaxFreqForConfig` applies it for **all** interfaces (was WiFi-only); dead WiFi-only helper removed.
- `STREAMING_ISR_MAX_HZ` 13000→16000 so single-channel isn't ADC-capped below the transport ceiling.
- `Capabilities.c`: `current_max_rate_hz` now = `ComputeMaxFreqForConfig` — matches what START enforces (was channel-only → over-advertised).

Hardware-verified (1ch): `USB 15000 · WiFi PB 11250/CSV 9000 · SD PB 9000/CSV 7500 · USB+SD 8000` — all match the equation.

## 2. Hard-error over-cap  ⚠️ BREAKING
`SYSTem:STReam:START <freq>` above the cap now returns SCPI **-222** (Data out of range) + a `LOG_E` detail line and does **not** start streaming — instead of silently lowering the rate (which left clients streaming at a rate they never requested, unaware). `rate_validation` in the capabilities JSON: `silent_cap → error`. Benchmark mode (`SYST:STR:BENCHmark`) bypasses.

Hardware-verified: `START 20000` (cap 15000) → `-222` + `"Streaming rejected: 20000 Hz exceeds max 15000 Hz"`; `START 10000` → streams.

**Client impact:** clients that over-ask expecting capped streaming will now get an error instead of capped data. They should pre-validate against `current_max_rate_hz` (`CONF:CAP:JSON?`, which equals the cap as of #524) or handle `-222`. Assessed low-risk in practice.

## Known follow-ups
- Mid-stream `CONFigure:ADC:CHANnel` recompute still silently re-caps (needs a channel-state snapshot/restore to error without runtime/HW desync).
- `rate_model` preview formula is still ADC-only (optimistic for transport-limited configs); committed-config truth is `current_max_rate_hz`.
- USB CSV cap is the one ~86%-tight cell (noise-limited plateau); safe-conservative, multi-trial follow-up logged.

## Base note
Based on `feat/520-wifi-throughput-finder`; carries 2 prerequisite commits from that lineage (`dd688a8d` #520/#522 WiFi-cap foundation, `a5164067` doc). The #524 commits are `ae7528d6` (cap) and `df73b625` (hard-error).

Data + methodology: `daqifi-python-test-suite` `benchmarks/524_streaming_characterization`.

Refs #524, #520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
