### PR TITLE
fix(scpi): reject channel enable/disable while streaming (#116)

### DIFF
--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -130,7 +130,15 @@ scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
     // invisible to the client. Mirror SCPI_MemRejectIfStreaming: stop streaming,
     // reconfigure, restart. Rejecting BEFORE ADC_WriteChannelStateAll() leaves both
     // runtime config and ADC hardware untouched (no snapshot/rollback needed).
-    if (pRunTimeStreamConfig->IsEnabled && pRunTimeStreamConfig->Running) {
+    //
+    // Use IsEnabled || Running (not &&): the two flags are set/cleared in separate
+    // steps at stream start/stop (StartStreaming arms IsEnabled, then
+    // Streaming_UpdateState flips Running; stop clears them in turn). An && guard
+    // would leave a transition window — IsEnabled set but Running not yet, or vice
+    // versa — through which a concurrent SCPI session (USB pri 7 vs WiFi pri 2)
+    // could slip a channel change after the pool/mapping was sized. Reject unless
+    // streaming is FULLY idle (both flags clear).
+    if (pRunTimeStreamConfig->IsEnabled || pRunTimeStreamConfig->Running) {
         LOG_E("Channel enable rejected: streaming is active (stop streaming first)");
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         return SCPI_RES_ERR;

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -121,6 +121,21 @@ scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
             BOARDCONFIG_AIN_CHANNELS,
             0);
 
+    // #116: reject channel enable/disable while streaming is active. The sample
+    // pool element stride is fixed at StartStreamData for the then-current channel
+    // count (AInSampleList_InitializeExternal is only called at stream start, never
+    // mid-stream), so changing the channel set live would desync the pool layout
+    // from the ISR write width. The old behavior here silently re-capped the
+    // frequency (LOG_I only) without re-partitioning the pool — unsound and
+    // invisible to the client. Mirror SCPI_MemRejectIfStreaming: stop streaming,
+    // reconfigure, restart. Rejecting BEFORE ADC_WriteChannelStateAll() leaves both
+    // runtime config and ADC hardware untouched (no snapshot/rollback needed).
+    if (pRunTimeStreamConfig->IsEnabled && pRunTimeStreamConfig->Running) {
+        LOG_E("Channel enable rejected: streaming is active (stop streaming first)");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+
     if (!SCPI_ParamInt32(context, &param1, TRUE)) {
         return SCPI_RES_ERR;
     }


### PR DESCRIPTION
## Summary

Completes the #524 cap-consistency story. `SYST:STR:START` already **hard-errors** (`-222`) on an over-cap rate (#524); mid-stream channel changes now also **fail loudly** instead of silently changing the streaming rate.

`SCPI_ADCChanEnableSet` (`ENAble:VOLTage:DC` / `CONFigure:ADC:CHANnel`) now rejects with `SCPI_ERROR_EXECUTION_ERROR` when streaming is active (`IsEnabled && Running`), mirroring the existing `SCPI_MemRejectIfStreaming` pattern. Stop streaming, reconfigure, restart.

## Why reject (vs. the snapshot/recap alternative)

The sample-pool **element stride is fixed at `StartStreamData`** for the then-current channel count — `AInSampleList_InitializeExternal` is only called at stream start, never mid-stream. The previous behavior silently re-capped the streaming frequency (`LOG_I` only) on a mid-stream channel change **without re-partitioning the pool**, so the ISR sample width could desync from the pool slot size — unsound *and* invisible to the client.

Rejecting **before** `ADC_WriteChannelStateAll()` leaves both runtime config and ADC hardware untouched — no channel-state snapshot/rollback machinery needed. Pre-stream channel configuration is unchanged.

## Verification

- **Build:** clean (`-O3 -Werror`), zero warnings.
- **Hardware** (bench primary, NQ1, USB), deterministic low-rate test:
  - Mid-stream `ENA:VOLT:DC 8,1` → **rejected**: ch8 reads `0` afterward (channel set untouched), and `SYST:LOG?` shows `Channel enable rejected: streaming is active (stop streaming first)`.
  - Pre-stream channel enable/disable → still succeeds.

Refs #116, #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)