### PR TITLE
fix(streaming): remove 1kHz Type-2 muxed cap; T2 obeys #524 transport cap (#107)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -601,6 +601,8 @@ The firmware computes a maximum safe streaming frequency — the `min()` of an *
 
 **Verified caps (hardware, 1 channel, #524):** USB 15000 · WiFi PB 11250 / CSV 9000 · SD PB 9000 / CSV 7500 · USB+SD 8000 — all match the equation and `current_max_rate_hz` (capabilities query reflects the full cap as of #524).
 
+**Type-2 (muxed MODULE7) channels obey this same cap (#107).** Earlier firmware throttled the shared-ADC mux scan to 1 kHz (`ChannelScanFreqDiv = freq/1000`) and rejected any T2 stream above 1 kHz up-front (the old `STREAMING_MUXED_CAP_HZ` / #232). Real-ADC characterization (18-pass overnight matrix, `daqifi-python-test-suite` `benchmarks/107_t2_scan_characterization/`) showed the mux scan **never overruns up to ≥40 kHz** at any channel count (EosOverruns=0) — it is never the bottleneck. So #107 set `ChannelScanFreqDiv = 1` (T2 scans every tick = real full-rate data) and removed the 1 kHz reject; T2 streaming is now bounded by the per-interface/format transport cap above, exactly like Type-1. HW-verified: 11×T2 PB streams clean to the #524 cap (EosOverruns=0, QueueDropped=0, ch0 accurate), over-cap → `-222`, OBDiag on/off both bounded.
+
 **Fit basis — measured zero-loss ceilings (real ADC / PAT0) the F3 coefficients are fitted at-or-below (Hz):**
 
 > This is the **normative** basis for the enforced cap — the zero-loss sweep-escalator subset (1/5/10/16 ch, all four interfaces). It is distinct from the **Session 24 soak ceilings** in "Characterization results" above (ADC Architecture section), which are a broader *descriptive* endurance record across more configs and a different method (400 s soak + haircut). Different methods → different numbers by design; this table is what the firmware actually enforces.

--- a/docs/PIPELINE_TIMING.md
+++ b/docs/PIPELINE_TIMING.md
@@ -169,6 +169,14 @@ BUDGET=110000/(6+1)=15714)`.
 Type 1 dedicated-module conversions no longer fire EOS (the residual
 1 kHz rate is the divided-rate shared/OBDiag scan path).
 
+> **⚠️ Superseded by #107 (2026-06-08).** This session predates #107, which
+> removed the `ChannelScanFreqDiv = freq/1000` shared-scan throttle — it is now
+> **always 1**, so the shared MODULE7 (Type-2) scan fires on *every* tick, and
+> the EOS ISR/shared-scan cadence equals the full streaming rate (not the divided
+> ~1 kHz seen here). Real-ADC characterization showed the mux scan never overruns
+> to ≥40 kHz (`daqifi-python-test-suite benchmarks/107_t2_scan_characterization/`).
+> Re-measure probe cadences against the full-rate scan for any new timing work.
+
 #### Pulse probes (work duration)
 
 | Probe | Description | Tpos mean | Tpos min | Tpos max | Tstd |
@@ -591,6 +599,10 @@ P1 (EOS ISR) fmean = 500 Hz (→ 1000 Hz ISR) regardless of T2
 enablement. `ChannelScanFreqDiv` effectively fixes shared-scan
 cadence at 1 kHz for 13 kHz ticks (ratio 1:13). So even when T2 is
 enabled, the scan only completes ~77× per second, not per tick.
+
+> **⚠️ Superseded by #107 (2026-06-08):** `ChannelScanFreqDiv` is now always 1,
+> so the shared MODULE7 scan runs on *every* tick (full streaming rate), not the
+> divided ~1 kHz described here. The scan was HW-shown to keep up to ≥40 kHz.
 
 ---
 

--- a/docs/PIPELINE_TIMING.md
+++ b/docs/PIPELINE_TIMING.md
@@ -167,7 +167,7 @@ BUDGET=110000/(6+1)=15714)`.
 
 **Probe 1 (EOS ISR) is at ~1 kHz, not 13 kHz.** Expected post-PR #290 —
 Type 1 dedicated-module conversions no longer fire EOS (the residual
-1 kHz rate is the divided-rate shared/OBDiag scan path).
+1 kHz rate WAS the divided-rate shared/OBDiag scan path — pre-#107; now full-rate, see note below).
 
 > **⚠️ Superseded by #107 (2026-06-08).** This session predates #107, which
 > removed the `ChannelScanFreqDiv = freq/1000` shared-scan throttle — it is now
@@ -593,11 +593,11 @@ to the 2.87 µs/ch observed at 1 ch). P8 per-channel is much larger —
 PB encoding appends per-channel fields (timestamp delta + varint
 value) per sample.
 
-#### P1 confirms divided shared-scan rate
+#### P1 confirms divided shared-scan rate (pre-#107 — see superseded note below)
 
 P1 (EOS ISR) fmean = 500 Hz (→ 1000 Hz ISR) regardless of T2
-enablement. `ChannelScanFreqDiv` effectively fixes shared-scan
-cadence at 1 kHz for 13 kHz ticks (ratio 1:13). So even when T2 is
+enablement. `ChannelScanFreqDiv` effectively *fixed* shared-scan
+cadence at 1 kHz for 13 kHz ticks (pre-#107) (ratio 1:13). So even when T2 is
 enabled, the scan only completes ~77× per second, not per tick.
 
 > **⚠️ Superseded by #107 (2026-06-08):** `ChannelScanFreqDiv` is now always 1,

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -296,11 +296,9 @@ scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
     }
     pRunTimeStreamConfig->Frequency = freq;
     pRunTimeStreamConfig->TSClockPeriod = 0xFFFFFFFF;
-    if (freq > 1000) {
-        pRunTimeStreamConfig->ChannelScanFreqDiv = freq / 1000;
-    } else {
-        pRunTimeStreamConfig->ChannelScanFreqDiv = 1;
-    }
+    // #107: Type-2 (muxed) channels scan every tick at the full rate (not the old
+    // freq/1000 throttle that pinned them to 1 kHz). Mirrors SCPI_StartStreaming.
+    pRunTimeStreamConfig->ChannelScanFreqDiv = 1;
 
     return SCPI_RES_OK;
 }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3274,49 +3274,16 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         // See https://github.com/daqifi/daqifi-nyquist-firmware/issues/215
         // Bypass cap in benchmark mode to measure pure interface throughput.
         if (Streaming_GetBenchmarkMode() == BENCHMARK_OFF) {
-            // #232: reject up-front when any Type 2 (muxed) MC12b channel is
-            // enabled and the requested freq would silently cap the muxed
-            // scan rate.  The firmware always sets
-            //   ChannelScanFreqDiv = freq / 1000 (when freq > 1000)
-            // so T2 channels sample at most 1 kHz regardless of timer rate.
-            // Pre-#232 we silently throttled — user saw "5 kHz streaming"
-            // but T2 data was 1 kHz.  Now we surface that as a SCPI error
-            // so the client can either reduce freq, disable T2 channels,
-            // or opt-in via SYST:STR:BENCHmark (which bypasses the check
-            // since benchmarks intentionally measure timer-rate throughput).
-            if (freq > (int32_t)STREAMING_MUXED_CAP_HZ) {
-                bool hasMuxed = false;
-                volatile AInRuntimeArray* rt = (volatile AInRuntimeArray*)pRuntimeAInChannels;
-                volatile AInArray* cfg = (volatile AInArray*)pBoardConfigADC;
-                size_t cnt = (cfg->Size < rt->Size) ? cfg->Size : rt->Size;
-                for (size_t i = 0; i < cnt; i++) {
-                    if (rt->Data[i].IsEnabled != 1) continue;
-                    if (cfg->Data[i].Type != AIn_MC12bADC) continue;
-                    if (!cfg->Data[i].Config.MC12b.IsPublic) continue;
-                    if (cfg->Data[i].Config.MC12b.ChannelType == MC12B_CHANNEL_TYPE_MUXED) {
-                        hasMuxed = true;
-                        break;
-                    }
-                }
-                if (hasMuxed) {
-                    LOG_I("Streaming rejected: T2 channels max %u Hz (requested %d Hz)",
-                          (unsigned)STREAMING_MUXED_CAP_HZ, (int)freq);
-                    /* Stringify STREAMING_MUXED_CAP_HZ into the user-facing
-                     * error so the message stays in sync if the constant
-                     * ever changes (#449 Qodo r2 finding). */
-                    #define MUXED_CAP_STR_HELPER(x) #x
-                    #define MUXED_CAP_STR(x) MUXED_CAP_STR_HELPER(x)
-                    static const char muxedErrMsg[] =
-                        "T2 (muxed) channels cap at " MUXED_CAP_STR(STREAMING_MUXED_CAP_HZ)
-                        " Hz; reduce freq, disable T2 channels, or use "
-                        "SYST:STR:BENCHmark to bypass";
-                    #undef MUXED_CAP_STR
-                    #undef MUXED_CAP_STR_HELPER
-                    SCPI_ErrorPushEx(context, SCPI_ERROR_SETTINGS_CONFLICT,
-                                     (char *)muxedErrMsg, sizeof(muxedErrMsg) - 1);
-                    return SCPI_RES_ERR;
-                }
-            }
+            // #107: Type-2 (muxed MODULE7) channels now scan at the full timer
+            // rate (ChannelScanFreqDiv=1, set below) — real per-tick conversions,
+            // not 1 kHz held values — so the old fixed 1 kHz T2 reject (#232) is
+            // removed. T2 is now bounded by the SAME per-interface/format transport
+            // cap as T1 (#524), computed below. Real-ADC evidence: an 18-pass
+            // overnight matrix ({1,3,5,8,11} T2 ch × OBDiag × 1–40 kHz, 2477 pts)
+            // showed the mux scan never overran (EosOverruns=0) up to ≥40 kHz at any
+            // channel count — the scan is never the bottleneck; the encoder/pool
+            // pipeline (already modeled by #524) is. See daqifi-python-test-suite
+            // benchmarks/107_t2_scan_characterization/.
 
             // Includes the WiFi wire-rate term when ActiveInterface==WiFi
             // (#522) on top of the ADC/ISR/tick constraints.
@@ -3359,11 +3326,11 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
             pRunTimeStreamConfig->ClockPeriod = periodCycles - 1;
             pRunTimeStreamConfig->Frequency = freq;
             pRunTimeStreamConfig->TSClockPeriod = 0xFFFFFFFF;
-            if (freq > 1000) {
-                pRunTimeStreamConfig->ChannelScanFreqDiv = freq / 1000;
-            } else {
-                pRunTimeStreamConfig->ChannelScanFreqDiv = 1;
-            }
+            // #107: scan the shared MODULE7 (Type-2) mux on EVERY tick so T2 yields
+            // real full-rate conversions (not 1 kHz held values). The mux scan keeps
+            // up to >=40 kHz (HW-characterized); the streaming rate is bounded by the
+            // #524 transport cap above, well within the scan's capability.
+            pRunTimeStreamConfig->ChannelScanFreqDiv = 1;
         } else {
             return SCPI_RES_ERR;
         }

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -63,13 +63,13 @@ extern "C" {
 // Streaming_TransportMaxFreq below (#524), which superseded the earlier
 // WiFi-only budget term (#520/#522) and generalized it to all interfaces.
 
-// Type 2 (shared MODULE7 mux) hard cap.  T2 channels are scanned via the
-// analog multiplexer sequentially; the firmware applies
-// ChannelScanFreqDiv = freq/1000 in SCPI_StartStreaming so the muxed scan
-// rate stays at 1 kHz regardless of timer rate.  When BENCHMARK_OFF, any
-// freq > this constant with T2 channels enabled is rejected up-front
-// instead of being silently throttled (#232).
-#define STREAMING_MUXED_CAP_HZ      1000
+// Type 2 (shared MODULE7 mux) channels are scanned sequentially via the analog
+// multiplexer. The former fixed 1 kHz throttle (ChannelScanFreqDiv = freq/1000)
+// and its up-front reject (#232) were REMOVED in #107: real-ADC characterization
+// (18-pass overnight matrix, daqifi-python-test-suite benchmarks/107_*) showed the
+// mux scan never overruns up to >=40 kHz at any channel count. ChannelScanFreqDiv
+// is now always 1 (T2 scans every tick = real full-rate data), and T2 is bounded
+// by the same per-interface/format transport cap as T1 (Streaming_TransportMaxFreq).
 
 /**
  * Compute maximum safe streaming frequency for a given channel configuration.


### PR DESCRIPTION
## Summary

Real-ADC characterization (18-pass overnight matrix, 2477 pts — daqifi-python-test-suite `benchmarks/107_t2_scan_characterization/`, PR #51) showed the shared-MODULE7 (Type-2) mux scan **never overruns (EosOverruns=0) up to ≥40 kHz** at any channel count or OBDiag state. The scan is *never* the bottleneck — T2 streaming is limited by the encoder/sample-pool pipeline, the same limit the **#524 transport cap already models**. So the fixed 1 kHz T2 throttle was ~40× too conservative.

## Changes
- **`ChannelScanFreqDiv = 1` always** (`SCPI_StartStreaming` + `SCPI_ADCChanEnableSet`): T2 scans every tick → real full-rate conversions, not 1 kHz held values.
- **Removed the #232 up-front T2 reject** (`STREAMING_MUXED_CAP_HZ`) — it existed only because the `freq/1000` throttle made T2 data secretly 1 kHz; with full-rate scanning the data is real, so T2 obeys the #524 cap like Type-1.
- Removed the `STREAMING_MUXED_CAP_HZ` define + `MUXED_CAP_STR` macro; CLAUDE.md updated.

## HW-verified (normal mode, 11×T2 PB, ch0 = 4 V @ 10 kΩ)
- `START 2000` now **ACCEPTED** (was `-221` pre-#107)
- Clean to the #524 cap: **EosOverruns=0, QueueDropped=0, UsbDropped=0, ch0=4.005 V**
- Over-cap → **`-222`** (transport cap governs T2 now)
- OBDiag on/off both correctly bounded

Refs #107, #232, #524. Data: test-suite PR #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)