### PR TITLE
fix(streaming): multi-output SD write is no-retry — a stalled SD can't block USB (#534)

### DIFF
--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1655,9 +1655,15 @@ size_t sd_card_manager_WriteToBuffer(const char* pData, size_t len) {
         return 0;
     }
 
-    // All-or-nothing: only write if full packet fits. Prevents convoy effect
-    // where tiny partial writes burn CPU on mutex cycles. Callers retry via
-    // Streaming_WriteWithRetry — no data loss.
+    // All-or-nothing, NON-BLOCKING: returns 0 immediately when the full
+    // packet doesn't fit (prevents the convoy effect of tiny partial
+    // writes burning CPU on mutex cycles).  Retry policy is the CALLER's:
+    // solo-SD streaming wraps this in Streaming_WriteWithRetry (#520
+    // backpressure); multi-output streaming intentionally does NOT retry
+    // (#534 — drop+count so a stalled SD can't block the USB path).  The
+    // wMutex hold here is microseconds (free-space check + memcpy); the
+    // SD task's slow f_write runs OUTSIDE the mutex, so a hung card makes
+    // this return 0, never block.
     SD_TakeMutexDebug(gSDCardData.wMutex, "write_buffer_add");
     if (CircularBuf_NumBytesFree(&gSDCardData.wCirbuf) < len) {
         xSemaphoreGive(gSDCardData.wMutex);

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -124,12 +124,16 @@ extern "C" {
      * @brief Writes data to the SD card manager's write buffer.
      *
      * This function adds data to the internal circular buffer for writing to the SD card.
-     * If the buffer does not have enough space, the function will block until space becomes available.
+     * NON-BLOCKING and all-or-nothing: if the buffer does not have enough space for the
+     * full packet, it returns 0 immediately (no partial write, no wait). Retry policy
+     * belongs to the caller: solo-SD streaming wraps this in Streaming_WriteWithRetry
+     * (#520 backpressure); multi-output streaming intentionally does not retry (#534 —
+     * drop+count so a stalled SD cannot block the USB path).
      *
      * @param[in] pData Pointer to the data to be written.
      * @param[in] len   Length of the data in bytes.
      *
-     * @return The number of bytes successfully added to the buffer.
+     * @return len on success, 0 if the full packet did not fit (or SD not in write mode).
      *
      * @note This function is thread-safe and can be called from multiple contexts.
      *       Ensure that the SD card manager is initialized and in write mode before calling.

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2102,24 +2102,53 @@ void streaming_Task(void) {
                 //       STREAM_WRITE_RETURN_STOPPED (stop-abort, no bookkeeping).
             }
             if (hasSD && gSdFileWasReady) {
-                size_t wr = Streaming_WriteWithRetry(
-                    sd_card_manager_WriteToBuffer, buffer, packetSize);
-                if (wr == STREAM_WRITE_RETURN_TIMEOUT) {
-                    /* True 10 s interface-dead timeout (pass-5 Qodo
-                     * refinement): bump drop counters + QUES bit + log. */
-                    bool pastGrace = Streaming_PastStartupGrace();
-                    taskENTER_CRITICAL();
-                    gStreamStats.sdDroppedBytes += packetSize;
-                    if (pastGrace) {
-                        gStreamStats.sdDroppedBytesSteady += packetSize;
+                if (pRunTimeStreamConf->ActiveInterface == StreamingInterface_UsbAndSd) {
+                    /* #534: multi-output — a stalled SD must never block the
+                     * (healthy) USB path through this shared encoder loop.
+                     * Saturation is already shed by the per-iteration
+                     * hasSD = (sdSize >= 128) gate above (HW-verified: USB
+                     * holds 100% of target at 2x SD over-rate while SD
+                     * drops).  The remaining hazard is a HARD-STALLED card
+                     * with the circular buffer stuck at partial fill —
+                     * free space >= 128 but nothing draining — where
+                     * WriteWithRetry would block 10 s PER PACKET and
+                     * throttle USB to ~0.  No-retry write-if-space-else-
+                     * drop+count, mirroring the USB side of this branch.
+                     * Solo-SD keeps the blocking backpressure below
+                     * (#520: pool absorbs the burst; single drop point). */
+                    if (sd_card_manager_WriteToBuffer((const char*)buffer,
+                                                      packetSize) != packetSize) {
+                        bool pastGrace = Streaming_PastStartupGrace();
+                        taskENTER_CRITICAL();
+                        gStreamStats.sdDroppedBytes += packetSize;
+                        if (pastGrace) {
+                            gStreamStats.sdDroppedBytesSteady += packetSize;
+                        }
+                        gQuesBits |= QUES_BIT_SD_OVERFLOW;
+                        taskEXIT_CRITICAL();
+                        LOG_E_SESSION(LOG_SESSION_SD_DROP,
+                            "Streaming: SD buffer overflow (multi-output no-retry)");
                     }
-                    gQuesBits |= QUES_BIT_SD_OVERFLOW;
-                    taskEXIT_CRITICAL();
-                    LOG_E_SESSION(LOG_SESSION_SD_DROP, "Streaming: SD interface dead (10s timeout)");
+                } else {
+                    size_t wr = Streaming_WriteWithRetry(
+                        sd_card_manager_WriteToBuffer, buffer, packetSize);
+                    if (wr == STREAM_WRITE_RETURN_TIMEOUT) {
+                        /* True 10 s interface-dead timeout (pass-5 Qodo
+                         * refinement): bump drop counters + QUES bit + log. */
+                        bool pastGrace = Streaming_PastStartupGrace();
+                        taskENTER_CRITICAL();
+                        gStreamStats.sdDroppedBytes += packetSize;
+                        if (pastGrace) {
+                            gStreamStats.sdDroppedBytesSteady += packetSize;
+                        }
+                        gQuesBits |= QUES_BIT_SD_OVERFLOW;
+                        taskEXIT_CRITICAL();
+                        LOG_E_SESSION(LOG_SESSION_SD_DROP, "Streaming: SD interface dead (10s timeout)");
+                    }
+                    /* else: wr == packetSize (success) or
+                     *       wr == STREAM_WRITE_RETURN_STOPPED (stop-abort,
+                     *       intentional, no bookkeeping). */
                 }
-                /* else: wr == packetSize (success) or
-                 *       wr == STREAM_WRITE_RETURN_STOPPED (stop-abort,
-                 *       intentional, no bookkeeping). */
             }
 
             // Track packets discarded due to output buffer backpressure.

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1302,6 +1302,23 @@ bool Streaming_TasksAreQuiescent(void) {
  * Stops the streaming timer
  */
 /**
+ * Shared SD drop bookkeeping (#534 DRY): counter pair + QUES bit under one
+ * critical section so a concurrent SYST:STR:STATS? snapshot sees them
+ * coherently (steady never > total).  Callers log their own context-
+ * specific LOG_E_SESSION line.
+ */
+static void Streaming_CountSdDrop(size_t packetSize) {
+    bool pastGrace = Streaming_PastStartupGrace();
+    taskENTER_CRITICAL();
+    gStreamStats.sdDroppedBytes += packetSize;
+    if (pastGrace) {
+        gStreamStats.sdDroppedBytesSteady += packetSize;
+    }
+    gQuesBits |= QUES_BIT_SD_OVERFLOW;
+    taskEXIT_CRITICAL();
+}
+
+/**
  * #533: drain both per-session sample queues (AIN + DIO) so no sample
  * captured by one session can be encoded into the next.  Called from
  * Streaming_Stop (the session is over — discard) and Streaming_Start
@@ -2123,16 +2140,16 @@ void streaming_Task(void) {
                      * (#520: pool absorbs the burst; single drop point). */
                     if (sd_card_manager_WriteToBuffer((const char*)buffer,
                                                       packetSize) != packetSize) {
-                        bool pastGrace = Streaming_PastStartupGrace();
-                        taskENTER_CRITICAL();
-                        gStreamStats.sdDroppedBytes += packetSize;
-                        if (pastGrace) {
-                            gStreamStats.sdDroppedBytesSteady += packetSize;
+                        /* Skip the bookkeeping when streaming was stopped
+                         * mid-iteration — mirrors WriteWithRetry's STOPPED
+                         * path: a non-write during the stop transition (file
+                         * closing, buffers being torn down) is not an SD
+                         * fault and must not pollute the session stats. */
+                        if (pRunTimeStreamConf->IsEnabled) {
+                            Streaming_CountSdDrop(packetSize);
+                            LOG_E_SESSION(LOG_SESSION_SD_DROP,
+                                "Streaming: SD buffer overflow (multi-output no-retry)");
                         }
-                        gQuesBits |= QUES_BIT_SD_OVERFLOW;
-                        taskEXIT_CRITICAL();
-                        LOG_E_SESSION(LOG_SESSION_SD_DROP,
-                            "Streaming: SD buffer overflow (multi-output no-retry)");
                     }
                 } else {
                     size_t wr = Streaming_WriteWithRetry(
@@ -2140,14 +2157,7 @@ void streaming_Task(void) {
                     if (wr == STREAM_WRITE_RETURN_TIMEOUT) {
                         /* True 10 s interface-dead timeout (pass-5 Qodo
                          * refinement): bump drop counters + QUES bit + log. */
-                        bool pastGrace = Streaming_PastStartupGrace();
-                        taskENTER_CRITICAL();
-                        gStreamStats.sdDroppedBytes += packetSize;
-                        if (pastGrace) {
-                            gStreamStats.sdDroppedBytesSteady += packetSize;
-                        }
-                        gQuesBits |= QUES_BIT_SD_OVERFLOW;
-                        taskEXIT_CRITICAL();
+                        Streaming_CountSdDrop(packetSize);
                         LOG_E_SESSION(LOG_SESSION_SD_DROP, "Streaming: SD interface dead (10s timeout)");
                     }
                     /* else: wr == packetSize (success) or
@@ -2172,14 +2182,7 @@ void streaming_Task(void) {
                 bool sdWritten = hasSD && gSdFileWasReady;
 
                 if (sdExpected && !sdWritten) {
-                    bool pastGrace = Streaming_PastStartupGrace();
-                    taskENTER_CRITICAL();
-                    gStreamStats.sdDroppedBytes += packetSize;
-                    if (pastGrace) {
-                        gStreamStats.sdDroppedBytesSteady += packetSize;
-                    }
-                    gQuesBits |= QUES_BIT_SD_OVERFLOW;
-                    taskEXIT_CRITICAL();
+                    Streaming_CountSdDrop(packetSize);
                     LOG_E_SESSION(LOG_SESSION_SD_DROP, "Streaming: SD output skipped (buffer full or file not ready)");
                 }
             }

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2102,9 +2102,14 @@ void streaming_Task(void) {
                 //       STREAM_WRITE_RETURN_STOPPED (stop-abort, no bookkeeping).
             }
             if (hasSD && gSdFileWasReady) {
-                if (pRunTimeStreamConf->ActiveInterface == StreamingInterface_UsbAndSd) {
+                if (pRunTimeStreamConf->ActiveInterface != StreamingInterface_SD) {
                     /* #534: multi-output — a stalled SD must never block the
                      * (healthy) USB path through this shared encoder loop.
+                     * Gate is "not solo-SD" rather than "== UsbAndSd" because
+                     * the SD-logging override above (SD enabled while
+                     * ActiveInterface == USB) also produces concurrent
+                     * USB+SD writes without the UsbAndSd enum value (Qodo
+                     * pass-1 catch on PR #536).
                      * Saturation is already shed by the per-iteration
                      * hasSD = (sdSize >= 128) gate above (HW-verified: USB
                      * holds 100% of target at 2x SD over-rate while SD

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2182,8 +2182,15 @@ void streaming_Task(void) {
                 bool sdWritten = hasSD && gSdFileWasReady;
 
                 if (sdExpected && !sdWritten) {
-                    Streaming_CountSdDrop(packetSize);
-                    LOG_E_SESSION(LOG_SESSION_SD_DROP, "Streaming: SD output skipped (buffer full or file not ready)");
+                    // Gate on IsEnabled, mirroring the #484 encoder-failure
+                    // guard: if Streaming_Stop ran between this iteration's
+                    // top-of-loop check and here, the SD file is mid-close
+                    // and the failed write is teardown, not data loss the
+                    // operator should see counted (Qodo #536).
+                    if (pRunTimeStreamConf->IsEnabled) {
+                        Streaming_CountSdDrop(packetSize);
+                        LOG_E_SESSION(LOG_SESSION_SD_DROP, "Streaming: SD output skipped (buffer full or file not ready)");
+                    }
                 }
             }
             DioProbe_PulseEnd(9);


### PR DESCRIPTION
## What the bench taught us

#534's hazard splits in two, and only one of them was real:

- **Saturation (slow-but-draining SD) was already safe.** The per-iteration `hasSD = (sdSize >= 128)` gate sheds load before the write reaches `WriteWithRetry`. HW-verified on the pre-fix build: USB+SD CSV 16-ch at 3 kHz (2× SD's ceiling, NOCAP) → USB delivers **100.0%** of target with 0 `UsbDroppedBytes` / 0 `QueueDroppedSamples` while SD drops 4.4 MB counted.
- **The hard-stall window was the real violation**: a dead/hung card with the circular buffer stuck at partial fill (free ≥ 128 but nothing draining) sends *every* packet into `WriteWithRetry`'s 10 s dead-interface block — throttling the healthy USB path to ~one packet per 10 s.

## Fix

In `UsbAndSd` mode the SD write becomes no-retry write-if-space-else-drop+count (mirroring the USB side of the same branch, with `SdDroppedBytes` + QUES bit + session log). Solo-SD keeps the blocking `WriteWithRetry` backpressure — that's the intentional #520 design (pool absorbs bursts; single drop point), and with one output there's no healthy path to protect.

## Verification

| Leg | Build | Result |
|---|---|---|
| A (saturation) | pre-fix | USB 100.0% of 3 kHz, UsbDropped 0, QueueDropped 0, SdDropped 4.4 MB |
| B (saturation regression) | this fix | USB 100.0% of 3 kHz, UsbDropped 0, QueueDropped 0, SdDropped 5.0 MB |

The hard-stall case is closed by inspection (the blocking call is no longer reachable in multi-output mode); it isn't bench-reproducible without physically hanging a card mid-stream. Regression test `test_534_per_path_backpressure.py` PR'd to daqifi-python-test-suite.

Fixes #534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)