### PR TITLE
fix(adc): run the shared MODULE7 scan when T2 user channels need it (#537)

### DIFF
--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -52,15 +52,20 @@ static uint64_t gTestPatternSampleCount = 0;      // Monotonic counter, reset on
 // Uses uint32_t for guaranteed 32-bit atomic access on PIC32MZ.
 static volatile uint32_t gBenchmarkMode = BENCHMARK_OFF;
 
-// #537: any Type-2 (shared MODULE7) USER channel enabled for this session.
-// Computed in Streaming_Start (before the timer is armed) from the enabled-
-// channel counts; read by the deferred ISR task's trigger logic and by
-// Streaming_Start's hardware-trigger setup so the shared scan runs whenever
-// T2 user data is needed, independent of OnboardDiagEnabled.  volatile:
-// written in SCPI-task context, read in the priority-9 deferred task.
-// (Counts AD7609 channels as "T2 user" on NQ3 — conservative: the extra
-// MODULE7 scan is harmless there.)
-static volatile bool gAnyT2UserEnabled = false;
+// #537: the shared (MODULE7) scan must run for ANY MC12b streaming session,
+// independent of OnboardDiagEnabled.  Two consumers depend on it:
+//   1. Type-2 USER channels — their conversions ARE the scan.
+//   2. Type-1 result reads — since #292 these happen in
+//      MC12bADC_EosInterruptTask, and EOS only fires at end-of-scan, so a
+//      T1-only session with no scan never reads its results either.
+// Pre-#535 builds streamed frozen LATEST values silently in both cases; the
+// #535 validity gate turned them into 100% encoder failures (the 2026-06-11
+// overnight caught T2 on its first cell, then the T1 variant on the next).
+// Computed in Streaming_Start before any trigger is armed (true when any
+// public channel is enabled); read by the deferred ISR task's trigger logic.
+// volatile: written in SCPI-task context, read in the priority-9 deferred
+// task.
+static volatile bool gNeedSharedScan = false;
 
 // Task priority constant (benchmark no longer changes priority)
 #define STREAMING_ISR_TASK_PRIORITY     8
@@ -725,7 +730,7 @@ pool_done:
                 // task already skips monitoring-channel READS when OBDiag=0,
                 // so monitoring stays dormant as intended.
                 bool skipShared = !pRunTimeStreamConf->OnboardDiagEnabled &&
-                                  !gAnyT2UserEnabled;
+                                  !gNeedSharedScan;
 
                 if (pRunTimeStreamConf->ChannelScanFreqDiv == 1) {
                     for (i = 0; i < pRunTimeAInModules->Size; ++i) {
@@ -1188,10 +1193,13 @@ static void Streaming_Start(void) {
             {
                 uint16_t t1 = 0, total = 0;
                 Streaming_CountActiveChannels(&t1, &total, NULL);
-                gAnyT2UserEnabled = (total > t1);
+                // Any enabled public channel needs the scan: T2 channels for
+                // their conversions, T1 channels because their results are
+                // read in the EOS task and EOS only fires at end-of-scan.
+                gNeedSharedScan = (total > 0);
             }
             bool hwShared = (gpRuntimeConfigStream->OnboardDiagEnabled ||
-                             gAnyT2UserEnabled) &&
+                             gNeedSharedScan) &&
                             (gpRuntimeConfigStream->ChannelScanFreqDiv <= 1);
             MC12b_ConfigureHardwareTrigger(true, hwShared);
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -52,6 +52,16 @@ static uint64_t gTestPatternSampleCount = 0;      // Monotonic counter, reset on
 // Uses uint32_t for guaranteed 32-bit atomic access on PIC32MZ.
 static volatile uint32_t gBenchmarkMode = BENCHMARK_OFF;
 
+// #537: any Type-2 (shared MODULE7) USER channel enabled for this session.
+// Computed in Streaming_Start (before the timer is armed) from the enabled-
+// channel counts; read by the deferred ISR task's trigger logic and by
+// Streaming_Start's hardware-trigger setup so the shared scan runs whenever
+// T2 user data is needed, independent of OnboardDiagEnabled.  volatile:
+// written in SCPI-task context, read in the priority-9 deferred task.
+// (Counts AD7609 channels as "T2 user" on NQ3 — conservative: the extra
+// MODULE7 scan is harmless there.)
+static volatile bool gAnyT2UserEnabled = false;
+
 // Task priority constant (benchmark no longer changes priority)
 #define STREAMING_ISR_TASK_PRIORITY     8
 
@@ -706,7 +716,16 @@ pool_done:
                 DioProbe_PulseStart(4);  /* probe 4: ADC trigger duration */
                 bool hwDed = MC12b_IsHwTriggerDedicated();
                 bool hwShd = MC12b_IsHwTriggerShared();
-                bool skipShared = !pRunTimeStreamConf->OnboardDiagEnabled;
+                // #537: the shared (MODULE7) scan carries BOTH the OBDiag
+                // monitoring channels AND every Type-2 USER channel, so it
+                // must run whenever either consumer needs it.  Gating it on
+                // OnboardDiagEnabled alone froze T2 user data in OBDiag=0
+                // streams (silently on pre-#535 builds; 100% encoder
+                // failures once the #535 validity gate landed).  The EOS
+                // task already skips monitoring-channel READS when OBDiag=0,
+                // so monitoring stays dormant as intended.
+                bool skipShared = !pRunTimeStreamConf->OnboardDiagEnabled &&
+                                  !gAnyT2UserEnabled;
 
                 if (pRunTimeStreamConf->ChannelScanFreqDiv == 1) {
                     for (i = 0; i < pRunTimeAInModules->Size; ++i) {
@@ -1159,9 +1178,20 @@ static void Streaming_Start(void) {
             // Enable hardware ADC triggering only when actually streaming.
             // Streaming_Start runs at boot before ADC_Init — must not
             // write ADCTRG/ADCCON1 until ADC is ready.
-            // hwShared: enable MODULE7 scan trigger unless onboard diag is
-            // disabled (max dedicated throughput mode).
-            bool hwShared = gpRuntimeConfigStream->OnboardDiagEnabled &&
+            // #537: compute the session's T2-user flag BEFORE arming any
+            // trigger: the shared (MODULE7) scan carries both the OBDiag
+            // monitoring channels AND every Type-2 user channel, so it must
+            // run when either consumer needs it.  The old OnboardDiagEnabled-
+            // only gate froze T2 user data in OBDiag=0 streams (silent stale
+            // values pre-#535; 100% encoder failures after the #535 validity
+            // gate landed).
+            {
+                uint16_t t1 = 0, total = 0;
+                Streaming_CountActiveChannels(&t1, &total, NULL);
+                gAnyT2UserEnabled = (total > t1);
+            }
+            bool hwShared = (gpRuntimeConfigStream->OnboardDiagEnabled ||
+                             gAnyT2UserEnabled) &&
                             (gpRuntimeConfigStream->ChannelScanFreqDiv <= 1);
             MC12b_ConfigureHardwareTrigger(true, hwShared);
 


### PR DESCRIPTION
Fixes #537 — with `OBDiag=0`, T2 user channels never converted because both shared-scan trigger gates (`hwShared` in `Streaming_Start`, `skipShared` in the deferred task) keyed on `OnboardDiagEnabled` alone. Pre-#535 builds silently streamed **frozen** T2 values in that mode (clean loss counters, stale data); #535's validity gate turned it into 100% `EncoderFailures` + an empty wire, which is how tonight's at-cap soak caught it on its first cell.

Fix: `gAnyT2UserEnabled` (set in `Streaming_Start` before any trigger arms) ORs into both gates. Monitoring reads stay OBDiag-gated in the EOS task as before.

## Hardware A/B (1×T2 ch0, real ADC, USB)

| Build | OBDiag=1 | OBDiag=0 |
|---|---|---|
| pre-fix (main+#535) | wire flows, EncFail 1 | **wire EMPTY, EncFail 5991/5991** |
| this fix | live data, EncFail 0 | **live data (jittering ch0 values), EncFail 0** |

Historical-data caveat recorded in the issue: pre-fix "OBD=OFF" characterization rows with T2 channels carried frozen T2 values (throughput numbers stand; data values were stale).

The overnight at-cap walk-down soak (derate ∪ this fix) is the extended validation run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)