### PR TITLE
fix(streaming): WiFi cap refit to honest-scan soak basis + extended #537 scan fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,13 +645,21 @@ The firmware computes a maximum safe streaming frequency — the `min()` of an *
 | interface | single (n=1) PB / CSV | A/(B+n) PB | A/(B+n) CSV |
 |-----------|----:|----:|----:|
 | USB    | 15000 / 15000 | 180000/(10+n) | 34000/(1+n) |
-| WiFi   | 11250 / 9000  | 210000/(30+n) | 21000/(1+n) |
+| WiFi   | 6774 / 8000   | 210000/(30+n) | 20000/(2+n) |
 | SD     | 9000 / 7500   | 150000/(15+n) | 42000/(12+n) |
 | USB+SD | 8000 / 8000   | 66000/(6+n)   | 15000/(0+n) |
 
+**WiFi soak derate (2026-06-10).** The original sweep-fitted WiFi terms (PB single 11250, CSV single 9000, CSV 21000/(1+n)) were *burst*-fitted; the at-cap endurance runs (1200 s real-ADC soaks, `benchmarks/atcap_20260610_*.csv` in the test suite) showed they leak 13–31,000 `QueueDroppedSamples` per soak — with `WifiDroppedBytes = 0` everywhere (pool exhaustion at sustained tick rate, not transport loss). Soak-driven refit:
+- **PB 1-ch = the multi-channel curve value `210000/31 = 6774`** (soak-clean both variants): the 11250 special case was a burst-fit outlier (60 s trials ranged 6000–12500 run-to-run in `wifi_v2_matrix`); a −11% trim to 10000 still leaked 15–31k per soak; every PB cell ≤6363 ticks/s holds zero-loss for 20 min.
+- **CSV single 9000→8000** (soak-clean both variants).
+- **CSV multi 21000/(1+n)→20000/(2+n)**, anchored on the soak-clean cells (8ch 2111, 10ch 1909, 11ch 1750, 16ch 1117): T2-heavy 3/5-ch variants leaked at the old curve (3×T2 @5250 and @4750, 5×T2 @3500 and @3166) — the extra pri-9 EOS deferred-task wakeup per tick (vs T1 variants, which were clean at the same rates) competes with the pri-6 encoder. New 3ch=4000 / 5ch=2857 sit 10–16% under the dirty points.
+- PB `A/(B+n)` multi-channel held clean at every soak cell and is unchanged.
+
+The static derate is the interim fix; runtime AIMD (#523) remains the long-term answer to transient ceiling variation.
+
 **Effective limit:** `min(ISR_MAX, TYPE1_AGG/type1Count, TICK_BUDGET/(OVERHEAD+totalEnabled), TransportMax(interface, encoding, totalEnabled))`
 
-**Verified caps (hardware, 1 channel, #524):** USB 15000 · WiFi PB 11250 / CSV 9000 · SD PB 9000 / CSV 7500 · USB+SD 8000 — all match the equation and `current_max_rate_hz` (capabilities query reflects the full cap as of #524).
+**Verified caps (hardware, 1 channel, #524; WiFi figures pre-derate):** USB 15000 · WiFi PB 11250 / CSV 9000 (now derated to 10000/8000, see above) · SD PB 9000 / CSV 7500 · USB+SD 8000 — all match the equation and `current_max_rate_hz` (capabilities query reflects the full cap as of #524).
 
 **Type-2 (muxed MODULE7) channels obey this same cap (#107).** Earlier firmware throttled the shared-ADC mux scan to 1 kHz (`ChannelScanFreqDiv = freq/1000`) and rejected any T2 stream above 1 kHz up-front (the old `STREAMING_MUXED_CAP_HZ` / #232). Real-ADC characterization (18-pass overnight matrix, `daqifi-python-test-suite` `benchmarks/107_t2_scan_characterization/`) showed the mux scan **never overruns up to ≥40 kHz** at any channel count (EosOverruns=0) — it is never the bottleneck. So #107 set `ChannelScanFreqDiv = 1` (T2 scans every tick = real full-rate data) and removed the 1 kHz reject; T2 streaming is now bounded by the per-interface/format transport cap above, exactly like Type-1. HW-verified: 11×T2 PB streams clean to the #524 cap (EosOverruns=0, QueueDropped=0, ch0 accurate), over-cap → `-222`, OBDiag on/off both bounded.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,7 +645,7 @@ The firmware computes a maximum safe streaming frequency — the `min()` of an *
 | interface | single (n=1) PB / CSV | A/(B+n) PB | A/(B+n) CSV |
 |-----------|----:|----:|----:|
 | USB    | 15000 / 15000 | 180000/(10+n) | 34000/(1+n) |
-| WiFi   | 6774 / 8000   | 210000/(30+n) | 20000/(2+n) |
+| WiFi   | 5175 / 4675   | 139000/(30+n) | min(20000/(2+n), 3050) |
 | SD     | 9000 / 7500   | 150000/(15+n) | 42000/(12+n) |
 | USB+SD | 8000 / 8000   | 66000/(6+n)   | 15000/(0+n) |
 
@@ -655,7 +655,16 @@ The firmware computes a maximum safe streaming frequency — the `min()` of an *
 - **CSV multi 21000/(1+n)→20000/(2+n)**, anchored on the soak-clean cells (8ch 2111, 10ch 1909, 11ch 1750, 16ch 1117): T2-heavy 3/5-ch variants leaked at the old curve (3×T2 @5250 and @4750, 5×T2 @3500 and @3166) — the extra pri-9 EOS deferred-task wakeup per tick (vs T1 variants, which were clean at the same rates) competes with the pri-6 encoder. New 3ch=4000 / 5ch=2857 sit 10–16% under the dirty points.
 - PB `A/(B+n)` multi-channel held clean at every soak cell and is unchanged.
 
-The static derate is the interim fix; runtime AIMD (#523) remains the long-term answer to transient ceiling variation.
+**WiFi honest-scan refit (2026-06-11).** The 2026-06-10 basis above — and every earlier WiFi OBDiag=off characterization — was measured on firmware with the #537 bug: OBDiag=0 silently skipped the MODULE7 scan, so T2 streams carried frozen values while the device did materially less work per tick (no scan, no EOS, no pri-9 EOS-task wakeups) and sustained ~1.5× the honest rate. Take-5 (2026-06-11, `benchmarks/atcap_20260611_045901.csv`, walk-down soaks with the #537 fix in) is the first honest OBDiag=off endurance basis:
+
+| | 1ch | 3ch | 5ch | 8ch | 11ch |
+|---|--:|--:|--:|--:|--:|
+| PB measured ceiling | 5175 | 4225 | 4000 | 3675 | 3400 |
+| CSV measured ceiling | 4675 | 3050 | 2857 (at cap) | 2000 (at cap) | 1538 (at cap) |
+
+Refit (all caps ≤ measured, within 1%): **PB single 6774→5175, PB multi 210000→139000/(30+n)** (~0.66×); **CSV single 8000→4675**; CSV multi keeps `20000/(2+n)` (validated AT CAP for n≥5 same-night) **clamped to 3050 for n=2..4** (the hyperbola over-caps low-n, where higher tick rates cost more per-tick overhead). HW-verified post-flash via `CONF:CAP:JSON?` (6/6 configs exact). T1/mixed WiFi cells were not re-characterized — blocked on #539 (T1 validity collapses above ~5.2 kHz; the T1-relevant rates sit in the dead zone).
+
+The static derate is the interim fix; runtime AIMD (#523) remains the long-term answer to transient ceiling variation — underscored by the 06-10 vs 06-11 spread: the same soak methodology on the same AP produced caps 1.5× apart once the workload was honest.
 
 **Effective limit:** `min(ISR_MAX, TYPE1_AGG/type1Count, TICK_BUDGET/(OVERHEAD+totalEnabled), TransportMax(interface, encoding, totalEnabled))`
 

--- a/firmware/src/services/SCPI/SCPIADC.h
+++ b/firmware/src/services/SCPI/SCPIADC.h
@@ -150,10 +150,16 @@ extern "C" {
     scpi_result_t SCPI_ADCUseCalGet(scpi_t * context);
 
     /**
-     * Enable/disable onboard diagnostic channel scanning during streaming.
+     * Enable/disable onboard diagnostic (monitoring) channel READS during
+     * streaming.
      *   CONFigure:ADC:OBDiag <0|1>
-     *     0 = skip shared/MODULE7 scanning entirely during streaming
-     *     1 = allow shared/MODULE7 scanning as configured by ChannelScanFreqDiv (default)
+     *     0 = EOS task skips monitoring-channel reads during streaming
+     *         (SYST:INFo? rail values go stale with an age banner)
+     *     1 = monitoring channels refresh every scan (default)
+     * NOTE (#537): the shared/MODULE7 scan itself runs whenever ANY public
+     * MC12b channel is enabled regardless of this setting — T2 user channels
+     * need it for their conversions and T1 results are read at EOS (#292).
+     * OBDiag=0 only gates the monitoring-channel reads, not the scan.
      * Rejected while streaming is active (returns EXECUTION_ERROR).
      */
     scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -52,15 +52,20 @@ static uint64_t gTestPatternSampleCount = 0;      // Monotonic counter, reset on
 // Uses uint32_t for guaranteed 32-bit atomic access on PIC32MZ.
 static volatile uint32_t gBenchmarkMode = BENCHMARK_OFF;
 
-// #537: any Type-2 (shared MODULE7) USER channel enabled for this session.
-// Computed in Streaming_Start (before the timer is armed) from the enabled-
-// channel counts; read by the deferred ISR task's trigger logic and by
-// Streaming_Start's hardware-trigger setup so the shared scan runs whenever
-// T2 user data is needed, independent of OnboardDiagEnabled.  volatile:
-// written in SCPI-task context, read in the priority-9 deferred task.
-// (Counts AD7609 channels as "T2 user" on NQ3 — conservative: the extra
-// MODULE7 scan is harmless there.)
-static volatile bool gAnyT2UserEnabled = false;
+// #537: the shared (MODULE7) scan must run for ANY MC12b streaming session,
+// independent of OnboardDiagEnabled.  Two consumers depend on it:
+//   1. Type-2 USER channels — their conversions ARE the scan.
+//   2. Type-1 result reads — since #292 these happen in
+//      MC12bADC_EosInterruptTask, and EOS only fires at end-of-scan, so a
+//      T1-only session with no scan never reads its results either.
+// Pre-#535 builds streamed frozen LATEST values silently in both cases; the
+// #535 validity gate turned them into 100% encoder failures (the 2026-06-11
+// overnight caught T2 on its first cell, then the T1 variant on the next).
+// Computed in Streaming_Start before any trigger is armed (true when any
+// public channel is enabled); read by the deferred ISR task's trigger logic.
+// volatile: written in SCPI-task context, read in the priority-9 deferred
+// task.
+static volatile bool gNeedSharedScan = false;
 
 // Task priority constant (benchmark no longer changes priority)
 #define STREAMING_ISR_TASK_PRIORITY     8
@@ -725,7 +730,7 @@ pool_done:
                 // task already skips monitoring-channel READS when OBDiag=0,
                 // so monitoring stays dormant as intended.
                 bool skipShared = !pRunTimeStreamConf->OnboardDiagEnabled &&
-                                  !gAnyT2UserEnabled;
+                                  !gNeedSharedScan;
 
                 if (pRunTimeStreamConf->ChannelScanFreqDiv == 1) {
                     for (i = 0; i < pRunTimeAInModules->Size; ++i) {
@@ -1188,10 +1193,13 @@ static void Streaming_Start(void) {
             {
                 uint16_t t1 = 0, total = 0;
                 Streaming_CountActiveChannels(&t1, &total, NULL);
-                gAnyT2UserEnabled = (total > t1);
+                // Any enabled public channel needs the scan: T2 channels for
+                // their conversions, T1 channels because their results are
+                // read in the EOS task and EOS only fires at end-of-scan.
+                gNeedSharedScan = (total > 0);
             }
             bool hwShared = (gpRuntimeConfigStream->OnboardDiagEnabled ||
-                             gAnyT2UserEnabled) &&
+                             gNeedSharedScan) &&
                             (gpRuntimeConfigStream->ChannelScanFreqDiv <= 1);
             MC12b_ConfigureHardwareTrigger(true, hwShared);
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -52,6 +52,16 @@ static uint64_t gTestPatternSampleCount = 0;      // Monotonic counter, reset on
 // Uses uint32_t for guaranteed 32-bit atomic access on PIC32MZ.
 static volatile uint32_t gBenchmarkMode = BENCHMARK_OFF;
 
+// #537: any Type-2 (shared MODULE7) USER channel enabled for this session.
+// Computed in Streaming_Start (before the timer is armed) from the enabled-
+// channel counts; read by the deferred ISR task's trigger logic and by
+// Streaming_Start's hardware-trigger setup so the shared scan runs whenever
+// T2 user data is needed, independent of OnboardDiagEnabled.  volatile:
+// written in SCPI-task context, read in the priority-9 deferred task.
+// (Counts AD7609 channels as "T2 user" on NQ3 — conservative: the extra
+// MODULE7 scan is harmless there.)
+static volatile bool gAnyT2UserEnabled = false;
+
 // Task priority constant (benchmark no longer changes priority)
 #define STREAMING_ISR_TASK_PRIORITY     8
 
@@ -706,7 +716,16 @@ pool_done:
                 DioProbe_PulseStart(4);  /* probe 4: ADC trigger duration */
                 bool hwDed = MC12b_IsHwTriggerDedicated();
                 bool hwShd = MC12b_IsHwTriggerShared();
-                bool skipShared = !pRunTimeStreamConf->OnboardDiagEnabled;
+                // #537: the shared (MODULE7) scan carries BOTH the OBDiag
+                // monitoring channels AND every Type-2 USER channel, so it
+                // must run whenever either consumer needs it.  Gating it on
+                // OnboardDiagEnabled alone froze T2 user data in OBDiag=0
+                // streams (silently on pre-#535 builds; 100% encoder
+                // failures once the #535 validity gate landed).  The EOS
+                // task already skips monitoring-channel READS when OBDiag=0,
+                // so monitoring stays dormant as intended.
+                bool skipShared = !pRunTimeStreamConf->OnboardDiagEnabled &&
+                                  !gAnyT2UserEnabled;
 
                 if (pRunTimeStreamConf->ChannelScanFreqDiv == 1) {
                     for (i = 0; i < pRunTimeAInModules->Size; ++i) {
@@ -1159,9 +1178,20 @@ static void Streaming_Start(void) {
             // Enable hardware ADC triggering only when actually streaming.
             // Streaming_Start runs at boot before ADC_Init — must not
             // write ADCTRG/ADCCON1 until ADC is ready.
-            // hwShared: enable MODULE7 scan trigger unless onboard diag is
-            // disabled (max dedicated throughput mode).
-            bool hwShared = gpRuntimeConfigStream->OnboardDiagEnabled &&
+            // #537: compute the session's T2-user flag BEFORE arming any
+            // trigger: the shared (MODULE7) scan carries both the OBDiag
+            // monitoring channels AND every Type-2 user channel, so it must
+            // run when either consumer needs it.  The old OnboardDiagEnabled-
+            // only gate froze T2 user data in OBDiag=0 streams (silent stale
+            // values pre-#535; 100% encoder failures after the #535 validity
+            // gate landed).
+            {
+                uint16_t t1 = 0, total = 0;
+                Streaming_CountActiveChannels(&t1, &total, NULL);
+                gAnyT2UserEnabled = (total > t1);
+            }
+            bool hwShared = (gpRuntimeConfigStream->OnboardDiagEnabled ||
+                             gAnyT2UserEnabled) &&
                             (gpRuntimeConfigStream->ChannelScanFreqDiv <= 1);
             MC12b_ConfigureHardwareTrigger(true, hwShared);
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1191,29 +1191,22 @@ static void Streaming_Start(void) {
             // values pre-#535; 100% encoder failures after the #535 validity
             // gate landed).
             {
-                // Any enabled public MC12b channel needs the scan: T2
-                // channels for their conversions, T1 channels because their
-                // results are read in the EOS task and EOS only fires at
-                // end-of-scan.  Count MC12b specifically rather than
-                // CountActiveChannels' total so an AD7609-only NQ3 session
-                // doesn't arm the MC12b scan + EOS task for nothing
-                // (Qodo #540).  Same volatile-pointer/min-size idiom as
-                // Streaming_CountActiveChannels.
-                uint16_t mc12bPublic = 0;
-                volatile AInRuntimeArray* rtCh =
-                    BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_AIN_CHANNELS);
-                volatile AInArray* cfgCh =
-                    BoardConfig_Get(BOARDCONFIG_AIN_CHANNELS, 0);
-                size_t chCnt = (cfgCh->Size < rtCh->Size) ? cfgCh->Size
-                                                          : rtCh->Size;
-                for (size_t ci = 0; ci < chCnt; ci++) {
-                    if (rtCh->Data[ci].IsEnabled == 1 &&
-                        cfgCh->Data[ci].Type == AIn_MC12bADC &&
-                        cfgCh->Data[ci].Config.MC12b.IsPublic) {
-                        mc12bPublic++;
-                    }
-                }
-                gNeedSharedScan = (mc12bPublic > 0);
+                // Any enabled public channel arms the scan: T2 channels for
+                // their conversions, T1 channels because their results are
+                // read in the EOS task and EOS only fires at end-of-scan.
+                // DELIBERATELY total-based, not MC12b-specific: a Qodo
+                // pass-1 suggestion narrowed this to MC12b-only (so an
+                // AD7609-only NQ3 session wouldn't arm the scan), but
+                // pass-2 correctly flagged the edge it created — a
+                // mid-stream MC12b channel enable after an AD7609-only
+                // start would find the scan unarmed (frozen data, #537
+                // class) unless a mid-stream trigger re-arm path were
+                // added.  The scan is idle-cheap (#107: no overruns to
+                // >=40 kHz), so arming it for any public channel is the
+                // safe, simple invariant.
+                uint16_t t1 = 0, total = 0;
+                Streaming_CountActiveChannels(&t1, &total, NULL);
+                gNeedSharedScan = (total > 0);
             }
             bool hwShared = (gpRuntimeConfigStream->OnboardDiagEnabled ||
                              gNeedSharedScan) &&

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1191,12 +1191,29 @@ static void Streaming_Start(void) {
             // values pre-#535; 100% encoder failures after the #535 validity
             // gate landed).
             {
-                uint16_t t1 = 0, total = 0;
-                Streaming_CountActiveChannels(&t1, &total, NULL);
-                // Any enabled public channel needs the scan: T2 channels for
-                // their conversions, T1 channels because their results are
-                // read in the EOS task and EOS only fires at end-of-scan.
-                gNeedSharedScan = (total > 0);
+                // Any enabled public MC12b channel needs the scan: T2
+                // channels for their conversions, T1 channels because their
+                // results are read in the EOS task and EOS only fires at
+                // end-of-scan.  Count MC12b specifically rather than
+                // CountActiveChannels' total so an AD7609-only NQ3 session
+                // doesn't arm the MC12b scan + EOS task for nothing
+                // (Qodo #540).  Same volatile-pointer/min-size idiom as
+                // Streaming_CountActiveChannels.
+                uint16_t mc12bPublic = 0;
+                volatile AInRuntimeArray* rtCh =
+                    BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_AIN_CHANNELS);
+                volatile AInArray* cfgCh =
+                    BoardConfig_Get(BOARDCONFIG_AIN_CHANNELS, 0);
+                size_t chCnt = (cfgCh->Size < rtCh->Size) ? cfgCh->Size
+                                                          : rtCh->Size;
+                for (size_t ci = 0; ci < chCnt; ci++) {
+                    if (rtCh->Data[ci].IsEnabled == 1 &&
+                        cfgCh->Data[ci].Type == AIn_MC12bADC &&
+                        cfgCh->Data[ci].Config.MC12b.IsPublic) {
+                        mc12bPublic++;
+                    }
+                }
+                gNeedSharedScan = (mc12bPublic > 0);
             }
             bool hwShared = (gpRuntimeConfigStream->OnboardDiagEnabled ||
                              gNeedSharedScan) &&

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -137,30 +137,31 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
             else    { single = 15000u; A =  34000u; B =  1u; }
             break;
         case StreamingInterface_WiFi:
-            /* Derated from the sweep-fitted 11250/9000/21000 after the
-             * 2026-06-10 at-cap endurance runs (1200 s real-ADC soaks,
-             * atcap_20260610_002733/092839.csv): at the old caps, 1-ch PB
-             * and <=5-ch + 16-ch CSV leaked 13..31000 QueueDroppedSamples
-             * per soak (WifiDroppedBytes = 0 everywhere — pool exhaustion
-             * at sustained tick rate, not transport loss).
+            /* Refit 2026-06-11 (take-5 walk-down soaks, T2-only,
+             * atcap_20260611_045901.csv) — the first endurance basis with
+             * the #537 fix in.  All earlier WiFi OBDiag=off soak bases
+             * (2026-06-02 sweep, 2026-06-10 atcap) were measured with the
+             * MODULE7 scan silently skipped (#537): frozen T2 data and no
+             * EOS-task load, so the device sustained ~1.5x the honest
+             * rate.  With the scan actually running, walk-down ceilings:
              *
-             * PB 1-ch uses the multi-channel curve value A/(B+1) = 6774:
-             * the old 11250 special case was a burst-fit outlier (60 s
-             * trials ranged 6000..12500 run-to-run in wifi_v2_matrix);
-             * soaks leak at 10000-11250 but every cell <=6363 ticks/s
-             * holds zero-loss for 20 min. PB A/(B+n) multi-channel is
-             * unchanged (clean at every soak cell).
+             *   PB : 1ch 5175 · 3ch 4225 · 5ch 4000 · 8ch 3675 · 11ch 3400
+             *        -> single 5175; A/(B+n) refit 210000->139000 (B=30):
+             *        139000/(30+n) = 4212/3971/3658/3390 — under every
+             *        measured cell within 1%.
+             *   CSV: 1ch 4675 · 3ch 3050 · 5ch 2857 / 8ch 2000 / 11ch 1538
+             *        AT CAP (zero-drop at the existing 20000/(2+n) curve).
+             *        Keep the curve (validated at cap for n>=5 same-night);
+             *        single 8000->4675; clamp low-n multi to the measured
+             *        3-ch ceiling 3050 (the curve over-caps n=2..4, where
+             *        higher Hz costs more per-tick overhead than the
+             *        hyperbola predicts).
              *
-             * CSV multi-channel refit 21000/(1+n) -> 20000/(2+n), anchored
-             * on the soak-CLEAN cells (8ch 2111, 10ch 1909, 11ch 1750,
-             * 16ch 1117): T2-heavy 3/5-ch variants leak at the old curve
-             * (3xT2 @5250/4750, 5xT2 @3500/3166 — the extra pri-9 EOS
-             * deferred-task wakeup per tick vs T1 variants competes with
-             * the pri-6 encoder). New 3ch=4000 / 5ch=2857 sit 10-16%
-             * under the dirty points. CSV single 8000 soak-clean both
-             * variants. */
-            if (pb) { single =  6774u; A = 210000u; B = 30u; }
-            else    { single =  8000u; A =  20000u; B =  2u; }
+             * Night-to-night link variation remains (the 06-10 basis held
+             * its caps clean; tonight needed 0.66x) — static caps are
+             * worst-observed-safe, runtime AIMD (#523) is the real fix. */
+            if (pb) { single =  5175u; A = 139000u; B = 30u; }
+            else    { single =  4675u; A =  20000u; B =  2u; }
             break;
         case StreamingInterface_SD:
             if (pb) { single =  9000u; A = 150000u; B = 15u; }
@@ -180,6 +181,14 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
     if (totalChannels != 1u) {
         uint64_t denom = (uint64_t)B + (uint64_t)totalChannels;
         hz = (uint32_t)((uint64_t)A / denom);
+        /* WiFi CSV low-n clamp (2026-06-11 take-5): 20000/(2+n) is
+         * validated AT CAP for n>=5 but over-caps n=2..4 — the measured
+         * 3-ch soak ceiling is 3050 while the curve gives 4000.  Clamp
+         * multi-channel WiFi CSV to that measured ceiling; transparent
+         * for n>=5 where the curve is already below it. */
+        if (interface == StreamingInterface_WiFi && !pb && hz > 3050u) {
+            hz = 3050u;
+        }
     }
     /* JSON emits ~2-3x CSV bytes/sample (object braces + per-sample field names),
      * so its true ceiling is below CSV's and it was not separately characterized.

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -137,8 +137,30 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
             else    { single = 15000u; A =  34000u; B =  1u; }
             break;
         case StreamingInterface_WiFi:
-            if (pb) { single = 11250u; A = 210000u; B = 30u; }
-            else    { single =  9000u; A =  21000u; B =  1u; }
+            /* Derated from the sweep-fitted 11250/9000/21000 after the
+             * 2026-06-10 at-cap endurance runs (1200 s real-ADC soaks,
+             * atcap_20260610_002733/092839.csv): at the old caps, 1-ch PB
+             * and <=5-ch + 16-ch CSV leaked 13..31000 QueueDroppedSamples
+             * per soak (WifiDroppedBytes = 0 everywhere — pool exhaustion
+             * at sustained tick rate, not transport loss).
+             *
+             * PB 1-ch uses the multi-channel curve value A/(B+1) = 6774:
+             * the old 11250 special case was a burst-fit outlier (60 s
+             * trials ranged 6000..12500 run-to-run in wifi_v2_matrix);
+             * soaks leak at 10000-11250 but every cell <=6363 ticks/s
+             * holds zero-loss for 20 min. PB A/(B+n) multi-channel is
+             * unchanged (clean at every soak cell).
+             *
+             * CSV multi-channel refit 21000/(1+n) -> 20000/(2+n), anchored
+             * on the soak-CLEAN cells (8ch 2111, 10ch 1909, 11ch 1750,
+             * 16ch 1117): T2-heavy 3/5-ch variants leak at the old curve
+             * (3xT2 @5250/4750, 5xT2 @3500/3166 — the extra pri-9 EOS
+             * deferred-task wakeup per tick vs T1 variants competes with
+             * the pri-6 encoder). New 3ch=4000 / 5ch=2857 sit 10-16%
+             * under the dirty points. CSV single 8000 soak-clean both
+             * variants. */
+            if (pb) { single =  6774u; A = 210000u; B = 30u; }
+            else    { single =  8000u; A =  20000u; B =  2u; }
             break;
         case StreamingInterface_SD:
             if (pb) { single =  9000u; A = 150000u; B = 15u; }

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -193,7 +193,10 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
     /* JSON emits ~2-3x CSV bytes/sample (object braces + per-sample field names),
      * so its true ceiling is below CSV's and it was not separately characterized.
      * Derate the CSV-based cap by half to stay conservative (never over-cap JSON)
-     * until JSON is measured (#524 follow-up). */
+     * until JSON is measured (#524 follow-up).  Intentionally applied AFTER the
+     * WiFi low-n clamp above: JSON derives from CSV's EFFECTIVE (measured-safe)
+     * cap — halving the unclamped curve would put low-n JSON above what the CSV
+     * soak data supports. */
     if (json) hz /= 2u;
     return (hz == 0u) ? 1u : hz;
 }

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -194,9 +194,14 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
      * so its true ceiling is below CSV's and it was not separately characterized.
      * Derate the CSV-based cap by half to stay conservative (never over-cap JSON)
      * until JSON is measured (#524 follow-up).  Intentionally applied AFTER the
-     * WiFi low-n clamp above: JSON derives from CSV's EFFECTIVE (measured-safe)
-     * cap — halving the unclamped curve would put low-n JSON above what the CSV
-     * soak data supports. */
+     * WiFi low-n clamp above.  Rationale is BYTE-rate equivalence: the clamp
+     * encodes the measured low-n WiFi byte ceiling (CSV 3ch zero-loss at
+     * 3050 Hz).  JSON at the same Hz pushes 2-3x the bytes, so its Hz cap must
+     * derive from the EFFECTIVE (clamped) CSV cap: clamp-then-halve gives
+     * 3ch 1525 Hz ~= 3812 CSV-equivalent bytes/s — near the measured ceiling —
+     * while halve-without-clamp gives 2000 Hz ~= 5000 CSV-equivalent, well
+     * above it.  (An earlier comment argued this in Hz terms, which was
+     * arithmetically wrong — Qodo #540 pass-2 catch.) */
     if (json) hz /= 2u;
     return (hz == 0u) ? 1u : hz;
 }

--- a/firmware/src/version.h
+++ b/firmware/src/version.h
@@ -16,7 +16,7 @@ extern "C" {
 #define HARDWARE_REVISION "2.0.0"
 
 //! Firmware revision string
-#define FIRMWARE_REVISION "3.5.0"
+#define FIRMWARE_REVISION "3.5.1b1"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## What

Two tightly coupled changes that shipped through the same characterization cycle:

### 1. Extended #537 fix (integration of PR #538's scope + T1 extension)

`gNeedSharedScan = (totalPublic > 0)` — the MODULE7 shared scan runs whenever ANY public channel is enabled, not just when OBDiag or T2 channels need it: T2 channels need it for their conversions, T1 channels because their results are read in the EOS deferred task (#292) and EOS only fires at end-of-scan.

### 2. WiFi transport-cap refit (take-5 honest-scan soak basis)

Every prior WiFi OBDiag=off characterization (2026-06-02 sweep, 2026-06-10 at-cap soaks) ran with the #537 bug active — the scan silently skipped, T2 data frozen, and the device doing materially less work per tick, inflating sustainable rates ~1.5×. Take-5 (2026-06-11, `daqifi-python-test-suite` `benchmarks/atcap_20260611_045901.csv`, 1200 s walk-down soaks with the scan fix in) is the first honest basis:

| | 1ch | 3ch | 5ch | 8ch | 11ch |
|---|--:|--:|--:|--:|--:|
| PB ceiling | 5175 | 4225 | 4000 | 3675 | 3400 |
| CSV ceiling | 4675 | 3050 | 2857 (at cap) | 2000 (at cap) | 1538 (at cap) |

Refit (all caps ≤ measured, within 1%):
- PB single 6774 → **5175**; PB multi 210000/(30+n) → **139000/(30+n)**
- CSV single 8000 → **4675**; CSV multi keeps 20000/(2+n) (validated AT CAP same-night for n≥5), **clamped to 3050 for n=2..4**

T1/mixed WiFi cells intentionally not re-characterized: blocked on #539 (T1 validity collapses above ~5.2 kHz — discovered during this validation; the T1 at-cap rates sit in the dead zone).

## Hardware verification

- Build clean at -O3, map-checked standalone (kseg0 origin 0x9d000000), flashed to bench primary `7E2898F46200E8A7`
- `CONF:CAP:JSON?` post-flash: PB 1/3/11ch → 5175/4212/3390; CSV 1/3/5ch → 4675/3050/2857 — **6/6 exact**
- #537 fix validated: 3×T1 OBDiag=0 streams real values (validMask=0x0007) at 100–5000 Hz; take-5 ran 28 zero-encFail T2 soak rows on this build
- Test environment: suite `test/walkdown` @ 8185146 · python-core main · firmware this branch @ 8814c695

Refs #537, #539; refs #523 (runtime AIMD remains the long-term fix — the 06-10 vs 06-11 basis spread shows static caps can't be both tight and safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)