### PR TITLE
fix(streaming): keep active USB ring ≥ USBCDC_WBUFFER_SIZE on partition overcommit (#549)

### DIFF
--- a/firmware/src/Util/StreamingBufferPool.c
+++ b/firmware/src/Util/StreamingBufferPool.c
@@ -12,6 +12,13 @@
 #define STATIC_POOL_SIZE (194U * 1024U)
 static uint8_t gPoolStorage[STATIC_POOL_SIZE];
 
+/* The overcommit fallback below carves these four minimums and expects the
+ * remainder to host the sample pool — so the minimums must comfortably fit.
+ * Compile-time guard complements the runtime "too small for minimums" check. */
+_Static_assert(STREAMING_USB_ACTIVE_MIN + STREAMING_WIFI_MIN +
+               ENCODER_BUFFER_MIN + STREAMING_SD_CIRCULAR_MIN < STATIC_POOL_SIZE,
+               "fallback minimum buffers must fit the streaming pool");
+
 static uint8_t* gPool = NULL;
 static uint32_t gPoolSize = 0;
 

--- a/firmware/src/Util/StreamingBufferPool.c
+++ b/firmware/src/Util/StreamingBufferPool.c
@@ -60,10 +60,19 @@ void StreamingBufferPool_Partition(uint32_t usbSize, uint32_t wifiSize,
     if (encoderSize < ENCODER_BUFFER_MIN) encoderSize = ENCODER_BUFFER_MIN;
     if (sdCircularSize < STREAMING_SD_CIRCULAR_MIN) sdCircularSize = STREAMING_SD_CIRCULAR_MIN;
 
-    /* Ensure buffers fit in pool — fall back to minimums if needed */
+    /* Ensure buffers fit in pool — fall back to minimums if needed.
+     * #549: when USB was requested active (size above its inactive floor),
+     * keep it at STREAMING_USB_ACTIVE_MIN rather than STREAMING_USB_MIN so a
+     * degraded partition never advertises/validates 4096 yet hands back a
+     * 2048-byte active USB ring. This only triggers on a manual buffer
+     * over-config (auto-balance is sized to fit); LOG_E it so the silent
+     * override is diagnosable. */
     uint32_t bufTotal = usbSize + wifiSize + encoderSize + sdCircularSize;
     if (bufTotal > gPoolSize) {
-        usbSize = STREAMING_USB_MIN;
+        LOG_E("Streaming buffers overcommit pool (%u > %u) — falling back to minimums",
+              (unsigned)bufTotal, (unsigned)gPoolSize);
+        usbSize = (usbSize > STREAMING_USB_MIN) ? STREAMING_USB_ACTIVE_MIN
+                                                : STREAMING_USB_MIN;
         wifiSize = STREAMING_WIFI_MIN;
         encoderSize = ENCODER_BUFFER_MIN;
         sdCircularSize = STREAMING_SD_CIRCULAR_MIN;

--- a/firmware/src/Util/StreamingBufferPool.h
+++ b/firmware/src/Util/StreamingBufferPool.h
@@ -29,6 +29,12 @@ extern "C" {
 
 /** Minimum buffer sizes (from module constraints) */
 #define STREAMING_USB_MIN           2048   /* Min for SCPI responses when not streaming */
+/* USB circular floor when USB is the ACTIVE streaming interface — the setter
+ * floor and the CONF:CAP-advertised usb.min. The overcommit fallback uses this
+ * (not STREAMING_USB_MIN) so a degraded partition can't drop active USB below
+ * the advertised minimum (#549). Must equal USBCDC_WBUFFER_SIZE; a
+ * _Static_assert in streaming.c ties the two so they can't drift. */
+#define STREAMING_USB_ACTIVE_MIN    4096
 #define STREAMING_WIFI_MIN          1400   /* SOCKET_BUFFER_MAX_LENGTH (one TCP packet) */
 #define ENCODER_BUFFER_MIN          1024   /* Must fit at least one encoded sample set */
 #define ENCODER_BUFFER_DEFAULT      8192   /* Optimal for USB; SD benefits from 16384 */

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -329,6 +329,14 @@ static const uint16_t kSineLutQ16[SINE_PERIOD] = {
 _Static_assert((sizeof(kSineLutQ16) / sizeof(kSineLutQ16[0])) == SINE_PERIOD,
                "kSineLutQ16 must have exactly SINE_PERIOD entries");
 
+/* #549: the pool's active-USB overcommit floor must equal one USB CDC DMA
+ * write, so a degraded partition never hands back an active USB ring below
+ * the setter floor / CONF:CAP-advertised usb.min. StreamingBufferPool.c can't
+ * include the heavyweight UsbCdc.h, so the value is mirrored there and tied
+ * here (this TU sees both). */
+_Static_assert(STREAMING_USB_ACTIVE_MIN == USBCDC_WBUFFER_SIZE,
+               "#549: STREAMING_USB_ACTIVE_MIN must track USBCDC_WBUFFER_SIZE");
+
 /**
  * Generate a synthetic ADC value for test pattern streaming.
  * @param pattern    Pattern type (1-6, see switch cases)


### PR DESCRIPTION
Closes #549.

## What

`StreamingBufferPool_Partition()`'s overcommit fallback reset USB to `STREAMING_USB_MIN` (2048, the *inactive* floor) even when USB was the active interface — below the 4096 the USB setter validates and `CONF:CAP` advertises (`usb.min`, fixed in #548). Now it falls back to `STREAMING_USB_ACTIVE_MIN` (4096) when USB was requested active, and `LOG_E`s the overcommit so the previously-silent override is diagnosable.

`STREAMING_USB_ACTIVE_MIN` mirrors `USBCDC_WBUFFER_SIZE` (the lean pool `.c` can't pull in the heavyweight `UsbCdc.h`); a `_Static_assert` in `streaming.c` (which sees both headers) ties them so they can't drift — same single-source-of-truth discipline as #548.

## Severity — downgraded from the issue's framing

#549 was filed as a possible "USB buffer underflow / hang." Investigation found it is **not** a hang:
- The overcommit fallback also degrades the encoder to `ENCODER_BUFFER_MIN` (1024). Streaming packets are capped at the encoder buffer (`maxSize = bufferSize`), so they stay ≤1024 < 2048 — they fit a 2048 ring.
- The USB DMA read-out (`CircularBuf_ProcessBytes(..., dmaWriteBufferSize, ...)`) reads *up to* that many bytes; it does **not** require the ring ≥4096.

So the pre-fix degraded state was functional. This is an **invariant-consistency + future-proofing** fix (the advertised/validated `usb.min` now actually holds for active USB; safe if the encoder min ever rises or a >2048 single write lands), not a hang fix.

## Risk

Only the manual-overcommit path changes (4 buffers set near 65536 via `SYST:MEM:*:BUFfer`, summing > the 194KB pool). Auto-balance is sized to fit, so **normal/auto operation is byte-identical** — the changed code never executes outside overcommit.

## Validation

- Build clean (`-Werror -Wall`, exit 0); `_Static_assert(STREAMING_USB_ACTIVE_MIN == USBCDC_WBUFFER_SIZE)` passes.
- **Pre-merge gate (hardware):** reproduce overcommit (`SYST:MEM:USB/WIFI/SD/ENC:BUFfer` all 65536 → `STR:START`), confirm `SYST:MEM:FREE?` reports active USB = 4096 (was 2048) and the LOG_E fires; confirm a normal USB stream is unaffected. **Do not merge until this bench repro is done.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)