### PR TITLE
fix(#525): EOS-task stack-overflow wedge + USB-CDC host-stall robustness (minimal)

### DIFF
--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -121,9 +121,17 @@ void MC12bADC_EosInterruptTask(void) {
         uint32_t notifCount = ulTaskNotifyTake(pdTRUE, xBlockTime);
         DioProbe_Toggle(5);  /* probe 5: EOS task wake rate */
         if (notifCount > 1) {
+            // #525 ROOT CAUSE: do NOT call LOG_E_SESSION / LogMessage / vsnprintf
+            // here. This is a pri-9 deferred-interrupt task with a small stack;
+            // vsnprintf's float-printf frame needs far more stack than this task
+            // has and OVERFLOWED into the adjacent heap TCB (the encoder's),
+            // NULLing its ready-list link → vTaskSwitchContext TLBL → CDC-dead
+            // wedge under USB host-stall (stochastic, one-shot LOG gated; caught
+            // by a vTaskSwitchContext integrity trap = "MC12bADC EOS", 2026-06-18).
+            // The overrun is still COUNTED here (eosOverruns, queryable via
+            // SYST:STR:STATS?); the per-occurrence log is intentionally dropped on
+            // this tiny-stack path rather than risk the stack frame.
             Streaming_IncrEosOverruns(notifCount - 1);
-            LOG_E_SESSION(LOG_SESSION_EOS_OVERRUN,
-                "EOS: %u result overruns", (unsigned)(notifCount - 1));
         }
 
         DioProbe_PulseStart(6);  /* probe 6: result read loop duration */
@@ -186,7 +194,12 @@ void ADC_Init(
     gpBoardData = (tBoardData *) pBoardDataADCInit;
     BaseType_t result = xTaskCreate((TaskFunction_t) MC12bADC_EosInterruptTask,
             "MC12bADC EOS",
-            160, NULL, 9, &gADCInterruptHandle);  // Profiled: 80 words peak. 2x margin. (was 2048)
+            256, NULL, 9, &gADCInterruptHandle);  // Profiled: 80 words peak. 3x margin.
+            // #525: was 160 (#230 cut from 2048). The notifCount>1 path used to
+            // call LOG_E_SESSION→vsnprintf here, which needs >>160 words and
+            // overflowed into the adjacent heap encoder TCB → scheduler TLBL →
+            // CDC-dead wedge. That call is removed (overrun stays counted in
+            // stats); 256 keeps margin against any future LOG creep on this path.
     if (result != pdPASS) {
         LOG_E("FATAL: Failed to create MC12bADC_EosInterruptTask\r\n");
     }

--- a/firmware/src/Util/Logger.h
+++ b/firmware/src/Util/Logger.h
@@ -175,6 +175,8 @@ extern "C" {
         LOG_ONCE_WIFI_DISCONNECT_DISABLE, /**< wifi_manager.c: forced BSS disconnect on !isEnabled (#467) */
         LOG_ONCE_WIFI_DISCONNECT_STA2AP,  /**< wifi_manager.c: forced BSS disconnect on STA->AP switch (#467) */
         LOG_ONCE_WIFI_DISCONNECT_STA2STA, /**< wifi_manager.c: forced BSS disconnect on STA reconfigure (#467) */
+        LOG_ONCE_USB_WRITE_STUCK,         /**< UsbCdc.c: write DMA stalled (host not reading) — bail without blocking, drop until drained (#525) */
+        LOG_ONCE_USB_FLUSH_STUCK,         /**< UsbCdc.c: flush timeout (host not reading) — defer flush (#525); distinct bit so it isn't masked by the write-stall one-shot */
         /* Add new entries above this line */
         LOG_ONCE_COUNT                     /**< Must be <= 32 */
     } LogOnceBit_t;

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -48,6 +48,15 @@ void UsbCdc_Profile_ResetPendingStamp(void) {
 static UsbCdcData_t gRunTimeUsbSttings __attribute__((coherent));
 static bool UsbCdc_FinalizeWrite(UsbCdcData_t* client);
 
+/* A write DMA that hasn't completed within this long means the host has
+ * stopped draining the CDC IN endpoint (not a transient hiccup). #525:
+ * bail out of the wait rather than block — the in-flight transfer completes
+ * on its own when the host resumes reading; new stream data is dropped (and
+ * counted as usbDroppedBytes by streaming's WriteWithRetry path) until then.
+ * We deliberately do NOT cancel/close the transfer: cancelling disrupts the
+ * host's open connection (observed as ClearCommError + reconnect). */
+#define USBCDC_WRITE_STALL_MS 1000U
+
 /**
  * Filters input characters to reject potentially dangerous control characters
  * Used only in normal command mode, NOT in transparent mode
@@ -178,6 +187,10 @@ USB_DEVICE_CDC_EVENT_RESPONSE UsbCdc_CDCEventHandler
             } else {
                 gRunTimeUsbSttings.state = USB_CDC_STATE_PROCESS;
                 gRunTimeUsbSttings.isCdcHostConnected=1;
+                // #525: a freshly connecting host must not inherit a stall
+                // latch from a prior session that disconnected mid-stall
+                // (where FinalizeWrite never ran to clear it).
+                gRunTimeUsbSttings.writeStalled = false;
             }
 
             USB_DEVICE_ControlStatus(pUsbCdcDataObject->deviceHandle, USB_DEVICE_CONTROL_STATUS_OK);
@@ -518,12 +531,37 @@ static bool UsbCdc_WaitForWrite(UsbCdcData_t* client) {
         return false;
     }
 
+    // #525: if a prior wait already detected a host-read stall, bail immediately
+    // (drop) instead of burning the full timeout again. We do NOT read
+    // writeTransferHandle here: the stalled in-flight transfer completes on its
+    // own when the host resumes draining, firing the WRITE_COMPLETE ISR →
+    // UsbCdc_FinalizeWrite, which clears this latch — independent of whether we
+    // attempt a write. So the next call after the host resumes sees writeStalled
+    // == false, skips this branch, and proceeds normally. (volatile writeStalled
+    // is the single completion signal; no non-volatile handle poll needed.)
+    if (client->writeStalled) {
+        return false;
+    }
+
+    TickType_t start = xTaskGetTickCount();
     while (client->writeTransferHandle != USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID) {
         if (client->state != USB_CDC_STATE_PROCESS) {
             return false;
         }
-
-        vTaskDelay(100);
+        // #525: this loop was UNBOUNDED — when the host stops draining the CDC
+        // IN endpoint the in-flight DMA never completes, so this blocked
+        // forever, starving the whole USB task (the OUT endpoint too) and
+        // hard-wedging the device. Bound it and bail without cancelling: the
+        // transfer completes on its own once the host resumes reading, the task
+        // stays responsive, and new stream data is dropped+counted meanwhile.
+        // The connection is never disrupted (throttle-and-drop, not close).
+        if ((xTaskGetTickCount() - start) > pdMS_TO_TICKS(USBCDC_WRITE_STALL_MS)) {
+            client->writeStalled = true;  // #525: latch — see field doc
+            LOG_E_ONCE(LOG_ONCE_USB_WRITE_STUCK,
+                       "USB write stalled (host not reading) - dropping until drained");
+            return false;
+        }
+        vTaskDelay(pdMS_TO_TICKS(5));
     }
 
     return true;
@@ -547,6 +585,10 @@ static bool UsbCdc_FinalizeWrite(UsbCdcData_t* client) {
 #endif
     client->writeTransferHandle = USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID;
     client->writeBufferLength = 0;
+    // #525: a completed transfer means the host resumed draining the IN
+    // endpoint — clear the stall latch so the next write proceeds normally
+    // instead of being dropped by the early-bail in WaitForWrite.
+    client->writeStalled = false;
     return true;
 }
 
@@ -920,6 +962,13 @@ bool UsbCdc_FlushWriteBuffer(void) {
     // then start the next write chunk, repeat until nothing left to write.
     // All waits (both initial DMA and each new write DMA) share the deadline,
     // so the function is fully bounded even if the host disconnects mid-flush.
+    // #525: already-latched host stall — don't burn the 500ms flush deadline
+    // again. The latch clears in UsbCdc_FinalizeWrite (WRITE_COMPLETE ISR) once
+    // the host resumes, independent of this call — no handle poll needed.
+    if (client->writeStalled) {
+        return false;
+    }
+
     TickType_t start = xTaskGetTickCount();
 
     while (true) {
@@ -929,7 +978,12 @@ bool UsbCdc_FlushWriteBuffer(void) {
                 return false;
             }
             if ((xTaskGetTickCount() - start) > pdMS_TO_TICKS(500)) {
-                LOG_E("USB flush: timeout waiting for DMA");
+                // #525: host stopped draining — bail without blocking/cancel.
+                // The in-flight transfer completes when the host resumes; the
+                // task stays responsive and the connection is preserved.
+                client->writeStalled = true;  // #525: latch — see field doc
+                LOG_E_ONCE(LOG_ONCE_USB_FLUSH_STUCK,
+                           "USB flush: host not reading - deferring");
                 return false;
             }
             vTaskDelay(pdMS_TO_TICKS(10));

--- a/firmware/src/services/UsbCdc/UsbCdc.h
+++ b/firmware/src/services/UsbCdc/UsbCdc.h
@@ -81,6 +81,16 @@ extern "C" {
         /** Write transfer handle */
         USB_DEVICE_CDC_TRANSFER_HANDLE writeTransferHandle;
 
+        /** #525: latched true when a write/flush wait times out (host stopped
+         * draining the CDC IN endpoint). While set, WaitForWrite/FlushWriteBuffer
+         * bail immediately instead of each burning the full stall timeout, so a
+         * sustained host stall doesn't delay the OUT endpoint (SCPI) by up to 1s
+         * per attempt. Cleared in UsbCdc_FinalizeWrite (WRITE_COMPLETE ISR) when
+         * the in-flight transfer finishes — i.e. the host has resumed reading.
+         * Written by the USB task (set) and the WRITE_COMPLETE ISR (clear);
+         * volatile + single-writer-per-context plain bool store (no RMW). */
+        volatile bool writeStalled;
+
         /** Break data */
         uint16_t breakData;
 


### PR DESCRIPTION
## Summary
Minimal, surgical fix for the **#525** high-rate-streaming hard wedge (device enumerated but CDC-dead, reflash required) plus a second independent USB-CDC host-stall wedge path. **4 files, +85/−6 lines**, on the existing FreeRTOS-queue streaming architecture — no architectural change.

> **History note:** an earlier revision of this PR bundled a large lock-free-ring / in-ISR-acquisition rearchitecture built to fix a *hypothesized* notify-give `configASSERT` race. We later root-caused the actual wedge elsewhere (the EOS-task stack overflow below), and a controlled experiment confirmed the rearchitecture was **not** needed: the old architecture + just the EOS fix survives the wedge repro 3/3. The rearchitecture is preserved on branch `feat/streaming-inisr-ring` to be evaluated on its own perf/maintainability merits as a separate PR — it does **not** ride in on the bug fix.

## Root cause #1 — EOS-task `vsnprintf` stack overflow (the hard wedge)
`MC12bADC_EosInterruptTask` (pri 9) had its stack cut **2048 → 160 words** by #230. On its `notifCount > 1` overrun path it called `LOG_E_SESSION → vsnprintf`, whose float-printf frame needs ≫160 words. Under a host stall (which spikes EOS overruns) the frame **overflowed into the adjacent heap encoder TCB**, NULLing its ready-list link → `vTaskSwitchContext` TLBL → CDC-dead wedge. The one-shot LOG gating made it stochastic. **Confirmed** by a `vTaskSwitchContext` integrity trap that caught the outgoing task as `"MC12bADC EOS"`.

**Fix:** remove the `vsnprintf` LOG from the EOS task (overrun still counted → `SYST:STR:STATS? eosOverruns`); bump its stack 160 → 256 words.

## Root cause #2 — unbounded CDC `WaitForWrite` (host-read-stall wedge)
The single in-flight write DMA is cleared only by WRITE_COMPLETE. When the host stops draining the IN endpoint, `WaitForWrite` spun **unbounded**, blocking the USB task forever and starving the OUT endpoint too.

**Fix:** bound `WaitForWrite`/`FlushWriteBuffer`; on timeout bail without cancelling (transfer completes when the host resumes — connection preserved, dropped data counted). A `volatile writeStalled` latch makes subsequent attempts during a sustained stall bail immediately (so SCPI on the OUT endpoint isn't delayed ~1s/attempt); cleared in `FinalizeWrite` (host resumed) and on host-connect.

## Hardware validation (production build, DEBUG=OFF, board `7E2898F46200E8A7`)
- **12 kHz NOCAP host-stall (drain-stop-5s-resume): 3/3 SURVIVED + recovered** on the old architecture + this fix. (This is also the experiment proving the rearchitecture was unnecessary.)
- Real-ADC USB PB at-cap 60 s soak: `SampleLossPercent=0`, `ByteLossPercent=0`, `EosOverruns=0`, `MEAS:VOLT` live, `*IDN?` responsive.

## Follow-ups
- `feat/streaming-inisr-ring` — the rearchitecture, evaluated separately on merit (not gated on this bug fix).
- Audit other #230-shrunk tiny-stack deferred-interrupt tasks that call `LOG`/`vsnprintf` on rare branches (e.g. `AD7609_DeferredInterruptTask` @160 words). A new `mcu-hygiene` checklist/skill will codify this class.
- #390 — pipeline N>1 CDC DMA transfers (structural answer to host-read stalls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
