### PR TITLE
fix(adc): stop AD7609 BSY-stuck LOG vsnprintf overflowing its 160-word task stack (#525 follow-up)

### DIFF
--- a/firmware/src/HAL/ADC/AD7609.c
+++ b/firmware/src/HAL/ADC/AD7609.c
@@ -178,7 +178,17 @@ void AD7609_DeferredInterruptTask(void) {
                 // BSY should be idle-high by now (SPI read complete)
                 // If still low, indicates hardware fault - log error but don't block
                 if (!GPIO_PinRead(pModuleConfigAD7609->BSY_Pin)) {
-                    LOG_E("AD7609: BSY pin stuck low after SPI read - possible hardware fault");
+                    // #525 follow-up: LOG_E_ONCE, not LOG_E. This is a pri-9
+                    // deferred-interrupt task; LOG -> vsnprintf has a large
+                    // (float-printf) stack frame. A genuinely stuck BSY pin fires
+                    // this every conversion (kHz), repeatedly re-entering vsnprintf
+                    // and flooding the log — the same tiny-stack vsnprintf hazard
+                    // that wedged the EOS task in #525. One-shot bounds it; the
+                    // task stack is also sized clear of the vsnprintf frame
+                    // (see tasks.c). Untested on AD7609 hardware (none on bench) —
+                    // tracked follow-up to validate on an NQ2/NQ3 board.
+                    LOG_E_ONCE(LOG_ONCE_AD7609_BSY_STUCK,
+                        "AD7609: BSY pin stuck low after SPI read - possible hardware fault");
                 }
                 // Re-enable interrupt for next conversion
                 GPIO_PinIntEnable(pModuleConfigAD7609->BSY_Pin, GPIO_INTERRUPT_ON_FALLING_EDGE);

--- a/firmware/src/Util/Logger.h
+++ b/firmware/src/Util/Logger.h
@@ -177,6 +177,7 @@ extern "C" {
         LOG_ONCE_WIFI_DISCONNECT_STA2STA, /**< wifi_manager.c: forced BSS disconnect on STA reconfigure (#467) */
         LOG_ONCE_USB_WRITE_STUCK,         /**< UsbCdc.c: write DMA stalled (host not reading) — bail without blocking, drop until drained (#525) */
         LOG_ONCE_USB_FLUSH_STUCK,         /**< UsbCdc.c: flush timeout (host not reading) — defer flush (#525); distinct bit so it isn't masked by the write-stall one-shot */
+        LOG_ONCE_AD7609_BSY_STUCK,        /**< AD7609.c: BSY pin stuck low after SPI read — hardware fault; one-shot so a stuck pin can't flood + repeatedly enter vsnprintf (#525 follow-up) */
         /* Add new entries above this line */
         LOG_ONCE_COUNT                     /**< Must be <= 32 */
     } LogOnceBit_t;

--- a/firmware/src/config/default/tasks.c
+++ b/firmware/src/config/default/tasks.c
@@ -281,7 +281,14 @@ void SYS_Tasks ( void )
     BaseType_t ad7609Result = xTaskCreate(
         (TaskFunction_t) AD7609_DeferredInterruptTask,
         "AD7609 BSY",
-        160,   // Profiled: 76 words peak. 2x margin. (was 512)
+        1024,  // #525 follow-up: was 160 (#230 cut from 512). The BSY-stuck
+               // branch calls LOG_E -> vsnprintf, whose float-printf frame is
+               // far bigger than the 76-word non-LOG peak the #230 profiling
+               // measured — same tiny-stack vsnprintf hazard that wedged the
+               // EOS task in #525. 1024 gives a >10x margin over peak that
+               // comfortably accommodates the vsnprintf frame (no plausible
+               // float-printf frame approaches it). NQ3-only, rare-running; the
+               // RAM cost is immaterial. Untested on AD7609 HW (none on bench).
         NULL,
         9,
         (TaskHandle_t*)pAD7609TaskHandle


### PR DESCRIPTION
## Summary
Follow-up to #525, found by the post-fix tiny-stack `vsnprintf` audit. Same bug class as the EOS-task wedge, in `AD7609_DeferredInterruptTask`.

## The bug
The pri-9 `AD7609_DeferredInterruptTask` stack was cut **512 → 160 words** by #230 (profiled 76-word peak). Its BSY-stuck-low branch calls `LOG_E` → `vsnprintf`, whose float-printf frame is far larger than the 76-word non-LOG peak the #230 profiling measured — the **identical** hazard that wedged `MC12bADC_EosInterruptTask` in #525 (frame overflows into the adjacent heap TCB → scheduler TLBL → CDC-dead wedge). A genuinely stuck BSY pin fires this every conversion (kHz), re-entering `vsnprintf` and flooding the log.

## Fix
- Stack **160 → 1024 words** (>10× the 76-word peak; comfortably fits the `vsnprintf` frame — no plausible float-printf frame approaches it). NQ3-only, rare-running; RAM cost immaterial.
- `LOG_E` → `LOG_E_ONCE(LOG_ONCE_AD7609_BSY_STUCK)` so a stuck pin can't flood the log or repeatedly re-enter `vsnprintf`.

## Validation
- **Build:** clean (NQ1 default config compiles `AD7609.c` + `tasks.c`).
- **cppcheck:** clean (== committed baseline, no new findings).
- **⚠️ NOT hardware-validated:** there is no AD7609 (NQ2/NQ3) board on the bench. The fix mirrors the proven #525 EOS-task fix and is correct by inspection; runtime validation on AD7609 hardware is the tracked follow-up (see linked issue).

## Scope note
This is the AD7609 instance from the `mcu-hygiene` tiny-stack audit. The streaming deferred task (512 w, also `LOG_E_SESSION`) is a separate, lower-confidence suspect still to be worst-case-stack-profiled — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
