### PR TITLE
chore(logger): bump logISR drain-task stack 128 -> 256 words for margin

### DIFF
--- a/firmware/src/Util/Logger.c
+++ b/firmware/src/Util/Logger.c
@@ -577,7 +577,14 @@ void LogMessageClear(void) {
 
 static TaskHandle_t  gIsrLogTaskHandle = NULL;
 
-#define LOG_ISR_TASK_STACK  128   /* words (512 bytes — only does queue drain) */
+#define LOG_ISR_TASK_STACK  256   /* words. Drain task only memcpy's a pre-formed
+                                   * message into the ring (LogMessageAdd — NO
+                                   * vsnprintf, so not a #525-class hazard), but
+                                   * at 128 its measured peak (96 w used) left
+                                   * only 32 w free — the thinnest task in the
+                                   * system, below the 2-3x-peak sizing
+                                   * convention. 256 restores margin + headroom
+                                   * for the ICSP-realtime-log UART write path. */
 #define LOG_ISR_TASK_PRIO   1     /* lowest priority, runs when nothing else does */
 
 /**


### PR DESCRIPTION
## Summary
Tiny-stack hygiene from the #525 follow-up audit. `LogIsrDrainTask` ("logISR") was the thinnest task in the system — 96-word measured peak left only **32 words (128 B) free** at 128 w, below the project's 2–3× sizing convention.

## Safe (not a #525 risk) but worth bumping
The drain task only `memcpy`s a pre-formed message into the log ring via `LogMessageAdd` — it does **not** `vsnprintf` (that's in the task-context `LogMessage` path the drain task never reaches). Usage is bounded ~96 w and stable. But 25% free leaves no headroom for the ICSP-realtime-log UART write (dev builds) or future `LogMessageAdd` changes.

## Change
`LOG_ISR_TASK_STACK 128 → 256` (~2.6× peak). Pure stack-size increase — strictly safer, no behavior change. Build + cppcheck clean.

Refs #525 (tiny-stack audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)