### PR TITLE
release: bump firmware revision 3.6.0 -> 3.6.1

### DIFF
--- a/firmware/src/version.h
+++ b/firmware/src/version.h
@@ -16,7 +16,7 @@ extern "C" {
 #define HARDWARE_REVISION "2.0.0"
 
 //! Firmware revision string
-#define FIRMWARE_REVISION "3.6.0"
+#define FIRMWARE_REVISION "3.6.1"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Bumps `FIRMWARE_REVISION` 3.6.0 → 3.6.1 so the six post-v3.6.0 fixes/hygiene PRs (#547–#555) ship under their own version instead of re-using 3.6.0. Patch-level (all fixes/hygiene). Build clean. This is the version under overnight RC soak validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)