### PR TITLE
chore(release): bump FIRMWARE_REVISION to 3.6.2

### DIFF
--- a/firmware/src/version.h
+++ b/firmware/src/version.h
@@ -16,7 +16,7 @@ extern "C" {
 #define HARDWARE_REVISION "2.0.0"
 
 //! Firmware revision string
-#define FIRMWARE_REVISION "3.6.1"
+#define FIRMWARE_REVISION "3.6.2"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Version bump for the **v3.6.2** release:
- #564 — boot on battery (read vsysStat from the BQ, not the stale ADC)
- #557/#563 — NQ1 freeze-aware ADC caps + scan-stale drop counter

One-line change to `firmware/src/version.h`. Both feature PRs already merged to main and hardware-validated on the bench (NQ1 7E2898F46200E8A7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)