### PR TITLE
docs+tools(release): scripted bootloader-linked release process + v3.6.2 notes

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,106 @@
+# Cutting a firmware release
+
+This is the end-to-end process for shipping a new firmware version. The
+load-bearing, error-prone part — building a **bootloader-linked** hex (so it
+doesn't clobber the bootloader on customer devices) and proving its layout —
+is automated by [`tools/release/cut_release.sh`](../tools/release/cut_release.sh).
+
+> ⚠️ **The single most important rule:** the shipped `.hex` must be linked with
+> `old_hv2_bootld.ld` (application at **`0x9D000480`**), NOT the default
+> standalone bench layout (`0x9D000000`). A standalone hex flashed onto a
+> customer device **overwrites the bootloader** and bricks the field-update
+> path. The default MPLAB X `default` config is the standalone layout; the
+> release build flips one linker-script flag. `cut_release.sh` does the flip and
+> **hard-fails** if the resulting hex isn't bootloader-linked.
+
+## Prerequisites
+
+- MPLAB X v6.30 + XC32 v4.60 (see `CLAUDE.md` → Build Instructions).
+- WSL with `powershell.exe` reachable (the makefile regen runs Windows-side —
+  the Linux `prjMakefilesGenerator` fails with "Device pack missing").
+- `gh` authenticated to `daqifi/daqifi-nyquist-firmware`.
+- All feature PRs for the release already merged to `main` and **hardware-validated**.
+
+## Steps
+
+### 1. Land all feature work on `main`
+Merge every PR that belongs in the release. Don't cut from a feature branch.
+
+### 2. Bump the version (via PR)
+`FIRMWARE_REVISION` in `firmware/src/version.h` is the single source of truth
+(it's what `*IDN?` reports and what the desktop updater compares). Bump it on a
+branch, open a PR, merge it. Direct pushes to `main` are blocked by branch
+protection by design.
+
+### 3. Write the release notes
+`docs/release-notes/RELEASE_NOTES_v<VERSION>.md`. Follow the existing files'
+shape: headline, Highlights (per issue), "All changes since v<prev>", and a
+**Validation (hardware)** section with the bench serial and concrete results.
+Commit it (it can ride in the same PR as the version bump, or its own).
+
+### 4. Build + verify + package the bootloader-linked hex
+From the repo root, on `main`:
+
+```bash
+bash tools/release/cut_release.sh --version <VERSION>
+```
+
+This:
+1. flips the `default` config to include `old_hv2_bootld.ld` (keeps
+   `p32MZ2048EFM144.ld` excluded),
+2. regenerates the makefiles (Windows-side),
+3. clean-builds,
+4. **hard-verifies** the layout — `.map` `kseg0_program_mem` origin
+   `0x9d000480`, lowest physical address `0x1D000000`, a ~408-byte `.reset`
+   vector in `[0x1D000000, 0x1D000480)`, and the code bulk starting at
+   `0x1D000480`. If any check fails it aborts (it will not let you ship a
+   standalone hex),
+5. packages `daqifi-nyquist-firmware-<VERSION>.hex` + `.zip`,
+6. restores the working tree (reverts the config flip and regenerates the
+   standalone makefiles so the next bench `make`/flash isn't a ship-layout
+   build).
+
+### 5. Publish (irreversible)
+`cut_release.sh` prints the exact command. It attaches **both** a raw `.hex`
+(REQUIRED — the desktop in-app updater selects the main-firmware asset by
+`name.EndsWith(".hex")`; a release with no `.hex` is skipped) and a `.zip`
+(archival; also the shape the WiFi-firmware path expects):
+
+```bash
+gh release create v<VERSION> --repo daqifi/daqifi-nyquist-firmware --target main \
+  --title "v<VERSION> — <headline>" \
+  --notes-file docs/release-notes/RELEASE_NOTES_v<VERSION>.md --latest \
+  "daqifi-nyquist-firmware-<VERSION>.hex" "daqifi-nyquist-firmware-<VERSION>.zip"
+```
+
+### 6. Verify the updater will pick it up
+The desktop app takes the **newest non-draft, non-prerelease** release that
+**has a `.hex` asset**. Confirm the new tag qualifies:
+
+```bash
+gh api repos/daqifi/daqifi-nyquist-firmware/releases \
+  --jq '.[] | select(.draft==false and .prerelease==false) |
+        "\(.tag_name) hex=\([.assets[].name]|map(select(endswith(".hex")))|length>0)"' | head -3
+```
+
+The top line should be your new tag with `hex=true`.
+
+### 7. Clean up
+Delete the two asset files from the repo root (they're build artifacts, not
+tracked). `cut_release.sh` leaves them for the `gh release create` step.
+
+## Why the hex shape is checked so precisely
+
+Every shipped release (v3.4.4 / v3.4.6b1 / v3.5.0 / v3.6.0 / v3.6.1 / v3.6.2)
+has an identical *shape* — only the top address grows with code size:
+
+| Property | Expected |
+|---|---|
+| `.map` `kseg0_program_mem` origin | `0x9d000480` |
+| Lowest physical address (hex) | `0x1D000000` |
+| Bytes in `[0x1D000000, 0x1D000480)` (`.reset` vector) | 408 |
+| Code bulk starts at | `0x1D000480` |
+
+A standalone build instead starts the bulk at `0x1D000000` and has no
+bootloader gap — visually similar in a casual glance, catastrophic in the
+field. The verification in `cut_release.sh` is the guardrail.

--- a/docs/release-notes/RELEASE_NOTES_v3.6.2.md
+++ b/docs/release-notes/RELEASE_NOTES_v3.6.2.md
@@ -1,0 +1,33 @@
+# v3.6.2 — battery-boot fix (#564) + NQ1 freeze-aware ADC caps & scan-stale counter (#557/#563)
+
+Patch release over v3.6.1. The headline is a fix for a device that **would not power on from the button when running on battery alone** (no USB). The rest is an ADC streaming-cap correction for NQ1 plus a new data-integrity counter. Normal USB/WiFi/SD streaming is unaffected except where the NQ1 caps were previously wrong (see below).
+
+## Highlights
+
+### Fixed: device won't power on from the button on battery (#564)
+On battery-only power, pressing the button to turn the device on could fail — the white LED would light for ~1 s and the device would immediately power back down. Root cause: `Power_UpdateStatusFromGPIO` **synthesized** the BQ24297's `vsysStat` low-battery flag from the PIC's VBATT ADC (`vsysStat = battVoltage < 3.0 V`). At cold boot the VBATT ADC reads a stale **0 V** before it has sampled, so the synthesized `vsysStat` latched to "battery critically low" → `Power_HasSufficientPower()` refused the power-up. USB masked it (the GPIO `pgStat` path satisfied the check), so it only bit on battery.
+
+**Fix:** read the **real** `vsysStat` from the BQ24297 over I²C (REG08 bit 0) — the BMIC's authoritative measurement — instead of inferring it from an unsampled ADC. A healthy battery now correctly reads `vsysStat = 0` and powers up.
+
+Hardening that came with it:
+- **`chargePct` is now a signed tri-state** (`int16_t`): `-1` = UNKNOWN (no valid VBATT reading yet) vs a real `0..100`. A stale `0 V` ADC reading no longer masquerades as "0 %, dead battery" — it reads UNKNOWN, and the critical-battery decision falls back to the BQ's `vsysStat`. `battVoltageValid` is tracked per-reading (cleared when the reading is invalid/missing).
+- The protobuf `batt_status` field clamps the `-1` sentinel to `0` for wire compatibility.
+
+### Changed: NQ1 freeze-aware ADC streaming caps (#557/#563)
+The enforced max streaming rate for **NQ1** now uses a freeze-aware **additive ADC model** fitted to drop-aware sweeps, replacing the old tick-budget / aggregate-event terms. The prior sweeps were drop-blind and counted frozen scanned data as clean, so the old caps were simultaneously **over-conservative on Type 1** channels and **inflated (unsafe) on Type 2** channels. The SAMC/divider-dependent hardware **scan-busy** bound (#539) is still applied as a `min()` so a non-default `CONF:ADC:SAMC` can't push the cap past the real scan-retrigger limit. NQ2/NQ3 are unchanged (no MODULE7 scan).
+
+### Added: scan-stale drop counter (#557/#563)
+A new `SYST:STR:STATS? ScanStaleDropped` field counts streaming ticks where the shared MODULE7 scan was armed but its end-of-scan hadn't fired by the next hardware trigger (scan-busy / frozen data, the #539 condition) — an edge-safe sequence counter, gated to the HW-trigger-every-tick path. It reads ~0 with the rate cap in place and turns otherwise-silent frozen data into a visible, accounted metric. It is reported separately (like `EosOverruns`), **not** folded into `SampleLossPercent` (the stale sample was still streamed, just with frozen data).
+
+## All changes since v3.6.1
+- **#564** — `fix(power)`: boot on battery — read `vsysStat` from the BQ, not the stale ADC; `chargePct` tri-state UNKNOWN; per-reading `battVoltageValid`.
+- **#563/#557** — `feat(adc)`: NQ1 freeze-aware additive ADC cap + `ScanStaleDropped` counter; SAMC scan-busy bound preserved via `MC12b_HardwareScanMaxFreq`.
+- **#565** — `chore(release)`: bump `FIRMWARE_REVISION` to 3.6.2.
+
+## Validation (hardware, NQ1 `7E2898F46200E8A7`)
+- **#564 on the combined release build:** `vsysStat` read live from the BQ (`REG08 VSYS=0`, healthy); `chargePct` reads `-1` UNKNOWN when the VBATT ADC is unsampled (not a false 0 %); device reaches POWERED_UP cleanly (no power-state-machine regression).
+- **#563 on the combined release build:** NQ1 additive cap computes `7453 Hz` for 2×T2; streaming runs clean; `ScanStaleDropped ≈ 0` (4 over ~900 k ticks); `EosOverruns=0`; the `TimerISRCalls == TotalSamples + QueueDropped` invariant (#265) holds exactly; error queue clean.
+
+## Upgrade notes
+- Standard in-app update (the desktop app selects the `.hex` asset) or manual flash.
+- Every flash wipes NVM (WiFi / calibration / voltage-precision settings) — re-save after updating.

--- a/docs/release-notes/RELEASE_NOTES_v3.6.2.md
+++ b/docs/release-notes/RELEASE_NOTES_v3.6.2.md
@@ -26,6 +26,7 @@ A new `SYST:STR:STATS? ScanStaleDropped` field counts streaming ticks where the 
 
 ## Validation (hardware, NQ1 `7E2898F46200E8A7`)
 - **#564 on the combined release build:** `vsysStat` read live from the BQ (`REG08 VSYS=0`, healthy); `chargePct` reads `-1` UNKNOWN when the VBATT ADC is unsampled (not a false 0 %); device reaches POWERED_UP cleanly (no power-state-machine regression).
+- **#564 field-confirmed on the shipped v3.6.2 build:** the device now powers on properly from the button on battery alone (no USB) — the original failing symptom, verified fixed.
 - **#563 on the combined release build:** NQ1 additive cap computes `7453 Hz` for 2×T2; streaming runs clean; `ScanStaleDropped ≈ 0` (4 over ~900 k ticks); `EosOverruns=0`; the `TimerISRCalls == TotalSamples + QueueDropped` invariant (#265) holds exactly; error queue clean.
 
 ## Upgrade notes

--- a/tools/release/cut_release.sh
+++ b/tools/release/cut_release.sh
@@ -66,17 +66,49 @@ say "Building release for FIRMWARE_REVISION $VER"
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 [ "$BRANCH" = "main" ] || echo "WARNING: not on main (on '$BRANCH') — releases are normally cut from main."
-[ -z "$(git status --porcelain --untracked-files=no)" ] || echo "WARNING: working tree has tracked changes; configurations.xml will be restored from git at the end."
+[ -z "$(git status --porcelain --untracked-files=no)" ] || echo "WARNING: working tree has tracked changes; configurations.xml will be restored to its pre-run state at the end."
+
+# Unique per-run temp files (safe under concurrent runs / multiple clones).
+BACKUP_CFG="$(mktemp -t cut_release_cfg.XXXXXX)"
+BUILD_LOG="$(mktemp -t cut_release_build.XXXXXX.log)"
 
 # --- 1. flip the default conf to bootloader-linked (include old_hv2_bootld.ld, keep p32MZ excluded) ---
 say "Flipping default config to bootloader-linked (old_hv2_bootld.ld included)"
-cp "$CFG" "/tmp/configurations.xml.release.bak"
+# Back up the pre-run file BEFORE arming the trap (reading $CFG is not a mutation),
+# so cleanup() can always restore the exact pre-run state.
+cp "$CFG" "$BACKUP_CFG"
+
+# Restore the working tree on exit, even on failure. Armed BEFORE the first
+# mutation (the sed below) so an early failure can never strand the
+# bootloader-linked config on disk.
+cleanup() {
+  say "Restoring configurations.xml (standalone default)"
+  # Restore the EXACT pre-run file from our backup (preserves any uncommitted
+  # local edits the user had); fall back to git only if the backup is missing.
+  if [ -s "$BACKUP_CFG" ]; then
+    cp "$BACKUP_CFG" "$CFG"
+  else
+    git checkout -- "$CFG" 2>/dev/null || true
+  fi
+  if [ "$KEEP_BL_MK" -eq 0 ]; then
+    echo "  regenerating makefiles back to standalone (bench default)…"
+    ( powershell.exe -Command "cd \"$(wslpath -w "$REPO/$PRJ")\"; & '$PRJGEN_WIN' -v ." ) >/dev/null 2>&1 \
+      && echo "  standalone makefiles restored" \
+      || echo "  WARNING: regen-back failed — run the regen manually before the next bench build"
+  else
+    echo "  --keep-bootloader-makefiles: on-disk makefiles remain bootloader-linked (regen before bench flashing)"
+  fi
+  rm -f "$BACKUP_CFG"
+}
+trap cleanup EXIT
+
 # Find old_hv2_bootld.ld inside the <conf name="default"> block and flip the ex=
 # flag on the line that follows it. Robust to line moves: locate by block, not
-# hardcoded line numbers.
+# hardcoded line numbers. Bound the block by the </conf> close tag rather than
+# the name of the next conf (which could be renamed).
 LN="$(awk '
   /<conf name="default"/ {indef=1}
-  indef && /<conf name="Nq/ {indef=0}
+  indef && /<\/conf>/      {indef=0}
   indef && /old_hv2_bootld\.ld"/ {print NR; exit}
 ' "$CFG")"
 [ -n "$LN" ] || die "could not locate default-conf old_hv2_bootld.ld item in $CFG"
@@ -84,22 +116,6 @@ EXLN=$((LN + 1))
 grep -q 'ex="true"' <(sed -n "${EXLN}p" "$CFG") || die "expected ex=\"true\" at line $EXLN (got: $(sed -n "${EXLN}p" "$CFG"))"
 sed -i "${EXLN}s/ex=\"true\"/ex=\"false\"/" "$CFG"
 echo "  old_hv2_bootld.ld -> included (line $EXLN)"
-
-# Always restore the working tree on exit, even on failure.
-cleanup() {
-  say "Restoring configurations.xml (standalone default)"
-  git checkout -- "$CFG" 2>/dev/null || cp "/tmp/configurations.xml.release.bak" "$CFG"
-  if [ "$KEEP_BL_MK" -eq 0 ]; then
-    echo "  regenerating makefiles back to standalone (bench default)…"
-    ( cd "$(wslpath -w "$PRJ")" >/dev/null 2>&1 || true
-      powershell.exe -Command "cd \"$(wslpath -w "$REPO/$PRJ")\"; & '$PRJGEN_WIN' -v ." ) >/dev/null 2>&1 \
-      && echo "  standalone makefiles restored" \
-      || echo "  WARNING: regen-back failed — run the regen manually before the next bench build"
-  else
-    echo "  --keep-bootloader-makefiles: on-disk makefiles remain bootloader-linked (regen before bench flashing)"
-  fi
-}
-trap cleanup EXIT
 
 # --- 2. regenerate makefiles (Windows-side) ---
 say "Regenerating makefiles from the flipped config (Windows prjMakefilesGenerator)"
@@ -110,36 +126,45 @@ grep -q "old_hv2_bootld" "$PRJ/nbproject/Makefile-default.mk" \
 # --- 3. clean build ---
 say "Clean-building the bootloader-linked hex"
 ( cd "$PRJ" && rm -rf build dist && "$MAKE" -f nbproject/Makefile-default.mk CONF=default build -j"$(nproc)" ) \
-  >/tmp/cut_release_build.log 2>&1 \
-  || { tail -20 /tmp/cut_release_build.log; die "build failed (see /tmp/cut_release_build.log)"; }
+  >"$BUILD_LOG" 2>&1 \
+  || { tail -20 "$BUILD_LOG"; die "build failed (see $BUILD_LOG)"; }
 [ -f "$HEX" ] || die "hex not produced: $HEX"
 echo "  built: $HEX"
 
 # --- 4. HARD-VERIFY the bootloader-linked layout (the whole point of this script) ---
 say "Verifying bootloader-linked layout"
-grep -qiE 'kseg0_program_mem[[:space:]]+0x000000009d000480' "$MAP" \
+grep -qiE 'kseg0_program_mem[[:space:]]+0x0*9d000480' "$MAP" \
   || die "kseg0_program_mem origin is NOT 0x9d000480 — this is a STANDALONE build, DO NOT SHIP. (.map: $(grep -i 'kseg0_program_mem 0x' "$MAP" | head -1))"
 echo "  .map kseg0_program_mem origin = 0x9d000480 OK"
 python3 - "$HEX" <<'PY' || die "hex layout verification failed — DO NOT SHIP"
 import sys
-addrs=[]; ext=0
+addrs=[]; base=0; saw_eof=False
 with open(sys.argv[1]) as f:
-    for line in f:
-        line=line.strip()
+    for raw in f:
+        line=raw.strip()
         if not line.startswith(':'): continue
         ln=int(line[1:3],16); off=int(line[3:7],16); rt=int(line[7:9],16)
-        if rt==0x04: ext=int(line[9:13],16)<<16
-        elif rt==0x00: addrs.append((ext+off, ln))
-addrs.sort()
-lo=addrs[0][0]
-reset_bytes=sum(ln for a,ln in addrs if 0x1D000000<=a<0x1D000480)
-bulk=[a for a,ln in addrs if a>=0x1D000480]
+        if rt==0x01:      # End Of File
+            saw_eof=True; break
+        elif rt==0x04:    # Extended Linear Address
+            base=int(line[9:13],16)<<16
+        elif rt==0x02:    # Extended Segment Address
+            base=int(line[9:13],16)<<4
+        elif rt==0x00:    # Data
+            addrs.append((base+off, ln))
 ok=True
 def chk(cond,msg):
     global ok
     print(("  OK  " if cond else "  FAIL")+" "+msg); ok=ok and cond
+chk(saw_eof, "EOF record present")
+if not addrs:
+    chk(False, "no data records found in hex"); sys.exit(1)
+addrs.sort()
+lo=addrs[0][0]
+reset_bytes=sum(ln for a,ln in addrs if 0x1D000000<=a<0x1D000480)
+bulk=[a for a,ln in addrs if a>=0x1D000480]
 chk(lo==0x1D000000, f"lowest phys addr 0x{lo:08X} == 0x1D000000")
-chk(380<=reset_bytes<=440, f"reset vector [0x1D000000,0x1D000480) = {reset_bytes} bytes (~408)")
+chk(reset_bytes==408, f"reset vector [0x1D000000,0x1D000480) = {reset_bytes} bytes == 408")
 chk(bool(bulk) and min(bulk)==0x1D000480, f"bulk starts at 0x{(min(bulk) if bulk else 0):08X} == 0x1D000480")
 sys.exit(0 if ok else 1)
 PY
@@ -149,7 +174,7 @@ say "Packaging assets"
 ASSET_HEX="daqifi-nyquist-firmware-${VER}.hex"
 ASSET_ZIP="daqifi-nyquist-firmware-${VER}.zip"
 cp "$HEX" "$ASSET_HEX"
-rm -f "$ASSET_ZIP"; zip -j "$ASSET_ZIP" "$HEX" >/dev/null
+rm -f "$ASSET_ZIP"; zip -j "$ASSET_ZIP" "$ASSET_HEX" >/dev/null
 echo "  $ASSET_HEX  ($(stat -c%s "$ASSET_HEX") bytes)"
 echo "  $ASSET_ZIP  ($(stat -c%s "$ASSET_ZIP") bytes)"
 

--- a/tools/release/cut_release.sh
+++ b/tools/release/cut_release.sh
@@ -38,7 +38,9 @@ KEEP_BL_MK=0
 WANT_VER=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --version) WANT_VER="$2"; shift 2 ;;
+    --version)
+      [ $# -ge 2 ] || { echo "FATAL: --version requires an argument (X.Y.Z)" >&2; exit 2; }
+      WANT_VER="$2"; shift 2 ;;
     --keep-bootloader-makefiles) KEEP_BL_MK=1; shift ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
@@ -82,6 +84,7 @@ cp "$CFG" "$BACKUP_CFG"
 # mutation (the sed below) so an early failure can never strand the
 # bootloader-linked config on disk.
 cleanup() {
+  rc=$?   # capture the script's exit status FIRST, before anything resets $?
   say "Restoring configurations.xml (standalone default)"
   # Restore the EXACT pre-run file from our backup (preserves any uncommitted
   # local edits the user had); fall back to git only if the backup is missing.
@@ -99,6 +102,7 @@ cleanup() {
     echo "  --keep-bootloader-makefiles: on-disk makefiles remain bootloader-linked (regen before bench flashing)"
   fi
   rm -f "$BACKUP_CFG"
+  [ "$rc" -eq 0 ] && rm -f "$BUILD_LOG"   # keep the build log only when something failed
 }
 trap cleanup EXIT
 
@@ -162,17 +166,19 @@ if not spans:
 spans.sort()
 lo=spans[0][0]
 RESET_LO=0x1D000000; RESET_HI=0x1D000480
-reset_bytes=0; bulk_start=None
+reset_bytes=0
 for s,e in spans:
     # Count only the bytes inside [RESET_LO, RESET_HI) — intersection length,
     # so a record straddling the 0x1D000480 boundary is counted correctly.
     isect=min(e,RESET_HI)-max(s,RESET_LO)
     if isect>0: reset_bytes+=isect
-    # First byte at/after RESET_HI, even if it lands mid-record.
-    if bulk_start is None and e>RESET_HI: bulk_start=max(s,RESET_HI)
+# Rule 984830: a data record must START exactly at 0x1D000480 (the bulk origin).
+# The lowest record start at/after RESET_HI must BE RESET_HI — a record that
+# merely straddles the boundary (starts before, ends after) does NOT satisfy this.
+bulk_starts=sorted(s for s,e in spans if s>=RESET_HI)
 chk(lo==RESET_LO, f"lowest phys addr 0x{lo:08X} == 0x1D000000")
 chk(reset_bytes==408, f"reset vector [0x1D000000,0x1D000480) = {reset_bytes} bytes == 408")
-chk(bulk_start==RESET_HI, f"bulk starts at 0x{(bulk_start if bulk_start is not None else 0):08X} == 0x1D000480")
+chk(bool(bulk_starts) and bulk_starts[0]==RESET_HI, f"bulk starts at 0x{(bulk_starts[0] if bulk_starts else 0):08X} == 0x1D000480")
 sys.exit(0 if ok else 1)
 PY
 

--- a/tools/release/cut_release.sh
+++ b/tools/release/cut_release.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+#
+# cut_release.sh — build + verify + package a BOOTLOADER-LINKED release hex.
+#
+# The release hex MUST be linked with old_hv2_bootld.ld (app @ 0x9D000480) so it
+# does not clobber the bootloader on customer devices. The default MPLAB X
+# "default" config is the STANDALONE bench layout (app @ 0x9D000000) — flashing
+# that to a customer device bricks the bootloader. This script does the linker
+# flip, regenerates the makefiles, clean-builds, HARD-VERIFIES the resulting hex
+# shape, packages the .hex + .zip assets, and restores the working tree.
+#
+# It does NOT run `gh release create` (that step is irreversible and needs the
+# release notes) — it prints the exact command to run.
+#
+# Usage:
+#   bash tools/release/cut_release.sh [--version X.Y.Z] [--keep-bootloader-makefiles]
+#
+#   --version X.Y.Z   Expected FIRMWARE_REVISION (asserts version.h matches;
+#                     does NOT edit version.h — bump + merge that via PR first).
+#                     Defaults to whatever version.h currently holds.
+#   --keep-bootloader-makefiles
+#                     Skip the final regen-back-to-standalone (leaves the on-disk
+#                     makefiles bootloader-linked). Default restores standalone so
+#                     a subsequent bench `make` / flash isn't accidentally a
+#                     ship-layout build.
+#
+# Run from the repo root. Requires: MPLAB X v6.30, XC32 v4.60, WSL (wslpath),
+# powershell.exe (for the Windows-side makefile regen — the Linux-side
+# prjMakefilesGenerator fails with "Device pack missing" on this toolchain).
+#
+set -euo pipefail
+
+MPLABX="/mnt/c/Program Files/Microchip/MPLABX/v6.30"
+MAKE="$MPLABX/gnuBins/GnuWin32/bin/make.exe"
+PRJGEN_WIN='C:\Program Files\Microchip\MPLABX\v6.30\mplab_platform\bin\prjMakefilesGenerator.bat'
+
+KEEP_BL_MK=0
+WANT_VER=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) WANT_VER="$2"; shift 2 ;;
+    --keep-bootloader-makefiles) KEEP_BL_MK=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# --- locate repo root (script lives in tools/release/) ---
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO"
+PRJ="firmware/daqifi.X"
+CFG="$PRJ/nbproject/configurations.xml"
+HEX="$PRJ/dist/default/production/daqifi.X.production.hex"
+MAP="$PRJ/dist/default/production/daqifi.X.production.map"
+VERSION_H="firmware/src/version.h"
+
+say() { printf '\n=== %s ===\n' "$*"; }
+die() { printf '\nFATAL: %s\n' "$*" >&2; exit 1; }
+
+# --- version check ---
+VER="$(grep -oE 'FIRMWARE_REVISION[[:space:]]+"[^"]+"' "$VERSION_H" | grep -oE '[0-9][^"]*')"
+[ -n "$VER" ] || die "could not read FIRMWARE_REVISION from $VERSION_H"
+if [ -n "$WANT_VER" ] && [ "$WANT_VER" != "$VER" ]; then
+  die "version.h says '$VER' but --version was '$WANT_VER'. Bump version.h (via PR) first."
+fi
+say "Building release for FIRMWARE_REVISION $VER"
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[ "$BRANCH" = "main" ] || echo "WARNING: not on main (on '$BRANCH') — releases are normally cut from main."
+[ -z "$(git status --porcelain --untracked-files=no)" ] || echo "WARNING: working tree has tracked changes; configurations.xml will be restored from git at the end."
+
+# --- 1. flip the default conf to bootloader-linked (include old_hv2_bootld.ld, keep p32MZ excluded) ---
+say "Flipping default config to bootloader-linked (old_hv2_bootld.ld included)"
+cp "$CFG" "/tmp/configurations.xml.release.bak"
+# Find old_hv2_bootld.ld inside the <conf name="default"> block and flip the ex=
+# flag on the line that follows it. Robust to line moves: locate by block, not
+# hardcoded line numbers.
+LN="$(awk '
+  /<conf name="default"/ {indef=1}
+  indef && /<conf name="Nq/ {indef=0}
+  indef && /old_hv2_bootld\.ld"/ {print NR; exit}
+' "$CFG")"
+[ -n "$LN" ] || die "could not locate default-conf old_hv2_bootld.ld item in $CFG"
+EXLN=$((LN + 1))
+grep -q 'ex="true"' <(sed -n "${EXLN}p" "$CFG") || die "expected ex=\"true\" at line $EXLN (got: $(sed -n "${EXLN}p" "$CFG"))"
+sed -i "${EXLN}s/ex=\"true\"/ex=\"false\"/" "$CFG"
+echo "  old_hv2_bootld.ld -> included (line $EXLN)"
+
+# Always restore the working tree on exit, even on failure.
+cleanup() {
+  say "Restoring configurations.xml (standalone default)"
+  git checkout -- "$CFG" 2>/dev/null || cp "/tmp/configurations.xml.release.bak" "$CFG"
+  if [ "$KEEP_BL_MK" -eq 0 ]; then
+    echo "  regenerating makefiles back to standalone (bench default)…"
+    ( cd "$(wslpath -w "$PRJ")" >/dev/null 2>&1 || true
+      powershell.exe -Command "cd \"$(wslpath -w "$REPO/$PRJ")\"; & '$PRJGEN_WIN' -v ." ) >/dev/null 2>&1 \
+      && echo "  standalone makefiles restored" \
+      || echo "  WARNING: regen-back failed — run the regen manually before the next bench build"
+  else
+    echo "  --keep-bootloader-makefiles: on-disk makefiles remain bootloader-linked (regen before bench flashing)"
+  fi
+}
+trap cleanup EXIT
+
+# --- 2. regenerate makefiles (Windows-side) ---
+say "Regenerating makefiles from the flipped config (Windows prjMakefilesGenerator)"
+powershell.exe -Command "cd \"$(wslpath -w "$REPO/$PRJ")\"; & '$PRJGEN_WIN' -v ." 2>&1 | tail -2
+grep -q "old_hv2_bootld" "$PRJ/nbproject/Makefile-default.mk" \
+  || die "Makefile-default.mk does not reference old_hv2_bootld.ld after regen — the flip didn't take"
+
+# --- 3. clean build ---
+say "Clean-building the bootloader-linked hex"
+( cd "$PRJ" && rm -rf build dist && "$MAKE" -f nbproject/Makefile-default.mk CONF=default build -j"$(nproc)" ) \
+  >/tmp/cut_release_build.log 2>&1 \
+  || { tail -20 /tmp/cut_release_build.log; die "build failed (see /tmp/cut_release_build.log)"; }
+[ -f "$HEX" ] || die "hex not produced: $HEX"
+echo "  built: $HEX"
+
+# --- 4. HARD-VERIFY the bootloader-linked layout (the whole point of this script) ---
+say "Verifying bootloader-linked layout"
+grep -qiE 'kseg0_program_mem[[:space:]]+0x000000009d000480' "$MAP" \
+  || die "kseg0_program_mem origin is NOT 0x9d000480 — this is a STANDALONE build, DO NOT SHIP. (.map: $(grep -i 'kseg0_program_mem 0x' "$MAP" | head -1))"
+echo "  .map kseg0_program_mem origin = 0x9d000480 OK"
+python3 - "$HEX" <<'PY' || die "hex layout verification failed — DO NOT SHIP"
+import sys
+addrs=[]; ext=0
+with open(sys.argv[1]) as f:
+    for line in f:
+        line=line.strip()
+        if not line.startswith(':'): continue
+        ln=int(line[1:3],16); off=int(line[3:7],16); rt=int(line[7:9],16)
+        if rt==0x04: ext=int(line[9:13],16)<<16
+        elif rt==0x00: addrs.append((ext+off, ln))
+addrs.sort()
+lo=addrs[0][0]
+reset_bytes=sum(ln for a,ln in addrs if 0x1D000000<=a<0x1D000480)
+bulk=[a for a,ln in addrs if a>=0x1D000480]
+ok=True
+def chk(cond,msg):
+    global ok
+    print(("  OK  " if cond else "  FAIL")+" "+msg); ok=ok and cond
+chk(lo==0x1D000000, f"lowest phys addr 0x{lo:08X} == 0x1D000000")
+chk(380<=reset_bytes<=440, f"reset vector [0x1D000000,0x1D000480) = {reset_bytes} bytes (~408)")
+chk(bool(bulk) and min(bulk)==0x1D000480, f"bulk starts at 0x{(min(bulk) if bulk else 0):08X} == 0x1D000480")
+sys.exit(0 if ok else 1)
+PY
+
+# --- 5. package assets ---
+say "Packaging assets"
+ASSET_HEX="daqifi-nyquist-firmware-${VER}.hex"
+ASSET_ZIP="daqifi-nyquist-firmware-${VER}.zip"
+cp "$HEX" "$ASSET_HEX"
+rm -f "$ASSET_ZIP"; zip -j "$ASSET_ZIP" "$HEX" >/dev/null
+echo "  $ASSET_HEX  ($(stat -c%s "$ASSET_HEX") bytes)"
+echo "  $ASSET_ZIP  ($(stat -c%s "$ASSET_ZIP") bytes)"
+
+# --- 6. hand off the irreversible step ---
+cat <<EOF
+
+================================================================================
+Bootloader-linked v${VER} hex built, VERIFIED, and packaged. Next (manual):
+
+  1. Ensure the release notes exist:
+       docs/release-notes/RELEASE_NOTES_v${VER}.md
+
+  2. Publish (irreversible — review first):
+       gh release create v${VER} --repo daqifi/daqifi-nyquist-firmware --target main \\
+         --title "v${VER} — <headline>" \\
+         --notes-file docs/release-notes/RELEASE_NOTES_v${VER}.md --latest \\
+         "${ASSET_HEX}" "${ASSET_ZIP}"
+
+  3. Verify the in-app updater will pick it up (newest non-draft/non-prerelease
+     release that HAS a .hex asset):
+       gh api repos/daqifi/daqifi-nyquist-firmware/releases \\
+         --jq '.[] | select(.draft==false and .prerelease==false) |
+               "\\(.tag_name) hex=\\([.assets[].name]|map(select(endswith(".hex")))|length>0)"' | head -3
+
+The working tree (configurations.xml + makefiles) is restored on exit.
+The two asset files are left in the repo root — delete them after publishing
+(they are build artifacts, not tracked).
+================================================================================
+EOF

--- a/tools/release/cut_release.sh
+++ b/tools/release/cut_release.sh
@@ -138,7 +138,7 @@ grep -qiE 'kseg0_program_mem[[:space:]]+0x0*9d000480' "$MAP" \
 echo "  .map kseg0_program_mem origin = 0x9d000480 OK"
 python3 - "$HEX" <<'PY' || die "hex layout verification failed — DO NOT SHIP"
 import sys
-addrs=[]; base=0; saw_eof=False
+spans=[]; base=0; saw_eof=False   # spans: (start, end_exclusive)
 with open(sys.argv[1]) as f:
     for raw in f:
         line=raw.strip()
@@ -151,21 +151,28 @@ with open(sys.argv[1]) as f:
         elif rt==0x02:    # Extended Segment Address
             base=int(line[9:13],16)<<4
         elif rt==0x00:    # Data
-            addrs.append((base+off, ln))
+            start=base+off; spans.append((start, start+ln))
 ok=True
 def chk(cond,msg):
     global ok
     print(("  OK  " if cond else "  FAIL")+" "+msg); ok=ok and cond
 chk(saw_eof, "EOF record present")
-if not addrs:
+if not spans:
     chk(False, "no data records found in hex"); sys.exit(1)
-addrs.sort()
-lo=addrs[0][0]
-reset_bytes=sum(ln for a,ln in addrs if 0x1D000000<=a<0x1D000480)
-bulk=[a for a,ln in addrs if a>=0x1D000480]
-chk(lo==0x1D000000, f"lowest phys addr 0x{lo:08X} == 0x1D000000")
+spans.sort()
+lo=spans[0][0]
+RESET_LO=0x1D000000; RESET_HI=0x1D000480
+reset_bytes=0; bulk_start=None
+for s,e in spans:
+    # Count only the bytes inside [RESET_LO, RESET_HI) — intersection length,
+    # so a record straddling the 0x1D000480 boundary is counted correctly.
+    isect=min(e,RESET_HI)-max(s,RESET_LO)
+    if isect>0: reset_bytes+=isect
+    # First byte at/after RESET_HI, even if it lands mid-record.
+    if bulk_start is None and e>RESET_HI: bulk_start=max(s,RESET_HI)
+chk(lo==RESET_LO, f"lowest phys addr 0x{lo:08X} == 0x1D000000")
 chk(reset_bytes==408, f"reset vector [0x1D000000,0x1D000480) = {reset_bytes} bytes == 408")
-chk(bool(bulk) and min(bulk)==0x1D000480, f"bulk starts at 0x{(min(bulk) if bulk else 0):08X} == 0x1D000480")
+chk(bulk_start==RESET_HI, f"bulk starts at 0x{(bulk_start if bulk_start is not None else 0):08X} == 0x1D000480")
 sys.exit(0 if ok else 1)
 PY
 


### PR DESCRIPTION
Makes the release-cutting process (the bootloader-linker flip + regen + layout verification) a documented tool, per request after cutting v3.6.2 by hand.

- `tools/release/cut_release.sh` — automates the dangerous part: flips the default MPLAB config to include `old_hv2_bootld.ld`, regenerates makefiles (Windows-side), clean-builds, and **hard-verifies** the bootloader-linked layout (`kseg0` origin `0x9d000480`, 408-byte `.reset` vector at `0x1D000000`, bulk at `0x1D000480`). Aborts rather than ship a standalone hex. Packages `.hex`+`.zip`; restores the working tree on exit. Leaves `gh release create` (irreversible) to a human.
- `docs/RELEASING.md` — end-to-end process.
- `docs/release-notes/RELEASE_NOTES_v3.6.2.md` — the v3.6.2 notes (release already published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)