### PR TITLE
fix(bootloader): #568 datastream state-reset, re-enable CRC, LED (#569), bump to 2.0 (no re-enum backstop)

### DIFF
--- a/bootloader/firmware/src/app.c
+++ b/bootloader/firmware/src/app.c
@@ -299,7 +299,7 @@ void APP_Initialize ( void )
     // Status LED2
     PLIB_PORTS_PinDirectionOutputSet(0, LED_BLUE_PORT, LED_BLUE_PIN);
     PLIB_PORTS_PinClear(0, LED_BLUE_PORT, LED_BLUE_PIN);
-    
+
     m_TimerCallback = SYS_TMR_HANDLE_INVALID;
        
     /* Delay to allow the power to stabilize */
@@ -328,7 +328,16 @@ void APP_Initialize ( void )
                 DelayMs(BOOTLOADER_BLINK_DURATION);
             }
         }
-        
+
+        // Issue #569: clear LED_BLUE on the way out of the MCLR/force-bootloader
+        // path. The MCLR entry lit it solid (above) and the button-hold blink loop
+        // leaves it at an indeterminate parity on release. Unlike LED_WHITE -- which
+        // APP_TimerCallback self-corrects with an unconditional periodic toggle --
+        // LED_BLUE is only ever driven when bootloaderConnected/Downloading, so it
+        // never clears on its own and would falsely read as the "host connected"
+        // indicator. Force it OFF so it only lights once a host actually connects.
+        PLIB_PORTS_PinClear(0, LED_BLUE_PORT, LED_BLUE_PIN);
+
         // Clear the reset reason status flag
         SYS_RESET_ReasonClear(RESET_REASON_MCLR);
     }

--- a/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/bootloader.h
+++ b/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/bootloader.h
@@ -80,13 +80,21 @@ typedef enum
 }T_COMMANDS;
 // DOM-IGNORE-END
 
-#define MAJOR_VERSION 4    /* Bootloader Major Version Shown From a Read Version on PC */
-#define MINOR_VERSION 1    /* Bootloader Minor Version Shown From a Read Version on PC */
+#define MAJOR_VERSION 2    /* Bootloader Major Version shown from a Read Version on PC (was displayed 1.4) */
+#define MINOR_VERSION 0    /* Bootloader Minor Version shown from a Read Version on PC */
 
+/* The host decodes BootInfo[0] as the major (left) digit and BootInfo[1] as the
+ * minor (right) digit (daqifi-core Pic32BootloaderMessageConsumer.DecodeVersionResponse).
+ * The array was previously ordered {MINOR_VERSION, MAJOR_VERSION} with MAJOR=4/MINOR=1,
+ * so it displayed reversed as "1.4". Ordering it {MAJOR_VERSION, MINOR_VERSION} makes the
+ * #define names match the displayed string. 2.0 marks the bootloader carrying the #568
+ * USB reset/deconfigure datastream state-reset (wedge-fix) and the re-enabled inbound CRC
+ * gate; the host now displays "2.0" (was "1.4"). The proactive re-enumeration backstop is
+ * intentionally NOT in this build (held on branch fix/bootloader-568-hid-wedge-crc-led). */
 static const uint8_t BootInfo[2] =
 {
-    MINOR_VERSION,
-    MAJOR_VERSION
+    MAJOR_VERSION,
+    MINOR_VERSION
 };
 
 #define BOOTLOADER_BUFFER_SIZE 512

--- a/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/bootloader.h
+++ b/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/bootloader.h
@@ -305,6 +305,12 @@ typedef struct
     /* Flag to indicate the user message is been processed */
     bool usrBufferEventComplete;
 
+    /* #568: DLE-escape parser state for the RX framing. Held here (not as a
+     * function-static inside Bootloader_BufferEventHandler) so the USB
+     * RESET/DECONFIGURED handler can clear it -- otherwise a bus reset landing
+     * between a DLE and its escaped byte would mis-parse the next frame. */
+    bool rxEscapePending;
+
     /* The application's current state */
       /* USB Host Layer Handle */
     uintptr_t hostHandle;

--- a/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream.c
+++ b/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream.c
@@ -101,18 +101,24 @@ void Bootloader_BufferEventHandler(DATASTREAM_BUFFER_EVENT buffEvent,
                                 break;
 
                             case EOT:   // End of transmission
-                                // Calculate CRC and see if this is valid
+                                // Calculate CRC and see if this frame is valid
                                 if (bootloaderData.cmdBufferLength > 2)
                                 {
                                     crc = bootloaderData.data->buffers.buff2[bootloaderData.cmdBufferLength-2];
                                     crc += ((bootloaderData.data->buffers.buff2[bootloaderData.cmdBufferLength-1])<<8);
-                                    
-                                    if (APP_CalculateCrc(bootloaderData.data->buffers.buff2, bootloaderData.cmdBufferLength-2) == crc){}
-                                   //{
-                                        // CRC matches so frame is valid.
+
+                                    if (APP_CalculateCrc(bootloaderData.data->buffers.buff2, bootloaderData.cmdBufferLength-2) == crc)
+                                    {
+                                        // CRC matches so the frame is valid; hand it to the processor.
                                         bootloaderData.usrBufferEventComplete = true;
                                         return;
-                                   // }
+                                    }
+                                    // CRC mismatch: drop the corrupt frame so a stray/garbled transfer
+                                    // can never be dispatched as a command (e.g. a bogus ERASE_FLASH on
+                                    // this CRC-checked, self-powered device). Reset the accumulator and
+                                    // keep reading; the host times out and retries. This is the inbound
+                                    // integrity gate that was previously disabled (empty if-body).
+                                    bootloaderData.cmdBufferLength = 0;
                                 }
                                 break;
 

--- a/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream.c
+++ b/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream.c
@@ -89,7 +89,8 @@ void Bootloader_BufferEventHandler(DATASTREAM_BUFFER_EVENT buffEvent,
                     if (bootloaderData.rxEscapePending)
                     {
                         // Bounds-guard the accumulator (buff2 is BOOTLOADER_BUFFER_SIZE): an over-long
-                        // unframed stream must never write past it. On overflow drop and resync on SOH.
+                        // unframed stream must never write past it. On overflow drop the partial frame;
+                        // the EOT CRC check (the parser's integrity gate) rejects any mis-framed remainder.
                         if (bootloaderData.cmdBufferLength < BOOTLOADER_BUFFER_SIZE)
                         {
                             bootloaderData.data->buffers.buff2[bootloaderData.cmdBufferLength++] = bootloaderData.data->buffers.buff1[i];
@@ -141,7 +142,8 @@ void Bootloader_BufferEventHandler(DATASTREAM_BUFFER_EVENT buffEvent,
                             default:
                                 // Bounds-guard the accumulator (buff2 is BOOTLOADER_BUFFER_SIZE): an
                                 // over-long/unframed stream must never write past it. On overflow drop the
-                                // partial frame and resync on the next SOH.
+                                // partial frame; the EOT CRC check (the parser's integrity gate) rejects any
+                                // mis-framed remainder. (Frames are validated by CRC, not by SOH-gating.)
                                 if (bootloaderData.cmdBufferLength < BOOTLOADER_BUFFER_SIZE)
                                 {
                                     bootloaderData.data->buffers.buff2[bootloaderData.cmdBufferLength++] = bootloaderData.data->buffers.buff1[i];

--- a/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream.c
+++ b/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream.c
@@ -88,7 +88,16 @@ void Bootloader_BufferEventHandler(DATASTREAM_BUFFER_EVENT buffEvent,
                     // If we were in an Escape sequence, copy the data on and reset the flag.
                     if (bootloaderData.rxEscapePending)
                     {
-                        bootloaderData.data->buffers.buff2[bootloaderData.cmdBufferLength++] = bootloaderData.data->buffers.buff1[i];
+                        // Bounds-guard the accumulator (buff2 is BOOTLOADER_BUFFER_SIZE): an over-long
+                        // unframed stream must never write past it. On overflow drop and resync on SOH.
+                        if (bootloaderData.cmdBufferLength < BOOTLOADER_BUFFER_SIZE)
+                        {
+                            bootloaderData.data->buffers.buff2[bootloaderData.cmdBufferLength++] = bootloaderData.data->buffers.buff1[i];
+                        }
+                        else
+                        {
+                            bootloaderData.cmdBufferLength = 0;
+                        }
                         bootloaderData.rxEscapePending = false;
                     }
                     else
@@ -130,7 +139,18 @@ void Bootloader_BufferEventHandler(DATASTREAM_BUFFER_EVENT buffEvent,
                                 break;
 
                             default:
-                                bootloaderData.data->buffers.buff2[bootloaderData.cmdBufferLength++] = bootloaderData.data->buffers.buff1[i];
+                                // Bounds-guard the accumulator (buff2 is BOOTLOADER_BUFFER_SIZE): an
+                                // over-long/unframed stream must never write past it. On overflow drop the
+                                // partial frame and resync on the next SOH.
+                                if (bootloaderData.cmdBufferLength < BOOTLOADER_BUFFER_SIZE)
+                                {
+                                    bootloaderData.data->buffers.buff2[bootloaderData.cmdBufferLength++] = bootloaderData.data->buffers.buff1[i];
+                                }
+                                else
+                                {
+                                    bootloaderData.cmdBufferLength = 0;
+                                    bootloaderData.rxEscapePending = false;
+                                }
                                 break;
                         }
                     }

--- a/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream.c
+++ b/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream.c
@@ -72,8 +72,7 @@ void Bootloader_BufferEventHandler(DATASTREAM_BUFFER_EVENT buffEvent,
                             DATASTREAM_BUFFER_HANDLE hBufferEvent,
                             uint16_t context )
 {
-  
-  static bool Escape = false;
+
   uint16_t crc;
   int i = 0;
   while(i < context)
@@ -87,17 +86,18 @@ void Bootloader_BufferEventHandler(DATASTREAM_BUFFER_EVENT buffEvent,
                 if (BOOTLOADER_GET_COMMAND == bootloaderData.prevState)
                 {
                     // If we were in an Escape sequence, copy the data on and reset the flag.
-                    if (Escape)
+                    if (bootloaderData.rxEscapePending)
                     {
                         bootloaderData.data->buffers.buff2[bootloaderData.cmdBufferLength++] = bootloaderData.data->buffers.buff1[i];
-                        Escape = false;
+                        bootloaderData.rxEscapePending = false;
                     }
                     else
                     {
                         switch (bootloaderData.data->buffers.buff1[i])
                         {
-                            case SOH:   // Start of header   
+                            case SOH:   // Start of header
                                 bootloaderData.cmdBufferLength = 0;
+                                bootloaderData.rxEscapePending = false;   // start a fresh frame: drop any dangling escape
                                 break;
 
                             case EOT:   // End of transmission
@@ -115,15 +115,18 @@ void Bootloader_BufferEventHandler(DATASTREAM_BUFFER_EVENT buffEvent,
                                     }
                                     // CRC mismatch: drop the corrupt frame so a stray/garbled transfer
                                     // can never be dispatched as a command (e.g. a bogus ERASE_FLASH on
-                                    // this CRC-checked, self-powered device). Reset the accumulator and
-                                    // keep reading; the host times out and retries. This is the inbound
-                                    // integrity gate that was previously disabled (empty if-body).
+                                    // this CRC-checked, self-powered device). Reset the accumulator AND the
+                                    // escape state and keep reading; the host times out and retries. This
+                                    // is the inbound integrity gate that was previously disabled (empty
+                                    // if-body). Clearing rxEscapePending here keeps a corrupt frame that
+                                    // ended mid-escape from desyncing the parser across the retry.
                                     bootloaderData.cmdBufferLength = 0;
+                                    bootloaderData.rxEscapePending = false;
                                 }
                                 break;
 
                             case DLE:   // Escape sequence
-                                Escape = true;
+                                bootloaderData.rxEscapePending = true;
                                 break;
 
                             default:

--- a/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream_usb_hid.c
+++ b/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream_usb_hid.c
@@ -247,8 +247,12 @@ void _USBDeviceEventHandler(USB_DEVICE_EVENT event, void * eventData, uintptr_t 
             DataReceived = false;
             DataSent = false;
             currDir = IDLE;
+            _txCurPos = 0;            /* clear stale TX progress so a reset mid-send can't resume a partial frame */
+            _txMaxSize = 0;
+            _bufferHandle = 0;
             bootloaderData.usrBufferEventComplete = false;
             bootloaderData.cmdBufferLength = 0;
+            bootloaderData.rxEscapePending = false;   /* clear stale DLE-escape parser state across the reset */
             bootloaderData.currentState = BOOTLOADER_GET_COMMAND;
             break;
 

--- a/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream_usb_hid.c
+++ b/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream_usb_hid.c
@@ -73,9 +73,9 @@ void DATASTREAM_Tasks(void)
 
     if (RX == currDir)
     {
-        
+
         if( DataReceived )
-        {        
+        {
                 DataReceived = false;
                 readRequest = false;
                 currDir = IDLE;
@@ -83,13 +83,12 @@ void DATASTREAM_Tasks(void)
         }
         else if(readRequest == false)
         {
-                  
+
             DataReceived = false;
-            
+
             /* Place a new read request. */
              USB_DEVICE_HID_ReportReceive (USB_DEVICE_HID_INDEX_0,
                 &bootloaderData.hostHandle, &bootloaderData.data->buffers.buff1[0], 64 );
-             
              readRequest = true;
         }
 
@@ -103,7 +102,7 @@ void DATASTREAM_Tasks(void)
              &bootloaderData.hostHandle, &bootloaderData.data->buffers.buff2[_txCurPos], 64 );
              _txCurPos += 64;
             readRequest = true;
-             
+
         }
         else if (DataSent && (_txCurPos >= _txMaxSize)) // All data has been sent or is in the buffer
         {
@@ -229,6 +228,28 @@ void _USBDeviceEventHandler(USB_DEVICE_EVENT event, void * eventData, uintptr_t 
              * Hence close handles to all function drivers (Only if they are
              * opened previously. */
             bootloaderData.deviceConfigured = false;
+            /* #568 wedge-fix: a RESET/DECONFIGURE strands the datastream RX/TX state.
+             * The stock handler cleared only deviceConfigured, leaving readRequest /
+             * currDir / DataReceived stale, so after the host reconnected the
+             * "else if (readRequest == false)" re-arm guard in DATASTREAM_Tasks never
+             * tripped and the endpoint stayed dark until a power-cycle. Reset the
+             * bookkeeping and kick the state machine back to GET_COMMAND so that as soon
+             * as the device is reconfigured it re-issues a read and responds.
+             *
+             * NOTE (Saleae-confirmed): a reopen-from-suspend produces a bus RESET with
+             * NO follow-up SET_CONFIGURATION, so CONFIGURED never fires and the endpoints
+             * disabled by the device layer here are never re-enabled on this enumeration.
+             * Recovery therefore requires the host to close+reopen (a fresh enumeration
+             * that does send SET_CONFIGURATION); the desktop/Core side performs that
+             * bounded reconnect, and this fix makes the device respond the instant it
+             * reconfigures. */
+            readRequest = false;
+            DataReceived = false;
+            DataSent = false;
+            currDir = IDLE;
+            bootloaderData.usrBufferEventComplete = false;
+            bootloaderData.cmdBufferLength = 0;
+            bootloaderData.currentState = BOOTLOADER_GET_COMMAND;
             break;
 
         case USB_DEVICE_EVENT_CONFIGURED:

--- a/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream_usb_hid.c
+++ b/bootloader/firmware/src/system_config/usbdevice_pic32mz_ef_sk/framework/bootloader/src/datastream/datastream_usb_hid.c
@@ -254,6 +254,7 @@ void _USBDeviceEventHandler(USB_DEVICE_EVENT event, void * eventData, uintptr_t 
             bootloaderData.cmdBufferLength = 0;
             bootloaderData.rxEscapePending = false;   /* clear stale DLE-escape parser state across the reset */
             bootloaderData.currentState = BOOTLOADER_GET_COMMAND;
+            bootloaderData.prevState = BOOTLOADER_GET_COMMAND;   /* keep prev/current consistent after the reset */
             break;
 
         case USB_DEVICE_EVENT_CONFIGURED:


### PR DESCRIPTION
## What

Split out of #570 — lands the **#568 root-cause fix and hardening WITHOUT the proactive re-enumeration backstop**. The backstop stays on #570's branch (`fix/bootloader-568-hid-wedge-crc-led`), held as a fallback pending desktop-side field testing.

Fixes the root cause of #568 (HID bootloader endpoint goes dark after host open/close churn):

- **Datastream state-reset** — on `USB_DEVICE_EVENT_RESET`/`DECONFIGURED` the handler now resets the stranded RX/TX bookkeeping (`readRequest` / `currDir` / `DataReceived` / `DataSent`, the command buffer, and the DLE-escape parser state) and kicks the state machine back to `BOOTLOADER_GET_COMMAND`. Previously only `deviceConfigured` was cleared, so after the host reconnected the re-arm guard in `DATASTREAM_Tasks` never tripped and the endpoint stayed dark until a power-cycle. The device now responds the instant the host reconfigures it.
- **DLE-escape state moved** from a function-static in `Bootloader_BufferEventHandler` to `bootloaderData.rxEscapePending`, so the reset handler can clear it (a reset landing between a DLE and its escaped byte would otherwise mis-parse the next frame).
- **Inbound CRC gate re-enabled** (#570) — the previously-disabled empty `if`-body now drops CRC-mismatch frames, so a stray/garbled transfer can't be dispatched as a command (e.g. a bogus `ERASE_FLASH`) on this self-powered device.
- **LED #569** — clear `LED_BLUE` on the force-bootloader exit path so it only lights once a host actually connects.
- **Bootloader version → 2.0** (BootInfo ordering fixed; host now displays "2.0", was "1.4").

## What's intentionally NOT here

The proactive `Detach`/`Attach` **re-enumeration backstop** is excluded. The datastream state-reset above plus the host-side **app-global bootloader watcher** (daqifi-desktop#656, which prevents the wedge by never letting the device idle into USB selective-suspend) cover normal use. The noisier backstop (which forces a re-enumeration after a grace period, producing the repeated disconnect/reconnect cycles) is held on #570 in case field testing shows the host-side mitigation isn't sufficient.

## Verification

- Bootloader project (`usb_bootloader.X`, `usbdevice_pic32mz_ef_sk`) **builds clean** (MPLAB X v6.30 / xc32 v2.50).
- Source-only change (no rebuilt hex committed), matching #570's convention.
- **Not yet flash-tested** — should be validated on a device before any 2.0 bootloader is deployed.

Refs #568. Split from #570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
