### PR TITLE
fix(usb): drain USB write buffer during large SCPI responses (#572)

### DIFF
--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -1005,7 +1005,26 @@ bool UsbCdc_FlushWriteBuffer(void) {
  * Thin wrapper to match ScpiTransportWriteFn signature.
  */
 static size_t UsbCdc_ScpiWrite(const char* data, size_t len) {
-    return UsbCdc_WriteToBuffer(NULL, data, len);
+    size_t n = UsbCdc_WriteToBuffer(NULL, data, len);
+    if (n == 0 && len > 0) {
+        // #572 drain-while-writing. WriteToBuffer returned 0 (the USB write
+        // circular buffer is full, or its mutex is briefly busy). The buffer's
+        // ONLY drainer is UsbCdc_BeginWrite, normally called from
+        // UsbCdc_ProcessState — but SCPI commands are processed INLINE in the
+        // USB task (ProcessState -> FinalizeRead -> SCPI_Input -> scpi_printf
+        // -> here), so while a handler is emitting, ProcessState cannot run and
+        // the buffer never drains. A large response (e.g. CONF:CAP:JSON? ~8KB)
+        // into a streaming-shrunk (~2KB) USB buffer would then livelock
+        // SCPI_WriteWithRetry until its retry budget expires, leaving the CDC
+        // read un-armed = the "enumerated-but-CDC-dead" wedge. Pump the DMA
+        // here so the circular buffer drains to the host before the caller's
+        // (SCPI_WriteWithRetry) next retry, letting the already-chunked
+        // response stream out in DMA-sized pieces. BeginWrite is a safe no-op
+        // when a transfer is already in flight (it completes during the
+        // retry's vTaskDelay) and is serialized on the same wMutex.
+        UsbCdc_BeginWrite(&gRunTimeUsbSttings);
+    }
+    return n;
 }
 
 /**


### PR DESCRIPTION
## Problem (#572)
Large SCPI responses — `CONF:CAP:JSON?` (~8 KB; also `SYST:INFo?` / `SYST:LOG?`) — **livelock the USB-CDC task** after any streaming session shrinks the USB write circular buffer to its ~2 KB floor (auto-balance gives non-active interfaces the minimum), leaving the device "enumerated-but-CDC-dead" (host write-timeout, hardware reset required). It surfaced as "SD multi-channel streaming wedges the device," but is **independent of SD saturation** (verified: SD @ 4 kHz, 0 drops still wedged `CONF:CAP`).

## Root cause (mdb-verified)
SCPI commands run **inline in the USB task** (`UsbCdc_ProcessState → FinalizeRead → microrl → SCPI_Input → scpi_printf`). The USB write buffer's **only drainer** is `UsbCdc_BeginWrite`, called from `ProcessState` — which can't run while a handler is mid-emission. So a response larger than the (shrunk) buffer makes `SCPI_WriteWithRetry` spin its full retry budget, and the CDC read is never re-armed.

mdb at the wedge: `state=PROCESS`, `isConfigured=TRUE`, heap healthy (14 KB), `readTransferHandle=INVALID`, `readBufferLength` stuck at the `CONF:CAP:JSON?` bytes. Scheduler alive — **not** corruption / heap / teardown.

## Fix
`UsbCdc_ScpiWrite` now pumps `UsbCdc_BeginWrite` when `WriteToBuffer` reports the buffer full, draining it to the host before the caller's (`SCPI_WriteWithRetry`) next retry — so the already-chunked response **streams out in DMA-sized pieces** instead of livelocking. `BeginWrite` is a safe no-op when a transfer is in flight (completes during the retry's `vTaskDelay`) and is serialized on the same `wMutex`.

## Validation (bench, v3.6.2 + fix)
- Post-SD `CONF:CAP:JSON?` returns the **full ~8 KB** (was `len=0` / wedged).
- The **full 28-config SD at-cap matrix** (14 PB + 14 CSV) runs with **zero CDC wedges** (was: died on the 2nd config).

## Not in scope
The SD enforced cap is over-set (e.g. 8413 vs ~7350 sustainable) and silently drops SD samples — a **separate data-integrity issue, deferred**. It still appears as `drops` in the validation matrix but no longer wedges the device.

Fixes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)
