### PR TITLE
fix(sd): hard-timeout SDSPI bus-completion waits (#567)

### DIFF
--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
@@ -906,12 +906,23 @@ static DRV_SDSPI_ATTACH lDRV_SDSPI_MediaCommandDetect
 
             if (dObj->spiTransferStatus == DRV_SDSPI_SPI_TRANSFER_STATUS_COMPLETE)
             {
+                /* #567: detect transfer done — disarm the watchdog. */
+                if (dObj->spiXferTimerFlag == true)
+                {
+                    (void) DRV_SDSPI_SpiXferTimerStop(dObj);
+                    dObj->spiXferTimerFlag = false;
+                }
                 /* Re-enable Chip Select */
                 (void) DRV_SDSPI_SPISpeedSetup(dObj, DRV_SDSPI_SPI_INITIAL_SPEED, dObj->chipSelectPin);
                 dObj->cmdDetectState = DRV_SDSPI_CMD_DETECT_RESET_SDCARD;
             }
             else if (dObj->spiTransferStatus == DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR)
             {
+                if (dObj->spiXferTimerFlag == true)
+                {
+                    (void) DRV_SDSPI_SpiXferTimerStop(dObj);
+                    dObj->spiXferTimerFlag = false;
+                }
                 /* Re-enable Chip Select */
                 (void) DRV_SDSPI_SPISpeedSetup(dObj, DRV_SDSPI_SPI_INITIAL_SPEED, dObj->chipSelectPin);
                 dObj->cmdDetectState = DRV_SDSPI_CMD_DETECT_CHK_FOR_CARD;
@@ -919,7 +930,34 @@ static DRV_SDSPI_ATTACH lDRV_SDSPI_MediaCommandDetect
             }
             else
             {
-                /* Nothing to do */
+                /* #567: same lost-completion hazard as the buffer-IO wait. A
+                 * never-firing callback here leaves mediaState latched
+                 * DETACHED (the "No SD Card Detected" face) while holding the
+                 * bus. On timeout, behave like the ERROR branch: re-enable CS
+                 * and retry detection so a transient completion loss self-heals
+                 * instead of wedging until power-cycle. */
+                if (dObj->spiXferTimerFlag == false)
+                {
+                    if (DRV_SDSPI_SpiXferTimerStart(dObj, DRV_SDSPI_SPI_XFER_TIMEOUT_IN_MS) == false)
+                    {
+                        (void) DRV_SDSPI_SPISpeedSetup(dObj, DRV_SDSPI_SPI_INITIAL_SPEED, dObj->chipSelectPin);
+                        dObj->cmdDetectState = DRV_SDSPI_CMD_DETECT_CHK_FOR_CARD;
+                        dObj->sdState = TASK_STATE_IDLE;
+                        break;
+                    }
+                    dObj->spiXferTimerFlag = true;
+                }
+                else if (dObj->spiXferTimerExpired == true)
+                {
+                    dObj->spiXferTimerFlag = false;
+                    (void) DRV_SDSPI_SPISpeedSetup(dObj, DRV_SDSPI_SPI_INITIAL_SPEED, dObj->chipSelectPin);
+                    dObj->cmdDetectState = DRV_SDSPI_CMD_DETECT_CHK_FOR_CARD;
+                    dObj->sdState = TASK_STATE_IDLE;
+                }
+                else
+                {
+                    /* Still waiting, timer running. Nothing to do. */
+                }
             }
             break;
 
@@ -1815,15 +1853,53 @@ static void lDRV_SDSPI_BufferIOTasks
 
             if (dObj->spiTransferStatus == DRV_SDSPI_SPI_TRANSFER_STATUS_COMPLETE)
             {
+                /* #567: transfer done — disarm the bus-completion watchdog. */
+                if (dObj->spiXferTimerFlag == true)
+                {
+                    (void) DRV_SDSPI_SpiXferTimerStop(dObj);
+                    dObj->spiXferTimerFlag = false;
+                }
                 dObj->taskBufferIOState = dObj->nextTaskState;
             }
             else if (dObj->spiTransferStatus == DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR)
             {
+                if (dObj->spiXferTimerFlag == true)
+                {
+                    (void) DRV_SDSPI_SpiXferTimerStop(dObj);
+                    dObj->spiXferTimerFlag = false;
+                }
                 dObj->taskBufferIOState = DRV_SDSPI_TASK_READ_WRITE_ABORT;
             }
             else
             {
-                /* Nothing to do */
+                /* #567: spiTransferStatus is written only by the DMA completion
+                 * callback (DRV_SDSPI_SPIDriverEventHandler). If that event is
+                 * lost (observed under SD write load) this wait used to spin
+                 * forever holding the SPI0 exclusive lock — the root cause of
+                 * the read-0 / no-file / no-SD wedge that only a power-cycle
+                 * cleared. Arm a hard timeout; on expiry force ERROR and route
+                 * to READ_WRITE_ABORT, which releases the exclusive lock and
+                 * lets the manager FSM recover without a power-cycle. */
+                if (dObj->spiXferTimerFlag == false)
+                {
+                    if (DRV_SDSPI_SpiXferTimerStart(dObj, DRV_SDSPI_SPI_XFER_TIMEOUT_IN_MS) == false)
+                    {
+                        dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
+                        dObj->taskBufferIOState = DRV_SDSPI_TASK_READ_WRITE_ABORT;
+                        break;
+                    }
+                    dObj->spiXferTimerFlag = true;
+                }
+                else if (dObj->spiXferTimerExpired == true)
+                {
+                    dObj->spiXferTimerFlag = false;
+                    dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
+                    dObj->taskBufferIOState = DRV_SDSPI_TASK_READ_WRITE_ABORT;
+                }
+                else
+                {
+                    /* Still waiting, timer running. Nothing to do. */
+                }
             }
             break;
 

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.c
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.c
@@ -90,6 +90,17 @@ void DRV_SDSPI_SPIDriverEventHandler(
 {
     DRV_SDSPI_OBJ* dObj = (DRV_SDSPI_OBJ *)context;
 
+    /* #567: ignore a completion that doesn't belong to the transfer we are
+     * currently waiting on. After the spiXferTimer watchdog times out and
+     * aborts a transfer, its completion may still arrive late; without this
+     * guard it would overwrite spiTransferStatus (falsely completing a later
+     * transfer) and de-assert CS mid-transfer. The expected handle is updated
+     * on every submit, so a stale handle here means a timed-out transfer. */
+    if (transferHandle != dObj->expectedXferHandle)
+    {
+        return;
+    }
+
     if (event == DRV_SPI_TRANSFER_EVENT_COMPLETE)
     {
         dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_COMPLETE;
@@ -126,6 +137,7 @@ bool DRV_SDSPI_SPIWrite(
     dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_IN_PROGRESS;
 
     DRV_SPI_WriteTransferAdd (dObj->spiDrvHandle, pWriteBuffer, nBytes, &wrTransferHandle);
+    dObj->expectedXferHandle = wrTransferHandle;   /* #567: correlate completion */
 
     if (wrTransferHandle != DRV_SPI_TRANSFER_HANDLE_INVALID)
     {
@@ -164,6 +176,7 @@ bool DRV_SDSPI_SPIRead(
     dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_IN_PROGRESS;
 
     DRV_SPI_ReadTransferAdd (dObj->spiDrvHandle, pReadBuffer, nBytes, &rdTransferHandle);
+    dObj->expectedXferHandle = rdTransferHandle;   /* #567: correlate completion */
 
     if (rdTransferHandle != DRV_SPI_TRANSFER_HANDLE_INVALID)
     {
@@ -192,6 +205,7 @@ bool DRV_SDSPI_SPIWriteWithChipSelectDisabled(
     dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_IN_PROGRESS;
 
     DRV_SPI_WriteTransferAdd (dObj->spiDrvHandle, pWriteBuffer, nBytes, &wrTransferHandle);
+    dObj->expectedXferHandle = wrTransferHandle;   /* #567: correlate completion */
 
     if (wrTransferHandle != DRV_SPI_TRANSFER_HANDLE_INVALID)
     {

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.c
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.c
@@ -412,3 +412,40 @@ bool DRV_SDSPI_TimerStop( DRV_SDSPI_OBJ* const dObj )
 
     return isSuccess;
 }
+
+/* #567: dedicated start/stop for the SPI bus-completion (DMA) wait timer.
+ * Mirrors DRV_SDSPI_TimerStart/Stop but targets spiXferTimer* so it never
+ * collides with the shared read/write busy-token timer (timerHandle), which
+ * can be concurrently armed while DRV_SDSPI_TASK_SPI_STATUS is waiting.
+ * Reuses the generic DRV_SDSPI_TimerCallback (sets *(bool*)context = true). */
+bool DRV_SDSPI_SpiXferTimerStart(
+    DRV_SDSPI_OBJ* const dObj,
+    uint32_t period
+)
+{
+    bool isSuccess = false;
+    dObj->spiXferTimerExpired = false;
+
+    dObj->spiXferTimerHandle = SYS_TIME_CallbackRegisterMS(DRV_SDSPI_TimerCallback,
+             (uintptr_t)&dObj->spiXferTimerExpired, period, SYS_TIME_SINGLE);
+
+    if (dObj->spiXferTimerHandle != SYS_TIME_HANDLE_INVALID)
+    {
+        isSuccess = true;
+    }
+
+    return isSuccess;
+}
+
+bool DRV_SDSPI_SpiXferTimerStop( DRV_SDSPI_OBJ* const dObj )
+{
+    bool isSuccess = false;
+
+    if (dObj->spiXferTimerHandle != SYS_TIME_HANDLE_INVALID)
+    {
+        (void) SYS_TIME_TimerDestroy(dObj->spiXferTimerHandle);
+        isSuccess = true;
+    }
+
+    return isSuccess;
+}

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.h
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.h
@@ -215,6 +215,21 @@ bool DRV_SDSPI_CmdResponseTimerStart(
 bool DRV_SDSPI_TimerStop( DRV_SDSPI_OBJ* const dObj );
 
 // *****************************************************************************
+/* #567: SPI bus-completion (DMA) wait timer start/stop.
+
+  Summary:
+    Arms/stops a dedicated hard timeout for the SPI transfer-completion waits,
+    independent of the shared read/write timer so a lost DMA completion can no
+    longer park the driver forever holding the SPI0 exclusive lock.
+*/
+bool DRV_SDSPI_SpiXferTimerStart(
+    DRV_SDSPI_OBJ* const dObj,
+    uint32_t period
+);
+
+bool DRV_SDSPI_SpiXferTimerStop( DRV_SDSPI_OBJ* const dObj );
+
+// *****************************************************************************
 /* SD Card Command-Response Timer Stop
 
   Summary:

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi_local.h
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi_local.h
@@ -92,6 +92,14 @@
 #define DRV_SDSPI_READ_TIMEOUT_IN_MS              (250)
 #define DRV_SDSPI_WRITE_TIMEOUT_IN_MS             (250)
 
+/* #567: hard timeout for the SPI bus-completion (DMA) waits. A single block
+ * or command-byte DRV_SPI transfer completes in well under 1 ms; the only way
+ * a bus-completion wait lasts this long is a LOST DMA completion callback,
+ * which (pre-fix) parked the driver forever holding the SPI0 exclusive lock.
+ * 500 ms is generous against any legitimate transfer + SD-task preemption,
+ * and recovering a previously-permanent wedge in 500 ms is a large win. */
+#define DRV_SDSPI_SPI_XFER_TIMEOUT_IN_MS          (500)
+
 #define DRV_SDSPI_APP_CMD_RESP_TIMEOUT_IN_MS      (1000)
 #define DRV_SDSPI_CSD_TOKEN_TIMEOUT_IN_MS         (1000)
 
@@ -1426,6 +1434,15 @@ typedef struct
     volatile bool                                   timerExpired;
 
     volatile bool                                   cardPollingTimerExpired;
+
+    /* #567: dedicated timer for the SPI bus-completion (DMA) wait. Kept
+     * separate from timerHandle/timerFlag/timerExpired because the shared
+     * read/write timer is concurrently armed by the write-stop busy-token
+     * poll while DRV_SDSPI_TASK_SPI_STATUS waits for that poll's SPI read to
+     * complete — reusing it would corrupt the 250 ms busy-token budget. */
+    bool                                            spiXferTimerFlag;
+    SYS_TIME_HANDLE                                 spiXferTimerHandle;
+    volatile bool                                   spiXferTimerExpired;
 
     /* Flag to indicate if the device is Standard Speed or High Speed */
     uint8_t                                         sdHcHost;

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi_local.h
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi_local.h
@@ -55,6 +55,7 @@
 
 #include "configuration.h"
 #include "driver/sdspi/drv_sdspi.h"
+#include "driver/spi/drv_spi.h"   /* #567: DRV_SPI_TRANSFER_HANDLE (expectedXferHandle) */
 #include "osal/osal.h"
 
 // *****************************************************************************
@@ -1443,6 +1444,14 @@ typedef struct
     bool                                            spiXferTimerFlag;
     SYS_TIME_HANDLE                                 spiXferTimerHandle;
     volatile bool                                   spiXferTimerExpired;
+
+    /* #567: handle of the SPI transfer we are currently waiting on. The
+     * completion callback ignores any event whose transferHandle doesn't
+     * match this, so a late completion from a transfer that was already
+     * timed-out (and aborted by the spiXferTimer watchdog) can't overwrite
+     * spiTransferStatus — or de-assert CS — during a later transfer.
+     * Set once per submit (atomic 32-bit store), read in the callback. */
+    DRV_SPI_TRANSFER_HANDLE                         expectedXferHandle;
 
     /* Flag to indicate if the device is Standard Speed or High Speed */
     uint8_t                                         sdHcHost;


### PR DESCRIPTION
## Problem (#567)

The SDSPI block driver's two SPI bus-completion waits have **no timeout**:

- `DRV_SDSPI_TASK_SPI_STATUS` (read/write data path, `drv_sdspi.c`)
- `DRV_SDSPI_CMD_DETECT_WAIT_TRANSFER_COMPLETE` (card detect)

`spiTransferStatus` is written **only** by the DMA completion callback
(`DRV_SDSPI_SPIDriverEventHandler`). If that event is lost under SD write
load, it stays `IN_PROGRESS` forever and the wait spins in an empty `else`
branch — **holding the SPI0 exclusive lock**. That single stuck state
produces all three observed faces of #567: read-0 (a GET of a non-empty file
returns marker-only), no-new-file, and "No SD Card Detected" — recovered only
by a **full power-cycle** (the driver object resets only at boot).

The trigger is **WiFi-independent** (a pure USB+SD logging session reproduces
it), so the hard-timeout is the load-bearing fix, not bus arbitration.

## Fix (A) — dedicated bus-completion watchdog

A `SYS_TIME` watchdog (`DRV_SDSPI_SpiXferTimer{Start,Stop}`,
`DRV_SDSPI_SPI_XFER_TIMEOUT_IN_MS = 500`) arms on entry to each wait:

- **buffer-IO wait**: on expiry, force `spiTransferStatus = ERROR` and route
  to `DRV_SDSPI_TASK_READ_WRITE_ABORT` — which **releases the exclusive lock**
  (`DRV_SDSPI_SPIExclusiveAccess(false)`) and fires a `COMMAND_ERROR`, so the
  `sd_card_manager` FSM self-recovers **without a power-cycle**.
- **card-detect wait**: on expiry, mirror the existing ERROR branch (re-enable
  CS, retry detection) so a transient completion loss self-heals.

A single SPI block/command transfer completes in **<1 ms**; the completion
callback is DMA/ISR-driven (independent of SD-task scheduling), so a wait that
lasts 500 ms can only mean a **genuinely lost** completion. 500 ms recovery of
a previously-permanent wedge is a large win with no false-positive risk on a
healthy-but-busy system.

### Why a dedicated timer (not the shared one)
The watchdog uses dedicated `spiXferTimer*` fields rather than the shared
`timerHandle/timerFlag/timerExpired`, because the write-stop busy-token poll
arms the shared 250 ms timer **while** `SPI_STATUS` is waiting for that poll's
SPI read to complete. Reusing the shared timer would reset/corrupt the
busy-token budget every bus completion. The two timers are otherwise mutually
exclusive across phases, and reuse the same generic callback.

## Files
- `drv_sdspi_local.h` — `DRV_SDSPI_SPI_XFER_TIMEOUT_IN_MS` + 3 struct fields
- `drv_sdspi_driver_interface.{c,h}` — `DRV_SDSPI_SpiXferTimer{Start,Stop}`
- `drv_sdspi.c` — the two wait states

## Known limitation / follow-up
If a completion is merely **delayed** past 500 ms (vs truly lost) and fires
during a later transfer's wait, it could falsely complete that transfer. The
<1 ms transfer vs 500 ms window makes this negligible; a `DRV_SPI`
transfer-cancel on abort would close it entirely. Fix (B) (a runtime
`DRV_SDSPI_Deinitialize` so `SD:ENAble 0/1` also recovers) is deferred — fix
(A) self-heals so it isn't required for the bench repro.

## Build
Builds clean at -O3 (`daqifi.X.production.hex`, 1.75 MB).

## Test plan (bench validation pending — gates merge)
- Repro recipe: `daqifi-python-test-suite/test_567_sd_wedge.py` (pure USB+SD
  logging-session loop; distinguishes self-heal-on-retry = PASS from
  wedge-persists-until-power-cycle = FAIL).
- Sequence: confirm the wedge triggers on shipping v3.6.2, flash this build,
  re-run and confirm self-heal. Validation is queued behind the in-flight #574
  SD characterization that currently holds the bench (COM3).

Refs #567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)