### PR TITLE
fix(adc): derate SD-PB streaming cap for scan-armed configs (#574)

### DIFF
--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -505,6 +505,16 @@ uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
             uint32_t hwScanMax = MC12b_HardwareScanMaxFreq(scanCount);
             if (hwScanMax < maxFreq) maxFreq = hwScanMax;
         }
+        /* #574: SD-PB writer-vs-scan cap. The SD writer task loses CPU to the
+         * scan's data-ready/EOS ISRs, so scan-armed configs sustain a lower
+         * zero-loss SD rate than the ADC/transport terms predict. SD interface
+         * only — UsbAndSd is uncharacterized (separate follow-up). */
+        if (iface == StreamingInterface_SD) {
+            uint32_t sdMax = Streaming_SdAdditiveCap_NQ1(
+                    type1, userT2, nMon,
+                    (sc->Encoding == Streaming_ProtoBuffer) ? 1u : 0u);
+            if (sdMax < maxFreq) maxFreq = sdMax;
+        }
     } else {
         /* NQ2/NQ3 (AD7609 — no MODULE7 scan) and the 0-channel case: legacy
          * conservative formula (#541). Mirror ComputeMaxFreq's ISR_MAX-for-0

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -132,6 +132,42 @@ static inline uint32_t Streaming_AdcAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2us
 }
 
 /**
+ * #574: NQ1 SD-PB sustainable-rate cap (Hz). The SD writer task (pri 5) loses
+ * CPU to the ADC scan's per-conversion data-ready + EOS ISRs, so a scan-armed
+ * config sustains a LOWER zero-loss SD rate than a pure-T1 (no-scan) config.
+ * The interface-agnostic ADC additive cap and the byte-rate transport cap both
+ * MISS this (neither models SD-writer starvation), so several scan-armed
+ * configs were enforced ABOVE their true SD ceiling and silently dropped
+ * (SdDroppedBytes > 0) — issue #574.
+ *
+ *   period_ns = base + arm*armed + cT1*nT1 + cT2*nT2user
+ *   hz        = 1e9 / period_ns ;   armed = (nT2user>0 || nMon>0)
+ *
+ * Fitted by LP (never-over) to the 2026-06-30 MULTI-TRIAL SD ceilings. (The
+ * single-pass campaign was unreliable — transient SD-GC stalls produced
+ * spurious leaks; 3xT1's single-pass "dip" below its neighbours was the giveaway
+ * and re-tested clean.) Constraints: cap <= measured ceiling for the 6 genuine
+ * over-cap configs (1xT2, 3xT2, 1xT1+OBDiag, 5xT1+OBDiag, 5T1+3T2, 5T1+5T2),
+ * AND cap >= the existing enforced cap for the pure-T1 / published configs so
+ * their existing terms still bind (1ch=9000, 5ch=7500, 10ch, 16ch unchanged).
+ * cMon fit to 0 — monitoring load is captured by `armed`. CSV is byte-bound
+ * (the transport term binds it below this), so this is PB-only. Applied for the
+ * SD interface only; UsbAndSd is uncharacterized (separate follow-up).
+ */
+static inline uint32_t Streaming_SdAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2user,
+                                                   uint32_t nMon, uint32_t isProtoBuf) {
+    if (isProtoBuf == 0u) {
+        return STREAMING_ISR_MAX_HZ;   /* CSV is byte-bound: the transport term binds it */
+    }
+    uint32_t armed = (nT2user > 0u || nMon > 0u) ? 1u : 0u;
+    uint64_t period_ns = 93539ULL + 63468ULL*armed
+                       + 7959ULL*(uint64_t)nT1 + 4615ULL*(uint64_t)nT2user;
+    uint32_t hz = (uint32_t)(1000000000ULL / period_ns);  /* period_ns >= base, no div-by-0 */
+    if (hz > STREAMING_ISR_MAX_HZ) hz = STREAMING_ISR_MAX_HZ;
+    return (hz == 0u) ? 1u : hz;
+}
+
+/**
  * Per-interface, per-format TRANSPORT wire-rate cap (Hz) — generalizes the
  * WiFi-only term (#520) to USB / SD / USB+SD (#524).  Fitted to the 3-run
  * real-ADC zero-loss characterization (matrix_524 run-1/2/3 + WiFi-v2,


### PR DESCRIPTION
## Problem (#574)

Six SD **ProtoBuf** configs were enforced *above* their true zero-loss SD rate and silently dropped samples (`SdDroppedBytes > 0`, surfaced only via `SYST:STR:STATS?`). An enforced cap should never exceed what the device sustains — that's the whole point of the #524 hard cap.

**Root cause:** the SD writer task (pri 5) loses CPU to the ADC scan's per-conversion data-ready + EOS ISRs, so a **scan-armed** config (T2 channels and/or OBDiag monitoring) sustains a *lower* zero-loss SD rate than a pure-T1 (no-scan) config of similar channel count. The interface-agnostic ADC additive cap (#557) and the byte-rate transport cap (#524) both miss this SD-writer-starvation effect.

## Fix

Adds `Streaming_SdAdditiveCap_NQ1` (streaming.h), min'd into the NQ1 branch of `Streaming_ComputeMaxFreqForConfigIface` **for the SD interface only**:

```
period_ns = 93539 + 63468*armed + 7959*nT1 + 4615*nT2user    (armed = nT2user>0 || nMon>0)
hz = 1e9 / period_ns
```

PB-only (CSV is byte-bound → the transport term binds it). Fitted by LP (**never-over**) to multi-trial SD ceilings.

### Per-config result (multi-trial ceiling → new cap)
| Config | old cap | ceiling | **new cap** |
|---|--:|--:|--:|
| 1×T2 | 8413 | 6440 | **6187** |
| 3×T2 | 6690 | 5853 | **5853** |
| 1×T1 OBD=on | 9000 | 6890 | **6062** |
| 5×T1 OBD=on | 7500 | 6562 | **5081** |
| 5T1+3T2 | 6182 | 5409 | **4747** |
| 5T1+5T2 (10ch) | 5198 | 4548 | **4548** |

**Preserved (existing term still binds, unchanged):** 1ch=9000, 5ch (5×T1)=7500, 10ch=4548 (≥ published 4500), 16ch=3756, and all pure-T1 / T2-only fine configs. No marketing number regresses.

## Methodology note (important)

The original single-pass at-cap soak that filed #574 was **unreliable** — transient SD-card GC stalls cause spurious leaks. The giveaway: `3×T1` measured a ceiling (7000) *below* both its 1ch (10000) and 5ch (8500) neighbours, which is physically impossible for a throughput limit (5×T1 pushes more ticks/samples/bytes yet drains clean). Multi-trial re-test confirmed `3×T1` is clean to ≥9000 — it was **not** over-cap. Every cap here derives from **3×30 s multi-trial** ceilings (single-pass SD measurements are unreliable in both directions — a spurious *fail* from a GC blip, never a spurious *pass*).

Characterization recipes + data (`char_574_sd_ceilings.py`, `remeasure_574_*.py`, CSVs, fitter) committed to `daqifi-python-test-suite`.

## Scope / follow-ups
- **UsbAndSd** uncharacterized (added USB contention lowers the SD ceiling further) — left on its existing provisional term; separate follow-up.
- CSV unaffected (transport-bound).

## Build
Builds clean at -O3 (1.75 MB hex).

## Test plan (bench validation pending — gates merge)
Flash this build, then per over-cap config: confirm `CONF:CAP:JSON?` `current_max_rate_hz` matches the fit (above table) with SD active, confirm `SYST:STR:START` above cap is rejected (`-222`), confirm fine configs still cap at their old values (1×T1 OBD=off = 9000), and at-cap multi-trial stream → `SdDroppedBytes = 0`. (The new caps *are* the multi-trial-proven-clean rates from the characterization, so this confirms the firmware computes/enforces them correctly.)

Refs #574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)