### PR TITLE
fix(usb): clear readBufferLength on transparent-mode decline path (#575)

### DIFF
--- a/firmware/src/Util/Logger.h
+++ b/firmware/src/Util/Logger.h
@@ -178,6 +178,7 @@ extern "C" {
         LOG_ONCE_USB_WRITE_STUCK,         /**< UsbCdc.c: write DMA stalled (host not reading) — bail without blocking, drop until drained (#525) */
         LOG_ONCE_USB_FLUSH_STUCK,         /**< UsbCdc.c: flush timeout (host not reading) — defer flush (#525); distinct bit so it isn't masked by the write-stall one-shot */
         LOG_ONCE_AD7609_BSY_STUCK,        /**< AD7609.c: BSY pin stuck low after SPI read — hardware fault; one-shot so a stuck pin can't flood + repeatedly enter vsnprintf (#525 follow-up) */
+        LOG_ONCE_USB_TRANSPARENT_DECLINE, /**< UsbCdc.c: transparent-mode read CB declined a buffer — dropped to avoid un-arming the CDC read (#575); one-shot so a persistently-declining CB can't flood */
         /* Add new entries above this line */
         LOG_ONCE_COUNT                     /**< Must be <= 32 */
     } LogOnceBit_t;

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -870,10 +870,17 @@ static bool UsbCdc_FinalizeRead(UsbCdcData_t* client) {
                 client->readBufferLength = 0;
                 return true;
             }
-            if (UsbCdc_TransparentReadCmpltCB(client->readBuffer, client->readBufferLength) == true) {
-                client->readBufferLength = 0;
-                return true;
-            }
+            // #575: clear readBufferLength on BOTH outcomes. If the transparent
+            // consumer DECLINES (returns false), leaving readBufferLength > 0
+            // permanently un-arms the next CDC read — UsbCdc_BeginRead gates on
+            // readBufferLength == 0 — producing the enumerated-but-CDC-dead
+            // wedge. Drop the declined buffer and re-arm the control channel
+            // rather than wedge it. (Default CB returns true, so normal
+            // operation is unchanged; this only affects an override that
+            // declines.) The caller ignores this return value.
+            bool consumed = UsbCdc_TransparentReadCmpltCB(client->readBuffer, client->readBufferLength);
+            client->readBufferLength = 0;
+            return consumed;
         }
     }
     return false;

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -880,7 +880,14 @@ static bool UsbCdc_FinalizeRead(UsbCdcData_t* client) {
             // declines.) The caller ignores this return value.
             bool consumed = UsbCdc_TransparentReadCmpltCB(client->readBuffer, client->readBufferLength);
             client->readBufferLength = 0;
-            return consumed;
+            if (!consumed) {
+                // #575: surface a persistently-declining transparent consumer
+                // (one-shot so it can't flood). The buffer was dropped to keep
+                // the CDC read armed — losing it beats wedging the channel.
+                LOG_E_ONCE(LOG_ONCE_USB_TRANSPARENT_DECLINE,
+                           "USB transparent read declined; buffer dropped to re-arm CDC");
+            }
+            return true;   // always finalize: buffer cleared + read re-armed (caller ignores this)
         }
     }
     return false;


### PR DESCRIPTION
## Problem (#575 part a)

`UsbCdc_FinalizeRead`'s transparent-mode branch returned **without clearing `readBufferLength`** when `UsbCdc_TransparentReadCmpltCB` declined the buffer (returned `false`). `UsbCdc_BeginRead` re-arms the next CDC read only when `readBufferLength == 0`, so a stuck non-zero length permanently un-arms the read → the enumerated-but-CDC-dead wedge (same no-progress-guarantee class as #572/#573/#567). The non-transparent path always clears it; the transparent path didn't.

**Trigger:** transparent / firmware-update passthrough (`SYST:USB:TRANSparent:MODE 1`) when the transparent read callback declines a buffer.

## Fix
Clear `readBufferLength` on **both** outcomes (consumed and declined) and re-arm. The declined buffer is dropped rather than wedging the control channel (the caller ignores FinalizeRead's return value). The default `__WEAK` CB returns `true`, so **normal operation is unchanged** — this only affects an override that declines.

## Scope / follow-up
Part **(b)** (decouple the CDC read-arm from inline-SCPI-handler completion) is a larger structural change (double-buffering / async readBuffer processing) — deferred. #573 already fixed the specific write-drain blocking instance.

## Build
Clean at -O3.

## Test plan
Code-correct (mirrors the non-transparent clear-and-re-arm). Non-regression: transparent toggle + normal SCPI unaffected (default CB returns true → already cleared at the consumed path). The declined-path wedge needs an override CB returning false to exercise directly.

Refs #575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)