### PR TITLE
feat(diag): capture task name + EPC on stack overflow / exception (#552)

### DIFF
--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -138,6 +138,7 @@ static tBoardData * gpBoardData;
 static tBoardRuntimeConfig * gpBoardRuntimeConfig;
 static tBoardConfig * gpBoardConfig;
 extern const NanopbFlagsArray fields_discovery;
+extern void CrashCapture_Init(void);   /* #552 crash-capture globals scrub (exceptions.c) */
 
 // USB transfer constants for SD card callback
 // Clamp chunk size to USB buffer capacity with underflow protection
@@ -550,6 +551,7 @@ void app_SystemInit() {
      * kseg1). crt0 does not zero those; without these calls the
      * statics retain values across MCLR / IPE flash. See #409. */
     wifi_manager_BootInit();
+    CrashCapture_Init();   /* #552: zero gCrash* crash-capture globals (retained RAM) */
 
     // Power initialization - enables 3.3V rail by default - other power
     // functions are in power task

--- a/firmware/src/config/default/exceptions.c
+++ b/firmware/src/config/default/exceptions.c
@@ -159,11 +159,17 @@ void CrashCapture_CopyName( const char * nm )
  * scrubs. See #552. */
 void CrashCapture_Init( void )
 {
+    unsigned int i;
     gCrashReason      = 0U;
     gCrashExcCode     = 0U;
     gCrashExcAddr     = 0U;
     gCrashTaskHandle  = 0U;
-    gCrashTaskName[0] = '\0';
+    /* Clear the WHOLE buffer (not just the terminator) so a raw memory dump
+     * before any crash shows no stale bytes. */
+    for ( i = 0U; i < CRASH_TASK_NAME_MAX; i++ )
+    {
+        gCrashTaskName[i] = '\0';
+    }
 }
 
 
@@ -198,6 +204,9 @@ void __attribute__((noreturn, weak)) _general_exception_handler ( void )
     gCrashExcAddr = exception_address;
     gCrashTaskName[0] = '\0';   /* fresh per-crash; overwritten below only on a good capture,
                                  * so a failed/invalid-TCB read can't show a stale name */
+    /* Only call into the kernel once the scheduler is running — a pre-scheduler
+     * exception has no valid pxCurrentTCB, so the accessors could nested-fault. */
+    if ( xTaskGetSchedulerState() == taskSCHEDULER_RUNNING )
     {
         TaskHandle_t tcb = xTaskGetCurrentTaskHandle();
         gCrashTaskHandle = (uint32_t) tcb;

--- a/firmware/src/config/default/exceptions.c
+++ b/firmware/src/config/default/exceptions.c
@@ -101,6 +101,53 @@ volatile static unsigned int exception_address;
 /* Code identifying the cause of the exception (CP0 Cause register). */
 volatile static uint32_t  exception_code;
 
+/* ---- #552 crash capture (custom — not MCC-generated; preserve on regen) ----
+ * A task stack overflow that corrupts pxTopOfStack faults inside the FreeRTOS
+ * context-switch restore (port_asm.S) and vectors to _general_exception_handler,
+ * BYPASSING vApplicationStackOverflowHook. Record the culprit into these fixed
+ * globals (BSS — NOT any task's stack) so the offending task is diagnosable via
+ * mdb (`print gCrash*`) or a Logger dump without a live repro. Peer capture in
+ * vApplicationStackOverflowHook (freertos_hooks.c) covers the guard-caught case.
+ * These read valid only after a crash sets them THIS boot (not zeroed across
+ * MCLR in retained-RAM regions — see #409). */
+#define CRASH_TASK_NAME_MAX 20
+
+volatile uint32_t gCrashReason     = 0U; /* 0 none, 1 stack-overflow hook, 2 general exception, 3 malloc-fail */
+volatile uint32_t gCrashExcCode    = 0U; /* CP0 ExcCode: 2=TLBL, 4=AdEL, 5=AdES, 7=DBE, ... */
+volatile uint32_t gCrashExcAddr    = 0U; /* EPC of the faulting instruction */
+volatile uint32_t gCrashTaskHandle = 0U; /* current TCB (pxCurrentTCB) at the fault */
+volatile char     gCrashTaskName[CRASH_TASK_NAME_MAX] = { 0 };
+
+/* FreeRTOS accessors used below (xTaskGetCurrentTaskHandle / pcTaskGetName) are
+ * declared via definitions.h -> task.h, already in scope here. Both are always
+ * compiled in this config (INCLUDE_xTaskGetCurrentTaskHandle == 1; pcTaskGetName
+ * is unconditional). */
+
+/* On-chip RAM bounds so a corrupt pointer can't cause a nested fault while we
+ * copy a name. PIC32MZ2048EFM144 has 512 KB RAM at KSEG0 0x80000000 (KSEG1
+ * uncached mirror at 0xA0000000). */
+static bool CrashCapture_PtrInRam( uint32_t p )
+{
+    return ( ( p >= 0x80000000U && p < 0x80080000U ) ||
+             ( p >= 0xA0000000U && p < 0xA0080000U ) );
+}
+
+static void CrashCapture_CopyName( const char * nm )
+{
+    unsigned int i;
+    if ( ( nm == NULL ) || !CrashCapture_PtrInRam( (uint32_t) nm ) )
+    {
+        return;
+    }
+    for ( i = 0U; i < ( CRASH_TASK_NAME_MAX - 1U ); i++ )
+    {
+        char c = nm[i];
+        if ( c == '\0' ) { break; }
+        gCrashTaskName[i] = ( ( c >= 0x20 ) && ( c <= 0x7E ) ) ? c : '?';
+    }
+    gCrashTaskName[i] = '\0';
+}
+
 
 // </editor-fold>
 
@@ -123,7 +170,24 @@ void __attribute__((noreturn, weak)) _general_exception_handler ( void )
     exception_code = ((_CP0_GET_CAUSE() & 0x0000007CU) >> 2U);
     exception_address = _CP0_GET_EPC();
 
-    while (true) 
+    /* #552: record the culprit into fixed globals (not any task stack) so a
+     * stack-overflow-escape TLBL — which never reaches the FreeRTOS overflow
+     * hook — is diagnosable via mdb without a live repro. pxCurrentTCB is a
+     * kernel global (not on a task stack), so it survives a task overflow; the
+     * bounds check guards against a wild pointer causing a nested fault. */
+    gCrashReason  = 2U;
+    gCrashExcCode = exception_code;
+    gCrashExcAddr = exception_address;
+    {
+        TaskHandle_t tcb = xTaskGetCurrentTaskHandle();
+        gCrashTaskHandle = (uint32_t) tcb;
+        if ( ( tcb != NULL ) && CrashCapture_PtrInRam( (uint32_t) tcb ) )
+        {
+            CrashCapture_CopyName( pcTaskGetName( tcb ) );
+        }
+    }
+
+    while (true)
     {
         #if defined(__DEBUG) || defined(__DEBUG_D) && defined(__XC32)
             __builtin_software_breakpoint();

--- a/firmware/src/config/default/exceptions.c
+++ b/firmware/src/config/default/exceptions.c
@@ -178,6 +178,8 @@ void __attribute__((noreturn, weak)) _general_exception_handler ( void )
     gCrashReason  = 2U;
     gCrashExcCode = exception_code;
     gCrashExcAddr = exception_address;
+    gCrashTaskName[0] = '\0';   /* fresh per-crash; overwritten below only on a good capture,
+                                 * so a failed/invalid-TCB read can't show a stale name */
     {
         TaskHandle_t tcb = xTaskGetCurrentTaskHandle();
         gCrashTaskHandle = (uint32_t) tcb;

--- a/firmware/src/config/default/exceptions.c
+++ b/firmware/src/config/default/exceptions.c
@@ -204,9 +204,11 @@ void __attribute__((noreturn, weak)) _general_exception_handler ( void )
     gCrashExcAddr = exception_address;
     gCrashTaskName[0] = '\0';   /* fresh per-crash; overwritten below only on a good capture,
                                  * so a failed/invalid-TCB read can't show a stale name */
-    /* Only call into the kernel once the scheduler is running — a pre-scheduler
-     * exception has no valid pxCurrentTCB, so the accessors could nested-fault. */
-    if ( xTaskGetSchedulerState() == taskSCHEDULER_RUNNING )
+    /* Capture whenever the scheduler has started (RUNNING or SUSPENDED — a
+     * scheduler-suspended crash still has a valid pxCurrentTCB); only skip
+     * pre-scheduler (NOT_STARTED), where pxCurrentTCB is invalid and the kernel
+     * accessors could nested-fault. */
+    if ( xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED )
     {
         TaskHandle_t tcb = xTaskGetCurrentTaskHandle();
         gCrashTaskHandle = (uint32_t) tcb;

--- a/firmware/src/config/default/exceptions.c
+++ b/firmware/src/config/default/exceptions.c
@@ -132,7 +132,8 @@ static bool CrashCapture_PtrInRam( uint32_t p )
              ( p >= 0xA0000000U && p < 0xA0080000U ) );
 }
 
-static void CrashCapture_CopyName( const char * nm )
+/* Non-static: also used by vApplicationStackOverflowHook (freertos_hooks.c). */
+void CrashCapture_CopyName( const char * nm )
 {
     unsigned int i;
     if ( ( nm == NULL ) || !CrashCapture_PtrInRam( (uint32_t) nm ) )
@@ -141,11 +142,28 @@ static void CrashCapture_CopyName( const char * nm )
     }
     for ( i = 0U; i < ( CRASH_TASK_NAME_MAX - 1U ); i++ )
     {
+        /* Validate EACH byte's address: a pointer near the RAM-top boundary
+         * could otherwise read past mapped RAM and nested-fault mid-capture. */
+        if ( !CrashCapture_PtrInRam( (uint32_t) &nm[i] ) ) { break; }
         char c = nm[i];
         if ( c == '\0' ) { break; }
         gCrashTaskName[i] = ( ( c >= 0x20 ) && ( c <= 0x7E ) ) ? c : '?';
     }
     gCrashTaskName[i] = '\0';
+}
+
+/* Zero the crash-capture globals at boot. They live in per-symbol .bss.<name>
+ * sections that crt0 does NOT zero across MCLR / IPE flash (retained RAM, #409),
+ * so without this an un-crashed boot could read stale metadata (e.g. a non-zero
+ * gCrashReason). Call pre-scheduler alongside the other #409 retained-RAM
+ * scrubs. See #552. */
+void CrashCapture_Init( void )
+{
+    gCrashReason      = 0U;
+    gCrashExcCode     = 0U;
+    gCrashExcAddr     = 0U;
+    gCrashTaskHandle  = 0U;
+    gCrashTaskName[0] = '\0';
 }
 
 

--- a/firmware/src/config/default/freertos_hooks.c
+++ b/firmware/src/config/default/freertos_hooks.c
@@ -75,6 +75,7 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
     * and no vsnprintf/LOG_E (that printf frame is itself what overflows). */
    gCrashReason     = 1U;
    gCrashTaskHandle = (uint32_t) xTask;
+   gCrashTaskName[0] = '\0';   /* fresh per-crash; a NULL name can't leave stale data */
    if ( pcTaskName != NULL )
    {
        unsigned int i;

--- a/firmware/src/config/default/freertos_hooks.c
+++ b/firmware/src/config/default/freertos_hooks.c
@@ -50,6 +50,7 @@ void vAssertCalled( const char * pcFile, unsigned long ulLine );
 extern volatile uint32_t gCrashReason;
 extern volatile uint32_t gCrashTaskHandle;
 extern volatile char     gCrashTaskName[];
+extern void CrashCapture_CopyName( const char * nm );  /* bounds-checked, in exceptions.c */
 
 /*
 *********************************************************************************************************
@@ -75,24 +76,11 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
     * and no vsnprintf/LOG_E (that printf frame is itself what overflows). */
    gCrashReason     = 1U;
    gCrashTaskHandle = (uint32_t) xTask;
-   gCrashTaskName[0] = '\0';   /* fresh per-crash; a NULL name can't leave stale data */
-   if ( pcTaskName != NULL )
-   {
-       unsigned int i;
-       /* Task names are <= configMAX_TASK_NAME_LEN (16) incl. null; gCrashTaskName
-        * is 20 bytes, so this never overruns. */
-       for ( i = 0U; i < configMAX_TASK_NAME_LEN; i++ )
-       {
-           char c = pcTaskName[i];
-           if ( c == '\0' ) { break; }
-           /* Keep it printable — the name field may be garbage if the overflow
-            * clobbered it (matches CrashCapture_CopyName in exceptions.c). */
-           gCrashTaskName[i] = ( ( c >= 0x20 ) && ( c <= 0x7E ) ) ? c : '?';
-       }
-       gCrashTaskName[i] = '\0';
-   }
+   gCrashTaskName[0] = '\0';   /* fresh per-crash; a NULL/bad name can't leave stale data */
+   /* Shared hardened copy — bounds-checks every byte and filters non-printables,
+    * so a name field clobbered by the overflow can't nested-fault or mislead. */
+   CrashCapture_CopyName( pcTaskName );
 
-   ( void ) pcTaskName;
    ( void ) xTask;
 
    /* Run time task stack overflow checking is performed if

--- a/firmware/src/config/default/freertos_hooks.c
+++ b/firmware/src/config/default/freertos_hooks.c
@@ -84,7 +84,9 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
        {
            char c = pcTaskName[i];
            if ( c == '\0' ) { break; }
-           gCrashTaskName[i] = c;
+           /* Keep it printable — the name field may be garbage if the overflow
+            * clobbered it (matches CrashCapture_CopyName in exceptions.c). */
+           gCrashTaskName[i] = ( ( c >= 0x20 ) && ( c <= 0x7E ) ) ? c : '?';
        }
        gCrashTaskName[i] = '\0';
    }

--- a/firmware/src/config/default/freertos_hooks.c
+++ b/firmware/src/config/default/freertos_hooks.c
@@ -44,6 +44,13 @@ void vApplicationIdleHook( void );
 void vApplicationTickHook( void );
 void vAssertCalled( const char * pcFile, unsigned long ulLine );
 
+/* #552 crash capture — shared globals defined in exceptions.c. Written here so
+ * the guard-caught (configCHECK_FOR_STACK_OVERFLOW == 2) overflow names its
+ * culprit into fixed BSS (not the dying task's stack) for mdb / Logger dump. */
+extern volatile uint32_t gCrashReason;
+extern volatile uint32_t gCrashTaskHandle;
+extern volatile char     gCrashTaskName[];
+
 /*
 *********************************************************************************************************
 *                                          vApplicationStackOverflowHook()
@@ -61,6 +68,27 @@ void vAssertCalled( const char * pcFile, unsigned long ulLine );
 */
 void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
 {
+   /* #552: record the culprit BEFORE disabling interrupts / spinning, into
+    * fixed globals (not this task's overflowed stack) so it is diagnosable via
+    * mdb (`print gCrashTaskName`) or a Logger dump without a live repro.
+    * FreeRTOS hands us the name and handle directly here — no TCB deref needed,
+    * and no vsnprintf/LOG_E (that printf frame is itself what overflows). */
+   gCrashReason     = 1U;
+   gCrashTaskHandle = (uint32_t) xTask;
+   if ( pcTaskName != NULL )
+   {
+       unsigned int i;
+       /* Task names are <= configMAX_TASK_NAME_LEN (16) incl. null; gCrashTaskName
+        * is 20 bytes, so this never overruns. */
+       for ( i = 0U; i < configMAX_TASK_NAME_LEN; i++ )
+       {
+           char c = pcTaskName[i];
+           if ( c == '\0' ) { break; }
+           gCrashTaskName[i] = c;
+       }
+       gCrashTaskName[i] = '\0';
+   }
+
    ( void ) pcTaskName;
    ( void ) xTask;
 


### PR DESCRIPTION
## What

Defense-in-depth **crash observability**: capture the offending task's name +
exception context into fixed BSS globals at both crash entry points, so a task
stack overflow (or any general exception) is diagnosable in one mdb read instead
of a multi-step forensic scan.

Globals (in `exceptions.c`): `gCrashReason`, `gCrashExcCode`, `gCrashExcAddr`,
`gCrashTaskHandle`, `gCrashTaskName[20]`.

- **`vApplicationStackOverflowHook`** (`freertos_hooks.c`) — the guard-caught case
  (`configCHECK_FOR_STACK_OVERFLOW == 2`). FreeRTOS passes the name + handle
  directly, copied with no TCB deref and **no `vsnprintf`** (that printf frame is
  itself what overflows small stacks — cf. #525).
- **`_general_exception_handler`** (`exceptions.c`) — the TLBL-escape variant that
  faults inside the FreeRTOS context-switch restore and **never reaches the hook**
  (this is #552's signature). Captures ExcCode + EPC + current TCB, plus a
  best-effort task name via `xTaskGetCurrentTaskHandle()` / `pcTaskGetName()`,
  guarded by an on-chip-RAM bounds check so a corrupt pointer can't nest-fault.

## Why

Root-causing #552 required a forensic mdb `0xa5`-fill scan + TCB walk to name the
overflowing task, precisely because both handlers discarded all context. With this
change, `print gCrashTaskName` names the offender immediately.

**#552 itself does not reproduce on v3.6.2** — it was filed against pre-#551
firmware and the #551/#525/#557 EOS-task `vsnprintf` removal + stack bump removed
the mechanism (101-event bench characterization posted on the issue). This PR is
observability hardening for the whole stack-overflow class, not the #552 fix.

## Validation

- Builds clean at `-O3 -Werror -Wall` (XC32 v4.60).
- Bench (primary NQ1 `7E2898…E8A7`, freshly flashed): boots + streams; **6/6**
  over-ceiling USB-CSV stop trials clean (43k dropped samples @ 22 kHz), stack
  high-water healthy — no `.bss`-layout regression (cf. #406/#271).
- Inert in normal operation (globals written only on a crash).

Refs #552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
