### PR TITLE
perf(clock): bump SYSCLK 200→252 MHz, peripheral buses to 84 MHz (#487)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -732,7 +732,7 @@ The firmware supports building for different board variants using MPLAB X config
 
 ### MCU Reference: PIC32MZ2048EFM144
 
-**Architecture**: MIPS32 M-Class (microAptiv), 200 MHz, 32-bit data bus
+**Architecture**: MIPS32 M-Class (microAptiv), 252 MHz (chip-rated max, DS60001320H §39; raised from 200 MHz in #487), 32-bit data bus
 **Flash**: 2MB | **RAM**: 512KB | **L1 Cache**: 16KB I-cache + 4KB D-cache
 **Package**: 144-pin LQFP
 **Datasheet**: [DS60001320](https://www.microchip.com/en-us/product/PIC32MZ2048EFM144)
@@ -757,18 +757,21 @@ The firmware supports building for different board variants using MPLAB X config
 - **No hardware cache coherency** — software must invalidate/flush cache around DMA transfers. Harmony drivers handle this for SPI, USB, etc.
 - **Coherent attribute** (`__attribute__((coherent, aligned(16)))`) maps buffers to uncached address space — simplest solution for DMA buffers.
 
-#### Clock Tree (as configured)
+#### Clock Tree (as configured — #487, 2026-07-01)
 
 | Clock | Source | Frequency | Peripherals |
 |-------|--------|-----------|-------------|
-| SYSCLK | SPLL (24MHz POSC × 50 / 3 / 2) | 200 MHz | CPU, REFCLK |
-| PBCLK1 | SYSCLK/2 | 100 MHz | Watchdog |
-| PBCLK2 | SYSCLK/2 | 100 MHz | I2C, UART, SPI (default) |
-| PBCLK3 | SYSCLK/2 | 100 MHz | Timers, OC, IC |
-| PBCLK5 | SYSCLK/2 | 100 MHz | Flash, Crypto, USB |
-| REFCLK1 | SYSCLK (passthrough) | 200 MHz | SPI4 master clock (MCLKSEL=1) |
+| SYSCLK | SPLL (24MHz POSC / 3 × 63 / 2) | 252 MHz | CPU, core timer (÷2 = 126 MHz) |
+| PBCLK1 | SYSCLK/3 | 84 MHz | Watchdog |
+| PBCLK2 | SYSCLK/3 | 84 MHz | I2C, UART, SPI2/4/6 |
+| PBCLK3 | SYSCLK/3 | 84 MHz | Timers (FreeRTOS tick T1, streaming TMR4/5), OC, IC, ADC control clock |
+| PBCLK5 | SYSCLK/3 | 84 MHz | Flash, Crypto, USB regs |
 
-SPI4 BRG formula with REFCLK1: `SPI_CLK = 200MHz / (2 × (BRG + 1))`
+The PBxDIV /3 writes live in `SystemInit`/`initialization.c` (Harmony's `CLK_Initialize` only sets PMD, so without them the buses run at the reset-default /2 — which would be 126 MHz, over the 100 MHz bus spec). Single defines that must track the clock tree: `TIMER_CLOCK_FRQ` (TimerApi.h), `configPERIPHERAL_CLOCK_HZ` (FreeRTOSConfig.h), `CORE_TIMER_FREQUENCY` (plib_coretimer.h), `SYS_TIME_CPU_CLOCK_FREQUENCY` (configuration.h), `USE_FREQ_CONFIGURED_IN_CLOCK_MANAGER` (drv_spi_local.h).
+
+**SPI4 (SD + WINC) is clocked from PBCLK2, not REFCLK1** — `MCLKSEL=0` in `plib_spi4_master.c`, and no `REFO1CON` configuration exists anywhere in the tree (the pre-#487 revision of this table claiming "REFCLK1 passthrough, MCLKSEL=1" was stale: the measured 16.67 MHz SPI4 clock matched PBCLK2=100/BRG=2 exactly, not REFCLK1=200). SPI4 BRG formula: `SPI_CLK = 84MHz / (2 × (BRG + 1))` — SDSPI's 20 MHz request now rounds to 21 MHz (BRG=1); at the old 100 MHz PBCLK2 it rounded to 16.67 MHz (BRG=2).
+
+> **⚠️ Throughput tables below pre-date #487.** All characterization numbers in this file (Session-24 soaks, fit basis, enforced caps) were measured at 200 MHz/100 MHz. The enforced caps are unchanged by #487 — the device only got faster, so they remain safe (just more conservative). Re-fitting at 252 MHz is follow-up work.
 
 #### Hardware FPU
 
@@ -821,7 +824,7 @@ All items verified against the actual errata document. Only issues affecting fea
 
 | Issue | Module | Rev | Summary | Our Status |
 |-------|--------|-----|---------|------------|
-| #1 | Oscillator | All | **REFCLK cannot divide inputs >100 MHz.** | **Safe.** Errata workaround: "do not divide the SYSCLK and allow the destination peripheral (SPI) to divide it. Set RODIV and ROTRIM to 0." This is exactly our PR #219 approach (RODIV=0 passthrough). |
+| #1 | Oscillator | All | **REFCLK cannot divide inputs >100 MHz.** | **Safe.** REFCLK1 is not configured/used in the current tree at all (SPI4 rides PBCLK2, MCLKSEL=0 — see Clock Tree above); the erratum cannot apply. (Historical: PR #219's RODIV=0 passthrough followed the documented workaround while REFCLK1 was in use.) |
 | #5 | Power-Saving | A1/A3 | Turning off REFCLK via PMD bits causes unpredictable behavior. | **Safe.** We never disable REFCLK via PMD. Not affected on B2/B3. |
 | #6 | I2C | A1/A3 | Indeterminate I2C at >100 kHz and/or >500 bytes continuous. False collision detect, receive overflow, suspended transactions. All recoverable in software. | **Monitor.** I2C5 for BQ24297 at 100 kHz with mutex. Not affected on B2/B3 but good to know. |
 | #8 | UART | All | **RX FIFO overflow → shift registers stop → UART loses sync.** Only recovery: toggle UART OFF/ON multiple times. | **Low risk.** Debug UART4 only. Workaround: ensure UART interrupt priority prevents RX overrun, or set URXISEL for earlier interrupt. |
@@ -830,7 +833,7 @@ All items verified against the actual errata document. Only issues affecting fea
 | #25/#26 | Crypto | All | Crypto DMA: no partial packets, no zero-length hash. | **N/A.** wolfSSL runs in software mode. |
 | #27 | SPI | All | **SRMT bit falsely indicates TX complete** before last block shifts out. Does NOT affect Transmit Buffer Empty Interrupt (STXISEL=0). | **Safe.** Harmony SPI driver uses interrupts, not SRMT polling. |
 | #37 | I2C | All | **SCL tLOW doesn't meet I2C spec at ≥400 kHz.** No workaround. | **Safe.** BQ24297 I2C at 100 kHz. Never use ≥400 kHz on this chip. |
-| #38 | System Bus | B2/B3 | **Flash wait states at SYSCLK >184 MHz with ECC need 3 wait states** (not 2). <2% CPU impact with cache. | **Safe.** Verified: `PRECONbits.PFMWS = 3` and `ECCCON = 3` in `initialization.c:645-646`. |
+| #38 | System Bus | B2/B3 | **Flash wait states at SYSCLK >184 MHz with ECC need 3 wait states** (not 2). <2% CPU impact with cache. | **Safe.** At 252 MHz (#487) we run `PRECONbits.PFMWS = 5` (set conservatively for bring-up; tune-down to the DS60001320H table value is a tracked follow-up) and `ECCCON = 3` in `initialization.c`. |
 | #39 | ADC | All | Excessive current through VREF- when external reference used and VREF- > AVss. | **Monitor.** Workaround: connect VREF- to AVss. Check NQ3 board schematic. |
 | #40 | USB | All | FLUSH bit (USBIENCSRx<19>) doesn't flush TX FIFO properly. | **Safe.** Harmony USB driver: set FLUSH + clear TXPKTRDY simultaneously, repeat twice. |
 | #42 | DMA | All | **DMA half-full interrupt can fire twice** when cleared at n/2 byte, re-triggers at (n/2)+1. | **Safe.** Workaround: clear CHDHIF along with CHBCIF. Harmony DMA driver handles this. |

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -373,7 +373,7 @@ void MC12b_RestoreIdleScanList(void) {
  * cap can min() with it directly: the additive model intentionally replaces the
  * EOS-rate/event-rate terms (re-tested non-fatal on v3.6.1, #557) but NOT this
  * one, which must scale with the live SAMC/TAD config. All terms read live:
- *   TAD7 = 2 x ADCDIV x TQ;  TQ = (CONCLKDIV+1) x 10ns (PBCLK3 100MHz).
+ *   TAD7 = 2 x ADCDIV x TQ;  TQ = (CONCLKDIV+1) x TCLK, TCLK = 1000/84 ns (PBCLK3 84MHz, #487).
  *   T_busy = N x (SAMC + 16) x TAD7 + ~6us;  cap = 1 / (T_busy x 1.1).
  * Returns 0xFFFFFFFF when no scan is armed (no bound). */
 uint32_t MC12b_HardwareScanMaxFreq(uint32_t nActive) {
@@ -382,7 +382,9 @@ uint32_t MC12b_HardwareScanMaxFreq(uint32_t nActive) {
     uint32_t adcdiv    = ADCCON2 & 0x7Fu;
     if (adcdiv == 0u) adcdiv = 1u;          // 0 is reserved — defensive
     uint32_t samc      = (ADCCON2 >> 16) & 0x3FFu;
-    uint32_t tadNs     = 2u * adcdiv * (conclkdiv + 1u) * 10u;
+    /* #487: TCLK = 1/PBCLK3.  PBCLK3 = 84 MHz at 252 MHz SYSCLK (/3), so
+     * TCLK = 1000/84 ns ~= 11.9 ns (was 10 ns at the old 100 MHz PBCLK3). */
+    uint32_t tadNs     = (2u * adcdiv * (conclkdiv + 1u) * 1000u) / 84u;
     uint64_t busyNs    = (uint64_t)nActive * (samc + 16u) * tadNs + 6000u;
     uint64_t minPeriodNs = (busyNs * 11u) / 10u;   // +10% margin
     uint32_t hz = (uint32_t)(1000000000ULL / minPeriodNs);

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -7,6 +7,7 @@
 #include "../DIO.h"
 #include "configuration.h"
 #include "definitions.h"
+#include "clock_config.h"   /* #487: DAQIFI_PBCLK_MHZ for ADC TCLK */
 #include "state/data/BoardData.h"
 #include "state/board/BoardConfig.h"
 #include "state/runtime/BoardRuntimeConfig.h"
@@ -382,9 +383,10 @@ uint32_t MC12b_HardwareScanMaxFreq(uint32_t nActive) {
     uint32_t adcdiv    = ADCCON2 & 0x7Fu;
     if (adcdiv == 0u) adcdiv = 1u;          // 0 is reserved — defensive
     uint32_t samc      = (ADCCON2 >> 16) & 0x3FFu;
-    /* #487: TCLK = 1/PBCLK3.  PBCLK3 = 84 MHz at 252 MHz SYSCLK (/3), so
-     * TCLK = 1000/84 ns ~= 11.9 ns (was 10 ns at the old 100 MHz PBCLK3). */
-    uint32_t tadNs     = (2u * adcdiv * (conclkdiv + 1u) * 1000u) / 84u;
+    /* #487: TCLK = 1/PBCLK3 (ADC control clock).  DAQIFI_PBCLK_MHZ from
+     * clock_config.h = 84 @252 MHz SYSCLK (TCLK ~11.9 ns) or 100 @200 MHz
+     * (TCLK 10 ns). tadNs = 2·ADCDIV·(CONCLKDIV+1)·TCLK, scaled ×1000 for ns. */
+    uint32_t tadNs     = (2u * adcdiv * (conclkdiv + 1u) * 1000u) / DAQIFI_PBCLK_MHZ;
     uint64_t busyNs    = (uint64_t)nActive * (samc + 16u) * tadNs + 6000u;
     uint64_t minPeriodNs = (busyNs * 11u) / 10u;   // +10% margin
     uint32_t hz = (uint32_t)(1000000000ULL / minPeriodNs);

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -385,8 +385,12 @@ uint32_t MC12b_HardwareScanMaxFreq(uint32_t nActive) {
     uint32_t samc      = (ADCCON2 >> 16) & 0x3FFu;
     /* #487: TCLK = 1/PBCLK3 (ADC control clock).  DAQIFI_PBCLK_MHZ from
      * clock_config.h = 84 @252 MHz SYSCLK (TCLK ~11.9 ns) or 100 @200 MHz
-     * (TCLK 10 ns). tadNs = 2·ADCDIV·(CONCLKDIV+1)·TCLK, scaled ×1000 for ns. */
-    uint32_t tadNs     = (2u * adcdiv * (conclkdiv + 1u) * 1000u) / DAQIFI_PBCLK_MHZ;
+     * (TCLK 10 ns). tadNs = 2·ADCDIV·(CONCLKDIV+1)·TCLK, scaled ×1000 for ns.
+     * Round the divide UP (ceil) so tadNs never under-estimates TAD — this is a
+     * safety bound, so an over-estimate of busy time (→ lower max freq) is the
+     * conservative direction. Qodo #584. */
+    uint32_t tadNumer  = 2u * adcdiv * (conclkdiv + 1u) * 1000u;
+    uint32_t tadNs     = (tadNumer + DAQIFI_PBCLK_MHZ - 1u) / DAQIFI_PBCLK_MHZ;
     uint64_t busyNs    = (uint64_t)nActive * (samc + 16u) * tadNs + 6000u;
     uint64_t minPeriodNs = (busyNs * 11u) / 10u;   // +10% margin
     uint32_t hz = (uint32_t)(1000000000ULL / minPeriodNs);

--- a/firmware/src/HAL/TimerApi/TimerApi.h
+++ b/firmware/src/HAL/TimerApi/TimerApi.h
@@ -26,7 +26,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#define TIMER_CLOCK_FRQ 100000000
+#define TIMER_CLOCK_FRQ 84000000  /* #487: PBCLK3 /3 @ 252 MHz SYSCLK (was 100 MHz). Governs streaming-timer period + CSV/JSON/PB timestamp rates. */
 
 typedef enum {
     TMR_INDEX_2 = 2,

--- a/firmware/src/HAL/TimerApi/TimerApi.h
+++ b/firmware/src/HAL/TimerApi/TimerApi.h
@@ -26,7 +26,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#define TIMER_CLOCK_FRQ 84000000  /* #487: PBCLK3 /3 @ 252 MHz SYSCLK (was 100 MHz). Governs streaming-timer period + CSV/JSON/PB timestamp rates. */
+#include "clock_config.h"
+#define TIMER_CLOCK_FRQ DAQIFI_PBCLK_HZ  /* #487: PBCLK3 (84 MHz @252 / 100 @200 via clock_config.h). Governs streaming-timer period + CSV/JSON/PB timestamps. */
 
 typedef enum {
     TMR_INDEX_2 = 2,

--- a/firmware/src/Util/Logger.c
+++ b/firmware/src/Util/Logger.c
@@ -229,9 +229,9 @@ static void InitICSPLogging(void)
     U4MODE = 0x8;           // BRGH = 1 for high-speed mode
     U4STASET = (_U4STA_UTXEN_MASK | _U4STA_UTXISEL1_MASK);
 
-    /* BAUD Rate: 921600 bps @ 100MHz peripheral clock */
-    /* U4BRG = (PBCLK / (4 * BAUD)) - 1 = (100MHz / (4 * 921600)) - 1 = 26 */
-    U4BRG = 26;
+    /* BAUD Rate: 921600 bps @ 84 MHz peripheral clock (#487: PBCLK2 /3 at 252 MHz SYSCLK) */
+    /* U4BRG = (PBCLK / (4 * BAUD)) - 1 = (84MHz / (4 * 921600)) - 1 = 22 -> ~913 kbps (0.9% err) */
+    U4BRG = 22;
 
     /* Enable UART4 */
     U4MODESET = _U4MODE_ON_MASK;

--- a/firmware/src/Util/Logger.c
+++ b/firmware/src/Util/Logger.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include "clock_config.h"   /* #487: PBCLK2-derived UART4 BRG */
 #include <stdbool.h>
 #include <ctype.h>
 #include <xc.h>
@@ -229,9 +230,9 @@ static void InitICSPLogging(void)
     U4MODE = 0x8;           // BRGH = 1 for high-speed mode
     U4STASET = (_U4STA_UTXEN_MASK | _U4STA_UTXISEL1_MASK);
 
-    /* BAUD Rate: 921600 bps @ 84 MHz peripheral clock (#487: PBCLK2 /3 at 252 MHz SYSCLK) */
-    /* U4BRG = (PBCLK / (4 * BAUD)) - 1 = (84MHz / (4 * 921600)) - 1 = 22 -> ~913 kbps (0.9% err) */
-    U4BRG = 22;
+    /* BAUD Rate: 921600 bps, BRGH=1. #487: BRG derived from PBCLK2 via
+     * clock_config.h — 22 @84 MHz (~913 kbps, 0.9% err), 26 @100 MHz. */
+    U4BRG = DAQIFI_UART_BRGH_DIV(921600UL);
 
     /* Enable UART4 */
     U4MODESET = _U4MODE_ON_MASK;

--- a/firmware/src/config/default/FreeRTOSConfig.h
+++ b/firmware/src/config/default/FreeRTOSConfig.h
@@ -296,7 +296,8 @@
 /* Interrupt nesting behaviour configuration. *********************************/
 /******************************************************************************/
 
-#define configPERIPHERAL_CLOCK_HZ               ( 84000000UL )  /* #487: PBCLK3 /3 @ 252 MHz SYSCLK (was 100 MHz). Tick timer (T1) rides PBCLK3 — must match for a correct 1000 Hz tick. */
+#include "clock_config.h"
+#define configPERIPHERAL_CLOCK_HZ               ( DAQIFI_PBCLK_HZ )  /* #487: PBCLK3 via clock_config.h toggle. Tick timer (T1) rides PBCLK3 — must match for a correct 1000 Hz tick. */
 #define configISR_STACK_SIZE                    ( 8192 )
 /* configKERNEL_INTERRUPT_PRIORITY sets the priority of the tick and context
  * switch performing interrupts.  Not supported by all FreeRTOS ports.  See

--- a/firmware/src/config/default/FreeRTOSConfig.h
+++ b/firmware/src/config/default/FreeRTOSConfig.h
@@ -50,8 +50,11 @@
 /* Scheduling behaviour related definitions. **********************************/
 /******************************************************************************/
 
-/* configTICK_RATE_HZ sets frequency of the tick interrupt in Hz, normally
- * calculated from the configCPU_CLOCK_HZ value. */
+/* configTICK_RATE_HZ sets frequency of the tick interrupt in Hz.  This PIC32MZ
+ * port runs the tick on peripheral Timer 1 (PBCLK3), so the compare value is
+ * derived from configPERIPHERAL_CLOCK_HZ (below), not configCPU_CLOCK_HZ (which
+ * this port does not use).  SYSCLK is 252 MHz (#487); the CPU clock is not
+ * referenced by the RTOS tick. */
 #define configTICK_RATE_HZ                      ( ( TickType_t ) 1000 )
 
 /* Force list-item link fields (pxNext/pxPrevious/pxContainer/xItemValue) to
@@ -293,7 +296,7 @@
 /* Interrupt nesting behaviour configuration. *********************************/
 /******************************************************************************/
 
-#define configPERIPHERAL_CLOCK_HZ               ( 100000000UL )
+#define configPERIPHERAL_CLOCK_HZ               ( 84000000UL )  /* #487: PBCLK3 /3 @ 252 MHz SYSCLK (was 100 MHz). Tick timer (T1) rides PBCLK3 — must match for a correct 1000 Hz tick. */
 #define configISR_STACK_SIZE                    ( 8192 )
 /* configKERNEL_INTERRUPT_PRIORITY sets the priority of the tick and context
  * switch performing interrupts.  Not supported by all FreeRTOS ports.  See

--- a/firmware/src/config/default/clock_config.h
+++ b/firmware/src/config/default/clock_config.h
@@ -1,0 +1,54 @@
+/*******************************************************************************
+  DAQiFi clock configuration — single 200/252 MHz toggle (#487)
+
+  Flip DAQIFI_SYSCLK_252 and rebuild to move the whole device between the
+  252 MHz (chip-rated max, DS60001320H §39) and the legacy 200 MHz operating
+  points. Every clock-derived constant is computed here so there is exactly
+  one place to change; the scattered consumers reference these macros:
+
+    - config/default/initialization.c   PLL config bits (#if), PBxDIV, PFMWS
+    - HAL/TimerApi/TimerApi.h            TIMER_CLOCK_FRQ  (streaming timer + timestamps)
+    - config/default/FreeRTOSConfig.h    configPERIPHERAL_CLOCK_HZ (tick on PBCLK3)
+    - config/default/peripheral/coretimer/plib_coretimer.h  CORE_TIMER_FREQUENCY
+    - config/default/configuration.h     SYS_TIME_CPU_CLOCK_FREQUENCY
+    - config/default/definitions.h       CPU_CLOCK_FREQUENCY (informational)
+    - HAL/ADC/MC12bADC.c                 ADC scan-busy TCLK (#539 cap)
+    - config/default/driver/spi/src/drv_spi_local.h  SPI4 (SD+WINC) source clock
+    - config/default/peripheral/i2c/master/plib_i2c5_master.c  I2C5 BRG (BQ24297)
+    - Util/Logger.c                      UART4 (ICSP debug) BRG
+
+  Header is preprocessor-only (safe to include from C and .S).
+
+  NOTE (#487): the FPLLMULT config-bit pragma cannot take a macro value, so
+  initialization.c selects it with `#if DAQIFI_SYSCLK_252` directly rather than
+  a DAQIFI_FPLLMULT token. Keep that #if in sync with this toggle.
+*******************************************************************************/
+#ifndef CLOCK_CONFIG_H
+#define CLOCK_CONFIG_H
+
+/* 1 = 252 MHz (chip-rated max, #487) · 0 = 200 MHz (legacy revert path) */
+#define DAQIFI_SYSCLK_252   1
+
+#if DAQIFI_SYSCLK_252
+  #define DAQIFI_SYSCLK_HZ   252000000UL   /* SPLL: 24 MHz POSC /3 x63 /2 */
+  #define DAQIFI_PBCLK_HZ     84000000UL   /* peripheral buses at PBxDIV /3 */
+  #define DAQIFI_PBCLK_MHZ           84u    /* = DAQIFI_PBCLK_HZ / 1e6 */
+  #define DAQIFI_PBDIV                2u    /* PBxDIVbits.PBDIV = divisor-1 → /3 */
+  #define DAQIFI_PFMWS                5u    /* flash wait states (bring-up conservative; datasheet tune-down pending) */
+#else
+  #define DAQIFI_SYSCLK_HZ   200000000UL   /* SPLL: 24 MHz POSC /3 x50 /2 */
+  #define DAQIFI_PBCLK_HZ    100000000UL   /* peripheral buses at PBxDIV /2 */
+  #define DAQIFI_PBCLK_MHZ          100u
+  #define DAQIFI_PBDIV                1u    /* → /2 */
+  #define DAQIFI_PFMWS                3u    /* errata #38: >184 MHz w/ ECC needs 3 */
+#endif
+
+/* MIPS M-class core timer (CP0 Count) increments at SYSCLK/2. */
+#define DAQIFI_CORE_TIMER_HZ   (DAQIFI_SYSCLK_HZ / 2UL)
+
+/* UARTx BRG for a target baud in BRGH=1 (high-speed) mode: PBCLK/(4·baud) - 1,
+ * rounded to nearest (add half-divisor before the integer divide). */
+#define DAQIFI_UART_BRGH_DIV(baud)  \
+    (((DAQIFI_PBCLK_HZ + (2UL * (baud))) / (4UL * (baud))) - 1UL)
+
+#endif /* CLOCK_CONFIG_H */

--- a/firmware/src/config/default/configuration.h
+++ b/firmware/src/config/default/configuration.h
@@ -85,7 +85,8 @@ extern "C" {
 #define SYS_TIME_HW_COUNTER_WIDTH                   (32)
 #define SYS_TIME_HW_COUNTER_PERIOD                  (4294967295U)
 #define SYS_TIME_HW_COUNTER_HALF_PERIOD             (SYS_TIME_HW_COUNTER_PERIOD>>1)
-#define SYS_TIME_CPU_CLOCK_FREQUENCY                (252000000)  /* #487: SYSCLK 252 MHz (was 200) */
+#include "clock_config.h"
+#define SYS_TIME_CPU_CLOCK_FREQUENCY                (DAQIFI_SYSCLK_HZ)  /* #487: SYSCLK via clock_config.h toggle (252/200) */
 #define SYS_TIME_COMPARE_UPDATE_EXECUTION_CYCLES    (620)
 
 

--- a/firmware/src/config/default/configuration.h
+++ b/firmware/src/config/default/configuration.h
@@ -85,7 +85,7 @@ extern "C" {
 #define SYS_TIME_HW_COUNTER_WIDTH                   (32)
 #define SYS_TIME_HW_COUNTER_PERIOD                  (4294967295U)
 #define SYS_TIME_HW_COUNTER_HALF_PERIOD             (SYS_TIME_HW_COUNTER_PERIOD>>1)
-#define SYS_TIME_CPU_CLOCK_FREQUENCY                (200000000)
+#define SYS_TIME_CPU_CLOCK_FREQUENCY                (252000000)  /* #487: SYSCLK 252 MHz (was 200) */
 #define SYS_TIME_COMPARE_UPDATE_EXECUTION_CYCLES    (620)
 
 

--- a/firmware/src/config/default/definitions.h
+++ b/firmware/src/config/default/definitions.h
@@ -117,7 +117,7 @@ extern "C" {
 #define DEVICE_SERIES        "PIC32MZ"
 
 /* CPU clock frequency */
-#define CPU_CLOCK_FREQUENCY 200000000U
+#define CPU_CLOCK_FREQUENCY 252000000U  /* #487: SYSCLK 252 MHz (was 200). Informational — not referenced functionally. */
 
 // *****************************************************************************
 // *****************************************************************************

--- a/firmware/src/config/default/definitions.h
+++ b/firmware/src/config/default/definitions.h
@@ -48,6 +48,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include "clock_config.h"   /* #487: single 200/252 MHz toggle */
 #include "crypto/crypto.h"
 #include "peripheral/ocmp/plib_ocmp8.h"
 #include "peripheral/ocmp/plib_ocmp6.h"
@@ -116,8 +117,8 @@ extern "C" {
 #define DEVICE_FAMILY        "PIC32MZEF"
 #define DEVICE_SERIES        "PIC32MZ"
 
-/* CPU clock frequency */
-#define CPU_CLOCK_FREQUENCY 252000000U  /* #487: SYSCLK 252 MHz (was 200). Informational — not referenced functionally. */
+/* CPU clock frequency (informational — not referenced functionally) */
+#define CPU_CLOCK_FREQUENCY DAQIFI_SYSCLK_HZ  /* #487: via clock_config.h toggle (252/200) */
 
 // *****************************************************************************
 // *****************************************************************************

--- a/firmware/src/config/default/driver/spi/src/drv_spi_local.h
+++ b/firmware/src/config/default/driver/spi/src/drv_spi_local.h
@@ -65,10 +65,12 @@
 #define DRV_SPI_TOKEN_MAX                       (0xFFFFU)
 
 
-/* #487: SPI4 (SD + WINC), SPI2/6 ride PBCLK2, now 84 MHz (was 100 MHz) at 252 MHz
- * SYSCLK. Was (0) = "use PLIB fallback", whose fallback is hardcoded 100 MHz —
- * which would compute BRG against the wrong source clock. Pass 84 MHz explicitly. */
-#define USE_FREQ_CONFIGURED_IN_CLOCK_MANAGER    (84000000)
+/* #487: SPI4 (SD + WINC) and SPI2/6 ride PBCLK2 (84 MHz @252 / 100 @200 via
+ * clock_config.h). Was (0) = "use PLIB fallback", whose fallback is hardcoded
+ * 100 MHz — would compute BRG against the wrong source clock at 252. Pass the
+ * real PBCLK explicitly. */
+#include "clock_config.h"
+#define USE_FREQ_CONFIGURED_IN_CLOCK_MANAGER    (DAQIFI_PBCLK_HZ)
 #define NULL_INDEX                              (0xFF)
 
 // *****************************************************************************

--- a/firmware/src/config/default/driver/spi/src/drv_spi_local.h
+++ b/firmware/src/config/default/driver/spi/src/drv_spi_local.h
@@ -65,7 +65,10 @@
 #define DRV_SPI_TOKEN_MAX                       (0xFFFFU)
 
 
-#define USE_FREQ_CONFIGURED_IN_CLOCK_MANAGER    (0)
+/* #487: SPI4 (SD + WINC), SPI2/6 ride PBCLK2, now 84 MHz (was 100 MHz) at 252 MHz
+ * SYSCLK. Was (0) = "use PLIB fallback", whose fallback is hardcoded 100 MHz —
+ * which would compute BRG against the wrong source clock. Pass 84 MHz explicitly. */
+#define USE_FREQ_CONFIGURED_IN_CLOCK_MANAGER    (84000000)
 #define NULL_INDEX                              (0xFF)
 
 // *****************************************************************************

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -46,6 +46,7 @@
 #include "configuration.h"
 #include "definitions.h"
 #include "device.h"
+#include "clock_config.h"   /* #487: single 200/252 MHz toggle (DAQIFI_SYSCLK_*) */
 
 
 // ****************************************************************************
@@ -91,8 +92,15 @@
 #pragma config FPLLIDIV =   DIV_3
 #pragma config FPLLRNG =    RANGE_5_10_MHZ
 #pragma config FPLLICLK =   PLL_POSC
-#pragma config FPLLMULT =   MUL_63    // #487: 8 MHz PLL in x63 = 504 MHz VCO
-#pragma config FPLLODIV =   DIV_2      // 504 / 2 = 252 MHz SYSCLK (was MUL_50 -> 200 MHz)
+/* #487: FPLLMULT selects SYSCLK via the DAQIFI_SYSCLK_252 toggle in
+ * clock_config.h (pragma can't take a macro). 8 MHz PLL input (FPLLIDIV DIV_3),
+ * /2 output (FPLLODIV) are the same for both points; only the multiplier moves. */
+#if DAQIFI_SYSCLK_252
+#pragma config FPLLMULT =   MUL_63    // 8 MHz x63 = 504 MHz VCO / 2 = 252 MHz SYSCLK
+#else
+#pragma config FPLLMULT =   MUL_50    // 8 MHz x50 = 400 MHz VCO / 2 = 200 MHz SYSCLK
+#endif
+#pragma config FPLLODIV =   DIV_2
 #pragma config UPLLFSEL =   FREQ_24MHZ
 
 /*** DEVCFG3 ***/
@@ -649,11 +657,11 @@ void SYS_Initialize ( void* data )
     SYSKEY = 0x00000000U;
     SYSKEY = 0xAA996655U;
     SYSKEY = 0x556699AAU;
-    PB1DIVbits.PBDIV = 2;   /* system / INT controller / DMA        -> 84 MHz */
-    PB2DIVbits.PBDIV = 2;   /* I2C5, UART4, SPI2/4/6                 -> 84 MHz */
-    PB3DIVbits.PBDIV = 2;   /* timers (FreeRTOS tick, streaming), OC/IC, ADC ctrl -> 84 MHz */
-    PB4DIVbits.PBDIV = 2;   /* PORTx                                 -> 84 MHz */
-    PB5DIVbits.PBDIV = 2;   /* flash controller, crypto, USB regs    -> 84 MHz */
+    PB1DIVbits.PBDIV = DAQIFI_PBDIV;   /* system / INT controller / DMA */
+    PB2DIVbits.PBDIV = DAQIFI_PBDIV;   /* I2C5, UART4, SPI2/4/6 */
+    PB3DIVbits.PBDIV = DAQIFI_PBDIV;   /* timers (FreeRTOS tick, streaming), OC/IC, ADC ctrl */
+    PB4DIVbits.PBDIV = DAQIFI_PBDIV;   /* PORTx */
+    PB5DIVbits.PBDIV = DAQIFI_PBDIV;   /* flash controller, crypto, USB regs */
     SYSKEY = 0x33333333U;
 
     /* Configure Prefetch, Wait States and ECC */
@@ -662,7 +670,7 @@ void SYS_Initialize ( void* data )
      * At 252 MHz set conservatively high (5) for the first bring-up so the CPU can
      * never fault on a flash read; extra wait states are hidden by prefetch + I-cache.
      * TODO(#487): tune down to the DS60001320H Table 7-1 / §39 value after boot-verify. */
-    PRECONbits.PFMWS = 5;
+    PRECONbits.PFMWS = DAQIFI_PFMWS;
     CFGCONbits.ECCCON = 3;
 
 

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -91,8 +91,8 @@
 #pragma config FPLLIDIV =   DIV_3
 #pragma config FPLLRNG =    RANGE_5_10_MHZ
 #pragma config FPLLICLK =   PLL_POSC
-#pragma config FPLLMULT =   MUL_50
-#pragma config FPLLODIV =   DIV_2
+#pragma config FPLLMULT =   MUL_63    // #487: 8 MHz PLL in x63 = 504 MHz VCO
+#pragma config FPLLODIV =   DIV_2      // 504 / 2 = 252 MHz SYSCLK (was MUL_50 -> 200 MHz)
 #pragma config UPLLFSEL =   FREQ_24MHZ
 
 /*** DEVCFG3 ***/
@@ -640,9 +640,29 @@ void SYS_Initialize ( void* data )
 
   
     CLK_Initialize();
+
+    /* #487: PBCLK divider /2 -> /3.  At 252 MHz SYSCLK the reset-default /2
+     * puts every peripheral bus at 126 MHz, over the 100 MHz spec.  /3 = 84 MHz.
+     * Harmony CLK_Initialize() only sets PMD, not PBxDIV, so these run at the
+     * reset default /2 unless set here.  PB7 (CPU) is left at its /1 default so
+     * the core runs at the full 252 MHz.  PBxDIV writes need the system unlock. */
+    SYSKEY = 0x00000000U;
+    SYSKEY = 0xAA996655U;
+    SYSKEY = 0x556699AAU;
+    PB1DIVbits.PBDIV = 2;   /* system / INT controller / DMA        -> 84 MHz */
+    PB2DIVbits.PBDIV = 2;   /* I2C5, UART4, SPI2/4/6                 -> 84 MHz */
+    PB3DIVbits.PBDIV = 2;   /* timers (FreeRTOS tick, streaming), OC/IC, ADC ctrl -> 84 MHz */
+    PB4DIVbits.PBDIV = 2;   /* PORTx                                 -> 84 MHz */
+    PB5DIVbits.PBDIV = 2;   /* flash controller, crypto, USB regs    -> 84 MHz */
+    SYSKEY = 0x33333333U;
+
     /* Configure Prefetch, Wait States and ECC */
     PRECONbits.PREFEN = 3;
-    PRECONbits.PFMWS = 3;
+    /* #487: flash wait states.  At 200 MHz this was 3 (errata #38: >184 MHz w/ ECC).
+     * At 252 MHz set conservatively high (5) for the first bring-up so the CPU can
+     * never fault on a flash read; extra wait states are hidden by prefetch + I-cache.
+     * TODO(#487): tune down to the DS60001320H Table 7-1 / §39 value after boot-verify. */
+    PRECONbits.PFMWS = 5;
     CFGCONbits.ECCCON = 3;
 
 

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -653,7 +653,17 @@ void SYS_Initialize ( void* data )
      * puts every peripheral bus at 126 MHz, over the 100 MHz spec.  /3 = 84 MHz.
      * Harmony CLK_Initialize() only sets PMD, not PBxDIV, so these run at the
      * reset default /2 unless set here.  PB7 (CPU) is left at its /1 default so
-     * the core runs at the full 252 MHz.  PBxDIV writes need the system unlock. */
+     * the core runs at the full 252 MHz.  PBxDIV writes need the system unlock.
+     *
+     * KNOWN transient (Qodo #584, accepted): between reset and this point the
+     * buses run at the /2 default = 126 MHz during crt0 (.data copy / .bss zero,
+     * ~sub-ms). Accepted, not fixed: the only peripheral clocked during crt0 is
+     * flash (PBCLK5), whose access timing is governed by PFMWS in SYSCLK cycles
+     * (reset default = max 7 = most tolerant), and no I2C/SPI/UART/timer/ADC is
+     * running yet. Empirically boots + runs clean. The spec-clean fix (set PBxDIV
+     * in an XC32 _on_reset() hook before crt0) is deferred: it adds a new boot
+     * path element (brick risk) disproportionate to a bounded, benign transient.
+     * If revisited, keep these writes as the fallback. */
     SYSKEY = 0x00000000U;
     SYSKEY = 0xAA996655U;
     SYSKEY = 0x556699AAU;

--- a/firmware/src/config/default/peripheral/coretimer/plib_coretimer.h
+++ b/firmware/src/config/default/peripheral/coretimer/plib_coretimer.h
@@ -47,7 +47,8 @@
     extern "C" {
 #endif
 
-#define CORE_TIMER_FREQUENCY    (126000000U)  /* #487: SYSCLK/2 at 252 MHz (was 100M @ 200 MHz). SYS_TIME divides ms by this. */
+#include "clock_config.h"
+#define CORE_TIMER_FREQUENCY    (DAQIFI_CORE_TIMER_HZ)  /* #487: SYSCLK/2 via clock_config.h (126M @252 / 100M @200). SYS_TIME divides ms by this. */
 
 
 typedef void (*CORETIMER_CALLBACK)(uint32_t status, uintptr_t context);

--- a/firmware/src/config/default/peripheral/coretimer/plib_coretimer.h
+++ b/firmware/src/config/default/peripheral/coretimer/plib_coretimer.h
@@ -47,7 +47,7 @@
     extern "C" {
 #endif
 
-#define CORE_TIMER_FREQUENCY    (100000000U)
+#define CORE_TIMER_FREQUENCY    (126000000U)  /* #487: SYSCLK/2 at 252 MHz (was 100M @ 200 MHz). SYS_TIME divides ms by this. */
 
 
 typedef void (*CORETIMER_CALLBACK)(uint32_t status, uintptr_t context);

--- a/firmware/src/config/default/peripheral/i2c/master/plib_i2c5_master.c
+++ b/firmware/src/config/default/peripheral/i2c/master/plib_i2c5_master.c
@@ -72,7 +72,7 @@ void I2C5_Initialize(void)
     /* Disable the I2C Bus collision interrupt */
     IEC5CLR = _IEC5_I2C5BIE_MASK;
 
-    I2C5BRG = 992;
+    I2C5BRG = 833;   /* #487: PBCLK2 84 MHz (was 100 MHz -> 992) to hold the same I2C bus speed */
 
     I2C5CONCLR = _I2C5CON_SIDL_MASK;
     I2C5CONCLR = _I2C5CON_DISSLW_MASK;
@@ -542,7 +542,7 @@ bool I2C5_TransferSetup(I2C_TRANSFER_SETUP* setup, uint32_t srcClkFreq )
 
     if( srcClkFreq == 0U)
     {
-        srcClkFreq = 100000000UL;
+        srcClkFreq = 84000000UL;   /* #487: PBCLK2 84 MHz at 252 MHz SYSCLK (was 100 MHz) */
     }
 
     fBaudValue = (((float)srcClkFreq / 2.0f) * ((1.0f / (float)i2cClkSpeed) - 0.000000130f)) - 1.0f;

--- a/firmware/src/config/default/peripheral/i2c/master/plib_i2c5_master.c
+++ b/firmware/src/config/default/peripheral/i2c/master/plib_i2c5_master.c
@@ -51,6 +51,7 @@
 #include "device.h"
 #include "plib_i2c5_master.h"
 #include "interrupts.h"
+#include "clock_config.h"   /* #487: PBCLK2-derived I2C5 BRG (DAQIFI_SYSCLK_252 / DAQIFI_PBCLK_HZ) */
 
 
 // *****************************************************************************
@@ -72,7 +73,11 @@ void I2C5_Initialize(void)
     /* Disable the I2C Bus collision interrupt */
     IEC5CLR = _IEC5_I2C5BIE_MASK;
 
-    I2C5BRG = 833;   /* #487: PBCLK2 84 MHz (was 100 MHz -> 992) to hold the same I2C bus speed */
+#if DAQIFI_SYSCLK_252
+    I2C5BRG = 833;   /* #487: PBCLK2 84 MHz — same I2C bus speed as the 100 MHz/992 setting */
+#else
+    I2C5BRG = 992;   /* PBCLK2 100 MHz */
+#endif
 
     I2C5CONCLR = _I2C5CON_SIDL_MASK;
     I2C5CONCLR = _I2C5CON_DISSLW_MASK;
@@ -542,7 +547,7 @@ bool I2C5_TransferSetup(I2C_TRANSFER_SETUP* setup, uint32_t srcClkFreq )
 
     if( srcClkFreq == 0U)
     {
-        srcClkFreq = 84000000UL;   /* #487: PBCLK2 84 MHz at 252 MHz SYSCLK (was 100 MHz) */
+        srcClkFreq = DAQIFI_PBCLK_HZ;   /* #487: PBCLK2 via clock_config.h (84 @252 / 100 @200) */
     }
 
     fBaudValue = (((float)srcClkFreq / 2.0f) * ((1.0f / (float)i2cClkSpeed) - 0.000000130f)) - 1.0f;


### PR DESCRIPTION
## Summary

Raises SYSCLK from 200 MHz to the chip-rated **252 MHz** (DS60001320H §39) and moves the peripheral buses from the reset-default ÷2 to ÷3 (84 MHz) so they stay within the 100 MHz bus spec. Closes #487.

**Headline win (bench-measured, USB, 600 s soaks):** CPU/transport-bound paths scale nearly linearly with SYSCLK — **1×T1 PB 15,000→22,000 Hz (+47%), 5×T1 PB 12,000→19,000 Hz (+58%)**, soak-confirmed zero-loss.

## Changes (coordinated so every clock consumer stays correct)
- **PLL** (`initialization.c`): `FPLLMULT MUL_50→MUL_63` → 8 MHz ×63 / 2 = 252 MHz.
- **PBCLK ÷2→÷3** (`initialization.c`): add `PB1-5DIV=/3` (84 MHz) under SYSKEY — Harmony `CLK_Initialize` only sets PMD, so the dividers otherwise run at the reset ÷2 (= 126 MHz, over spec). PB7 (CPU) stays ÷1 = 252 MHz.
- **Flash wait states** `PFMWS 3→5` — conservative for bring-up (extra states hidden by prefetch + I-cache). Tune-down to the datasheet value is a tracked follow-up.
- **`TIMER_CLOCK_FRQ` 100→84 MHz** — streaming-timer period + CSV/JSON/PB timestamps rescale through this one define.
- **`configPERIPHERAL_CLOCK_HZ` 100→84 MHz** — FreeRTOS tick (Timer 1 on PBCLK3) stays exactly 1000 Hz. (`configCPU_CLOCK_HZ` is unused by this port — stale comment corrected.)
- **`CORE_TIMER_FREQUENCY` 100→126 MHz** (SYSCLK/2) — SYS_TIME / SD polling delays.
- **`SYS_TIME_CPU_CLOCK_FREQUENCY` 200→252 MHz**.
- **ADC scan-busy (#539) cap** (`MC12bADC.c`): TCLK 10 ns → 84 MHz-derived (1000/84 ns) so the FRM-documented scan-retrigger bound stays conservative-correct at the slower ADC clock.
- **SPI source clock** (`drv_spi_local.h`) 100→84 MHz — SD + WINC ride SPI4/PBCLK2 (`MCLKSEL=0`, **not** REFCLK1 — CLAUDE.md clock-tree corrected).
- **I2C5 BRG** + fallback 100→84 MHz (BQ24297); **UART4 debug BRG** 26→22.
- **CLAUDE.md**: clock tree, SPI4-source correction, errata #1/#38 notes, pre-#487 caveat on throughput tables.

## Validation (bench, board 7E2898F46200E8A7)
- ✅ Build clean at `-O3 -Werror` (only the known wolfSSL `tfm.c` warning).
- ✅ Boots at 252 MHz; `*IDN?` responsive; error queue clean; task stacks + heap healthy; full `CONF:CAP:JSON?`.
- ✅ DIO dir/state; BQ24297 I2C5 (`POW:STAT`); WINC SPI4 (`GETChipInfo` reads `ChipId 1377184` at 84 MHz).
- ✅ **Timing dimensionally correct:** 5 kHz ch4 CSV measured **4998.8 Hz** on a PC-clock window, zero loss (would read ~7500 Hz if PBDIV ÷3 hadn't applied).
- ✅ **USB PB ceiling + 600 s soak** (stale-aware): pure-T1 no-scan cells +47–58% soak-clean; scan-armed cells honestly bounded 4000–9000 Hz by the 84 MHz ADC clock (TAD 10→11.9 ns) — *below* 200 MHz, a real trade-off recoverable via CONCLKDIV/ADCDIV retune. Test-suite PR: daqifi/daqifi-python-test-suite#66.

## Not yet validated end-to-end (bench hardware, **not** clock-change blockers)
- **SD streaming:** SD interface enables and inits, but no card is currently detected on the bench (media-absent; WINC works on the same SPI4, so bus/clock are healthy). Pending a card reseat.
- **WiFi streaming:** WINC + SPI + STA config all verified at 84 MHz, but the bench AP (Tesla) won't associate — it's still on 2.4 GHz ch8 (WINC needs ch1, per #515). Pending an AP-side fix.

## Follow-ups
- Tune `PFMWS` 5 → the DS60001320H Table value for 252 MHz.
- Retune ADC `CONCLKDIV`/`ADCDIV` to recover TAD (and scan-armed throughput) at the 84 MHz PBCLK3.
- Run the SD + WiFi PB ceiling/soak legs once the bench hardware is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)