### PR TITLE
fix(wifi/sd): recover WINC flash-update bridge + shared SPI bus lock hygiene

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -732,7 +732,7 @@ The firmware supports building for different board variants using MPLAB X config
 
 ### MCU Reference: PIC32MZ2048EFM144
 
-**Architecture**: MIPS32 M-Class (microAptiv), 200 MHz, 32-bit data bus
+**Architecture**: MIPS32 M-Class (microAptiv), 252 MHz (chip-rated max, DS60001320H §39; raised from 200 MHz in #487), 32-bit data bus
 **Flash**: 2MB | **RAM**: 512KB | **L1 Cache**: 16KB I-cache + 4KB D-cache
 **Package**: 144-pin LQFP
 **Datasheet**: [DS60001320](https://www.microchip.com/en-us/product/PIC32MZ2048EFM144)
@@ -757,18 +757,21 @@ The firmware supports building for different board variants using MPLAB X config
 - **No hardware cache coherency** — software must invalidate/flush cache around DMA transfers. Harmony drivers handle this for SPI, USB, etc.
 - **Coherent attribute** (`__attribute__((coherent, aligned(16)))`) maps buffers to uncached address space — simplest solution for DMA buffers.
 
-#### Clock Tree (as configured)
+#### Clock Tree (as configured — #487, 2026-07-01)
 
 | Clock | Source | Frequency | Peripherals |
 |-------|--------|-----------|-------------|
-| SYSCLK | SPLL (24MHz POSC × 50 / 3 / 2) | 200 MHz | CPU, REFCLK |
-| PBCLK1 | SYSCLK/2 | 100 MHz | Watchdog |
-| PBCLK2 | SYSCLK/2 | 100 MHz | I2C, UART, SPI (default) |
-| PBCLK3 | SYSCLK/2 | 100 MHz | Timers, OC, IC |
-| PBCLK5 | SYSCLK/2 | 100 MHz | Flash, Crypto, USB |
-| REFCLK1 | SYSCLK (passthrough) | 200 MHz | SPI4 master clock (MCLKSEL=1) |
+| SYSCLK | SPLL (24MHz POSC / 3 × 63 / 2) | 252 MHz | CPU, core timer (÷2 = 126 MHz) |
+| PBCLK1 | SYSCLK/3 | 84 MHz | Watchdog |
+| PBCLK2 | SYSCLK/3 | 84 MHz | I2C, UART, SPI2/4/6 |
+| PBCLK3 | SYSCLK/3 | 84 MHz | Timers (FreeRTOS tick T1, streaming TMR4/5), OC, IC, ADC control clock |
+| PBCLK5 | SYSCLK/3 | 84 MHz | Flash, Crypto, USB regs |
 
-SPI4 BRG formula with REFCLK1: `SPI_CLK = 200MHz / (2 × (BRG + 1))`
+The PBxDIV /3 writes live in `SystemInit`/`initialization.c` (Harmony's `CLK_Initialize` only sets PMD, so without them the buses run at the reset-default /2 — which would be 126 MHz, over the 100 MHz bus spec). Single defines that must track the clock tree: `TIMER_CLOCK_FRQ` (TimerApi.h), `configPERIPHERAL_CLOCK_HZ` (FreeRTOSConfig.h), `CORE_TIMER_FREQUENCY` (plib_coretimer.h), `SYS_TIME_CPU_CLOCK_FREQUENCY` (configuration.h), `USE_FREQ_CONFIGURED_IN_CLOCK_MANAGER` (drv_spi_local.h).
+
+**SPI4 (SD + WINC) is clocked from PBCLK2, not REFCLK1** — `MCLKSEL=0` in `plib_spi4_master.c`, and no `REFO1CON` configuration exists anywhere in the tree (the pre-#487 revision of this table claiming "REFCLK1 passthrough, MCLKSEL=1" was stale: the measured 16.67 MHz SPI4 clock matched PBCLK2=100/BRG=2 exactly, not REFCLK1=200). SPI4 BRG formula: `SPI_CLK = 84MHz / (2 × (BRG + 1))` — SDSPI's 20 MHz request now rounds to 21 MHz (BRG=1); at the old 100 MHz PBCLK2 it rounded to 16.67 MHz (BRG=2).
+
+> **⚠️ Throughput tables below pre-date #487.** All characterization numbers in this file (Session-24 soaks, fit basis, enforced caps) were measured at 200 MHz/100 MHz. The enforced caps are unchanged by #487 — the device only got faster, so they remain safe (just more conservative). Re-fitting at 252 MHz is follow-up work.
 
 #### Hardware FPU
 
@@ -821,7 +824,7 @@ All items verified against the actual errata document. Only issues affecting fea
 
 | Issue | Module | Rev | Summary | Our Status |
 |-------|--------|-----|---------|------------|
-| #1 | Oscillator | All | **REFCLK cannot divide inputs >100 MHz.** | **Safe.** Errata workaround: "do not divide the SYSCLK and allow the destination peripheral (SPI) to divide it. Set RODIV and ROTRIM to 0." This is exactly our PR #219 approach (RODIV=0 passthrough). |
+| #1 | Oscillator | All | **REFCLK cannot divide inputs >100 MHz.** | **Safe.** REFCLK1 is not configured/used in the current tree at all (SPI4 rides PBCLK2, MCLKSEL=0 — see Clock Tree above); the erratum cannot apply. (Historical: PR #219's RODIV=0 passthrough followed the documented workaround while REFCLK1 was in use.) |
 | #5 | Power-Saving | A1/A3 | Turning off REFCLK via PMD bits causes unpredictable behavior. | **Safe.** We never disable REFCLK via PMD. Not affected on B2/B3. |
 | #6 | I2C | A1/A3 | Indeterminate I2C at >100 kHz and/or >500 bytes continuous. False collision detect, receive overflow, suspended transactions. All recoverable in software. | **Monitor.** I2C5 for BQ24297 at 100 kHz with mutex. Not affected on B2/B3 but good to know. |
 | #8 | UART | All | **RX FIFO overflow → shift registers stop → UART loses sync.** Only recovery: toggle UART OFF/ON multiple times. | **Low risk.** Debug UART4 only. Workaround: ensure UART interrupt priority prevents RX overrun, or set URXISEL for earlier interrupt. |
@@ -830,7 +833,7 @@ All items verified against the actual errata document. Only issues affecting fea
 | #25/#26 | Crypto | All | Crypto DMA: no partial packets, no zero-length hash. | **N/A.** wolfSSL runs in software mode. |
 | #27 | SPI | All | **SRMT bit falsely indicates TX complete** before last block shifts out. Does NOT affect Transmit Buffer Empty Interrupt (STXISEL=0). | **Safe.** Harmony SPI driver uses interrupts, not SRMT polling. |
 | #37 | I2C | All | **SCL tLOW doesn't meet I2C spec at ≥400 kHz.** No workaround. | **Safe.** BQ24297 I2C at 100 kHz. Never use ≥400 kHz on this chip. |
-| #38 | System Bus | B2/B3 | **Flash wait states at SYSCLK >184 MHz with ECC need 3 wait states** (not 2). <2% CPU impact with cache. | **Safe.** Verified: `PRECONbits.PFMWS = 3` and `ECCCON = 3` in `initialization.c:645-646`. |
+| #38 | System Bus | B2/B3 | **Flash wait states at SYSCLK >184 MHz with ECC need 3 wait states** (not 2). <2% CPU impact with cache. | **Safe.** At 252 MHz (#487) we run `PRECONbits.PFMWS = 5` (set conservatively for bring-up; tune-down to the DS60001320H table value is a tracked follow-up) and `ECCCON = 3` in `initialization.c`. |
 | #39 | ADC | All | Excessive current through VREF- when external reference used and VREF- > AVss. | **Monitor.** Workaround: connect VREF- to AVss. Check NQ3 board schematic. |
 | #40 | USB | All | FLUSH bit (USBIENCSRx<19>) doesn't flush TX FIFO properly. | **Safe.** Harmony USB driver: set FLUSH + clear TXPKTRDY simultaneously, repeat twice. |
 | #42 | DMA | All | **DMA half-full interrupt can fire twice** when cleared at n/2 byte, re-triggers at (n/2)+1. | **Safe.** Workaround: clear CHDHIF along with CHBCIF. Harmony DMA driver handles this. |

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -373,7 +373,7 @@ void MC12b_RestoreIdleScanList(void) {
  * cap can min() with it directly: the additive model intentionally replaces the
  * EOS-rate/event-rate terms (re-tested non-fatal on v3.6.1, #557) but NOT this
  * one, which must scale with the live SAMC/TAD config. All terms read live:
- *   TAD7 = 2 x ADCDIV x TQ;  TQ = (CONCLKDIV+1) x 10ns (PBCLK3 100MHz).
+ *   TAD7 = 2 x ADCDIV x TQ;  TQ = (CONCLKDIV+1) x TCLK, TCLK = 1000/84 ns (PBCLK3 84MHz, #487).
  *   T_busy = N x (SAMC + 16) x TAD7 + ~6us;  cap = 1 / (T_busy x 1.1).
  * Returns 0xFFFFFFFF when no scan is armed (no bound). */
 uint32_t MC12b_HardwareScanMaxFreq(uint32_t nActive) {
@@ -382,7 +382,9 @@ uint32_t MC12b_HardwareScanMaxFreq(uint32_t nActive) {
     uint32_t adcdiv    = ADCCON2 & 0x7Fu;
     if (adcdiv == 0u) adcdiv = 1u;          // 0 is reserved — defensive
     uint32_t samc      = (ADCCON2 >> 16) & 0x3FFu;
-    uint32_t tadNs     = 2u * adcdiv * (conclkdiv + 1u) * 10u;
+    /* #487: TCLK = 1/PBCLK3.  PBCLK3 = 84 MHz at 252 MHz SYSCLK (/3), so
+     * TCLK = 1000/84 ns ~= 11.9 ns (was 10 ns at the old 100 MHz PBCLK3). */
+    uint32_t tadNs     = (2u * adcdiv * (conclkdiv + 1u) * 1000u) / 84u;
     uint64_t busyNs    = (uint64_t)nActive * (samc + 16u) * tadNs + 6000u;
     uint64_t minPeriodNs = (busyNs * 11u) / 10u;   // +10% margin
     uint32_t hz = (uint32_t)(1000000000ULL / minPeriodNs);

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -7,6 +7,7 @@
 #include "../DIO.h"
 #include "configuration.h"
 #include "definitions.h"
+#include "clock_config.h"   /* #487: DAQIFI_PBCLK_MHZ for ADC TCLK */
 #include "state/data/BoardData.h"
 #include "state/board/BoardConfig.h"
 #include "state/runtime/BoardRuntimeConfig.h"
@@ -382,9 +383,10 @@ uint32_t MC12b_HardwareScanMaxFreq(uint32_t nActive) {
     uint32_t adcdiv    = ADCCON2 & 0x7Fu;
     if (adcdiv == 0u) adcdiv = 1u;          // 0 is reserved — defensive
     uint32_t samc      = (ADCCON2 >> 16) & 0x3FFu;
-    /* #487: TCLK = 1/PBCLK3.  PBCLK3 = 84 MHz at 252 MHz SYSCLK (/3), so
-     * TCLK = 1000/84 ns ~= 11.9 ns (was 10 ns at the old 100 MHz PBCLK3). */
-    uint32_t tadNs     = (2u * adcdiv * (conclkdiv + 1u) * 1000u) / 84u;
+    /* #487: TCLK = 1/PBCLK3 (ADC control clock).  DAQIFI_PBCLK_MHZ from
+     * clock_config.h = 84 @252 MHz SYSCLK (TCLK ~11.9 ns) or 100 @200 MHz
+     * (TCLK 10 ns). tadNs = 2·ADCDIV·(CONCLKDIV+1)·TCLK, scaled ×1000 for ns. */
+    uint32_t tadNs     = (2u * adcdiv * (conclkdiv + 1u) * 1000u) / DAQIFI_PBCLK_MHZ;
     uint64_t busyNs    = (uint64_t)nActive * (samc + 16u) * tadNs + 6000u;
     uint64_t minPeriodNs = (busyNs * 11u) / 10u;   // +10% margin
     uint32_t hz = (uint32_t)(1000000000ULL / minPeriodNs);

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -385,8 +385,12 @@ uint32_t MC12b_HardwareScanMaxFreq(uint32_t nActive) {
     uint32_t samc      = (ADCCON2 >> 16) & 0x3FFu;
     /* #487: TCLK = 1/PBCLK3 (ADC control clock).  DAQIFI_PBCLK_MHZ from
      * clock_config.h = 84 @252 MHz SYSCLK (TCLK ~11.9 ns) or 100 @200 MHz
-     * (TCLK 10 ns). tadNs = 2·ADCDIV·(CONCLKDIV+1)·TCLK, scaled ×1000 for ns. */
-    uint32_t tadNs     = (2u * adcdiv * (conclkdiv + 1u) * 1000u) / DAQIFI_PBCLK_MHZ;
+     * (TCLK 10 ns). tadNs = 2·ADCDIV·(CONCLKDIV+1)·TCLK, scaled ×1000 for ns.
+     * Round the divide UP (ceil) so tadNs never under-estimates TAD — this is a
+     * safety bound, so an over-estimate of busy time (→ lower max freq) is the
+     * conservative direction. Qodo #584. */
+    uint32_t tadNumer  = 2u * adcdiv * (conclkdiv + 1u) * 1000u;
+    uint32_t tadNs     = (tadNumer + DAQIFI_PBCLK_MHZ - 1u) / DAQIFI_PBCLK_MHZ;
     uint64_t busyNs    = (uint64_t)nActive * (samc + 16u) * tadNs + 6000u;
     uint64_t minPeriodNs = (busyNs * 11u) / 10u;   // +10% margin
     uint32_t hz = (uint32_t)(1000000000ULL / minPeriodNs);

--- a/firmware/src/HAL/TimerApi/TimerApi.h
+++ b/firmware/src/HAL/TimerApi/TimerApi.h
@@ -26,7 +26,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#define TIMER_CLOCK_FRQ 100000000
+#define TIMER_CLOCK_FRQ 84000000  /* #487: PBCLK3 /3 @ 252 MHz SYSCLK (was 100 MHz). Governs streaming-timer period + CSV/JSON/PB timestamp rates. */
 
 typedef enum {
     TMR_INDEX_2 = 2,

--- a/firmware/src/HAL/TimerApi/TimerApi.h
+++ b/firmware/src/HAL/TimerApi/TimerApi.h
@@ -26,7 +26,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#define TIMER_CLOCK_FRQ 84000000  /* #487: PBCLK3 /3 @ 252 MHz SYSCLK (was 100 MHz). Governs streaming-timer period + CSV/JSON/PB timestamp rates. */
+#include "clock_config.h"
+#define TIMER_CLOCK_FRQ DAQIFI_PBCLK_HZ  /* #487: PBCLK3 (84 MHz @252 / 100 @200 via clock_config.h). Governs streaming-timer period + CSV/JSON/PB timestamps. */
 
 typedef enum {
     TMR_INDEX_2 = 2,

--- a/firmware/src/Util/Logger.c
+++ b/firmware/src/Util/Logger.c
@@ -229,9 +229,9 @@ static void InitICSPLogging(void)
     U4MODE = 0x8;           // BRGH = 1 for high-speed mode
     U4STASET = (_U4STA_UTXEN_MASK | _U4STA_UTXISEL1_MASK);
 
-    /* BAUD Rate: 921600 bps @ 100MHz peripheral clock */
-    /* U4BRG = (PBCLK / (4 * BAUD)) - 1 = (100MHz / (4 * 921600)) - 1 = 26 */
-    U4BRG = 26;
+    /* BAUD Rate: 921600 bps @ 84 MHz peripheral clock (#487: PBCLK2 /3 at 252 MHz SYSCLK) */
+    /* U4BRG = (PBCLK / (4 * BAUD)) - 1 = (84MHz / (4 * 921600)) - 1 = 22 -> ~913 kbps (0.9% err) */
+    U4BRG = 22;
 
     /* Enable UART4 */
     U4MODESET = _U4MODE_ON_MASK;

--- a/firmware/src/Util/Logger.c
+++ b/firmware/src/Util/Logger.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include "clock_config.h"   /* #487: PBCLK2-derived UART4 BRG */
 #include <stdbool.h>
 #include <ctype.h>
 #include <xc.h>
@@ -229,9 +230,9 @@ static void InitICSPLogging(void)
     U4MODE = 0x8;           // BRGH = 1 for high-speed mode
     U4STASET = (_U4STA_UTXEN_MASK | _U4STA_UTXISEL1_MASK);
 
-    /* BAUD Rate: 921600 bps @ 84 MHz peripheral clock (#487: PBCLK2 /3 at 252 MHz SYSCLK) */
-    /* U4BRG = (PBCLK / (4 * BAUD)) - 1 = (84MHz / (4 * 921600)) - 1 = 22 -> ~913 kbps (0.9% err) */
-    U4BRG = 22;
+    /* BAUD Rate: 921600 bps, BRGH=1. #487: BRG derived from PBCLK2 via
+     * clock_config.h — 22 @84 MHz (~913 kbps, 0.9% err), 26 @100 MHz. */
+    U4BRG = DAQIFI_UART_BRGH_DIV(921600UL);
 
     /* Enable UART4 */
     U4MODESET = _U4MODE_ON_MASK;

--- a/firmware/src/Util/Logger.h
+++ b/firmware/src/Util/Logger.h
@@ -179,6 +179,7 @@ extern "C" {
         LOG_ONCE_USB_FLUSH_STUCK,         /**< UsbCdc.c: flush timeout (host not reading) — defer flush (#525); distinct bit so it isn't masked by the write-stall one-shot */
         LOG_ONCE_AD7609_BSY_STUCK,        /**< AD7609.c: BSY pin stuck low after SPI read — hardware fault; one-shot so a stuck pin can't flood + repeatedly enter vsnprintf (#525 follow-up) */
         LOG_ONCE_USB_TRANSPARENT_DECLINE, /**< UsbCdc.c: transparent-mode read CB declined a buffer — dropped to avoid un-arming the CDC read (#575); one-shot so a persistently-declining CB can't flood */
+        LOG_ONCE_BRIDGE_RX_OVERFLOW,      /**< wifi_serial_bridge_interface.c: transparent RX ring full — bytes dropped instead of wrapped (silent wrap corrupted WINC images mid-flash, #WINC-recovery) */
         /* Add new entries above this line */
         LOG_ONCE_COUNT                     /**< Must be <= 32 */
     } LogOnceBit_t;

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -276,7 +276,15 @@ static void app_WifiTask(void* p_arg) {
  * @return true if SD reached idle within timeout, false if timed out
  */
 static bool app_SDCard_GracefulShutdown(uint32_t timeoutMs, const char* reason) {
+    // Every exit below stops the app from calling DRV_SDSPI_Tasks (SUSPENDED /
+    // WAIT_POWER_UP), so the SDSPI attach-detect FSM must not be left holding
+    // the shared SPI0 bus's exclusive lock — a mid-cycle park used to leave the
+    // lock held forever, silently rejecting every WINC transfer (WiFi FW
+    // version 0.0.0, bogus chip IDs, NACKed WINC flash updates) until reboot.
+    extern void DRV_SDSPI_ReleaseBus(SYS_MODULE_OBJ object);
+
     if (sd_card_manager_IsIdle()) {
+        DRV_SDSPI_ReleaseBus(sysObj.drvSDSPI0);
         return true;
     }
 
@@ -301,10 +309,12 @@ static bool app_SDCard_GracefulShutdown(uint32_t timeoutMs, const char* reason) 
     if (!sd_card_manager_IsIdle()) {
         LOG_E("[SD] Graceful shutdown timeout after %u ms: %s",
               (unsigned)timeoutMs, reason);
+        DRV_SDSPI_ReleaseBus(sysObj.drvSDSPI0);
         return false;
     }
 
     LOG_I("[SD] Graceful shutdown complete: %s", reason);
+    DRV_SDSPI_ReleaseBus(sysObj.drvSDSPI0);
     return true;
 }
 

--- a/firmware/src/config/default/FreeRTOSConfig.h
+++ b/firmware/src/config/default/FreeRTOSConfig.h
@@ -296,7 +296,8 @@
 /* Interrupt nesting behaviour configuration. *********************************/
 /******************************************************************************/
 
-#define configPERIPHERAL_CLOCK_HZ               ( 84000000UL )  /* #487: PBCLK3 /3 @ 252 MHz SYSCLK (was 100 MHz). Tick timer (T1) rides PBCLK3 — must match for a correct 1000 Hz tick. */
+#include "clock_config.h"
+#define configPERIPHERAL_CLOCK_HZ               ( DAQIFI_PBCLK_HZ )  /* #487: PBCLK3 via clock_config.h toggle. Tick timer (T1) rides PBCLK3 — must match for a correct 1000 Hz tick. */
 #define configISR_STACK_SIZE                    ( 8192 )
 /* configKERNEL_INTERRUPT_PRIORITY sets the priority of the tick and context
  * switch performing interrupts.  Not supported by all FreeRTOS ports.  See

--- a/firmware/src/config/default/FreeRTOSConfig.h
+++ b/firmware/src/config/default/FreeRTOSConfig.h
@@ -50,8 +50,11 @@
 /* Scheduling behaviour related definitions. **********************************/
 /******************************************************************************/
 
-/* configTICK_RATE_HZ sets frequency of the tick interrupt in Hz, normally
- * calculated from the configCPU_CLOCK_HZ value. */
+/* configTICK_RATE_HZ sets frequency of the tick interrupt in Hz.  This PIC32MZ
+ * port runs the tick on peripheral Timer 1 (PBCLK3), so the compare value is
+ * derived from configPERIPHERAL_CLOCK_HZ (below), not configCPU_CLOCK_HZ (which
+ * this port does not use).  SYSCLK is 252 MHz (#487); the CPU clock is not
+ * referenced by the RTOS tick. */
 #define configTICK_RATE_HZ                      ( ( TickType_t ) 1000 )
 
 /* Force list-item link fields (pxNext/pxPrevious/pxContainer/xItemValue) to
@@ -293,7 +296,7 @@
 /* Interrupt nesting behaviour configuration. *********************************/
 /******************************************************************************/
 
-#define configPERIPHERAL_CLOCK_HZ               ( 100000000UL )
+#define configPERIPHERAL_CLOCK_HZ               ( 84000000UL )  /* #487: PBCLK3 /3 @ 252 MHz SYSCLK (was 100 MHz). Tick timer (T1) rides PBCLK3 — must match for a correct 1000 Hz tick. */
 #define configISR_STACK_SIZE                    ( 8192 )
 /* configKERNEL_INTERRUPT_PRIORITY sets the priority of the tick and context
  * switch performing interrupts.  Not supported by all FreeRTOS ports.  See

--- a/firmware/src/config/default/clock_config.h
+++ b/firmware/src/config/default/clock_config.h
@@ -1,0 +1,54 @@
+/*******************************************************************************
+  DAQiFi clock configuration — single 200/252 MHz toggle (#487)
+
+  Flip DAQIFI_SYSCLK_252 and rebuild to move the whole device between the
+  252 MHz (chip-rated max, DS60001320H §39) and the legacy 200 MHz operating
+  points. Every clock-derived constant is computed here so there is exactly
+  one place to change; the scattered consumers reference these macros:
+
+    - config/default/initialization.c   PLL config bits (#if), PBxDIV, PFMWS
+    - HAL/TimerApi/TimerApi.h            TIMER_CLOCK_FRQ  (streaming timer + timestamps)
+    - config/default/FreeRTOSConfig.h    configPERIPHERAL_CLOCK_HZ (tick on PBCLK3)
+    - config/default/peripheral/coretimer/plib_coretimer.h  CORE_TIMER_FREQUENCY
+    - config/default/configuration.h     SYS_TIME_CPU_CLOCK_FREQUENCY
+    - config/default/definitions.h       CPU_CLOCK_FREQUENCY (informational)
+    - HAL/ADC/MC12bADC.c                 ADC scan-busy TCLK (#539 cap)
+    - config/default/driver/spi/src/drv_spi_local.h  SPI4 (SD+WINC) source clock
+    - config/default/peripheral/i2c/master/plib_i2c5_master.c  I2C5 BRG (BQ24297)
+    - Util/Logger.c                      UART4 (ICSP debug) BRG
+
+  Header is preprocessor-only (safe to include from C and .S).
+
+  NOTE (#487): the FPLLMULT config-bit pragma cannot take a macro value, so
+  initialization.c selects it with `#if DAQIFI_SYSCLK_252` directly rather than
+  a DAQIFI_FPLLMULT token. Keep that #if in sync with this toggle.
+*******************************************************************************/
+#ifndef CLOCK_CONFIG_H
+#define CLOCK_CONFIG_H
+
+/* 1 = 252 MHz (chip-rated max, #487) · 0 = 200 MHz (legacy revert path) */
+#define DAQIFI_SYSCLK_252   1
+
+#if DAQIFI_SYSCLK_252
+  #define DAQIFI_SYSCLK_HZ   252000000UL   /* SPLL: 24 MHz POSC /3 x63 /2 */
+  #define DAQIFI_PBCLK_HZ     84000000UL   /* peripheral buses at PBxDIV /3 */
+  #define DAQIFI_PBCLK_MHZ           84u    /* = DAQIFI_PBCLK_HZ / 1e6 */
+  #define DAQIFI_PBDIV                2u    /* PBxDIVbits.PBDIV = divisor-1 → /3 */
+  #define DAQIFI_PFMWS                5u    /* flash wait states (bring-up conservative; datasheet tune-down pending) */
+#else
+  #define DAQIFI_SYSCLK_HZ   200000000UL   /* SPLL: 24 MHz POSC /3 x50 /2 */
+  #define DAQIFI_PBCLK_HZ    100000000UL   /* peripheral buses at PBxDIV /2 */
+  #define DAQIFI_PBCLK_MHZ          100u
+  #define DAQIFI_PBDIV                1u    /* → /2 */
+  #define DAQIFI_PFMWS                3u    /* errata #38: >184 MHz w/ ECC needs 3 */
+#endif
+
+/* MIPS M-class core timer (CP0 Count) increments at SYSCLK/2. */
+#define DAQIFI_CORE_TIMER_HZ   (DAQIFI_SYSCLK_HZ / 2UL)
+
+/* UARTx BRG for a target baud in BRGH=1 (high-speed) mode: PBCLK/(4·baud) - 1,
+ * rounded to nearest (add half-divisor before the integer divide). */
+#define DAQIFI_UART_BRGH_DIV(baud)  \
+    (((DAQIFI_PBCLK_HZ + (2UL * (baud))) / (4UL * (baud))) - 1UL)
+
+#endif /* CLOCK_CONFIG_H */

--- a/firmware/src/config/default/configuration.h
+++ b/firmware/src/config/default/configuration.h
@@ -85,7 +85,8 @@ extern "C" {
 #define SYS_TIME_HW_COUNTER_WIDTH                   (32)
 #define SYS_TIME_HW_COUNTER_PERIOD                  (4294967295U)
 #define SYS_TIME_HW_COUNTER_HALF_PERIOD             (SYS_TIME_HW_COUNTER_PERIOD>>1)
-#define SYS_TIME_CPU_CLOCK_FREQUENCY                (252000000)  /* #487: SYSCLK 252 MHz (was 200) */
+#include "clock_config.h"
+#define SYS_TIME_CPU_CLOCK_FREQUENCY                (DAQIFI_SYSCLK_HZ)  /* #487: SYSCLK via clock_config.h toggle (252/200) */
 #define SYS_TIME_COMPARE_UPDATE_EXECUTION_CYCLES    (620)
 
 

--- a/firmware/src/config/default/configuration.h
+++ b/firmware/src/config/default/configuration.h
@@ -85,7 +85,7 @@ extern "C" {
 #define SYS_TIME_HW_COUNTER_WIDTH                   (32)
 #define SYS_TIME_HW_COUNTER_PERIOD                  (4294967295U)
 #define SYS_TIME_HW_COUNTER_HALF_PERIOD             (SYS_TIME_HW_COUNTER_PERIOD>>1)
-#define SYS_TIME_CPU_CLOCK_FREQUENCY                (200000000)
+#define SYS_TIME_CPU_CLOCK_FREQUENCY                (252000000)  /* #487: SYSCLK 252 MHz (was 200) */
 #define SYS_TIME_COMPARE_UPDATE_EXECUTION_CYCLES    (620)
 
 

--- a/firmware/src/config/default/definitions.h
+++ b/firmware/src/config/default/definitions.h
@@ -117,7 +117,7 @@ extern "C" {
 #define DEVICE_SERIES        "PIC32MZ"
 
 /* CPU clock frequency */
-#define CPU_CLOCK_FREQUENCY 200000000U
+#define CPU_CLOCK_FREQUENCY 252000000U  /* #487: SYSCLK 252 MHz (was 200). Informational — not referenced functionally. */
 
 // *****************************************************************************
 // *****************************************************************************

--- a/firmware/src/config/default/definitions.h
+++ b/firmware/src/config/default/definitions.h
@@ -48,6 +48,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include "clock_config.h"   /* #487: single 200/252 MHz toggle */
 #include "crypto/crypto.h"
 #include "peripheral/ocmp/plib_ocmp8.h"
 #include "peripheral/ocmp/plib_ocmp6.h"
@@ -116,8 +117,8 @@ extern "C" {
 #define DEVICE_FAMILY        "PIC32MZEF"
 #define DEVICE_SERIES        "PIC32MZ"
 
-/* CPU clock frequency */
-#define CPU_CLOCK_FREQUENCY 252000000U  /* #487: SYSCLK 252 MHz (was 200). Informational — not referenced functionally. */
+/* CPU clock frequency (informational — not referenced functionally) */
+#define CPU_CLOCK_FREQUENCY DAQIFI_SYSCLK_HZ  /* #487: via clock_config.h toggle (252/200) */
 
 // *****************************************************************************
 // *****************************************************************************

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
@@ -49,6 +49,12 @@
 #include "drv_sdspi_driver_interface.h"
 #include "driver/spi/drv_spi.h"
 
+/* DAQiFi patch (#WINC-recovery, 2026-07-02): shared-SPI-bus lock hygiene.
+ * See DRV_SDSPI_ReleaseBus, the CHK_FOR_CARD lock rollback, and the
+ * command-executor bus-completion watchdog (#567 extension). */
+#define LOG_MODULE LOG_MODULE_SD
+#include "Util/Logger.h"
+
 #include "drv_sdspi_local.h"
 #include "driver/sdspi/src/drv_sdspi_file_system.h"
 
@@ -474,6 +480,54 @@ static void lDRV_SDSPI_CommandSend
     DRV_SDSPI_OBJ* dObj = (DRV_SDSPI_OBJ*)&gDrvSDSPIObj[object];
     uint8_t endianArray[4];
 
+    /* #567 extension (DAQiFi, #WINC-recovery 2026-07-02): the original #567
+     * watchdogs covered the detect and buffer-IO waits, but a lost SPI
+     * completion inside THIS executor's wait states (CHECK_TRANSFER_COMPLETE,
+     * EXEC_CHECK_COMPLETION, response reads, ...) was bench-observed to
+     * freeze the FSM forever while holding the shared SPI0 bus exclusive at
+     * depth 2 — every WINC transfer is then rejected until reboot (WiFi FW
+     * version 0.0.0 / dead sockets / NACKed WINC flash updates). One generic
+     * watchdog here covers every wait state: while a submitted transfer is
+     * pending, arm the bus-completion timer; on expiry force the ERROR status
+     * so the state's existing ERROR branch routes to CONFIRM_EXEC_ERROR,
+     * which releases the exclusive lock. */
+    if (dObj->spiTransferStatus == DRV_SDSPI_SPI_TRANSFER_STATUS_IN_PROGRESS)
+    {
+        if (dObj->spiXferTimerFlag == false)
+        {
+            if (DRV_SDSPI_SpiXferTimerStart(dObj, DRV_SDSPI_SPI_XFER_TIMEOUT_IN_MS) == true)
+            {
+                dObj->spiXferTimerFlag = true;
+            }
+            else
+            {
+                dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
+            }
+        }
+        else if (dObj->spiXferTimerExpired == true)
+        {
+            /* Fires routinely on card-less boards under concurrent WINC
+             * traffic — cap the logging so it can't flood the log buffer. */
+            static uint8_t sCmdTimeoutLogs = 0;
+            dObj->spiXferTimerFlag = false;
+            if (sCmdTimeoutLogs < 4U)
+            {
+                sCmdTimeoutLogs++;
+                LOG_E("SD: cmd bus-completion timeout — forcing error path");
+            }
+            dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
+        }
+        else
+        {
+            /* Timer armed and still counting. */
+        }
+    }
+    else if (dObj->spiXferTimerFlag == true)
+    {
+        (void) DRV_SDSPI_SpiXferTimerStop(dObj);
+        dObj->spiXferTimerFlag = false;
+    }
+
     switch (dObj->cmdState)
     {
         case DRV_SDSPI_CMD_FRAME_PACKET:
@@ -898,6 +952,17 @@ static DRV_SDSPI_ATTACH lDRV_SDSPI_MediaCommandDetect
                             MEDIA_INIT_ARRAY_SIZE) == true)
                 {
                     dObj->cmdDetectState = DRV_SDSPI_CMD_DETECT_WAIT_TRANSFER_COMPLETE;
+                }
+                else
+                {
+                    /* DAQiFi fix (#WINC-recovery): the write was rejected, so
+                     * this state re-enters next iteration and would take the
+                     * exclusive lock AGAIN — the recursive count ratchets and
+                     * the shared bus never releases (kills the WINC client).
+                     * Release the count taken above; sdState stays
+                     * CARD_STATUS so the caller doesn't double-unlock. */
+                    (void) DRV_SDSPI_SPIExclusiveAccess(dObj, false);
+                    LOG_E("SDDET: clk-pulse write rejected; exclusive lock rolled back");
                 }
             }
             break;
@@ -2477,6 +2542,63 @@ void DRV_SDSPI_Tasks
 {
     lDRV_SDSPI_AttachDetachTasks (object);
     lDRV_SDSPI_BufferIOTasks (object);
+}
+
+/* DAQiFi addition (#WINC-recovery, 2026-07-02): release the shared-bus
+ * exclusive lock before the app stops driving DRV_SDSPI_Tasks.
+ *
+ * The attach-detect FSM holds the underlying DRV_SPI instance's exclusive
+ * lock ACROSS task iterations (lock in CMD_DETECT_CHK_FOR_CARD /
+ * CHK_FOR_DETCH, unlock several iterations later in the caller).  If the
+ * app parks the SD task mid-cycle (WiFi FW-update / WiFi-streaming SPI
+ * handoff, power-down), the lock is never released and every transfer from
+ * the other client on the bus (WINC1500) is silently rejected by
+ * DRV_SPI_WriteTransferAdd until reboot — observed as WiFi FW version
+ * 0.0.0, bogus chip IDs, and NACKed WINC flash updates.
+ *
+ * Fully unwinds the recursive exclusive count and resets the detect/cmd
+ * FSMs so polling restarts cleanly when the app resumes DRV_SDSPI_Tasks.
+ */
+void DRV_SDSPI_ReleaseBus(SYS_MODULE_OBJ object)
+{
+    DRV_SDSPI_OBJ* dObj;
+    uint8_t unwind;
+
+    if (object >= DRV_SDSPI_INSTANCES_NUMBER)
+    {
+        return;
+    }
+
+    dObj = (DRV_SDSPI_OBJ*)&gDrvSDSPIObj[object];
+
+    /* Disarm the #567 bus-completion watchdog if it is running. */
+    if (dObj->spiXferTimerFlag == true)
+    {
+        (void) DRV_SDSPI_SpiXferTimerStop(dObj);
+        dObj->spiXferTimerFlag = false;
+    }
+
+    /* Unwind the recursive exclusive-use count.  The unlock call returns
+     * true while this client still holds the lock and false once the
+     * handle no longer matches (fully released / never held).  Bounded to
+     * defend against semantics changes in DRV_SPI_ExclusiveUse. */
+    for (unwind = 0; unwind < 16U; unwind++)
+    {
+        if (DRV_SDSPI_SPIExclusiveAccess(dObj, false) == false)
+        {
+            break;
+        }
+    }
+
+    if (unwind > 0U)
+    {
+        LOG_E("SD: released SPI exclusive lock on suspend (depth=%u)", (unsigned)unwind);
+    }
+
+    /* Restart detection from scratch when polling resumes. */
+    dObj->cmdDetectState = DRV_SDSPI_CMD_DETECT_START_INIT;
+    dObj->cmdState = DRV_SDSPI_CMD_FRAME_PACKET;
+    dObj->sdState = TASK_STATE_IDLE;
 }
 
 DRV_HANDLE DRV_SDSPI_Open

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
@@ -2595,6 +2595,18 @@ void DRV_SDSPI_ReleaseBus(SYS_MODULE_OBJ object)
         LOG_E("SD: released SPI exclusive lock on suspend (depth=%u)", (unsigned)unwind);
     }
 
+    /* Force the SD chip-select inactive (Qodo #587). DRV_SPI asserts CS at
+     * transfer start and deasserts it in its completion path — the exact path
+     * that is missing in the lost-completion wedge this function recovers
+     * from. Without this, the WINC could take the bus with the SD card still
+     * selected (active-low CS). Harmless when already deasserted. */
+    SYS_PORT_PinSet(dObj->chipSelectPin);
+
+    /* Clear a stale in-flight transfer status so the resumed FSM (and the
+     * CommandSend watchdog keyed on IN_PROGRESS) starts from a settled state
+     * instead of burning a timeout on a transfer that no longer exists. */
+    dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
+
     /* Restart detection from scratch when polling resumes. */
     dObj->cmdDetectState = DRV_SDSPI_CMD_DETECT_START_INIT;
     dObj->cmdState = DRV_SDSPI_CMD_FRAME_PACKET;

--- a/firmware/src/config/default/driver/spi/src/drv_spi.c
+++ b/firmware/src/config/default/driver/spi/src/drv_spi.c
@@ -48,6 +48,14 @@
 #include <string.h>
 #include "configuration.h"
 #include "driver/spi/drv_spi.h"
+
+/* DAQiFi patch (#WINC-recovery, 2026-07-02): TransferAdd rejects are silent
+ * by design upstream, but on the shared SPI0 bus (SD + WINC clients) they
+ * cascade into hard-to-diagnose wedges (WiFi FW version 0.0.0, NACKed WINC
+ * flash updates). Log the first few rejects with the reason. */
+#define LOG_MODULE LOG_MODULE_GENERAL
+#include "Util/Logger.h"
+static uint8_t gSpiAddRejectLogs = 0;
 #include "system/debug/sys_debug.h"
 
 // *****************************************************************************
@@ -1189,6 +1197,10 @@ void DRV_SPI_WriteReadTransferAdd (
     clientObj = lDRV_SPI_DriverHandleValidate(handle);
     if (clientObj == NULL)
     {
+        if (gSpiAddRejectLogs < 8) {
+            gSpiAddRejectLogs++;
+            LOG_E("SPIADD reject: stale handle=%08lx", (unsigned long)handle);
+        }
         return;
     }
 
@@ -1200,6 +1212,12 @@ void DRV_SPI_WriteReadTransferAdd (
         {
             if (dObj->exclusiveUseClientHandle != handle)
             {
+                if (gSpiAddRejectLogs < 8) {
+                    gSpiAddRejectLogs++;
+                    LOG_E("SPIADD reject: exclusive holder=%08lx me=%08lx cntr=%u",
+                          (unsigned long)dObj->exclusiveUseClientHandle,
+                          (unsigned long)handle, (unsigned)dObj->exclusiveUseCntr);
+                }
                 return;
             }
         }
@@ -1207,6 +1225,10 @@ void DRV_SPI_WriteReadTransferAdd (
         if(lDRV_SPI_ResourceLock(dObj) == false)
         {
             SYS_DEBUG_MESSAGE(SYS_ERROR_ERROR, "Failed to get resource lock");
+            if (gSpiAddRejectLogs < 8) {
+                gSpiAddRejectLogs++;
+                LOG_E("SPIADD reject: resource lock fail");
+            }
             return;
         }
 
@@ -1219,6 +1241,10 @@ void DRV_SPI_WriteReadTransferAdd (
              * transfer queue size parameter is configured to be less */
 
             SYS_DEBUG_MESSAGE(SYS_ERROR_ERROR, "Insufficient Queue Depth");
+            if (gSpiAddRejectLogs < 8) {
+                gSpiAddRejectLogs++;
+                LOG_E("SPIADD reject: queue full (handle=%08lx)", (unsigned long)handle);
+            }
             lDRV_SPI_ResourceUnlock(dObj);
             return;
         }

--- a/firmware/src/config/default/driver/spi/src/drv_spi_local.h
+++ b/firmware/src/config/default/driver/spi/src/drv_spi_local.h
@@ -65,10 +65,12 @@
 #define DRV_SPI_TOKEN_MAX                       (0xFFFFU)
 
 
-/* #487: SPI4 (SD + WINC), SPI2/6 ride PBCLK2, now 84 MHz (was 100 MHz) at 252 MHz
- * SYSCLK. Was (0) = "use PLIB fallback", whose fallback is hardcoded 100 MHz —
- * which would compute BRG against the wrong source clock. Pass 84 MHz explicitly. */
-#define USE_FREQ_CONFIGURED_IN_CLOCK_MANAGER    (84000000)
+/* #487: SPI4 (SD + WINC) and SPI2/6 ride PBCLK2 (84 MHz @252 / 100 @200 via
+ * clock_config.h). Was (0) = "use PLIB fallback", whose fallback is hardcoded
+ * 100 MHz — would compute BRG against the wrong source clock at 252. Pass the
+ * real PBCLK explicitly. */
+#include "clock_config.h"
+#define USE_FREQ_CONFIGURED_IN_CLOCK_MANAGER    (DAQIFI_PBCLK_HZ)
 #define NULL_INDEX                              (0xFF)
 
 // *****************************************************************************

--- a/firmware/src/config/default/driver/spi/src/drv_spi_local.h
+++ b/firmware/src/config/default/driver/spi/src/drv_spi_local.h
@@ -65,7 +65,10 @@
 #define DRV_SPI_TOKEN_MAX                       (0xFFFFU)
 
 
-#define USE_FREQ_CONFIGURED_IN_CLOCK_MANAGER    (0)
+/* #487: SPI4 (SD + WINC), SPI2/6 ride PBCLK2, now 84 MHz (was 100 MHz) at 252 MHz
+ * SYSCLK. Was (0) = "use PLIB fallback", whose fallback is hardcoded 100 MHz —
+ * which would compute BRG against the wrong source clock. Pass 84 MHz explicitly. */
+#define USE_FREQ_CONFIGURED_IN_CLOCK_MANAGER    (84000000)
 #define NULL_INDEX                              (0xFF)
 
 // *****************************************************************************

--- a/firmware/src/config/default/driver/winc/dev/spi/wdrv_winc_spi.c
+++ b/firmware/src/config/default/driver/winc/dev/spi/wdrv_winc_spi.c
@@ -78,6 +78,23 @@ static WDRV_WINC_SPIDCPT spiDcpt;
 // share coherent memory with SD/USB DMA buffers.
 static uint8_t* alignedBuffer = NULL;
 static uint32_t alignedBufferSize = 0;
+// Capped fail-path logging — a rejected transfer here cascades into
+// M2M_ERR_BUS_FAIL wedges that used to be completely silent (#WINC-recovery).
+static uint8_t gWincSpiFailLogs = 0;
+
+// DRV_SPI_*TransferAdd rejects transfers while the SD card client holds the
+// shared bus in exclusive mode (attach-detect polling locks it for several
+// task iterations). Retry briefly instead of failing the whole HIF operation
+// — task context only, so a tick sleep is safe.
+#define WINC_SPI_ADD_RETRIES        100U
+static bool WincSpiAddRetryDelay(uint32_t attempt)
+{
+    if (attempt >= WINC_SPI_ADD_RETRIES) {
+        return false;
+    }
+    vTaskDelay(pdMS_TO_TICKS(1));
+    return true;
+}
 
 void WDRV_WINC_SPI_SetBuffer(uint8_t* buf, uint32_t size) {
     if (buf == NULL || size == 0) return;
@@ -160,12 +177,29 @@ static void spiTransferEventHandler(DRV_SPI_TRANSFER_EVENT event,
 
 bool WDRV_WINC_SPISend(void* pTransmitData, size_t txSize)
 {
-    if (alignedBuffer == NULL || txSize > alignedBufferSize) return false;
+    if (alignedBuffer == NULL || txSize > alignedBufferSize) {
+        if (gWincSpiFailLogs < 8) {
+            gWincSpiFailLogs++;
+            LOG_E("WSPI tx guard: buf=%p sz=%u cap=%u", alignedBuffer,
+                  (unsigned)txSize, (unsigned)alignedBufferSize);
+        }
+        return false;
+    }
     memcpy(alignedBuffer, pTransmitData, txSize);
-    DRV_SPI_WriteTransferAdd(spiDcpt.spiHandle, alignedBuffer, txSize, &spiDcpt.transferTxHandle);
+
+    uint32_t attempt = 0;
+    do {
+        DRV_SPI_WriteTransferAdd(spiDcpt.spiHandle, alignedBuffer, txSize, &spiDcpt.transferTxHandle);
+    } while ((DRV_SPI_TRANSFER_HANDLE_INVALID == spiDcpt.transferTxHandle) &&
+             WincSpiAddRetryDelay(attempt++));
 
     if (DRV_SPI_TRANSFER_HANDLE_INVALID == spiDcpt.transferTxHandle)
     {
+        if (gWincSpiFailLogs < 8) {
+            gWincSpiFailLogs++;
+            LOG_E("WSPI tx add fail: drvHandle=%08lx sz=%u",
+                  (unsigned long)spiDcpt.spiHandle, (unsigned)txSize);
+        }
         return false;
     }
 
@@ -197,11 +231,27 @@ bool WDRV_WINC_SPIReceive(void* pReceiveData, size_t rxSize)
 {
     static uint8_t dummy = 0;
 
-    if (alignedBuffer == NULL || rxSize > alignedBufferSize) return false;
-    DRV_SPI_WriteReadTransferAdd(spiDcpt.spiHandle, &dummy, 1, alignedBuffer, rxSize, &spiDcpt.transferRxHandle);
+    if (alignedBuffer == NULL || rxSize > alignedBufferSize) {
+        if (gWincSpiFailLogs < 8) {
+            gWincSpiFailLogs++;
+            LOG_E("WSPI rx guard: buf=%p sz=%u cap=%u", alignedBuffer,
+                  (unsigned)rxSize, (unsigned)alignedBufferSize);
+        }
+        return false;
+    }
+    uint32_t attempt = 0;
+    do {
+        DRV_SPI_WriteReadTransferAdd(spiDcpt.spiHandle, &dummy, 1, alignedBuffer, rxSize, &spiDcpt.transferRxHandle);
+    } while ((DRV_SPI_TRANSFER_HANDLE_INVALID == spiDcpt.transferRxHandle) &&
+             WincSpiAddRetryDelay(attempt++));
 
     if (DRV_SPI_TRANSFER_HANDLE_INVALID == spiDcpt.transferRxHandle)
     {
+        if (gWincSpiFailLogs < 8) {
+            gWincSpiFailLogs++;
+            LOG_E("WSPI rx add fail: drvHandle=%08lx sz=%u",
+                  (unsigned long)spiDcpt.spiHandle, (unsigned)rxSize);
+        }
         return false;
     }
 

--- a/firmware/src/config/default/driver/winc/drv/driver/nmdrv.c
+++ b/firmware/src/config/default/driver/winc/drv/driver/nmdrv.c
@@ -243,7 +243,19 @@ int8_t nm_drv_init_download_mode(void)
     if(!ISNMC3000(GET_CHIPID()))
     {
         /*Execuate that function only for 1500A/B, no room in 3000, but it may be needed in 3400 no wait*/
-        cpu_halt();
+        /* DAQiFi (#WINC-recovery, 2026-07-02): the stock code only called
+         * cpu_halt() here, on a chip that may be mid-flight running its WiFi
+         * firmware (this download mode is entered from FW-update mode while
+         * the AP is beaconing). The PC-side programmer
+         * (winc_programmer 2.0.2) expects to take over a chip in a clean
+         * post-reset state — it performs its own halt, IRAM download and
+         * cpu-start sequence over the bridge. Against a soft-halted,
+         * dirty-state chip the start sequence goes nowhere: the boot ROM
+         * never runs (BOOTROM_REG keeps the unconsumed 0xEF522F61 start
+         * magic) and the tool fails with "time out waiting for firmware to
+         * run" (bench-verified via bridge command tracing). Give it the real
+         * thing: the canonical hard CHIP_EN/RESET_N power-cycle pulse. */
+        nm_reset();
     }
 
     /* Must do this after global reset to set SPI data packet size. */

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -46,6 +46,7 @@
 #include "configuration.h"
 #include "definitions.h"
 #include "device.h"
+#include "clock_config.h"   /* #487: single 200/252 MHz toggle (DAQIFI_SYSCLK_*) */
 
 
 // ****************************************************************************
@@ -91,8 +92,15 @@
 #pragma config FPLLIDIV =   DIV_3
 #pragma config FPLLRNG =    RANGE_5_10_MHZ
 #pragma config FPLLICLK =   PLL_POSC
-#pragma config FPLLMULT =   MUL_63    // #487: 8 MHz PLL in x63 = 504 MHz VCO
-#pragma config FPLLODIV =   DIV_2      // 504 / 2 = 252 MHz SYSCLK (was MUL_50 -> 200 MHz)
+/* #487: FPLLMULT selects SYSCLK via the DAQIFI_SYSCLK_252 toggle in
+ * clock_config.h (pragma can't take a macro). 8 MHz PLL input (FPLLIDIV DIV_3),
+ * /2 output (FPLLODIV) are the same for both points; only the multiplier moves. */
+#if DAQIFI_SYSCLK_252
+#pragma config FPLLMULT =   MUL_63    // 8 MHz x63 = 504 MHz VCO / 2 = 252 MHz SYSCLK
+#else
+#pragma config FPLLMULT =   MUL_50    // 8 MHz x50 = 400 MHz VCO / 2 = 200 MHz SYSCLK
+#endif
+#pragma config FPLLODIV =   DIV_2
 #pragma config UPLLFSEL =   FREQ_24MHZ
 
 /*** DEVCFG3 ***/
@@ -649,11 +657,11 @@ void SYS_Initialize ( void* data )
     SYSKEY = 0x00000000U;
     SYSKEY = 0xAA996655U;
     SYSKEY = 0x556699AAU;
-    PB1DIVbits.PBDIV = 2;   /* system / INT controller / DMA        -> 84 MHz */
-    PB2DIVbits.PBDIV = 2;   /* I2C5, UART4, SPI2/4/6                 -> 84 MHz */
-    PB3DIVbits.PBDIV = 2;   /* timers (FreeRTOS tick, streaming), OC/IC, ADC ctrl -> 84 MHz */
-    PB4DIVbits.PBDIV = 2;   /* PORTx                                 -> 84 MHz */
-    PB5DIVbits.PBDIV = 2;   /* flash controller, crypto, USB regs    -> 84 MHz */
+    PB1DIVbits.PBDIV = DAQIFI_PBDIV;   /* system / INT controller / DMA */
+    PB2DIVbits.PBDIV = DAQIFI_PBDIV;   /* I2C5, UART4, SPI2/4/6 */
+    PB3DIVbits.PBDIV = DAQIFI_PBDIV;   /* timers (FreeRTOS tick, streaming), OC/IC, ADC ctrl */
+    PB4DIVbits.PBDIV = DAQIFI_PBDIV;   /* PORTx */
+    PB5DIVbits.PBDIV = DAQIFI_PBDIV;   /* flash controller, crypto, USB regs */
     SYSKEY = 0x33333333U;
 
     /* Configure Prefetch, Wait States and ECC */
@@ -662,7 +670,7 @@ void SYS_Initialize ( void* data )
      * At 252 MHz set conservatively high (5) for the first bring-up so the CPU can
      * never fault on a flash read; extra wait states are hidden by prefetch + I-cache.
      * TODO(#487): tune down to the DS60001320H Table 7-1 / §39 value after boot-verify. */
-    PRECONbits.PFMWS = 5;
+    PRECONbits.PFMWS = DAQIFI_PFMWS;
     CFGCONbits.ECCCON = 3;
 
 

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -91,8 +91,8 @@
 #pragma config FPLLIDIV =   DIV_3
 #pragma config FPLLRNG =    RANGE_5_10_MHZ
 #pragma config FPLLICLK =   PLL_POSC
-#pragma config FPLLMULT =   MUL_50
-#pragma config FPLLODIV =   DIV_2
+#pragma config FPLLMULT =   MUL_63    // #487: 8 MHz PLL in x63 = 504 MHz VCO
+#pragma config FPLLODIV =   DIV_2      // 504 / 2 = 252 MHz SYSCLK (was MUL_50 -> 200 MHz)
 #pragma config UPLLFSEL =   FREQ_24MHZ
 
 /*** DEVCFG3 ***/
@@ -640,9 +640,29 @@ void SYS_Initialize ( void* data )
 
   
     CLK_Initialize();
+
+    /* #487: PBCLK divider /2 -> /3.  At 252 MHz SYSCLK the reset-default /2
+     * puts every peripheral bus at 126 MHz, over the 100 MHz spec.  /3 = 84 MHz.
+     * Harmony CLK_Initialize() only sets PMD, not PBxDIV, so these run at the
+     * reset default /2 unless set here.  PB7 (CPU) is left at its /1 default so
+     * the core runs at the full 252 MHz.  PBxDIV writes need the system unlock. */
+    SYSKEY = 0x00000000U;
+    SYSKEY = 0xAA996655U;
+    SYSKEY = 0x556699AAU;
+    PB1DIVbits.PBDIV = 2;   /* system / INT controller / DMA        -> 84 MHz */
+    PB2DIVbits.PBDIV = 2;   /* I2C5, UART4, SPI2/4/6                 -> 84 MHz */
+    PB3DIVbits.PBDIV = 2;   /* timers (FreeRTOS tick, streaming), OC/IC, ADC ctrl -> 84 MHz */
+    PB4DIVbits.PBDIV = 2;   /* PORTx                                 -> 84 MHz */
+    PB5DIVbits.PBDIV = 2;   /* flash controller, crypto, USB regs    -> 84 MHz */
+    SYSKEY = 0x33333333U;
+
     /* Configure Prefetch, Wait States and ECC */
     PRECONbits.PREFEN = 3;
-    PRECONbits.PFMWS = 3;
+    /* #487: flash wait states.  At 200 MHz this was 3 (errata #38: >184 MHz w/ ECC).
+     * At 252 MHz set conservatively high (5) for the first bring-up so the CPU can
+     * never fault on a flash read; extra wait states are hidden by prefetch + I-cache.
+     * TODO(#487): tune down to the DS60001320H Table 7-1 / §39 value after boot-verify. */
+    PRECONbits.PFMWS = 5;
     CFGCONbits.ECCCON = 3;
 
 

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -653,7 +653,17 @@ void SYS_Initialize ( void* data )
      * puts every peripheral bus at 126 MHz, over the 100 MHz spec.  /3 = 84 MHz.
      * Harmony CLK_Initialize() only sets PMD, not PBxDIV, so these run at the
      * reset default /2 unless set here.  PB7 (CPU) is left at its /1 default so
-     * the core runs at the full 252 MHz.  PBxDIV writes need the system unlock. */
+     * the core runs at the full 252 MHz.  PBxDIV writes need the system unlock.
+     *
+     * KNOWN transient (Qodo #584, accepted): between reset and this point the
+     * buses run at the /2 default = 126 MHz during crt0 (.data copy / .bss zero,
+     * ~sub-ms). Accepted, not fixed: the only peripheral clocked during crt0 is
+     * flash (PBCLK5), whose access timing is governed by PFMWS in SYSCLK cycles
+     * (reset default = max 7 = most tolerant), and no I2C/SPI/UART/timer/ADC is
+     * running yet. Empirically boots + runs clean. The spec-clean fix (set PBxDIV
+     * in an XC32 _on_reset() hook before crt0) is deferred: it adds a new boot
+     * path element (brick risk) disproportionate to a bounded, benign transient.
+     * If revisited, keep these writes as the fallback. */
     SYSKEY = 0x00000000U;
     SYSKEY = 0xAA996655U;
     SYSKEY = 0x556699AAU;

--- a/firmware/src/config/default/peripheral/coretimer/plib_coretimer.h
+++ b/firmware/src/config/default/peripheral/coretimer/plib_coretimer.h
@@ -47,7 +47,8 @@
     extern "C" {
 #endif
 
-#define CORE_TIMER_FREQUENCY    (126000000U)  /* #487: SYSCLK/2 at 252 MHz (was 100M @ 200 MHz). SYS_TIME divides ms by this. */
+#include "clock_config.h"
+#define CORE_TIMER_FREQUENCY    (DAQIFI_CORE_TIMER_HZ)  /* #487: SYSCLK/2 via clock_config.h (126M @252 / 100M @200). SYS_TIME divides ms by this. */
 
 
 typedef void (*CORETIMER_CALLBACK)(uint32_t status, uintptr_t context);

--- a/firmware/src/config/default/peripheral/coretimer/plib_coretimer.h
+++ b/firmware/src/config/default/peripheral/coretimer/plib_coretimer.h
@@ -47,7 +47,7 @@
     extern "C" {
 #endif
 
-#define CORE_TIMER_FREQUENCY    (100000000U)
+#define CORE_TIMER_FREQUENCY    (126000000U)  /* #487: SYSCLK/2 at 252 MHz (was 100M @ 200 MHz). SYS_TIME divides ms by this. */
 
 
 typedef void (*CORETIMER_CALLBACK)(uint32_t status, uintptr_t context);

--- a/firmware/src/config/default/peripheral/i2c/master/plib_i2c5_master.c
+++ b/firmware/src/config/default/peripheral/i2c/master/plib_i2c5_master.c
@@ -72,7 +72,7 @@ void I2C5_Initialize(void)
     /* Disable the I2C Bus collision interrupt */
     IEC5CLR = _IEC5_I2C5BIE_MASK;
 
-    I2C5BRG = 992;
+    I2C5BRG = 833;   /* #487: PBCLK2 84 MHz (was 100 MHz -> 992) to hold the same I2C bus speed */
 
     I2C5CONCLR = _I2C5CON_SIDL_MASK;
     I2C5CONCLR = _I2C5CON_DISSLW_MASK;
@@ -542,7 +542,7 @@ bool I2C5_TransferSetup(I2C_TRANSFER_SETUP* setup, uint32_t srcClkFreq )
 
     if( srcClkFreq == 0U)
     {
-        srcClkFreq = 100000000UL;
+        srcClkFreq = 84000000UL;   /* #487: PBCLK2 84 MHz at 252 MHz SYSCLK (was 100 MHz) */
     }
 
     fBaudValue = (((float)srcClkFreq / 2.0f) * ((1.0f / (float)i2cClkSpeed) - 0.000000130f)) - 1.0f;

--- a/firmware/src/config/default/peripheral/i2c/master/plib_i2c5_master.c
+++ b/firmware/src/config/default/peripheral/i2c/master/plib_i2c5_master.c
@@ -51,6 +51,7 @@
 #include "device.h"
 #include "plib_i2c5_master.h"
 #include "interrupts.h"
+#include "clock_config.h"   /* #487: PBCLK2-derived I2C5 BRG (DAQIFI_SYSCLK_252 / DAQIFI_PBCLK_HZ) */
 
 
 // *****************************************************************************
@@ -72,7 +73,11 @@ void I2C5_Initialize(void)
     /* Disable the I2C Bus collision interrupt */
     IEC5CLR = _IEC5_I2C5BIE_MASK;
 
-    I2C5BRG = 833;   /* #487: PBCLK2 84 MHz (was 100 MHz -> 992) to hold the same I2C bus speed */
+#if DAQIFI_SYSCLK_252
+    I2C5BRG = 833;   /* #487: PBCLK2 84 MHz — same I2C bus speed as the 100 MHz/992 setting */
+#else
+    I2C5BRG = 992;   /* PBCLK2 100 MHz */
+#endif
 
     I2C5CONCLR = _I2C5CON_SIDL_MASK;
     I2C5CONCLR = _I2C5CON_DISSLW_MASK;
@@ -542,7 +547,7 @@ bool I2C5_TransferSetup(I2C_TRANSFER_SETUP* setup, uint32_t srcClkFreq )
 
     if( srcClkFreq == 0U)
     {
-        srcClkFreq = 84000000UL;   /* #487: PBCLK2 84 MHz at 252 MHz SYSCLK (was 100 MHz) */
+        srcClkFreq = DAQIFI_PBCLK_HZ;   /* #487: PBCLK2 via clock_config.h (84 @252 / 100 @200) */
     }
 
     fBaudValue = (((float)srcClkFreq / 2.0f) * ((1.0f / (float)i2cClkSpeed) - 0.000000130f)) - 1.0f;

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1017,10 +1017,17 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 break;
             }
             SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_INITIALIZED);
+            // Failures below used to be completely silent — the FW-update
+            // bridge then ran against an unreachable chip and the PC-side
+            // programmer saw only bogus chip IDs and NACKs (#WINC-recovery).
             if (wincStatus == SYS_STATUS_READY) {
-                if (m2m_wifi_get_firmware_version(&pInstance->wifiFirmwareVersion) != M2M_SUCCESS) {
+                int8_t verRet = m2m_wifi_get_firmware_version(&pInstance->wifiFirmwareVersion);
+                if (verRet != M2M_SUCCESS) {
+                    LOG_E("FW-update entry: WINC version read failed (ret=%d)", (int)verRet);
                     memset(&pInstance->wifiFirmwareVersion, 0, sizeof (tstrM2mRev));
                 }
+            } else {
+                LOG_E("FW-update entry: WINC driver not ready (status=%d)", (int)wincStatus);
             }
             wifi_serial_bridge_Init(&pInstance->serialBridgeContext);
             SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_READY);
@@ -2568,7 +2575,19 @@ void wifi_manager_RequestWifiFirmwareUpdate(void) {
 }
 
 bool wifi_manager_IsWifiFirmwareUpdateActive(void) {
-    return GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_READY);
+    // REQUESTED counts too (#WINC-recovery): the SD task uses this to hand
+    // over the shared SPI bus. Waiting for READY was too late — the FW-update
+    // entry (fresh version read + download-mode chip reset) had already run,
+    // colliding with SD attach-detect polling that holds the DRV_SPI
+    // exclusive lock across iterations. Suspending SD as soon as the update
+    // is requested (SYST:COMM:LAN:FWUpdate, before APPLY) means the bridge
+    // comes up on a quiet bus. If the user never issues APPLY, SD stays
+    // suspended until the next reinit clears the flag — acceptable for an
+    // explicit maintenance mode.
+    return GetEventFlagStatus(gStateMachineContext.eventFlags,
+                              WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_READY) ||
+           GetEventFlagStatus(gStateMachineContext.eventFlags,
+                              WIFI_MANAGER_STATE_FLAG_WIFI_FW_UPDATE_REQUESTED);
 }
 
 bool wifi_manager_GetRSSI(uint8_t *pRssi, uint32_t timeoutMs) {

--- a/firmware/src/services/wifi_services/wifi_serial_bridge.c
+++ b/firmware/src/services/wifi_services/wifi_serial_bridge.c
@@ -2,6 +2,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#define LOG_MODULE LOG_MODULE_WIFI
+#include "Util/Logger.h"
 #include "wifi_serial_bridge_interface.h"
 #include "wifi_serial_bridge.h"
 #include "nmdrv.h"
@@ -149,7 +151,22 @@ void wifi_serial_bridge_Init(wifi_serial_bridge_context_t * const pContext) {
 
     wifi_serial_bridge_interface_Init();
     pContext->state = WIFI_SERIAL_BRIDGE_STATE_WAIT_OP_CODE;
-    m2m_wifi_download_mode();
+    {
+        int8_t dlRet = m2m_wifi_download_mode();
+        // Sanity-read the chip ID (reg 0x1000) so a bridge armed against an
+        // unreachable chip is visible in SYST:LOG? instead of surfacing only
+        // as NACKs in the PC-side programmer (#WINC-recovery). A live WINC1500
+        // reads 0x0015xxxx with firmware running or 0x0010xxxx once halted in
+        // download mode (bench-observed 0x001003A0).
+        uint32_t chipId = 0;
+        int8_t rdRet = nm_read_reg_with_ret(0x1000, &chipId);
+        uint32_t chipFamily = chipId >> 16;
+        if ((dlRet != M2M_SUCCESS) || (rdRet != M2M_SUCCESS) ||
+            ((chipFamily != 0x15UL) && (chipFamily != 0x10UL))) {
+            LOG_E("Serial bridge: WINC unreachable at download-mode entry (dl=%d rd=%d chipId=%08lx)",
+                  (int)dlRet, (int)rdRet, (unsigned long)chipId);
+        }
+    }
 }
 
 void wifi_serial_bridge_Deinit(wifi_serial_bridge_context_t * const pContext) {

--- a/firmware/src/services/wifi_services/wifi_serial_bridge_interface.c
+++ b/firmware/src/services/wifi_services/wifi_serial_bridge_interface.c
@@ -38,27 +38,30 @@ bool UsbCdc_TransparentReadCmpltCB(uint8_t* pBuff, size_t buffLen) {
      * losing bytes. The previous code copied unconditionally, silently
      * wrapping the ring over unread payload and corrupting WINC firmware
      * images mid-flash behind a valid-looking ACK. Bounded so a dead consumer
-     * degrades to a visible drop, not a wedged USB task. */
-    uint32_t waitedMs = 0;
-    while (waitedMs < 500U) {
-        OSAL_MUTEX_Lock(&gUsartReadMutex, OSAL_WAIT_FOREVER);
-        size_t freeSpace = WIFI_SERIAL_BRIDGE_INTERFACE_USART_RECEIVE_BUFFER_SIZE - gUsartReceiveLength;
-        if (freeSpace >= buffLen) {
-            for (size_t i = 0; i < buffLen; i++) {
-                gUsartReceiveBuffer[gUsartReceiveInOffset] = pBuff[i];
-                gUsartReceiveInOffset++;
-                gUsartReceiveLength++;
-                if (WIFI_SERIAL_BRIDGE_INTERFACE_USART_RECEIVE_BUFFER_SIZE == gUsartReceiveInOffset) {
-                    gUsartReceiveInOffset = 0;
+     * degrades to a visible drop, not a wedged USB task — the mutex take is
+     * bounded too and the window uses wrap-safe tick arithmetic, so the whole
+     * callback is hard-limited to ~500 ms (Qodo #587). */
+    const TickType_t startTick = xTaskGetTickCount();
+    const TickType_t windowTicks = pdMS_TO_TICKS(500);
+    do {
+        if (OSAL_RESULT_TRUE == OSAL_MUTEX_Lock(&gUsartReadMutex, 10)) {
+            size_t freeSpace = WIFI_SERIAL_BRIDGE_INTERFACE_USART_RECEIVE_BUFFER_SIZE - gUsartReceiveLength;
+            if (freeSpace >= buffLen) {
+                for (size_t i = 0; i < buffLen; i++) {
+                    gUsartReceiveBuffer[gUsartReceiveInOffset] = pBuff[i];
+                    gUsartReceiveInOffset++;
+                    gUsartReceiveLength++;
+                    if (WIFI_SERIAL_BRIDGE_INTERFACE_USART_RECEIVE_BUFFER_SIZE == gUsartReceiveInOffset) {
+                        gUsartReceiveInOffset = 0;
+                    }
                 }
+                OSAL_MUTEX_Unlock(&gUsartReadMutex);
+                return true;
             }
             OSAL_MUTEX_Unlock(&gUsartReadMutex);
-            return true;
         }
-        OSAL_MUTEX_Unlock(&gUsartReadMutex);
         vTaskDelay(pdMS_TO_TICKS(1));
-        waitedMs++;
-    }
+    } while ((xTaskGetTickCount() - startTick) < windowTicks);
 
     LOG_E_ONCE(LOG_ONCE_BRIDGE_RX_OVERFLOW,
                "Serial bridge RX ring overflow; bytes dropped");

--- a/firmware/src/services/wifi_services/wifi_serial_bridge_interface.c
+++ b/firmware/src/services/wifi_services/wifi_serial_bridge_interface.c
@@ -1,12 +1,22 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
+#define LOG_MODULE LOG_MODULE_WIFI
+#include "Util/Logger.h"
 #include "wifi_serial_bridge_interface.h"
 #include "definitions.h"
 #include "osal/osal.h"
 #include "../UsbCdc/UsbCdc.h"
 
-#define WIFI_SERIAL_BRIDGE_INTERFACE_USART_RECEIVE_BUFFER_SIZE   512
+/* One full USB CDC read (512) of headroom on top of the largest single read,
+ * BSS is too tight for a burst-sized ring (linker reserves 8 KB ISR stack).
+ * Loss-freedom comes from backpressure in UsbCdc_TransparentReadCmpltCB
+ * instead: it blocks (bounded) until the bridge drains, which holds off the
+ * next CDC read arm and NAK-throttles the host at the USB level.
+ * The previous 512-byte ring had NO overflow protection at all — it silently
+ * wrapped over unread payload, corrupting WINC firmware images mid-flash with
+ * a valid-looking ACK (#WINC-recovery). */
+#define WIFI_SERIAL_BRIDGE_INTERFACE_USART_RECEIVE_BUFFER_SIZE   1024
 
 
 
@@ -21,17 +31,37 @@ bool UsbCdc_TransparentReadCmpltCB(uint8_t* pBuff, size_t buffLen) {
         return true;
     if(gUsartReadMutex==NULL)
         return false;
-    if (OSAL_RESULT_TRUE == OSAL_MUTEX_Lock(&gUsartReadMutex, OSAL_WAIT_FOREVER)) {
-        for (size_t i = 0; i < buffLen; i++) {
-            gUsartReceiveBuffer[gUsartReceiveInOffset] = pBuff[i];
-            gUsartReceiveInOffset++;
-            gUsartReceiveLength++;
-            if (WIFI_SERIAL_BRIDGE_INTERFACE_USART_RECEIVE_BUFFER_SIZE == gUsartReceiveInOffset) {
-                gUsartReceiveInOffset = 0;
+
+    /* Backpressure (#WINC-recovery): runs on the USB task, and the next CDC
+     * read is not re-armed until this callback returns — so waiting here for
+     * the bridge task to drain makes the host NAK at the USB level instead of
+     * losing bytes. The previous code copied unconditionally, silently
+     * wrapping the ring over unread payload and corrupting WINC firmware
+     * images mid-flash behind a valid-looking ACK. Bounded so a dead consumer
+     * degrades to a visible drop, not a wedged USB task. */
+    uint32_t waitedMs = 0;
+    while (waitedMs < 500U) {
+        OSAL_MUTEX_Lock(&gUsartReadMutex, OSAL_WAIT_FOREVER);
+        size_t freeSpace = WIFI_SERIAL_BRIDGE_INTERFACE_USART_RECEIVE_BUFFER_SIZE - gUsartReceiveLength;
+        if (freeSpace >= buffLen) {
+            for (size_t i = 0; i < buffLen; i++) {
+                gUsartReceiveBuffer[gUsartReceiveInOffset] = pBuff[i];
+                gUsartReceiveInOffset++;
+                gUsartReceiveLength++;
+                if (WIFI_SERIAL_BRIDGE_INTERFACE_USART_RECEIVE_BUFFER_SIZE == gUsartReceiveInOffset) {
+                    gUsartReceiveInOffset = 0;
+                }
             }
+            OSAL_MUTEX_Unlock(&gUsartReadMutex);
+            return true;
         }
         OSAL_MUTEX_Unlock(&gUsartReadMutex);
+        vTaskDelay(pdMS_TO_TICKS(1));
+        waitedMs++;
     }
+
+    LOG_E_ONCE(LOG_ONCE_BRIDGE_RX_OVERFLOW,
+               "Serial bridge RX ring overflow; bytes dropped");
     return true;
 }
 


### PR DESCRIPTION
Root-causes and fixes the "WINC corrupted / WiFi FW version 0.0.0 / winc_programmer NACK & bogus chip ID 0x00050000" cluster seen on multiple boards. **The WINC modules were never corrupted** — bench forensics (register-level bridge tracing + IRAM read-back verification) found four independent host-side bugs:

### 1. Shared SPI4 exclusive-lock wedge (also the #560-class WiFi flakiness)
DRV_SDSPI attach-detect polling holds the DRV_SPI exclusive lock **across task iterations**. On card-less boards, a lost SPI completion inside `lDRV_SDSPI_CommandSend`'s wait states (not covered by the #567 watchdogs) froze the FSM at lock depth 2 within ~6 s of power-up — from then on every WINC transfer is **silently rejected** (`DRV_SPI_WriteTransferAdd` → INVALID) until reboot. The AP keeps beaconing autonomously, so the device looks half-alive: version reads 0.0.0, flash tool sees garbage chip IDs, writes NACK.
- `DRV_SDSPI_ReleaseBus()`: unwinds the exclusive count + resets the detect FSM; called from every SD park-point (`app_SDCard_GracefulShutdown`)
- Generic #567-style bus-completion watchdog at the top of `lDRV_SDSPI_CommandSend` covering **all** executor wait states; expiry routes to the existing ERROR path, which releases the lock (bench: fires-and-recovers routinely on card-less boards under WINC traffic)
- `CHK_FOR_CARD` rolls back its freshly-taken lock when the clock-pulse write is rejected (re-entry ratcheted the count)
- `wifi_manager_IsWifiFirmwareUpdateActive()` now includes REQUESTED so SD hands the bus over before the FW-update entry needs it
- `WDRV_WINC_SPISend/Receive`: bounded 1 ms retry on TransferAdd reject (SD exclusive window) instead of instant `M2M_ERR_BUS_FAIL`; capped reject logging in `drv_spi.c` with the reason (stale handle / exclusive holder / queue full) — this failure class was fully silent

### 2. Transparent-mode RX ring silently wrapped (likely the historical real corruption)
The 512-byte bridge ring had **no overflow check** — USB (pri 7) wrapped over unread flash payload while fwUpdateTask (pri 2) drained, and the bridge protocol's checksum covers headers only, so a corrupted WINC image was written and ACKed. Fixed with bounded backpressure in `UsbCdc_TransparentReadCmpltCB` (holds the next CDC read arm → host NAK-throttles at the USB level, zero loss) + drop-with-one-shot-log fallback; ring 512 → 1024.

### 3. Download-mode entry never reset the chip
`nm_drv_init_download_mode()` has a literal `TODO: reset the chip` and just soft-halted a WINC mid-AP-operation; winc_programmer's cpu-start sequence then went nowhere (boot-ROM start magic 0xEF522F61 stayed unconsumed → "time out waiting for firmware to run"). Now performs the canonical CHIP_EN/RESET_N hard pulse (`nm_reset()`), handing the tool a clean post-POR chip.

### 4. Silent FW-update entry failures
Version-read/driver-status failures at FW-update entry and an unreachable chip at bridge arm are now logged (`SYST:LOG?`) instead of failing silently.

### Validation (Nq1 7E2898F46200E8A7, no SD card — worst case; 252 MHz build on top of #584)
- Full `winc_flash_tool.cmd /e /x /i prog /w` of 19.7.7 through the DAQiFi bridge: erase + XO + write + read-back + **verify passed** (previously failed at every stage)
- Full 4 Mb flash read-back; IRAM download verified byte-perfect against source file
- FW-update entry reads 19.7.7 fresh even after 15 s of SD polling (previously 0.0.0 in 100 % of attempts)
- Normal WiFi AP boot unaffected; new watchdog observed self-healing 4 lost completions in a single boot that would previously each have permanently killed WiFi

Note: the correct PC-side kit is winc_programmer 2.0.2 **with its matched** `programmer_firmware.bin` from Harmony wireless_wifi `utilities/wifi/winc` — the 2021-era stub in the old `WINC1500_FIRMWARE_UPDATE_PROJECT` package downloads fine but never signals alive.

Refs #560 #567 #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz