### PR TITLE
fix(sd): repair #567 completion-correlation race that broke SD card detection

### DIFF
--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
@@ -501,13 +501,15 @@ static void lDRV_SDSPI_CommandSend
             }
             else
             {
+                dObj->abortedXferHandle = dObj->expectedXferHandle;
                 dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
             }
         }
         else if (dObj->spiXferTimerExpired == true)
         {
-            /* Fires routinely on card-less boards under concurrent WINC
-             * traffic — cap the logging so it can't flood the log buffer. */
+            /* With the completion-correlation race fixed (#567 rework in
+             * DRV_SDSPI_SPIDriverEventHandler), an expiry here means a
+             * genuinely lost completion — rare; capped logging regardless. */
             static uint8_t sCmdTimeoutLogs = 0;
             dObj->spiXferTimerFlag = false;
             if (sCmdTimeoutLogs < 4U)
@@ -515,6 +517,7 @@ static void lDRV_SDSPI_CommandSend
                 sCmdTimeoutLogs++;
                 LOG_E("SD: cmd bus-completion timeout — forcing error path");
             }
+            dObj->abortedXferHandle = dObj->expectedXferHandle;
             dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
         }
         else
@@ -1005,6 +1008,7 @@ static DRV_SDSPI_ATTACH lDRV_SDSPI_MediaCommandDetect
                 {
                     if (DRV_SDSPI_SpiXferTimerStart(dObj, DRV_SDSPI_SPI_XFER_TIMEOUT_IN_MS) == false)
                     {
+                        dObj->abortedXferHandle = dObj->expectedXferHandle;
                         (void) DRV_SDSPI_SPISpeedSetup(dObj, DRV_SDSPI_SPI_INITIAL_SPEED, dObj->chipSelectPin);
                         dObj->cmdDetectState = DRV_SDSPI_CMD_DETECT_CHK_FOR_CARD;
                         dObj->sdState = TASK_STATE_IDLE;
@@ -1015,6 +1019,7 @@ static DRV_SDSPI_ATTACH lDRV_SDSPI_MediaCommandDetect
                 else if (dObj->spiXferTimerExpired == true)
                 {
                     dObj->spiXferTimerFlag = false;
+                    dObj->abortedXferHandle = dObj->expectedXferHandle;
                     (void) DRV_SDSPI_SPISpeedSetup(dObj, DRV_SDSPI_SPI_INITIAL_SPEED, dObj->chipSelectPin);
                     dObj->cmdDetectState = DRV_SDSPI_CMD_DETECT_CHK_FOR_CARD;
                     dObj->sdState = TASK_STATE_IDLE;
@@ -1949,6 +1954,7 @@ static void lDRV_SDSPI_BufferIOTasks
                 {
                     if (DRV_SDSPI_SpiXferTimerStart(dObj, DRV_SDSPI_SPI_XFER_TIMEOUT_IN_MS) == false)
                     {
+                        dObj->abortedXferHandle = dObj->expectedXferHandle;
                         dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
                         dObj->taskBufferIOState = DRV_SDSPI_TASK_READ_WRITE_ABORT;
                         break;
@@ -1958,6 +1964,7 @@ static void lDRV_SDSPI_BufferIOTasks
                 else if (dObj->spiXferTimerExpired == true)
                 {
                     dObj->spiXferTimerFlag = false;
+                    dObj->abortedXferHandle = dObj->expectedXferHandle;
                     dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
                     dObj->taskBufferIOState = DRV_SDSPI_TASK_READ_WRITE_ABORT;
                 }
@@ -2464,6 +2471,8 @@ SYS_MODULE_OBJ DRV_SDSPI_Initialize
 
     dObj->spiDrvIndex           = sdSPIInit->spiDrvIndex;
     dObj->spiDrvHandle          = DRV_HANDLE_INVALID;
+    dObj->expectedXferHandle    = DRV_SPI_TRANSFER_HANDLE_INVALID;
+    dObj->abortedXferHandle     = DRV_SPI_TRANSFER_HANDLE_INVALID;
 
     dObj->status                = SYS_STATUS_UNINITIALIZED;
     dObj->inUse                 = true;
@@ -2604,7 +2613,9 @@ void DRV_SDSPI_ReleaseBus(SYS_MODULE_OBJ object)
 
     /* Clear a stale in-flight transfer status so the resumed FSM (and the
      * CommandSend watchdog keyed on IN_PROGRESS) starts from a settled state
-     * instead of burning a timeout on a transfer that no longer exists. */
+     * instead of burning a timeout on a transfer that no longer exists. Its
+     * late completion, if any, must be ignored by the callback. */
+    dObj->abortedXferHandle = dObj->expectedXferHandle;
     dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
 
     /* Restart detection from scratch when polling resumes. */

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
@@ -501,7 +501,7 @@ static void lDRV_SDSPI_CommandSend
             }
             else
             {
-                dObj->abortedXferHandle = dObj->expectedXferHandle;
+                DRV_SDSPI_AbortedXferRecord(dObj);
                 dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
             }
         }
@@ -517,7 +517,7 @@ static void lDRV_SDSPI_CommandSend
                 sCmdTimeoutLogs++;
                 LOG_E("SD: cmd bus-completion timeout — forcing error path");
             }
-            dObj->abortedXferHandle = dObj->expectedXferHandle;
+            DRV_SDSPI_AbortedXferRecord(dObj);
             dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
         }
         else
@@ -1008,7 +1008,7 @@ static DRV_SDSPI_ATTACH lDRV_SDSPI_MediaCommandDetect
                 {
                     if (DRV_SDSPI_SpiXferTimerStart(dObj, DRV_SDSPI_SPI_XFER_TIMEOUT_IN_MS) == false)
                     {
-                        dObj->abortedXferHandle = dObj->expectedXferHandle;
+                        DRV_SDSPI_AbortedXferRecord(dObj);
                         (void) DRV_SDSPI_SPISpeedSetup(dObj, DRV_SDSPI_SPI_INITIAL_SPEED, dObj->chipSelectPin);
                         dObj->cmdDetectState = DRV_SDSPI_CMD_DETECT_CHK_FOR_CARD;
                         dObj->sdState = TASK_STATE_IDLE;
@@ -1019,7 +1019,7 @@ static DRV_SDSPI_ATTACH lDRV_SDSPI_MediaCommandDetect
                 else if (dObj->spiXferTimerExpired == true)
                 {
                     dObj->spiXferTimerFlag = false;
-                    dObj->abortedXferHandle = dObj->expectedXferHandle;
+                    DRV_SDSPI_AbortedXferRecord(dObj);
                     (void) DRV_SDSPI_SPISpeedSetup(dObj, DRV_SDSPI_SPI_INITIAL_SPEED, dObj->chipSelectPin);
                     dObj->cmdDetectState = DRV_SDSPI_CMD_DETECT_CHK_FOR_CARD;
                     dObj->sdState = TASK_STATE_IDLE;
@@ -1954,7 +1954,7 @@ static void lDRV_SDSPI_BufferIOTasks
                 {
                     if (DRV_SDSPI_SpiXferTimerStart(dObj, DRV_SDSPI_SPI_XFER_TIMEOUT_IN_MS) == false)
                     {
-                        dObj->abortedXferHandle = dObj->expectedXferHandle;
+                        DRV_SDSPI_AbortedXferRecord(dObj);
                         dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
                         dObj->taskBufferIOState = DRV_SDSPI_TASK_READ_WRITE_ABORT;
                         break;
@@ -1964,7 +1964,7 @@ static void lDRV_SDSPI_BufferIOTasks
                 else if (dObj->spiXferTimerExpired == true)
                 {
                     dObj->spiXferTimerFlag = false;
-                    dObj->abortedXferHandle = dObj->expectedXferHandle;
+                    DRV_SDSPI_AbortedXferRecord(dObj);
                     dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
                     dObj->taskBufferIOState = DRV_SDSPI_TASK_READ_WRITE_ABORT;
                 }
@@ -2472,7 +2472,11 @@ SYS_MODULE_OBJ DRV_SDSPI_Initialize
     dObj->spiDrvIndex           = sdSPIInit->spiDrvIndex;
     dObj->spiDrvHandle          = DRV_HANDLE_INVALID;
     dObj->expectedXferHandle    = DRV_SPI_TRANSFER_HANDLE_INVALID;
-    dObj->abortedXferHandle     = DRV_SPI_TRANSFER_HANDLE_INVALID;
+    for (uint8_t slot = 0; slot < DRV_SDSPI_ABORTED_XFER_SLOTS; slot++)
+    {
+        dObj->abortedXferHandles[slot] = DRV_SPI_TRANSFER_HANDLE_INVALID;
+    }
+    dObj->abortedXferIdx        = 0U;
 
     dObj->status                = SYS_STATUS_UNINITIALIZED;
     dObj->inUse                 = true;
@@ -2615,7 +2619,7 @@ void DRV_SDSPI_ReleaseBus(SYS_MODULE_OBJ object)
      * CommandSend watchdog keyed on IN_PROGRESS) starts from a settled state
      * instead of burning a timeout on a transfer that no longer exists. Its
      * late completion, if any, must be ignored by the callback. */
-    dObj->abortedXferHandle = dObj->expectedXferHandle;
+    DRV_SDSPI_AbortedXferRecord(dObj);
     dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;
 
     /* Restart detection from scratch when polling resumes. */

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.c
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.c
@@ -82,6 +82,34 @@ static void DRV_SDSPI_TimerCallback( uintptr_t context )
   Remarks:
 */
 
+
+/* #567 rework (Qodo #590): remember a watchdog-aborted transfer so its late
+ * completion — DRV_SPI has no cancel API — is ignored exactly once. */
+void DRV_SDSPI_AbortedXferRecord(DRV_SDSPI_OBJ* const dObj)
+{
+    if (dObj->expectedXferHandle == DRV_SPI_TRANSFER_HANDLE_INVALID)
+    {
+        return;
+    }
+    dObj->abortedXferHandles[dObj->abortedXferIdx] = dObj->expectedXferHandle;
+    dObj->abortedXferIdx = (uint8_t)((dObj->abortedXferIdx + 1U) % DRV_SDSPI_ABORTED_XFER_SLOTS);
+}
+
+/* #567 rework (Qodo #590): DRV_SPI handle tokens wrap, so a fresh submit can
+ * receive the same handle VALUE as a stale aborted entry. Reuse means the old
+ * transfer object was freed and its completion can no longer arrive — forget
+ * the entry so the new transfer's valid completion isn't dropped. */
+static void lDRV_SDSPI_AbortedXferForget(DRV_SDSPI_OBJ* const dObj, DRV_SPI_TRANSFER_HANDLE handle)
+{
+    for (uint8_t slot = 0; slot < DRV_SDSPI_ABORTED_XFER_SLOTS; slot++)
+    {
+        if (dObj->abortedXferHandles[slot] == handle)
+        {
+            dObj->abortedXferHandles[slot] = DRV_SPI_TRANSFER_HANDLE_INVALID;
+        }
+    }
+}
+
 void DRV_SDSPI_SPIDriverEventHandler(
     DRV_SPI_TRANSFER_EVENT event,
     DRV_SPI_TRANSFER_HANDLE transferHandle,
@@ -100,11 +128,14 @@ void DRV_SDSPI_SPIDriverEventHandler(
      * ONLY the late completion of a transfer the watchdog explicitly aborted
      * (recorded at abort time, when the handle is stable), which is the case
      * the #567 guard existed for. */
-    if ((dObj->abortedXferHandle != DRV_SPI_TRANSFER_HANDLE_INVALID) &&
-        (transferHandle == dObj->abortedXferHandle))
+    for (uint8_t slot = 0; slot < DRV_SDSPI_ABORTED_XFER_SLOTS; slot++)
     {
-        dObj->abortedXferHandle = DRV_SPI_TRANSFER_HANDLE_INVALID;
-        return;
+        if ((dObj->abortedXferHandles[slot] != DRV_SPI_TRANSFER_HANDLE_INVALID) &&
+            (transferHandle == dObj->abortedXferHandles[slot]))
+        {
+            dObj->abortedXferHandles[slot] = DRV_SPI_TRANSFER_HANDLE_INVALID;
+            return;
+        }
     }
 
     if (event == DRV_SPI_TRANSFER_EVENT_COMPLETE)
@@ -143,6 +174,7 @@ bool DRV_SDSPI_SPIWrite(
     dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_IN_PROGRESS;
 
     DRV_SPI_WriteTransferAdd (dObj->spiDrvHandle, pWriteBuffer, nBytes, &wrTransferHandle);
+    lDRV_SDSPI_AbortedXferForget(dObj, wrTransferHandle);   /* Qodo #590: handle-value reuse */
     dObj->expectedXferHandle = wrTransferHandle;   /* #567: correlate completion */
 
     if (wrTransferHandle != DRV_SPI_TRANSFER_HANDLE_INVALID)
@@ -182,6 +214,7 @@ bool DRV_SDSPI_SPIRead(
     dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_IN_PROGRESS;
 
     DRV_SPI_ReadTransferAdd (dObj->spiDrvHandle, pReadBuffer, nBytes, &rdTransferHandle);
+    lDRV_SDSPI_AbortedXferForget(dObj, rdTransferHandle);   /* Qodo #590: handle-value reuse */
     dObj->expectedXferHandle = rdTransferHandle;   /* #567: correlate completion */
 
     if (rdTransferHandle != DRV_SPI_TRANSFER_HANDLE_INVALID)
@@ -211,6 +244,7 @@ bool DRV_SDSPI_SPIWriteWithChipSelectDisabled(
     dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_IN_PROGRESS;
 
     DRV_SPI_WriteTransferAdd (dObj->spiDrvHandle, pWriteBuffer, nBytes, &wrTransferHandle);
+    lDRV_SDSPI_AbortedXferForget(dObj, wrTransferHandle);   /* Qodo #590: handle-value reuse */
     dObj->expectedXferHandle = wrTransferHandle;   /* #567: correlate completion */
 
     if (wrTransferHandle != DRV_SPI_TRANSFER_HANDLE_INVALID)

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.c
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.c
@@ -90,14 +90,20 @@ void DRV_SDSPI_SPIDriverEventHandler(
 {
     DRV_SDSPI_OBJ* dObj = (DRV_SDSPI_OBJ *)context;
 
-    /* #567: ignore a completion that doesn't belong to the transfer we are
-     * currently waiting on. After the spiXferTimer watchdog times out and
-     * aborts a transfer, its completion may still arrive late; without this
-     * guard it would overwrite spiTransferStatus (falsely completing a later
-     * transfer) and de-assert CS mid-transfer. The expected handle is updated
-     * on every submit, so a stale handle here means a timed-out transfer. */
-    if (transferHandle != dObj->expectedXferHandle)
+    /* #567 rework (SD-detect regression fix): the original guard ignored any
+     * completion whose handle didn't match expectedXferHandle — but that
+     * field is stored only AFTER DRV_SPI_*TransferAdd() returns, and short
+     * transfers complete from ISR context before the store executes, so
+     * valid completions were dropped (spiTransferStatus stuck IN_PROGRESS,
+     * watchdog aborted, the card never initialized — bisected to #567/#578,
+     * clean on its parent commit). Accept completions by default; ignore
+     * ONLY the late completion of a transfer the watchdog explicitly aborted
+     * (recorded at abort time, when the handle is stable), which is the case
+     * the #567 guard existed for. */
+    if ((dObj->abortedXferHandle != DRV_SPI_TRANSFER_HANDLE_INVALID) &&
+        (transferHandle == dObj->abortedXferHandle))
     {
+        dObj->abortedXferHandle = DRV_SPI_TRANSFER_HANDLE_INVALID;
         return;
     }
 

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.h
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi_driver_interface.h
@@ -229,6 +229,10 @@ bool DRV_SDSPI_SpiXferTimerStart(
 
 bool DRV_SDSPI_SpiXferTimerStop( DRV_SDSPI_OBJ* const dObj );
 
+/* #567 rework (Qodo #590): record a watchdog-aborted transfer handle so its
+ * late completion is ignored exactly once by the SPI completion callback. */
+void DRV_SDSPI_AbortedXferRecord( DRV_SDSPI_OBJ* const dObj );
+
 // *****************************************************************************
 /* SD Card Command-Response Timer Stop
 

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi_local.h
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi_local.h
@@ -56,6 +56,9 @@
 #include "configuration.h"
 #include "driver/sdspi/drv_sdspi.h"
 #include "driver/spi/drv_spi.h"   /* #567: DRV_SPI_TRANSFER_HANDLE (expectedXferHandle) */
+
+/* #567 rework (Qodo #590): depth of the aborted-transfer ignore ring. */
+#define DRV_SDSPI_ABORTED_XFER_SLOTS    (4U)
 #include "osal/osal.h"
 
 // *****************************************************************************
@@ -1453,11 +1456,20 @@ typedef struct
      * which is the race that broke SD detection (bisected to #567/#578). */
     DRV_SPI_TRANSFER_HANDLE                         expectedXferHandle;
 
-    /* #567 rework: handle of a transfer the watchdog aborted. The completion
-     * callback ignores exactly this one late completion (then clears the
-     * field) so a timed-out transfer can't falsely complete a later one —
-     * the protection #567's original always-on guard was after. */
-    DRV_SPI_TRANSFER_HANDLE                         abortedXferHandle;
+    /* #567 rework: handles of transfers a watchdog aborted (Qodo #590: a
+     * ring, not a single slot, so back-to-back aborts can't evict an entry
+     * whose late completion is still in flight). The completion callback
+     * ignores a matching late completion once (then clears the slot) so a
+     * timed-out transfer can't falsely complete a later one — the protection
+     * #567's original always-on guard was after. Entries are also cleared
+     * when DRV_SPI reuses the same handle value for a new submit (the old
+     * transfer object was freed, so its completion can no longer arrive).
+     * Cross-context notes: slots are 32-bit (atomic on PIC32MZ), task writes
+     * precede any possible ISR read by the >=500 ms watchdog timeout, and
+     * every path crosses opaque call boundaries — per the project atomicity
+     * rules and the #578 precedent, no volatile. */
+    DRV_SPI_TRANSFER_HANDLE                         abortedXferHandles[DRV_SDSPI_ABORTED_XFER_SLOTS];
+    uint8_t                                         abortedXferIdx;
 
     /* Flag to indicate if the device is Standard Speed or High Speed */
     uint8_t                                         sdHcHost;

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi_local.h
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi_local.h
@@ -1445,13 +1445,19 @@ typedef struct
     SYS_TIME_HANDLE                                 spiXferTimerHandle;
     volatile bool                                   spiXferTimerExpired;
 
-    /* #567: handle of the SPI transfer we are currently waiting on. The
-     * completion callback ignores any event whose transferHandle doesn't
-     * match this, so a late completion from a transfer that was already
-     * timed-out (and aborted by the spiXferTimer watchdog) can't overwrite
-     * spiTransferStatus — or de-assert CS — during a later transfer.
-     * Set once per submit (atomic 32-bit store), read in the callback. */
+    /* #567 rework: handle of the most recently submitted SPI transfer.
+     * Recorded per submit; read ONLY by the watchdog abort paths (task
+     * context, ≥500 ms after submit) to note which transfer they aborted.
+     * The completion callback must NOT gate on this — short transfers
+     * complete from ISR context before the post-submit store executes,
+     * which is the race that broke SD detection (bisected to #567/#578). */
     DRV_SPI_TRANSFER_HANDLE                         expectedXferHandle;
+
+    /* #567 rework: handle of a transfer the watchdog aborted. The completion
+     * callback ignores exactly this one late completion (then clears the
+     * field) so a timed-out transfer can't falsely complete a later one —
+     * the protection #567's original always-on guard was after. */
+    DRV_SPI_TRANSFER_HANDLE                         abortedXferHandle;
 
     /* Flag to indicate if the device is Standard Speed or High Speed */
     uint8_t                                         sdHcHost;


### PR DESCRIPTION
## The regression
SD cards stopped being detected after #567/#578 merged (2026-06-30). Bisected on the bench with adjacent-commit proof (source-built, regenerated makefiles per checkout):
- `446681ee` (#578's parent): card detects + lists ✅
- `0884f7ce` (#567/#578): "No SD Card Detected" ❌
- v3.6.2 release: ✅ — main: ❌

## Root cause
#567's completion guard in `DRV_SDSPI_SPIDriverEventHandler` rejects any completion whose `transferHandle` doesn't match `dObj->expectedXferHandle` — but that field is stored only **after** `DRV_SPI_*TransferAdd()` returns, and short transfers (one-byte response reads) complete from ISR context **before the store executes**. Valid completions were silently dropped → `spiTransferStatus` stuck IN_PROGRESS → #567's own watchdogs aborted the operation → card init never completed.

The same race is what produced the background "lost completions" on card-less boards (detect polling) — i.e. the trigger of the shared-bus exclusive-lock wedge that #587 recovers from, and the previously-unexplained P0 in #589. It was never a DMA/event mystery.

## The fix
Invert the guard: accept completions by default; ignore **only** the late completion of a transfer a watchdog explicitly aborted. The aborted handle is recorded into the new `dObj->abortedXferHandle` at every abort site (detect wait, buffer-IO wait, command-executor watchdog, `DRV_SDSPI_ReleaseBus`) — points where the handle is stable — and cleared once consumed. This keeps exactly the protection #567 was built for (a timed-out transfer's late completion falsely completing a later one, mid-transfer CS deassert) without racing the ISR.

## Bench validation (Nq1 7E2898F46200E8A7, card installed, WINC 19.7.11)
- main + fix: card detects, mounts, lists **with WiFi fully active** — true concurrent SD + WiFi on the shared SPI4 bus — zero bus-completion watchdog fires, clean `SYST:LOG?`
- 32 KB benchmark file written through the filesystem
- WiFi/WINC unaffected (chip info reads concurrently; FW-update path untouched)

Fixes the SD-detection regression from #567 (#578). Resolves the P0 root-cause item of #589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz