### PR TITLE
chore(lint): regenerate cppcheck baseline (post-merge-train drift)

### DIFF
--- a/tools/lint/cppcheck-baseline.txt
+++ b/tools/lint/cppcheck-baseline.txt
@@ -1,2 +1,0 @@
-firmware/src/services/wifi_services/wifi_serial_bridge.c:155:69: style: Parameter 'pContext' can be declared as pointer to const [constParameterPointer]
-firmware/src/services/wifi_services/wifi_serial_bridge.c:65:19: style: The scope of the variable 'cnt' can be reduced. [variableScope]


### PR DESCRIPTION
The two style findings in the committed baseline lived in `wifi_serial_bridge.c`, which #592's merged rework resolved — the baseline gate now fails on every PR (removed-findings drift). Regenerated per the documented procedure; baseline is now empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz