### PR TITLE
feat(sd): #306 CRC32 utility + SYST:STOR:SD:CRC file-integrity query

### DIFF
--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -1014,6 +1014,7 @@
         <itemPath>../src/Util/CoherentPool.c</itemPath>
         <itemPath>../src/Util/CircularBuffer.c</itemPath>
         <itemPath>../src/Util/Logger.c</itemPath>
+        <itemPath>../src/Util/CRC32.c</itemPath>
         <itemPath>../src/Util/SpiBusHealth.c</itemPath>
         <itemPath>../src/Util/StringFormatters.c</itemPath>
         <itemPath>../src/Util/StreamingBufferPool.c</itemPath>

--- a/firmware/src/Util/CRC32.c
+++ b/firmware/src/Util/CRC32.c
@@ -1,0 +1,32 @@
+/**
+ * @file CRC32.c
+ * @brief CRC-32 (IEEE 802.3) - nibble-table implementation. See CRC32.h.
+ */
+#include "CRC32.h"
+
+/* 16-entry table for the reflected polynomial 0xEDB88320: table[i] is the
+ * CRC of the 4-bit value i. 64 bytes of flash vs 1 KB for the byte-wide
+ * table; two lookups per byte. */
+static const uint32_t crc32_nibble[16] = {
+    0x00000000u, 0x1DB71064u, 0x3B6E20C8u, 0x26D930ACu,
+    0x76DC4190u, 0x6B6B51F4u, 0x4DB26158u, 0x5005713Cu,
+    0xEDB88320u, 0xF00F9344u, 0xD6D6A3E8u, 0xCB61B38Cu,
+    0x9B64C2B0u, 0x86D3D2D4u, 0xA00AE278u, 0xBDBDF21Cu
+};
+
+uint32_t CRC32_Update(uint32_t crc, const void *data, size_t len)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    while (len-- != 0u)
+    {
+        crc ^= *p++;
+        crc = (crc >> 4) ^ crc32_nibble[crc & 0x0Fu];
+        crc = (crc >> 4) ^ crc32_nibble[crc & 0x0Fu];
+    }
+    return crc;
+}
+
+uint32_t CRC32_Compute(const void *data, size_t len)
+{
+    return CRC32_Finalize(CRC32_Update(CRC32_Init(), data, len));
+}

--- a/firmware/src/Util/CRC32.h
+++ b/firmware/src/Util/CRC32.h
@@ -1,0 +1,50 @@
+/**
+ * @file CRC32.h
+ * @brief Standalone CRC-32 (IEEE 802.3, reflected polynomial 0xEDB88320).
+ *
+ * #306: single small implementation serving settings integrity, SD file
+ * integrity, and transfer verification - severs those paths from wolfSSL
+ * (pinned at v5.4.0, not upgradable). Nibble-table variant: 64-byte table,
+ * ~2 cycles/bit - SD/NVM I/O dominates every intended use.
+ *
+ * Usage (streaming):
+ *   uint32_t crc = CRC32_Init();
+ *   crc = CRC32_Update(crc, buf, len);   // repeat per chunk
+ *   crc = CRC32_Finalize(crc);
+ * One-shot: CRC32_Compute(buf, len).
+ *
+ * Matches zlib crc32() / Python binascii.crc32 / `crc32` coreutils output.
+ */
+#ifndef UTIL_CRC32_H
+#define UTIL_CRC32_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Start a streaming CRC-32 computation. */
+static inline uint32_t CRC32_Init(void)
+{
+    return 0xFFFFFFFFu;
+}
+
+/** Fold `len` bytes into a running CRC started with CRC32_Init(). */
+uint32_t CRC32_Update(uint32_t crc, const void *data, size_t len);
+
+/** Final XOR - call once after the last CRC32_Update(). */
+static inline uint32_t CRC32_Finalize(uint32_t crc)
+{
+    return crc ^ 0xFFFFFFFFu;
+}
+
+/** One-shot convenience over a contiguous buffer. */
+uint32_t CRC32_Compute(const void *data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UTIL_CRC32_H */

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5257,6 +5257,8 @@ static const scpi_command_t scpi_commands[] = {
     //
     {.pattern = "SYSTem:STORage:SD:FILE", .callback = SCPI_StorageSDLoggingSet,},
     {.pattern = "SYSTem:STORage:SD:GET", .callback = SCPI_StorageSDGetData},
+    {.pattern = "SYSTem:STORage:SD:CRC", .callback = SCPI_StorageSDCrcStart,},
+    {.pattern = "SYSTem:STORage:SD:CRC?", .callback = SCPI_StorageSDCrcGet,},
     {.pattern = "SYSTem:STORage:SD:LISt?", .callback = SCPI_StorageSDListDir},
     {.pattern = "SYSTem:DIAGnostic:SPIBus:STATs?", .callback = SCPI_DiagSpiBusStatsGet,},
     {.pattern = "SYSTem:DIAGnostic:SPIBus:MISOFight?", .callback = SCPI_DiagSpiBusMisoFightGet,},

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -193,6 +193,59 @@ __exit_point:
     return result;
 }
 
+/* #306: start an async CRC32 computation over a stored file. Result via
+ * SYST:STOR:SD:CRC? - mirrors the GET_SPACE request/query split so the SCPI
+ * task never blocks on a multi-second file scan. */
+scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
+    const char* pBuff;
+    size_t fileLen = 0;
+    sd_card_manager_settings_t* pSDCardRuntimeConfig =
+            (sd_card_manager_settings_t*) BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
+
+    if (!pSDCardRuntimeConfig->enable) {
+        context->interface->write(context, SD_CARD_NOT_ENABLED_ERROR_MSG, strlen(SD_CARD_NOT_ENABLED_ERROR_MSG));
+        return SCPI_RES_ERR;
+    }
+    if (sd_card_manager_IsBusy()) {
+        LOG_SD_BUSY("CRC");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+    if (!SCPI_CheckSDCardPresent(context)) {
+        return SCPI_RES_ERR;
+    }
+    if (!SCPI_ParamCharacters(context, &pBuff, &fileLen, TRUE) ||
+        fileLen == 0 || fileLen > SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    memcpy(pSDCardRuntimeConfig->file, pBuff, fileLen);
+    pSDCardRuntimeConfig->file[fileLen] = '\0';
+    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_COMPUTE_CRC;
+    sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
+    return SCPI_RES_OK;
+}
+
+/* #306: CRC result query. "BUSY" while computing; "0xXXXXXXXX,<bytes>" when
+ * done; -230 (data corrupt/stale) if no valid result exists. */
+scpi_result_t SCPI_StorageSDCrcGet(scpi_t * context) {
+    uint32_t crc;
+    uint64_t len;
+    if (sd_card_manager_GetCrcResult(&crc, &len)) {
+        char out[40];
+        snprintf(out, sizeof(out), "0x%08lX,%llu",
+                 (unsigned long)crc, (unsigned long long)len);
+        SCPI_ResultText(context, out);
+        return SCPI_RES_OK;
+    }
+    if (sd_card_manager_IsBusy()) {
+        SCPI_ResultText(context, "BUSY");
+        return SCPI_RES_OK;
+    }
+    SCPI_ErrorPush(context, SCPI_ERROR_DATA_CORRUPT);
+    return SCPI_RES_ERR;
+}
+
 scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
     const char* pBuff;
     size_t fileLen = 0;

--- a/firmware/src/services/SCPI/SCPIStorageSD.h
+++ b/firmware/src/services/SCPI/SCPIStorageSD.h
@@ -32,6 +32,8 @@ scpi_result_t SCPI_StorageSDLoggingSet(scpi_t * context);
 scpi_result_t SCPI_StorageSDLoggingGet(scpi_t * context);
 scpi_result_t SCPI_StorageSDListDir(scpi_t * context);
 scpi_result_t SCPI_StorageSDGetData(scpi_t * context);
+scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context);   /* #306 */
+scpi_result_t SCPI_StorageSDCrcGet(scpi_t * context);     /* #306 */
 scpi_result_t SCPI_StorageSDEnableSet(scpi_t * context);
 scpi_result_t SCPI_StorageSDEnableGet(scpi_t * context);
 

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1661,10 +1661,17 @@ void sd_card_manager_ProcessState() {
             if (gSDOpMutex) {
                 SD_TakeMutexDebug(gSDOpMutex, "crc_operation");
             }
+            /* #306 fix (OOB write): clamp each read to the ACTUAL shared-buffer
+             * size. gSdSharedBuffer is the SD-circular partition, which shrinks
+             * to STREAMING_SD_CIRCULAR_MIN (512) whenever SD is not the active
+             * streaming target - a hardcoded 2048 overruns into the adjacent
+             * streaming sample pool. */
+            size_t crcChunk = (gSdSharedBufferSize < 2048u)
+                              ? (size_t)gSdSharedBufferSize : 2048u;
             bool done = false;
             for (int pass = 0; pass < 4 && !done; pass++) {
                 size_t rd = SYS_FS_FileRead(gSDCardData.fileHandle,
-                                            gSdSharedBuffer, 2048);
+                                            gSdSharedBuffer, crcChunk);
                 if ((int32_t)rd > 0) {
                     gSDCardData.crcRunning = CRC32_Update(gSDCardData.crcRunning,
                                                           gSdSharedBuffer, rd);
@@ -1692,6 +1699,12 @@ void sd_card_manager_ProcessState() {
                     xSemaphoreGive(gSDCardData.opCompleteSemaphore);
                 } else {
                     LOG_E("[SD] CRC read error before EOF on '%s'", gSDCardData.filePath);
+                    /* #306 fix (wedge): reset mode so this op is terminal -
+                     * otherwise IsBusy() stays true forever and the INIT
+                     * dispatch keeps re-arming COMPUTE_CRC, wedging the SD
+                     * subsystem until reboot. Mirrors every other terminal
+                     * error path. */
+                    gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                 }
             }
@@ -1777,6 +1790,15 @@ bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
 
     if (pSettings != NULL && gpSDCardSettings != NULL) {
         memcpy(gpSDCardSettings, pSettings, sizeof (sd_card_manager_settings_t));
+        /* #306 fix (stale CRC): a new CRC request must invalidate any prior
+         * result immediately, so a CRC? query in the window before OPEN_FILE
+         * cannot return the previous file's CRC (GetCrcResult is checked
+         * before IsBusy in the SCPI query). */
+        if (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_COMPUTE_CRC) {
+            taskENTER_CRITICAL();
+            gSDCardData.crcResultValid = false;
+            taskEXIT_CRITICAL();
+        }
     }
     // Drain any stale completion token, but only when idle to avoid
     // consuming a signal that an in-flight WaitForCompletion is expecting

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1046,6 +1046,16 @@ void sd_card_manager_ProcessState() {
 
                 if (gSDCardData.fileHandle == SYS_FS_HANDLE_INVALID) {
                     /* Could not open the file. Error out*/
+                    /* #306 fix (wedge): reset mode so this op is terminal.
+                     * This branch is shared by READ and COMPUTE_CRC; on a
+                     * missing/unopenable file the INIT guard
+                     * ((enable || GET_SPACE) && mode != NONE) would otherwise
+                     * re-arm the op every ERROR->UNMOUNT->INIT cycle, wedging
+                     * the SD subsystem (IsBusy() stuck true) until reboot.
+                     * Mirrors the CRC read-error terminal path. Fixes the
+                     * SYST:STOR:SD:CRC "missing" wedge and the pre-existing
+                     * latent SD:GET open-fail wedge. */
+                    gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                     LOG_E("[%s:%d]Failed to open SD Card file for reading: '%s'", __FILE__, __LINE__, gSDCardData.filePath);
                 }

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -7,6 +7,7 @@
 #include "Util/StreamingBufferPool.h"
 #include "sd_card_manager.h"
 #include "services/UsbCdc/UsbCdc.h"
+#include "Util/CRC32.h"   /* #306 */
 #include "services/streaming.h"  // For Streaming_ResetSdPbMetadata on file rotation
 
 #define SD_CARD_MANAGER_CIRCULAR_BUFFER_SIZE SD_CARD_MANAGER_DEFAULT_CIRCULAR_SIZE
@@ -128,6 +129,7 @@ typedef enum {
     SD_CARD_MANAGER_PROCESS_STATE_DELETE_FILE,
     SD_CARD_MANAGER_PROCESS_STATE_FORMAT,
     SD_CARD_MANAGER_PROCESS_STATE_GET_SPACE,
+    SD_CARD_MANAGER_PROCESS_STATE_COMPUTE_CRC,   /* #306 */
     SD_CARD_MANAGER_PROCESS_STATE_DEINIT,
     SD_CARD_MANAGER_PROCESS_STATE_IDLE,
     SD_CARD_MANAGER_PROCESS_STATE_ERROR,
@@ -177,6 +179,12 @@ typedef struct {
     // Mount retry tracking
     uint8_t mountRetryCount;
     uint8_t unmountRetryCount;   /* #603: bounded unmount retries */     // Number of consecutive mount failures
+
+    // #306: CRC result (populated by COMPUTE_CRC mode)
+    volatile bool crcResultValid;
+    uint32_t crcResult;
+    uint64_t crcLength;
+    uint32_t crcRunning;      /* streaming accumulator (task-only access) */
 
     // Space query result (populated by GET_SPACE mode)
     uint64_t spaceResultFreeBytes;
@@ -1015,15 +1023,26 @@ void sd_card_manager_ProcessState() {
                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                     LOG_E("[%s:%d]Failed to open SD Card file for writing: '%s'", __FILE__, __LINE__, gSDCardData.filePath);
                 }
-            } else if (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_READ) {
-                // For READ mode, construct filename directly from settings (no splitting)
+            } else if (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_READ ||
+                       gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_COMPUTE_CRC) {
+                // READ/CRC: construct filename directly from settings (no splitting)
                 snprintf(gSDCardData.filePath, SD_CARD_MANAGER_FILE_PATH_LEN_MAX, "%s/%s",
                         gpSDCardSettings->directory, gpSDCardSettings->file);
                 LOG_D("[SD] Opening file for read: '%s'\r\n", gSDCardData.filePath);
 
                 gSDCardData.fileHandle = SYS_FS_FileOpen(gSDCardData.filePath,
                         (SYS_FS_FILE_OPEN_READ));
-                gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_READ_FROM_FILE;
+                if (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_COMPUTE_CRC) {
+                    /* #306: invalidate prior result, arm the accumulator */
+                    taskENTER_CRITICAL();
+                    gSDCardData.crcResultValid = false;
+                    taskEXIT_CRITICAL();
+                    gSDCardData.crcRunning = CRC32_Init();
+                    gSDCardData.crcLength = 0;
+                    gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_COMPUTE_CRC;
+                } else {
+                    gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_READ_FROM_FILE;
+                }
 
                 if (gSDCardData.fileHandle == SYS_FS_HANDLE_INVALID) {
                     /* Could not open the file. Error out*/
@@ -1633,6 +1652,52 @@ void sd_card_manager_ProcessState() {
         }
             break;
 
+        case SD_CARD_MANAGER_PROCESS_STATE_COMPUTE_CRC:
+        {
+            /* #306: fold the file into the CRC in bounded chunks per task
+             * pass - no priority boost, no long loop: CRC is a background
+             * diagnostic and must not starve streaming/WiFi. ~8 KB per pass
+             * via the shared op buffer (serialized by gSDOpMutex). */
+            if (gSDOpMutex) {
+                SD_TakeMutexDebug(gSDOpMutex, "crc_operation");
+            }
+            bool done = false;
+            for (int pass = 0; pass < 4 && !done; pass++) {
+                size_t rd = SYS_FS_FileRead(gSDCardData.fileHandle,
+                                            gSdSharedBuffer, 2048);
+                if ((int32_t)rd > 0) {
+                    gSDCardData.crcRunning = CRC32_Update(gSDCardData.crcRunning,
+                                                          gSdSharedBuffer, rd);
+                    gSDCardData.crcLength += rd;
+                } else {
+                    done = true;
+                }
+            }
+            if (gSDOpMutex) {
+                xSemaphoreGive(gSDOpMutex);
+            }
+            if (done) {
+                bool eof = SYS_FS_FileEOF(gSDCardData.fileHandle);
+                SYS_FS_FileClose(gSDCardData.fileHandle);
+                gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
+                if (eof) {
+                    uint32_t crc = CRC32_Finalize(gSDCardData.crcRunning);
+                    taskENTER_CRITICAL();
+                    gSDCardData.crcResult = crc;
+                    gSDCardData.crcResultValid = true;
+                    taskEXIT_CRITICAL();
+                    gSDCardData.lastOperationSuccess = true;
+                    gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
+                    gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_IDLE;
+                    xSemaphoreGive(gSDCardData.opCompleteSemaphore);
+                } else {
+                    LOG_E("[SD] CRC read error before EOF on '%s'", gSDCardData.filePath);
+                    gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
+                }
+            }
+        }
+            break;
+
         case SD_CARD_MANAGER_PROCESS_STATE_IDLE:
 
             break;
@@ -1800,6 +1865,18 @@ void sd_card_manager_ClearStartupDiskFull(void) {
      * is correct, since gating on settings init could leave the
      * flag stuck-true if SCPI ever runs before sd init. */
     gSDCardData.startupDiskFull = false;
+}
+
+bool sd_card_manager_GetCrcResult(uint32_t *crc32, uint64_t *length) {
+    bool valid;
+    taskENTER_CRITICAL();
+    valid = gSDCardData.crcResultValid;
+    if (valid) {
+        if (crc32 != NULL)  { *crc32  = gSDCardData.crcResult; }
+        if (length != NULL) { *length = gSDCardData.crcLength; }
+    }
+    taskEXIT_CRITICAL();
+    return valid;
 }
 
 bool sd_card_manager_GetSpaceInfo(uint64_t *freeBytes, uint64_t *totalBytes) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1661,14 +1661,32 @@ void sd_card_manager_ProcessState() {
             if (gSDOpMutex) {
                 SD_TakeMutexDebug(gSDOpMutex, "crc_operation");
             }
-            /* #306 fix (OOB write): clamp each read to the ACTUAL shared-buffer
-             * size. gSdSharedBuffer is the SD-circular partition, which shrinks
-             * to STREAMING_SD_CIRCULAR_MIN (512) whenever SD is not the active
-             * streaming target - a hardcoded 2048 overruns into the adjacent
-             * streaming sample pool. */
+            /* #306 fix (OOB write) + Qodo #610: clamp each read to the ACTUAL
+             * shared-buffer size, never past it. gSdSharedBuffer is the
+             * SD-circular partition, which shrinks to STREAMING_SD_CIRCULAR_MIN
+             * (512) whenever SD is not the active streaming target - a hardcoded
+             * 2048 overruns into the adjacent streaming sample pool. */
             size_t crcChunk = (gSdSharedBufferSize < 2048u)
                               ? (size_t)gSdSharedBufferSize : 2048u;
             bool done = false;
+            /* Qodo #610: if the pool has not been partitioned yet the buffer is
+             * NULL / size 0. A 0-length read returns 0 and would falsely report
+             * "read error before EOF" for a perfectly good file - fail the CRC
+             * cleanly instead (mirrors the read-error terminal path below). */
+            if (gSdSharedBuffer == NULL || crcChunk == 0u) {
+                LOG_E("[SD] CRC: shared buffer unavailable (size=%u)",
+                      (unsigned)gSdSharedBufferSize);
+                if (gSDOpMutex) {
+                    xSemaphoreGive(gSDOpMutex);
+                }
+                SYS_FS_FileClose(gSDCardData.fileHandle);
+                gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
+                gSDCardData.lastOperationSuccess = false;
+                gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
+                gSDCardData.currentProcessState =
+                        SD_CARD_MANAGER_PROCESS_STATE_ERROR;
+                break;
+            }
             for (int pass = 0; pass < 4 && !done; pass++) {
                 size_t rd = SYS_FS_FileRead(gSDCardData.fileHandle,
                                             gSdSharedBuffer, crcChunk);

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -47,6 +47,7 @@ extern "C" {
         SD_CARD_MANAGER_MODE_DELETE_FILE,
         SD_CARD_MANAGER_MODE_FORMAT,
         SD_CARD_MANAGER_MODE_GET_SPACE,
+        SD_CARD_MANAGER_MODE_COMPUTE_CRC,   /**< #306: CRC32 of a stored file */
     } sd_card_manager_mode_t;
 
     /** #598: which interface receives async READ/LIST output data. */
@@ -269,6 +270,18 @@ extern "C" {
      * @return true if valid result available, false otherwise
      */
     bool sd_card_manager_GetSpaceInfo(uint64_t *freeBytes, uint64_t *totalBytes);
+
+    /**
+     * @brief Gets the result of the last COMPUTE_CRC operation (#306).
+     *
+     * Call after sd_card_manager_WaitForCompletion() (or poll while
+     * IsBusy()) following a MODE_COMPUTE_CRC request.
+     *
+     * @param[out] crc32   IEEE 802.3 CRC-32 of the file contents
+     * @param[out] length  File length in bytes that was hashed
+     * @return true if a valid result is available, false otherwise
+     */
+    bool sd_card_manager_GetCrcResult(uint32_t *crc32, uint64_t *length);
 
     /**
      * @brief Requests abort of an in-progress SD file transfer (GET).


### PR DESCRIPTION
Adds `Util/CRC32` (IEEE 802.3, nibble-table, zlib-compatible — verified against the 0xCBF43926 check value) and the ticket's Consumer 3: async `SYST:STOR:SD:CRC "file"` + `SYST:STOR:SD:CRC?` (BUSY / `0xXXXXXXXX,<bytes>` / -230). Runs bounded (8 KB/task-pass) on the SD task via the GET_SPACE request/query pattern — SCPI never blocks, streaming never starves. Pairs with #599: WiFi-fetched files are now end-to-end verifiable. Consumers 1 (settings MD5 migration — NVM-touching, post-release) and 2 (file trailers) stay open on #306. Builds clean; bench validation in tomorrow's pre-release pass.

Refs #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz