### PR TITLE
fix(encoder): #593 DIO-only streaming emits again

### DIFF
--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -1363,12 +1363,17 @@ size_t Nanopb_EncodeStreamingFast(tBoardData* state,
     size_t dioSize = 0;
     uint8_t dioDir[2] = {0};
     size_t dioDirSize = 0;
+    uint32_t dioTimestamp = state->StreamTrigStamp;  /* #614: fallback if no DIO sample */
 
     if (hasDIO) {
         DIOSample DIOdata;
         if (DIOSampleList_PopFront(&state->DIOSamples, &DIOdata)) {
             memcpy(dioValues, &DIOdata.Values, sizeof(dioValues));
             dioSize = sizeof(dioValues);
+            /* #614 (Qodo): stamp the standalone DIO frame with the tick that
+             * captured this sample, not the live StreamTrigStamp, which drifts
+             * ahead under encoder lag. */
+            dioTimestamp = DIOdata.Timestamp;
         }
 
         /* Build port direction bitmap (1=input per channel) */
@@ -1470,7 +1475,7 @@ size_t Nanopb_EncodeStreamingFast(tBoardData* state,
     if (!dioIncluded && dioSize > 0) {
         size_t written = encode_streaming_msg_delimited(
             pBuffer + bufferOffset, buffSize - bufferOffset,
-            state->StreamTrigStamp, NULL, 0,
+            dioTimestamp, NULL, 0,
             dioValues, dioSize, dioDir, dioDirSize);
 
         if (written > 0) {

--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -1388,10 +1388,11 @@ size_t Nanopb_EncodeStreamingFast(tBoardData* state,
      * Each sample set has its own timestamp that must be preserved.
      * DIO data is included in the first AIN message if available,
      * or in a standalone message if no AIN data is present. */
+    bool dioIncluded = false;
+
     if (hasAIN) {
         uint32_t queueSize = AInSampleList_Size();
         AInPublicSampleList_t *pPublicSampleList;
-        bool dioIncluded = false;
 
         while (queueSize > 0) {
             /* Check buffer space BEFORE consuming a sample from the queue.
@@ -1460,8 +1461,13 @@ size_t Nanopb_EncodeStreamingFast(tBoardData* state,
         }
     }
 
-    /* DIO-only message if no AIN data consumed the DIO */
-    if (!hasAIN && dioSize > 0) {
+    /* Standalone DIO message whenever no AIN message consumed it. #593: the
+     * old !hasAIN gate was unreachable in DIO-only sessions - the deferred
+     * tick task enqueues an EMPTY AIn list every tick (timestamp fallback),
+     * so hasAIN was always true, the AIN branch popped the DIO sample, every
+     * empty list skipped encoding at count>0, and the popped DIO sample was
+     * destroyed. Zero bytes forever, no SCPI error. Gate on dioIncluded. */
+    if (!dioIncluded && dioSize > 0) {
         size_t written = encode_streaming_msg_delimited(
             pBuffer + bufferOffset, buffSize - bufferOffset,
             state->StreamTrigStamp, NULL, 0,


### PR DESCRIPTION
One-gate fix for the silent DIO-only regression (v3.5.0+): standalone DIO emission now gates on `dioIncluded` (was `!hasAIN`, unreachable because the tick task enqueues empty AIn lists). Bench-validated on COM12 with the ticket's exact repro: 0 bytes → one PB message per tick, zero encoder failures.

Fixes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz