### PR TITLE
fix(scpi): #612 centralized SD path validation

### DIFF
--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -113,13 +113,24 @@ static bool SD_ValidatePathParam(const char *p, size_t len)
     if (p[0] == '/' || p[0] == '\\') {
         return false;               /* absolute paths */
     }
-    for (size_t i = 0; i < len; i++) {
-        unsigned char c = (unsigned char)p[i];
-        if (c < 0x20u || c == 0x7Fu || c == '\\' || c == ':') {
+    /* Reject '.' and '..' only as whole path SEGMENTS (between '/'), not as
+     * substrings - Qodo #615: the old substring check false-rejected
+     * legitimate names like "data..csv". */
+    size_t segStart = 0;
+    for (size_t i = 0; i <= len; i++) {
+        unsigned char c = (i < len) ? (unsigned char)p[i] : (unsigned char)'/';
+        if (i < len && (c < 0x20u || c == 0x7Fu || c == '\\' || c == ':')) {
             return false;           /* control chars, backslash, drive prefix */
         }
-        if (c == '.' && (i + 1u) < len && p[i + 1u] == '.') {
-            return false;           /* traversal */
+        if (c == '/') {
+            size_t segLen = i - segStart;
+            if (segLen == 1u && p[segStart] == '.') {
+                return false;       /* "." segment */
+            }
+            if (segLen == 2u && p[segStart] == '.' && p[segStart + 1u] == '.') {
+                return false;       /* ".." traversal segment */
+            }
+            segStart = i + 1u;
         }
     }
     return true;

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -99,6 +99,32 @@ static bool SCPI_CheckSDCardPresent(scpi_t *context) {
     return true;
 }
 
+
+/* #612: shared validation for SCPI-provided SD file/directory names.
+ * The FS root is the card itself, so exposure is bounded, but '..' can
+ * escape the configured directory (GET/DELete/CRC) and stray separators
+ * or control characters produce undefined FatFS behavior. Interior '/'
+ * stays legal (subdirectory paths like "DAQiFi/sub/file.csv"). */
+static bool SD_ValidatePathParam(const char *p, size_t len)
+{
+    if (len == 0u) {
+        return false;
+    }
+    if (p[0] == '/' || p[0] == '\\') {
+        return false;               /* absolute paths */
+    }
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)p[i];
+        if (c < 0x20u || c == 0x7Fu || c == '\\' || c == ':') {
+            return false;           /* control chars, backslash, drive prefix */
+        }
+        if (c == '.' && (i + 1u) < len && p[i + 1u] == '.') {
+            return false;           /* traversal */
+        }
+    }
+    return true;
+}
+
 scpi_result_t SCPI_StorageSDEnableSet(scpi_t * context){
     int param1;
     scpi_result_t result = SCPI_RES_ERR;
@@ -178,6 +204,11 @@ scpi_result_t SCPI_StorageSDLoggingSet(scpi_t * context) {
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
+        if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
+            SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+            result = SCPI_RES_ERR;
+            goto __exit_point;
+        }
         memcpy(pSDCardRuntimeConfig->file, pBuff, fileLen);
         pSDCardRuntimeConfig->file[fileLen] = '\0';
         LOG_D("SD:FILE - Set filename to '%s' (%zu bytes) dir='%s'\r\n",
@@ -223,6 +254,11 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
 
     if (fileLen > 0) {
         if (fileLen > SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX) {
+            result = SCPI_RES_ERR;
+            goto __exit_point;
+        }
+        if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
+            SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
@@ -274,6 +310,11 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
         if (fileLen >= sizeof(pSDCardRuntimeConfig->directory)) {
             LOG_E("SD:LIST? - Directory path too long: %d bytes, max: %d\r\n", 
                   fileLen, sizeof(pSDCardRuntimeConfig->directory) - 1);
+            result = SCPI_RES_ERR;
+            goto __exit_point;
+        }
+        if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
+            SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
@@ -619,6 +660,10 @@ scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
     }
 
     // Set the filename
+    if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        goto __exit_point;
+    }
     memcpy(pSDCardRuntimeConfig->file, pBuff, fileLen);
     pSDCardRuntimeConfig->file[fileLen] = '\0';
     LOG_D("SD:DELete - Deleting file '%s'\r\n", pSDCardRuntimeConfig->file);


### PR DESCRIPTION
One `SD_ValidatePathParam()` helper applied at all four SD SCPI filename/directory copy sites — rejects traversal, absolute paths, backslash, ':', control chars with -224. Interior '/' legal. Bench-validated on COM12 (traversal rejected, legit ops clean). #610's CRC site gets the guard post-merge.

Fixes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz