### PR TITLE
fix(sd): #613 atomic SD enable — roll back on unmountable card

### DIFF
--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -643,6 +643,15 @@ void sd_card_manager_ProcessState() {
                     if (gSDCardData.mountRetryCount >= SD_MOUNT_MAX_RETRIES) {
                         LOG_E("[SD] Mount failed after %d attempts - check SD card is FAT32 formatted",
                               gSDCardData.mountRetryCount);
+                        /* #613: roll the enable back so the armed-but-broken
+                         * state can't persist - it blocked ALL streaming
+                         * starts (SD logging rides alongside USB when
+                         * enabled) with a bare -200, and left the detect
+                         * path unable to recover a later hot-insert without
+                         * a reboot. User re-runs ENAble 1 after fixing the
+                         * card - which also restarts detection cleanly. */
+                        LOG_E("[SD] SD disabled - re-run SYST:STOR:SD:ENAble 1 after inserting/fixing the card");
+                        gpSDCardSettings->enable = false;
                         gSDCardData.lastOperationSuccess = false;
                         gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
                         gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
@@ -663,6 +672,7 @@ void sd_card_manager_ProcessState() {
                     } else {
                         LOG_E("[SD] Unsupported filesystem (type=%d) - reformat as FAT32",
                               fs ? fs->fs_type : 0);
+                        gpSDCardSettings->enable = false;   /* #613: atomic enable */
                         gSDCardData.lastOperationSuccess = false;
                         gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
                         gSDCardData.discMounted = true;  // Mark mounted so ERROR→UNMOUNT can clean up

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -650,8 +650,14 @@ void sd_card_manager_ProcessState() {
                          * path unable to recover a later hot-insert without
                          * a reboot. User re-runs ENAble 1 after fixing the
                          * card - which also restarts detection cleanly. */
-                        LOG_E("[SD] SD disabled - re-run SYST:STOR:SD:ENAble 1 after inserting/fixing the card");
-                        gpSDCardSettings->enable = false;
+                        /* #616: only the streaming/write arm path may clear
+                         * enable here. A transient read-only query
+                         * (GET_SPACE/READ/LIST/DELETE) also reaches
+                         * MOUNT_DISK and must NOT disarm the user's SD. */
+                        if (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
+                            LOG_E("[SD] SD disabled - re-run SYST:STOR:SD:ENAble 1 after inserting/fixing the card");
+                            gpSDCardSettings->enable = false;
+                        }
                         gSDCardData.lastOperationSuccess = false;
                         gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
                         gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
@@ -672,7 +678,11 @@ void sd_card_manager_ProcessState() {
                     } else {
                         LOG_E("[SD] Unsupported filesystem (type=%d) - reformat as FAT32",
                               fs ? fs->fs_type : 0);
-                        gpSDCardSettings->enable = false;   /* #613: atomic enable */
+                        /* #613/#616: only the streaming/write arm path may clear
+                         * enable; a read-only query must not disarm SD. */
+                        if (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
+                            gpSDCardSettings->enable = false;
+                        }
                         gSDCardData.lastOperationSuccess = false;
                         gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
                         gSDCardData.discMounted = true;  // Mark mounted so ERROR→UNMOUNT can clean up


### PR DESCRIPTION
A failed mount no longer leaves the SD subsystem armed-but-broken (which blocked all streaming with a bare -200 and made hot-insert unrecoverable without reboot). Both mount-failure exits roll `enable` back with an explicit log line. Alongside-logging design unchanged. Happy-path regression clean on COM12; card-less rollback validation queued for the next hands-on batch.

Fixes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz