### PR TITLE
fix(usb): #127 close write-submission TOCTOU with claim flag

### DIFF
--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -400,12 +400,17 @@ int UsbCdc_Wrapper_Write(uint8_t* buf, uint32_t len) {
     // Begin atomic section to prevent race conditions with concurrent writes
     taskENTER_CRITICAL();
 
-    // Check if previous write is still pending to prevent buffer corruption
-    if (gRunTimeUsbSttings.writeTransferHandle != USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID) {
+    // Check if previous write is still pending to prevent buffer corruption.
+    // #127: writeInProgress closes the TOCTOU window - the handle reads
+    // INVALID between this critical section and the driver call assigning
+    // it, so the handle alone can't exclude a concurrent writer.
+    if (gRunTimeUsbSttings.writeTransferHandle != USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID ||
+        gRunTimeUsbSttings.writeInProgress) {
         taskEXIT_CRITICAL();
         LOG_D("USB write: previous transfer pending");
         return -1;  // Previous write still in progress
     }
+    gRunTimeUsbSttings.writeInProgress = true;
 
     // Prepare buffer while in atomic section to prevent another task from corrupting it
     memcpy(gRunTimeUsbSttings.dmaWriteBuffer, buf, (size_t)len);
@@ -440,6 +445,7 @@ int UsbCdc_Wrapper_Write(uint8_t* buf, uint32_t len) {
         taskENTER_CRITICAL();
         gRunTimeUsbSttings.writeTransferHandle = USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID;
         gRunTimeUsbSttings.writeBufferLength = 0;
+        gRunTimeUsbSttings.writeInProgress = false;   /* #127: release claim */
         taskEXIT_CRITICAL();
 #if PB_PROFILE_COUNTERS
         // #388: ensure no stale start cycles linger after a partial
@@ -585,6 +591,7 @@ static bool UsbCdc_FinalizeWrite(UsbCdcData_t* client) {
 #endif
     client->writeTransferHandle = USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID;
     client->writeBufferLength = 0;
+    client->writeInProgress = false;   /* #127: release claim on completion */
     // #525: a completed transfer means the host resumed draining the IN
     // endpoint — clear the stall latch so the next write proceeds normally
     // instead of being dropped by the early-bail in WaitForWrite.

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -265,6 +265,14 @@ void UsbCdc_EventHandler(USB_DEVICE_EVENT event, void * eventData, uintptr_t con
             // NanoPB_Encoder reads it directly for the streaming device_status
             // "USB connected" bit. Clear it on real teardown (stale-global audit).
             gRunTimeUsbSttings.isCdcHostConnected = 0;
+            /* #127/#617: a write in flight at teardown may never get its
+             * WRITE_COMPLETE (comment below), so the writeInProgress claim
+             * and the transfer handle would stay set forever and wedge every
+             * write after re-enumeration. Clear both here - the abandoned
+             * transfer is gone with the disconnect; a late WRITE_COMPLETE for
+             * the old handle no longer matches and is harmlessly ignored. */
+            gRunTimeUsbSttings.writeInProgress = false;
+            gRunTimeUsbSttings.writeTransferHandle = USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID;
             if (gRunTimeUsbSttings.deviceHandle != USB_DEVICE_HANDLE_INVALID) {
                 gRunTimeUsbSttings.state = USB_CDC_STATE_BEGIN_CLOSE;
             }

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -379,6 +379,13 @@ void UsbCdc_EventHandler(USB_DEVICE_EVENT event, void * eventData, uintptr_t con
             // but conservative approach is to reset the interface
             gRunTimeUsbSttings.isConfigured = false;
             gRunTimeUsbSttings.isCdcHostConnected = 0;  // host link reset (stale-global audit)
+            /* #127/#617: mirror the DECONFIGURED/RESET clear - a write in
+             * flight when this error resets the interface may never get its
+             * WRITE_COMPLETE, so release the claim and the transfer handle
+             * here or writeInProgress stays stuck true and wedges every write
+             * once the interface is re-established. */
+            gRunTimeUsbSttings.writeInProgress = false;
+            gRunTimeUsbSttings.writeTransferHandle = USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID;
             gRunTimeUsbSttings.state = USB_CDC_STATE_BEGIN_CLOSE;
             break;
         default:
@@ -1332,6 +1339,13 @@ void UsbCdc_ProcessState() {
             gRunTimeUsbSttings.writeTransferHandle =
                     USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID;
             gRunTimeUsbSttings.readBufferLength = 0;
+            /* #127/#617: teardown funnel. The endpoint-halt / terminated-by-
+             * host resets in BeginRead/BeginWrite reach CLOSED only through
+             * BEGIN_CLOSE - no event handler clears them - so release the
+             * write claim here too. An in-flight write abandoned at teardown
+             * must not leave writeInProgress stuck true and wedge every write
+             * after re-enumeration. */
+            gRunTimeUsbSttings.writeInProgress = false;
 
             gRunTimeUsbSttings.state = USB_CDC_STATE_INIT;
 

--- a/firmware/src/services/UsbCdc/UsbCdc.h
+++ b/firmware/src/services/UsbCdc/UsbCdc.h
@@ -81,6 +81,14 @@ extern "C" {
         /** Write transfer handle */
         USB_DEVICE_CDC_TRANSFER_HANDLE writeTransferHandle;
 
+        /** #127: write-submission claim. writeTransferHandle alone can't gate
+         * concurrent writers - it is INVALID during the window between the
+         * critical-section check and USB_DEVICE_CDC_Write() assigning it, so
+         * two tasks could both pass the check and race on dmaWriteBuffer.
+         * Claimed (set true) inside the checking critical section; cleared on
+         * WRITE_COMPLETE (FinalizeWrite) or submission failure. */
+        volatile bool writeInProgress;
+
         /** #525: latched true when a write/flush wait times out (host stopped
          * draining the CDC IN endpoint). While set, WaitForWrite/FlushWriteBuffer
          * bail immediately instead of each burning the full stall timeout, so a


### PR DESCRIPTION
The handle-based exclusivity check has a hole: `writeTransferHandle` is INVALID between the critical-section check and the driver assigning it, so concurrent writers can both claim `dmaWriteBuffer`. A `writeInProgress` flag claimed inside the checking critical section closes it; released on WRITE_COMPLETE and submission failure. Streaming smoke on COM12: 1.92 MB @ 5 kHz CSV, zero drops/failures.

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz