### PR TITLE
feat(adc): #158/#270 raw ADC-code output via CONF:ADC:USECal 2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,30 @@ survives across `StopStreamData` until the next start or
 Out-of-band visibility (Saleae, PC-side iperf2.log) for long runs;
 never poll the device under test. Mirrored in the SCPI wiki.
 
+#### SCPI Command Surface — keep it lean
+
+**Before adding a new SCPI command, try to extend an existing one.** The
+command table is a maintenance and documentation surface (every entry needs
+a wiki row, a callback, client-library awareness); an ever-growing list is
+a liability. Order of preference when adding capability:
+
+1. **Add a parameter value to an existing setter.** A new mode almost always
+   fits an existing command as another enum value. *Example (#158/#270):
+   raw/no-calibration output shipped as `CONFigure:ADC:USECal 2` (0=factory,
+   1=user, 2=raw) rather than a separate `CONF:ADC:RAWmode` — one command,
+   backward-compatible (0/1 unchanged), no new table entry.*
+2. **Add an optional parameter** to an existing command (e.g. an extra
+   channel-index or flag argument) rather than a parallel command.
+3. **Group under an existing namespace** (`SYST:...:`, `CONF:ADC:...`) so
+   related functionality is discoverable together.
+4. **Only add a brand-new command** when the capability is genuinely
+   orthogonal to everything present and can't be expressed as a value/arg.
+
+When you do extend a command, keep old values' behavior identical (append
+new values at the end — don't renumber), and update the wiki row to document
+the full value set. This preference is the user's standing rule (2026-07-06):
+"keep our command list from blowing up."
+
 #### SCPI Command Verification Protocol
 
 **⚠️ CRITICAL: NEVER guess SCPI command syntax. ALWAYS verify first.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1300,6 +1300,18 @@ Fixes #23
 
 ### How we test (policy)
 
+**RULE (user standing rule, 2026-07-06): every firmware PR ships with a
+regression test in `daqifi-python-test-suite`.** When you open a PR that
+changes device behavior, a companion test that exercises the new behavior
+(and would fail on the old firmware) must land in the suite — committed and
+referenced in the PR body. Prefer building it from `test_harness.py`
+primitives; if the test needs a new reusable capability, add it to the
+harness (not a one-off in the script) so the next PR reuses it. Exempt:
+docs-only, lint-only, comment-only, and pure-refactor PRs with no behavior
+change. If bench hardware is occupied when the PR opens, the test is still
+committed and the run is queued (note it in the PR); the test existing is
+the requirement, not that it has run yet.
+
 All **durable regression tests** — firmware regression, MCP integration, client SDK validation, throughput characterization — live in **`daqifi-python-test-suite`**. The full policy is in [`docs/HOW_WE_TEST.md`](https://github.com/daqifi/daqifi-python-test-suite/blob/main/docs/HOW_WE_TEST.md) in that repo (private, see `docs/README.md` for access); the short version:
 
 1. **Anything you'd run again** — regression checks, ceiling sweeps, endurance soaks, integration validation — lives in `daqifi-python-test-suite`. Firmware-internal unit tests (boot self-tests, cppcheck, `mdb`-driven device tests) stay in the firmware repo.

--- a/firmware/src/services/JSON_Encoder.c
+++ b/firmware/src/services/JSON_Encoder.c
@@ -416,6 +416,7 @@ size_t Json_Encode(tBoardData* state,
         StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
                 BOARDRUNTIME_STREAMING_CONFIGURATION);
         uint8_t precision = (pStreamCfg != NULL) ? pStreamCfg->VoltagePrecision : 4;
+        bool rawMode = (pStreamCfg != NULL) ? pStreamCfg->RawOutputMode : false;   /* #158/#270 */
         while (((buffSize - startIndex) >= 65) && (qSize > 0)) {
             if (!AInSampleList_PopFront(&pPublicSampleList)) {
                 break;
@@ -453,9 +454,18 @@ size_t Json_Encode(tBoardData* state,
                     timestampAdded = true;
                 }
 
+                // #158/#270: raw mode emits the ADC code directly (no cal /
+                // no voltage conversion / no double math).
+                int written;
+                if (rawMode) {
+                    written = snprintf(charBuffer + startIndex,
+                            buffSize - startIndex,
+                            "{\"ch\":%u, \"val\":%u},\n",
+                            channelId,
+                            (unsigned)rawValue);
+                } else
                 // Convert raw ADC value to voltage by board config index
                 // directly (#268/#269). Skips O(N) channel-ID search.
-                int written;
                 if (precision == 0) {
                     // Integer millivolts (backwards compatible)
                     double voltage_mv = ADC_ConvertToVoltageByIndex(

--- a/firmware/src/services/JSON_Encoder.c
+++ b/firmware/src/services/JSON_Encoder.c
@@ -458,11 +458,15 @@ size_t Json_Encode(tBoardData* state,
                 // no voltage conversion / no double math).
                 int written;
                 if (rawMode) {
+                    // #620: AD7609 (18-bit bipolar) negative codes are
+                    // sign-extended two's-complement int32 (e.g. -4096 =
+                    // 0xFFFFF000); emit SIGNED (%d) to match the PB sint32
+                    // raw path (unsigned misprinted negatives as ~4.29e9).
                     written = snprintf(charBuffer + startIndex,
                             buffSize - startIndex,
-                            "{\"ch\":%u, \"val\":%u},\n",
+                            "{\"ch\":%u, \"val\":%d},\n",
                             channelId,
-                            (unsigned)rawValue);
+                            (int32_t)rawValue);
                 } else
                 // Convert raw ADC value to voltage by board config index
                 // directly (#268/#269). Skips O(N) channel-ID search.

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -653,10 +653,37 @@ scpi_result_t SCPI_ADCUseCalSet(scpi_t * context) {
     DaqifiSettings tmpTopLevelSettings;
     AInRuntimeArray * pRuntimeAInChannels = BoardRunTimeConfig_Get(
             BOARDRUNTIMECONFIG_AIN_CHANNELS);
+    StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_STREAMING_CONFIGURATION);
+
+    // #158/#270: this command also switches the encoder output format
+    // (value 2 = raw codes), so changing it mid-stream would alter the wire
+    // format under an active session. Reject while streaming (mirrors the
+    // CONF:ADC:CHANnel #116 guard); it also protects the mid-stream cal
+    // coefficient reload for values 0/1.
+    if (pRunTimeStreamConfig->IsEnabled || pRunTimeStreamConfig->Running) {
+        LOG_E("Calibration-mode change rejected: streaming is active (stop streaming first)");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
 
     if (!SCPI_ParamInt32(context, &param1, TRUE)) {
         return SCPI_RES_ERR;
     }
+
+    // #158/#270: value 2 = no calibration -> raw ADC-code output (CSV/JSON
+    // emit the integer code, skipping cal + voltage conversion; PB is
+    // already raw). Runtime-only streaming mode: it does NOT touch the NVM
+    // calVals coefficient selection, so switching back to 0/1 or rebooting
+    // restores the persisted factory/user cal choice.
+    if (param1 == 2) {
+        pRunTimeStreamConfig->RawOutputMode = true;
+        return SCPI_RES_OK;
+    }
+
+    // Values 0/1 select the calibration coefficient set and emit calibrated
+    // volts (leaving raw mode).
+    pRunTimeStreamConfig->RawOutputMode = false;
 
     //  Load existing settings
     if (!daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings, &tmpTopLevelSettings)) return SCPI_RES_ERR;
@@ -692,7 +719,15 @@ scpi_result_t SCPI_ADCUseCalSet(scpi_t * context) {
 
 scpi_result_t SCPI_ADCUseCalGet(scpi_t * context) {
     DaqifiSettings tmpTopLevelSettings;
+    StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_STREAMING_CONFIGURATION);
 
+    // #158/#270: raw mode (runtime-only) reports as 2, overriding the
+    // persisted 0/1 coefficient selection.
+    if (pRunTimeStreamConfig != NULL && pRunTimeStreamConfig->RawOutputMode) {
+        SCPI_ResultInt32(context, 2);
+        return SCPI_RES_OK;
+    }
     if (daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings, &tmpTopLevelSettings)) {
         SCPI_ResultInt32(context, tmpTopLevelSettings.settings.topLevelSettings.calVals);
         return SCPI_RES_OK;

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -671,6 +671,16 @@ scpi_result_t SCPI_ADCUseCalSet(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
+    // #620: reject an out-of-range value BEFORE any state mutation. The paths
+    // below clear RawOutputMode, assign calVals (a bool, so e.g. 7 -> 1) and
+    // SaveToNvm before the switch's default rejected it — a command that
+    // returns an error would otherwise persist a wrong calibration selection
+    // (loaded as USER cal on the next reboot).
+    if (param1 < 0 || param1 > 2) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+
     // #158/#270: value 2 = no calibration -> raw ADC-code output (CSV/JSON
     // emit the integer code, skipping cal + voltage conversion; PB is
     // already raw). Runtime-only streaming mode: it does NOT touch the NVM

--- a/firmware/src/services/csv_encoder.c
+++ b/firmware/src/services/csv_encoder.c
@@ -382,7 +382,11 @@ static size_t tryWriteRow(
             // no voltage conversion, no double math (fastest path; also the
             // uncalibrated high-speed-streaming path #158 asked for).
             if (rawMode) {
-                p = uint32_to_str(ainPeek->Values[j], p, space);
+                // #620: AD7609 (18-bit bipolar) negative codes are
+                // sign-extended two's-complement int32 (e.g. -4096 =
+                // 0xFFFFF000); emit SIGNED to match the PB sint32 raw path
+                // (unsigned would misprint negatives as ~4.29e9).
+                p = int_to_str((int32_t)ainPeek->Values[j], p, space);
                 if (p == NULL) return 0;
             } else
             // Convert raw ADC value to voltage using the board config index

--- a/firmware/src/services/csv_encoder.c
+++ b/firmware/src/services/csv_encoder.c
@@ -322,7 +322,8 @@ static size_t tryWriteRow(
     bool        dioEnabled,
     bool       *hadAIN,
     bool       *hadDIO,
-    uint8_t     voltagePrecision
+    uint8_t     voltagePrecision,
+    bool        rawMode              /* #158/#270: emit raw ADC codes */
 ) {
     // 1) peek queues
     AInPublicSampleList_t *ainPeek = NULL;
@@ -377,6 +378,13 @@ static size_t tryWriteRow(
             *p++ = ',';
             space--;
 
+            // #158/#270: raw mode emits the ADC code directly - no cal,
+            // no voltage conversion, no double math (fastest path; also the
+            // uncalibrated high-speed-streaming path #158 asked for).
+            if (rawMode) {
+                p = uint32_to_str(ainPeek->Values[j], p, space);
+                if (p == NULL) return 0;
+            } else
             // Convert raw ADC value to voltage using the board config index
             // directly (#268/#269). Skips the O(N) channel-ID-to-index linear
             // search that ADC_ConvertToVoltage performs internally.
@@ -533,7 +541,8 @@ size_t csv_Encode(
     while (1) {
         bool hadAIN, hadDIO;
         // attempt to write the next row in-place
-        size_t rowLen = tryWriteRow(p, rem, state, channelConfig, dioEnabled, &hadAIN, &hadDIO, voltagePrecision);
+        bool rawMode = (pStreamCfg != NULL) ? pStreamCfg->RawOutputMode : false;
+        size_t rowLen = tryWriteRow(p, rem, state, channelConfig, dioEnabled, &hadAIN, &hadDIO, voltagePrecision, rawMode);
         if (rowLen == 0 || rowLen > rem) {
             break;  // no data left or row won?t fit
         }

--- a/firmware/src/state/runtime/CommonRuntimeDefaults.h
+++ b/firmware/src/state/runtime/CommonRuntimeDefaults.h
@@ -100,6 +100,7 @@ _Static_assert(sizeof(DEFAULT_NETWORK_HOST_NAME) <= WIFI_MANAGER_DNS_CLIENT_MAX_
         .ActiveInterface = StreamingInterface_USB,  /* Default: stream to single interface (USB) */ \
         .VoltagePrecision = 4,  /* Initial default; overridden by board config at boot */ \
         .OnboardDiagEnabled = true, /* MODULE7 scans diag channels during streaming */ \
+        .RawOutputMode = false, /* #158/#270: emit calibrated volts by default */ \
     }
 
 /**

--- a/firmware/src/state/runtime/StreamingRuntimeConfig.h
+++ b/firmware/src/state/runtime/StreamingRuntimeConfig.h
@@ -121,6 +121,18 @@ extern "C" {
          */
         bool OnboardDiagEnabled;
 
+        /**
+         * #158/#270: raw ADC-code output mode. When true, CSV and JSON
+         * encoders emit the raw integer ADC code instead of the calibrated
+         * voltage - skipping ADC_ConvertToVoltageByIndex (slope/offset cal +
+         * double math) entirely. Serves both "disable calibration for
+         * high-speed streaming" (#158) and "raw ADC code output" (#270).
+         * ProtoBuf already ships raw codes, so it is unaffected. VoltagePrecision
+         * is ignored in raw mode. Controlled via CONF:ADC:RAWmode. Runtime-only,
+         * resets on reboot.
+         */
+        bool RawOutputMode;
+
     } StreamingRuntimeConfig;
 
     /**


### PR DESCRIPTION
Raw-code streaming mode (integer ADC codes, no cal/voltage conversion, no per-sample double math) serving both #158 (high-speed uncalibrated streaming) and #270 (raw code output). CSV/JSON gain a raw branch; PB was already raw.

**Lean SCPI surface** (per the user's standing rule, now in CLAUDE.md): extends the existing `CONF:ADC:USECal` enum with `2` (0=factory, 1=user unchanged, 2=raw) instead of a new command. Raw is runtime-only — doesn't touch NVM `calVals`, so 0/1 and reboot restore the persisted cal choice. Setter rejects mid-stream (#116 pattern).

**Bench-validated (COM12):** `USECal 2`→`ts,0` integers; `USECal 1`@prec4→`ts,0.0000` volts; `USECal?`=2 in raw; mid-stream change rejected -200, mode unchanged.

**Test:** `test_158_270_raw_mode.py` added to daqifi-python-test-suite (see companion commit).

Wiki: the `USECal` row value set (0/1/2) queued with the release wiki batch.

Closes #158, #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz