### PR TITLE
feat(wifi): SCPI control for AP SSID visibility (hidden/cloaked) — #45

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5100,6 +5100,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:COMMunicate:LAN:NETType?", .callback = SCPI_LANNetModeGet,},
     //    {.pattern = "SYSTem:COMMunicate:LAN:AvNETType?", .callback = SCPI_LANAVNetTypeGet, },
     {.pattern = "SYSTem:COMMunicate:LAN:NETType", .callback = SCPI_LANNetModeSet,},
+    {.pattern = "SYSTem:COMMunicate:LAN:HIDden?", .callback = SCPI_LANHiddenGet,},
+    {.pattern = "SYSTem:COMMunicate:LAN:HIDden", .callback = SCPI_LANHiddenSet,},
     //    {.pattern = "SYSTem:COMMunicate:LAN:IPV6?", .callback = SCPI_LANIpv6Get, },
     //    {.pattern = "SYSTem:COMMunicate:LAN:IPV6", .callback = SCPI_LANIpv6Set, },
     {.pattern = "SYSTem:COMMunicate:LAN:ADDRess?", .callback = SCPI_LANAddrGet,},

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -243,6 +243,41 @@ scpi_result_t SCPI_LANNetModeSet(scpi_t * context) {
 }
 
 /**
+ * SCPI Callback: Get the AP-mode SSID hidden/cloaked flag (#45)
+ * @return SCPI_RES_OK on success SCPI_RES_ERR on error
+ */
+scpi_result_t SCPI_LANHiddenGet(scpi_t * context) {
+    wifi_manager_settings_t * pWifiSettings = BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
+    SCPI_ResultInt32(context, (int) pWifiSettings->ssidHidden);
+
+    return SCPI_RES_OK;
+}
+
+/**
+ * SCPI Callback: Set the AP-mode SSID hidden/cloaked flag (#45)
+ * 1 = SSID hidden (not broadcast in beacons), 0 = SSID visible (default).
+ * Takes effect at the next LAN:APPLY / AP (re)start.
+ * @return SCPI_RES_OK on success SCPI_RES_ERR on error
+ */
+scpi_result_t SCPI_LANHiddenSet(scpi_t * context) {
+    wifi_manager_settings_t * pRunTimeWifiSettings = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_WIFI_SETTINGS);
+    int param1;
+
+    if (!SCPI_ParamInt32(context, &param1, TRUE)) {
+        return SCPI_RES_ERR;
+    }
+
+    if (param1 != 0 && param1 != 1) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+
+    pRunTimeWifiSettings->ssidHidden = (bool) param1;
+    return SCPI_RES_OK;
+}
+
+/**
  * SCPI Callback: Get the Ip address of the device
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error
  */

--- a/firmware/src/services/SCPI/SCPILAN.h
+++ b/firmware/src/services/SCPI/SCPILAN.h
@@ -39,6 +39,19 @@ scpi_result_t SCPI_LANNetModeGet(scpi_t * context);
 scpi_result_t SCPI_LANNetModeSet(scpi_t * context);
 
 /**
+ * SCPI Callback: Get the AP-mode SSID hidden/cloaked flag (#45)
+ * @return SCPI_RES_OK on success SCPI_RES_ERR on error
+ */
+scpi_result_t SCPI_LANHiddenGet(scpi_t * context);
+
+/**
+ * SCPI Callback: Set the AP-mode SSID hidden/cloaked flag (#45)
+ *   1 = SSID hidden (not broadcast), 0 = SSID visible (default)
+ * @return SCPI_RES_OK on success SCPI_RES_ERR on error
+ */
+scpi_result_t SCPI_LANHiddenSet(scpi_t * context);
+
+/**
  * SCPI Callback: Get the Ip address of the device
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error
  */

--- a/firmware/src/services/daqifi_settings.c
+++ b/firmware/src/services/daqifi_settings.c
@@ -113,6 +113,7 @@ bool daqifi_settings_LoadFactoryDeafult(DaqifiSettingsType type, DaqifiSettings*
             wifi->gateway.Val = inet_addr(DEFAULT_NETWORK_GATEWAY_IP_ADDRESS);
 
             wifi->tcpPort = DEFAULT_TCP_PORT;
+            wifi->ssidHidden = false;  // #45: AP SSID visible by default
             break;
         }
         default:

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1238,6 +1238,12 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     LOG_E("[%s:%d]Error WiFi init", __FILE__, __LINE__);
                     break;
                 }
+                // #45: apply AP SSID visibility (hidden = cloaked, not broadcast in beacons)
+                if (WDRV_WINC_STATUS_OK != WDRV_WINC_BSSCtxSetSSIDVisibility(&pInstance->bssCtx, !pInstance->pWifiSettings->ssidHidden)) {
+                    SendEvent(WIFI_MANAGER_EVENT_ERROR);
+                    LOG_E("[%s:%d]Error WiFi init", __FILE__, __LINE__);
+                    break;
+                }
                 if (pInstance->pWifiSettings->securityMode == WIFI_MANAGER_SECURITY_MODE_OPEN) {
                     if (WDRV_WINC_STATUS_OK != WDRV_WINC_AuthCtxSetOpen(&pInstance->authCtx)) {
                         SendEvent(WIFI_MANAGER_EVENT_ERROR);
@@ -1677,7 +1683,14 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     LOG_E("Error setting channel\r\n");
                     break;
                 }
-                
+
+                // #45: apply AP SSID visibility (hidden = cloaked, not broadcast in beacons)
+                if (WDRV_WINC_STATUS_OK != WDRV_WINC_BSSCtxSetSSIDVisibility(&pInstance->bssCtx, !pInstance->pWifiSettings->ssidHidden)) {
+                    SendEvent(WIFI_MANAGER_EVENT_ERROR);
+                    LOG_E("Error setting SSID visibility\r\n");
+                    break;
+                }
+
                 // Set auth mode
                 if (pInstance->pWifiSettings->securityMode == WIFI_MANAGER_SECURITY_MODE_OPEN) {
                     if (WDRV_WINC_STATUS_OK != WDRV_WINC_AuthCtxSetOpen(&pInstance->authCtx)) {

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -134,6 +134,14 @@ extern "C" {
          */
         uint16_t tcpPort;
 
+        /**
+         * AP-mode SSID visibility (#45). When true the soft-AP SSID is
+         * hidden/cloaked (not broadcast in beacons); when false (default)
+         * the SSID is broadcast normally. Appended at the end of the struct
+         * to preserve the NVM offsets of the existing fields.
+         */
+        bool ssidHidden;
+
     } wifi_manager_settings_t;
 
     typedef struct {

--- a/firmware/src/state/runtime/CommonRuntimeDefaults.h
+++ b/firmware/src/state/runtime/CommonRuntimeDefaults.h
@@ -122,6 +122,7 @@ _Static_assert(sizeof(DEFAULT_NETWORK_HOST_NAME) <= WIFI_MANAGER_DNS_CLIENT_MAX_
         .ipAddr = {.Val = 0}, \
         .ipMask = {.Val = 0}, \
         .gateway = {.Val = 0}, \
+        .ssidHidden = false, \
     }
 
 /**


### PR DESCRIPTION
## Summary

Implements #45 — SCPI control over whether the device's soft-AP SSID is broadcast in beacons.

New command under the existing LAN namespace (lean-SCPI: sibling of `NETType`/`SSID`):

```
SYSTem:COMMunicate:LAN:HIDden 0|1     # 0 = visible (default), 1 = hidden/cloaked
SYSTem:COMMunicate:LAN:HIDden?        # query
```

### Changes
- **`wifi_manager.h`** — new `bool ssidHidden` in `wifi_manager_settings_t`, **appended** after `tcpPort` to preserve the NVM field offsets of existing settings.
- **`CommonRuntimeDefaults.h`** / **`daqifi_settings.c`** — default `ssidHidden = false` (visible) in the shared runtime-defaults macro and the NVM restore-defaults path. Single shared struct + macro keeps NQ1/NQ2/NQ3 consistent.
- **`SCPILAN.c` / `SCPILAN.h`** — `SCPI_LANHiddenGet` / `SCPI_LANHiddenSet` (setter validates 0/1, pushes `-224` on out-of-range), mirroring the `NETType` setter/getter style.
- **`SCPIInterface.c`** — registered the two patterns next to `NETType`.
- **`wifi_manager.c`** — both AP-start paths call `WDRV_WINC_BSSCtxSetSSIDVisibility(&bssCtx, !ssidHidden)` after the SSID/channel are set (`visible = !ssidHidden`).
- Persists with the rest of the WiFi NVM block via `SYST:COMM:LAN:SAVE`. Takes effect at the next `LAN:APPLY` / AP restart.

### Build
Clean `-O3 -Werror` build (`daqifi.X.production.hex`, default config).

### Test
`daqifi-python-test-suite/test_45_ap_hidden.py` — SCPI round-trip: set 1 → query 1, set 0 → query 0, survives `LAN:SAVE`, rejects out-of-range. Fails on old firmware (pattern absent). **Bench validation is queued for the main loop.** Full hidden-beacon verification needs a WiFi scanner (out of scope for the USB-only board).

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz