### PR TITLE
feat(scpi): user-definable device friendly name (#14)

### DIFF
--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -550,6 +550,10 @@ void app_SystemInit() {
         }
     }
 
+    // #14: Seed the runtime friendly-name cache from persisted NVM.
+    daqifi_settings_SeedFriendlyName(
+            tmpTopLevelSettings.settings.topLevelSettings.friendlyDeviceName);
+
     // Try to load WiFiSettings from NVM - if this fails, store default 
     // settings to NVM (first run after a program)
 

--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -979,7 +979,15 @@ size_t Nanopb_Encode(tBoardData* state,
                 break;
             }
             case DaqifiOutMessage_friendly_device_name_tag:
+            {
+                // #14: emit the user-defined friendly name (empty when unset).
+                const char* friendlyName = daqifi_settings_GetFriendlyName();
+                size_t len = min(strlen(friendlyName),
+                        sizeof (message.friendly_device_name) - 1);
+                memcpy(message.friendly_device_name, friendlyName, len);
+                message.friendly_device_name[len] = '\0';
                 break;
+            }
             case DaqifiOutMessage_ssid_tag:
             {
                 wifi_manager_settings_t* wifiSettings = &state->wifiSettings;

--- a/firmware/src/services/JSON_Encoder.c
+++ b/firmware/src/services/JSON_Encoder.c
@@ -16,6 +16,7 @@
 #include "../HAL/ADC.h"
 #include "../HAL/TimerApi/TimerApi.h"
 #include "streaming.h"
+#include "services/daqifi_settings.h"
 
 #ifndef min
 #define min(x,y) x <= y ? x : y
@@ -329,8 +330,23 @@ size_t Json_Encode(tBoardData* state,
                 break;
             }
             case DaqifiOutMessage_friendly_device_name_tag:
-                //TODO:  message.friendly_device_name[32];
+            {
+                // #14: emit the user-defined friendly name when set.
+                const char* friendlyName = daqifi_settings_GetFriendlyName();
+                if (friendlyName[0] == '\0') {
+                    break;  // unset — omit the field
+                }
+                int written = snprintf(charBuffer + startIndex,
+                        buffSize - startIndex,
+                        "\"friendlyName\":\"%s\",\n",
+                        friendlyName);
+                if (written < 0 || written >= (int)(buffSize - startIndex)) {
+                    // Optional field - skip on buffer full, continue processing
+                    break;
+                }
+                startIndex += written;
                 break;
+            }
             default:
                 // Skip unknown fields
                 break;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3717,6 +3717,59 @@ static scpi_result_t SCPI_LoadDataPrecision(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+// #14: user-definable device friendly name (emitted in the PB/JSON info
+// message). Runtime cache lives in daqifi_settings; persisted into the
+// TopLevelSettings NVM blob (same page as voltagePrecision) via
+// SYSTem:DEVice:NAME:SAVE.
+static scpi_result_t SCPI_SetDeviceName(scpi_t * context) {
+    char nameBuf[FRIENDLY_DEVICE_NAME_SIZE];
+    size_t nameLen = 0;
+    // maxLen excludes the NUL terminator so SCPI_ParamCopyText's write at
+    // index nameLen stays inside nameBuf.
+    if (!SCPI_ParamCopyText(context, nameBuf, sizeof(nameBuf), &nameLen,
+            TRUE)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+        return SCPI_RES_ERR;
+    }
+    daqifi_settings_SetFriendlyName(nameBuf);
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_GetDeviceName(scpi_t * context) {
+    SCPI_ResultText(context, daqifi_settings_GetFriendlyName());
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_SaveDeviceName(scpi_t * context) {
+    DaqifiSettings settings;
+    memset(&settings, 0, sizeof(DaqifiSettings));
+    // Load existing NVM to preserve other TopLevelSettings fields.
+    if (!daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings,
+            &settings)) {
+        daqifi_settings_LoadFactoryDeafult(DaqifiSettings_TopLevelSettings,
+                &settings);
+    }
+    settings.type = DaqifiSettings_TopLevelSettings;
+    // SaveToNvm captures the current friendly name from the runtime cache
+    // automatically (same pattern as voltagePrecision).
+    if (!daqifi_settings_SaveToNvm(&settings)) {
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_LoadDeviceName(scpi_t * context) {
+    DaqifiSettings settings;
+    memset(&settings, 0, sizeof(DaqifiSettings));
+    if (!daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings,
+            &settings)) {
+        return SCPI_RES_ERR;
+    }
+    daqifi_settings_SetFriendlyName(
+            settings.settings.topLevelSettings.friendlyDeviceName);
+    return SCPI_RES_OK;
+}
+
 static scpi_result_t SCPI_SetStreamInterface(scpi_t * context) {
     int param1;
     StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
@@ -5178,6 +5231,10 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:VOLTage:PRECision?", .callback = SCPI_GetDataPrecision,},
     {.pattern = "CONFigure:VOLTage:SAVE", .callback = SCPI_SaveDataPrecision,},
     {.pattern = "CONFigure:VOLTage:LOAD", .callback = SCPI_LoadDataPrecision,},
+    {.pattern = "SYSTem:DEVice:NAME", .callback = SCPI_SetDeviceName,},          // #14
+    {.pattern = "SYSTem:DEVice:NAME?", .callback = SCPI_GetDeviceName,},
+    {.pattern = "SYSTem:DEVice:NAME:SAVE", .callback = SCPI_SaveDeviceName,},
+    {.pattern = "SYSTem:DEVice:NAME:LOAD", .callback = SCPI_LoadDeviceName,},
     //
     // DAC
     {.pattern = "SOURce:VOLTage:LEVel", .callback = SCPI_DACVoltageSet,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3731,6 +3731,15 @@ static scpi_result_t SCPI_SetDeviceName(scpi_t * context) {
         SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
         return SCPI_RES_ERR;
     }
+    // #625: reject control chars, non-ASCII, and the JSON-structural
+    // characters '"' / '\\' — an unescaped name in the JSON info message
+    // ("friendlyName":"%s") would otherwise emit malformed JSON. Rejecting
+    // at the setter keeps every downstream encoder safe without per-encoder
+    // escaping, and the cache/NVM never hold an unsafe name.
+    if (!daqifi_settings_FriendlyNameIsValid(nameBuf)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
     daqifi_settings_SetFriendlyName(nameBuf);
     return SCPI_RES_OK;
 }

--- a/firmware/src/services/daqifi_settings.c
+++ b/firmware/src/services/daqifi_settings.c
@@ -16,8 +16,35 @@ uint8_t gTempFflashBuffer[NVM_FLASH_ROWSIZE] __attribute__((coherent, aligned(16
  * readers always see a valid NUL-terminated string. */
 static char gFriendlyDeviceName[FRIENDLY_DEVICE_NAME_SIZE] = {0};
 
-void daqifi_settings_SetFriendlyName(const char* name) {
+/* #625: the friendly name is emitted UNESCAPED into the JSON info message
+ * ("friendlyName":"%s") and copied into the PB info message, so it must be
+ * printable ASCII with no JSON-structural characters. Reject control chars
+ * (< 0x20, 0x7F), non-ASCII (> 0x7E), and '"' / '\\'. Bounded scan: the
+ * boot-seed path hands us a fixed NVM field that may be blank flash (0xFF,
+ * no NUL) — a name with no terminator inside the field is invalid. */
+bool daqifi_settings_FriendlyNameIsValid(const char* name) {
     if (name == NULL) {
+        return false;
+    }
+    for (size_t i = 0; i < FRIENDLY_DEVICE_NAME_SIZE; i++) {
+        unsigned char c = (unsigned char)name[i];
+        if (c == '\0') {
+            return true;   // reached the terminator, all chars were safe
+        }
+        if (c < 0x20 || c > 0x7E || c == '"' || c == '\\') {
+            return false;
+        }
+    }
+    return false;          // no NUL within the field = malformed / invalid
+}
+
+void daqifi_settings_SetFriendlyName(const char* name) {
+    /* Fail safe: a NULL or invalid name (blank-flash NVM, an older build,
+     * or a corrupt blob reaching the boot-seed / NVM-load paths) leaves the
+     * cache EMPTY rather than injecting corruption into the JSON/PB
+     * encoders. The SCPI setter validates and rejects with an error first,
+     * so a user command never silently lands in this clear-to-empty branch. */
+    if (!daqifi_settings_FriendlyNameIsValid(name)) {
         gFriendlyDeviceName[0] = '\0';
         return;
     }

--- a/firmware/src/services/daqifi_settings.c
+++ b/firmware/src/services/daqifi_settings.c
@@ -8,6 +8,31 @@
 
 uint8_t gTempFflashBuffer[NVM_FLASH_ROWSIZE] __attribute__((coherent, aligned(16)));
 
+/* #14: Runtime cache of the device friendly name. Seeded at boot from
+ * NVM-persisted TopLevelSettings; read by the PB/JSON info-message
+ * encoders and the SYST:DEVice:NAME? query; captured into the NVM blob
+ * on the next TopLevelSettings save. Empty string = unset. Written only
+ * from task context (SCPI callbacks / boot); the fixed buffer means
+ * readers always see a valid NUL-terminated string. */
+static char gFriendlyDeviceName[FRIENDLY_DEVICE_NAME_SIZE] = {0};
+
+void daqifi_settings_SetFriendlyName(const char* name) {
+    if (name == NULL) {
+        gFriendlyDeviceName[0] = '\0';
+        return;
+    }
+    strncpy(gFriendlyDeviceName, name, FRIENDLY_DEVICE_NAME_SIZE - 1);
+    gFriendlyDeviceName[FRIENDLY_DEVICE_NAME_SIZE - 1] = '\0';
+}
+
+const char* daqifi_settings_GetFriendlyName(void) {
+    return gFriendlyDeviceName;
+}
+
+void daqifi_settings_SeedFriendlyName(const char* name) {
+    daqifi_settings_SetFriendlyName(name);
+}
+
 bool daqifi_settings_LoadFromNvm(DaqifiSettingsType type, DaqifiSettings* settings) {
 
     
@@ -63,6 +88,7 @@ bool daqifi_settings_LoadFactoryDeafult(DaqifiSettingsType type, DaqifiSettings*
             pTopLevelSettings->calVals = 0;
             pTopLevelSettings->voltagePrecision = pBoardConfig->DefaultVoltagePrecision;
             pTopLevelSettings->autoPowerOnUsb = false;  // #454: opt-in
+            pTopLevelSettings->friendlyDeviceName[0] = '\0';  // #14: unset by default
             strcpy(pTopLevelSettings->boardHardwareRev, HARDWARE_REVISION);
             strcpy(pTopLevelSettings->boardFirmwareRev, FIRMWARE_REVISION);
             pTopLevelSettings->boardVariant = pBoardConfig->BoardVariant;
@@ -148,6 +174,14 @@ bool daqifi_settings_SaveToNvm(DaqifiSettings* settings) {
             // Auto-capture would clobber the persisted value on every
             // unrelated save (e.g. CONF:VOLT:SAVE) if PowerData has been
             // toggled at runtime without an AUTOOn:SAVE.
+            // #14 friendly name IS captured from the runtime cache here
+            // (same auto-capture pattern as voltagePrecision), so any
+            // TopLevelSettings save persists the current name.
+            strncpy(settings->settings.topLevelSettings.friendlyDeviceName,
+                    daqifi_settings_GetFriendlyName(),
+                    FRIENDLY_DEVICE_NAME_SIZE - 1);
+            settings->settings.topLevelSettings
+                    .friendlyDeviceName[FRIENDLY_DEVICE_NAME_SIZE - 1] = '\0';
             address = TOP_LEVEL_SETTINGS_ADDR;
             dataSize = sizeof (TopLevelSettings);
             break;

--- a/firmware/src/services/daqifi_settings.h
+++ b/firmware/src/services/daqifi_settings.h
@@ -38,6 +38,11 @@
 #define BOARD_VARIANT       1       //TODO(Daqifi) : Relocate to proper location
 #define MAX_AV_NETWORK_SSID 8
 
+// User-definable device friendly name (#14). Buffer size MUST match the
+// protobuf field DaqifiOutMessage.friendly_device_name (char[32]); the
+// stored string is always NUL-terminated, so the usable length is 31.
+#define FRIENDLY_DEVICE_NAME_SIZE 32
+
 
 #define NVM_PROGRAM_UNLOCK_KEY1 0xAA996655
 #define NVM_PROGRAM_UNLOCK_KEY2 0x556699AA
@@ -103,6 +108,13 @@ extern "C" {
          * false for back-compat.
          */
         bool autoPowerOnUsb;
+
+        /**
+         * #14: user-definable device friendly name, emitted in the
+         * protobuf/JSON info message when set (empty string = unset).
+         * NUL-terminated; sized to match the proto field (char[32]).
+         */
+        char friendlyDeviceName[FRIENDLY_DEVICE_NAME_SIZE];
 
     } TopLevelSettings;
 
@@ -196,7 +208,28 @@ extern "C" {
      */
     bool daqifi_settings_SaveADCCalSettings(DaqifiSettingsType type, AInRuntimeArray* channelRuntimeConfig);
 
+    /**
+     * #14: Sets the runtime device friendly name cache. The value is
+     * persisted to NVM only on the next TopLevelSettings save (which
+     * captures this cache automatically). Truncated to fit
+     * FRIENDLY_DEVICE_NAME_SIZE and always NUL-terminated. A NULL or
+     * empty string clears the name.
+     * @param name The friendly name to store (may be NULL to clear)
+     */
+    void daqifi_settings_SetFriendlyName(const char* name);
 
+    /**
+     * #14: Returns a pointer to the runtime device friendly name cache
+     * (NUL-terminated; empty string when unset). Never returns NULL.
+     */
+    const char* daqifi_settings_GetFriendlyName(void);
+
+    /**
+     * #14: Seeds the runtime friendly-name cache from a loaded
+     * TopLevelSettings blob (called at boot after NVM load).
+     * @param name The NVM-stored name (may be empty)
+     */
+    void daqifi_settings_SeedFriendlyName(const char* name);
 
 
 #ifdef	__cplusplus

--- a/firmware/src/services/daqifi_settings.h
+++ b/firmware/src/services/daqifi_settings.h
@@ -219,6 +219,17 @@ extern "C" {
     void daqifi_settings_SetFriendlyName(const char* name);
 
     /**
+     * #625: True when @p name is a valid friendly name — printable ASCII
+     * (0x20..0x7E) with no NUL-region overrun and none of the
+     * JSON-structural characters '"' or '\\'. Used by the SCPI setter to
+     * reject unsafe input before it can corrupt the JSON info message.
+     * A NULL pointer or a field with no terminator returns false.
+     * @param name Candidate name (scanned up to FRIENDLY_DEVICE_NAME_SIZE)
+     * @return true if safe to store and emit, false otherwise
+     */
+    bool daqifi_settings_FriendlyNameIsValid(const char* name);
+
+    /**
      * #14: Returns a pointer to the runtime device friendly name cache
      * (NUL-terminated; empty string when unset). Never returns NULL.
      */


### PR DESCRIPTION
## Summary

Adds a user-definable **device friendly name** stored in NVM and emitted in the protobuf and JSON info messages. Closes #14.

The proto field `DaqifiOutMessage.friendly_device_name` (tag 57) already existed but was never populated — both encoders had stub `break;` cases and there was no storage or SCPI surface. This wires it end-to-end.

## SCPI surface (grouped under SYST:DEVice per the lean-SCPI rule)

| Command | Effect |
|---|---|
| `SYSTem:DEVice:NAME "My Nq1"` | set the friendly name (quoted string) |
| `SYSTem:DEVice:NAME?` | query current name (quoted response) |
| `SYSTem:DEVice:NAME:SAVE` | persist to NVM (TopLevelSettings page) |
| `SYSTem:DEVice:NAME:LOAD` | reload from NVM into the runtime cache |

## Implementation

- `TopLevelSettings.friendlyDeviceName[32]` (matches the proto char[32]) — factory default empty; captured into the NVM blob on every TopLevelSettings save, exactly like voltagePrecision. Struct shared across NQ1/NQ2/NQ3.
- Runtime cache in `daqifi_settings.c` with Set/Get/Seed accessors; boot seeds it from the loaded NVM settings.
- Encoders `NanoPB_Encoder.c` and `JSON_Encoder.c` emit the stored name in the info message when set (JSON omits when empty).

## Build

Clean -O3 build with XC32 v4.60; daqifi.X.production.hex produced.

## Testing

Regression test `test_14_friendly_name.py` added to daqifi-python-test-suite (set to query to SAVE to perturb to LOAD round-trip; clears cleanly). Fails on old firmware because SYST:DEVice:NAME does not exist. Bench validation on the free board is queued for the main loop (persist-across-reboot is a documented manual follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz