### PR TITLE
feat(microrl): insert-mode command-line editing for the SCPI console (#48)

### DIFF
--- a/firmware/src/libraries/microrl/src/microrl.c
+++ b/firmware/src/libraries/microrl/src/microrl.c
@@ -524,26 +524,31 @@ static int escape_process (microrl_t * pThis, char ch)
 #endif
 
 //*****************************************************************************
-// insert len char of text at cursor position
+// insert len char of text at cursor position (issue #48: true insert mode).
+// Any characters currently at/after the cursor are shifted right by len so
+// mid-line typing inserts rather than overwrites. Appending at end-of-line
+// (dataCursor == cmdlen, the common case) is unchanged behaviourally.
 static int buffer_insert_text(microrl_t * pThis, char * text, int len)
 {
-	if (pThis->dataCursor + len < _COMMAND_LINE_LEN)
+    // cmdlen + len chars plus a trailing '\0' must fit in the buffer.
+	if (pThis->cmdlen + len < _COMMAND_LINE_LEN)
     {
+        // Shift the tail (chars after the cursor) right to make room.
+        int tail = pThis->cmdlen - pThis->dataCursor;
+        if (tail > 0)
+        {
+            memmove (pThis->cmdline + pThis->dataCursor + len,
+                     pThis->cmdline + pThis->dataCursor,
+                     tail);
+        }
+        // Drop the new text into the gap at the cursor.
 		memmove (pThis->cmdline + pThis->dataCursor, text, len);
-        if (pThis->dataCursor + len > pThis->cmdlen)
-        {
-            pThis->cmdlen = pThis->dataCursor + len;
-            pThis->dataCursor = pThis->cmdlen;
-            pThis->cmdline [pThis->cmdlen] = '\0';
-        }
-        else
-        {
-            pThis->dataCursor += len;	
-        }
-        
+        pThis->cmdlen += len;
+        pThis->dataCursor += len;
+        pThis->cmdline [pThis->cmdlen] = '\0';
 		return true;
 	}
-    
+
 	return false;
 }
 
@@ -631,6 +636,10 @@ void new_line_handler(microrl_t * pThis){
 	
     // Pass it to the command processor
     // Make sure the command terminator is appended for libscpi (but e do not want this saved in the history!)
+    // #48: with true insert semantics, force the cursor to end-of-line first so
+    // the terminator lands after the command rather than splitting it when Enter
+    // is pressed with the cursor mid-line.
+    pThis->dataCursor = pThis->cmdlen;
     buffer_insert_text(pThis, ENDL, strlen(ENDL));
 	if (pThis->execute != NULL)
     {
@@ -739,18 +748,25 @@ void microrl_insert_char (microrl_t * pThis, int ch)
                 {
                     break;
                 }
-                
-                if (buffer_insert_text (pThis, (char*)&ch, 1))
+
+                // #48: remember whether we were appending at end-of-line.
+                // A mid-line insert shifts the tail right, so the whole line
+                // must be redrawn; the single-char echo fast-path only works
+                // when the cursor was at the end.
                 {
-                    if (pThis->terminalPos == 0)
+                    int wasAtEnd = (pThis->dataCursor == pThis->cmdlen);
+                    if (buffer_insert_text (pThis, (char*)&ch, 1))
                     {
-                        terminal_print_line(pThis);
-                    }
-                    else
-                    {
-                        if (pThis->echoOn > -1)
+                        if (pThis->terminalPos == 0 || !wasAtEnd)
                         {
-                            terminal_print(pThis, 1, (char*)&ch, 1);
+                            terminal_print_line(pThis);
+                        }
+                        else
+                        {
+                            if (pThis->echoOn > -1)
+                            {
+                                terminal_print(pThis, 1, (char*)&ch, 1);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Adds **insert-mode** command-line editing to the microrl SCPI console (shared by the USB-CDC and WiFi-TCP command paths). Previously the console operated in **overwrite** mode: with the cursor moved into the middle of a line (left-arrow), typed characters replaced existing ones instead of shifting them right.

Fixes #48.

## Root cause

`buffer_insert_text()` in `firmware/src/libraries/microrl/src/microrl.c` — despite its name — performed a plain `memmove` of the new text **onto** the cursor position without shifting the existing tail. That is overwrite, not insert.

## Change (confined to the DAQiFi microrl fork's line-editing path)

- **`buffer_insert_text()`**: shift the tail (chars after the cursor) right by `len`, then drop the new text into the gap and grow `cmdlen`. Bounds check tightened to `cmdlen + len < _COMMAND_LINE_LEN` (room for the whole shifted line + NUL). Appending at end-of-line — the common case — is behaviourally unchanged.
- **default char handler**: on a mid-line insert the whole line is redrawn (`terminal_print_line`, which also repositions the cursor right after the inserted char); the single-char echo fast-path is kept only for end-of-line appends.
- **`new_line_handler`**: force the cursor to end-of-line before appending the libscpi `ENDL` terminator, so pressing Enter with the cursor mid-line terminates the command rather than splitting it.

No config flag existed for this (there is no `_ENABLE_INSERT` in this fork), and microrl is not otherwise rewritten.

## Build

Standalone `default` config builds clean under `-O3 -Werror` (XC32 v4.60, MPLAB X v6.30); `daqifi.X.production.hex` produced.

## Test

Best-effort regression test added to `daqifi-python-test-suite`: `test_48_microrl_insert.py`. Interactive line editing is hard to fully drive over a byte stream, so it writes the exact bytes a terminal sends (printable chars + `ESC [ D` cursor-left + inserted char(s)) and confirms the console assembles the intended command:
- **baseline** (no-regression): plain `*IDN?` still returns identity;
- **single-char insert**: `*ID?` + `<Left>` + `N` → `*IDN?` (overwrite would clobber `?`);
- **multi-char tail-shift insert**: `*I?` + `<Left>` + `DN` → `*IDN?`.
Insert PASS requires both `DAQiFi` in the console response and `SYST:ERR?` → `0,"No error"`.

## Bench validation queued for the main loop (USB-only free board)

Automated:
```
python test_48_microrl_insert.py <PORT>
```
Manual insert-mode confirmation on a 115200 8N1 terminal:
1. Type `SYST:ERR?`
2. Press Left-arrow 5× (cursor just after `SYST`)
3. Type `:LOG` (do not press Enter)
4. Expect the line to read `SYST:LOG:ERR?` (inserted `:LOG`, `:ERR?` shifted right) — overwrite mode would show `SYST:LOG?`
5. Also confirm no console regression: type/enter a plain `*IDN?` and a mid-line-edited command, both parse (`SYST:ERR?` → `0,"No error"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz