### PR TITLE
feat(wifi): SYST:COMM:LAN:POWer WINC deep power-down (#334)

### DIFF
--- a/firmware/src/HAL/Power/PowerApi.c
+++ b/firmware/src/HAL/Power/PowerApi.c
@@ -697,7 +697,10 @@ static void Power_HandlePoweredUpExtDownState(void) {
  */
 static void Power_UpdateState(void) {
     static POWER_STATE lastLoggedState = -1;
-    
+    /* #334/#637: WiFi's enabled state captured on the way into STANDBY, so
+     * we know whether to bring it back up on the way out. */
+    static bool sWifiEnabledPreStandby = false;
+
     /* Monitor 3.3V rail state (debug/diagnostic) */
     static bool last3v3State = false;
     static bool first3v3Check = true;
@@ -711,6 +714,26 @@ static void Power_UpdateState(void) {
     // Log state changes
     if (pData->powerState != lastLoggedState) {
         LOG_D("Power_UpdateState: State changed from %d to %d", lastLoggedState, pData->powerState);
+
+        /* #334/#637: keep WiFi silent in STANDBY — no beacon, no STA
+         * reconnect. Hold the WINC in reset (CHIP_EN/RESET_N low, via the
+         * deep-power-down latch) on the way in; on the way out restore it
+         * ONLY if it was enabled before standby. wifi_manager_PowerOn()
+         * force-sets isEnabled=1, so an unconditional restore would turn
+         * WiFi on for a user who had it off; and Deinit (inside PowerOff)
+         * clears isEnabled, so the pre-standby value must be captured first.
+         * The (POWER_STATE)-1 sentinel skips first-boot: the normal WiFi
+         * init path owns the initial power-up, and PowerOff/PowerOn are
+         * NULL-guarded no-ops before wifi_manager is initialized anyway. */
+        if (lastLoggedState != (POWER_STATE)-1) {
+            if (pData->powerState == STANDBY) {
+                sWifiEnabledPreStandby = wifi_manager_IsEnabled();
+                wifi_manager_PowerOff();
+            } else if (lastLoggedState == STANDBY && sWifiEnabledPreStandby) {
+                wifi_manager_PowerOn();
+            }
+        }
+
         lastLoggedState = pData->powerState;
     }
     

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5097,6 +5097,8 @@ static const scpi_command_t scpi_commands[] = {
     //    // Wifi
     {.pattern = "SYSTem:COMMunicate:LAN:ENAbled?", .callback = SCPI_LANEnabledGet,},
     {.pattern = "SYSTem:COMMunicate:LAN:ENAbled", .callback = SCPI_LANEnabledSet,},
+    {.pattern = "SYSTem:COMMunicate:LAN:POWer?", .callback = SCPI_LANPowerGet,},  // #334
+    {.pattern = "SYSTem:COMMunicate:LAN:POWer", .callback = SCPI_LANPowerSet,},   // #334
     {.pattern = "SYSTem:COMMunicate:LAN:NETType?", .callback = SCPI_LANNetModeGet,},
     //    {.pattern = "SYSTem:COMMunicate:LAN:AvNETType?", .callback = SCPI_LANAVNetTypeGet, },
     {.pattern = "SYSTem:COMMunicate:LAN:NETType", .callback = SCPI_LANNetModeSet,},

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -199,6 +199,50 @@ __exit_point:
     return result;
 }
 
+/**
+ * SCPI Callback: Query WINC deep-power-down state (#334).
+ * Returns 1 if the WINC is powered/available, 0 if held in deep
+ * power-down (CHIP_EN low).
+ */
+scpi_result_t SCPI_LANPowerGet(scpi_t * context) {
+    SCPI_ResultInt32(context, wifi_manager_IsPoweredOff() ? 0 : 1);
+    return SCPI_RES_OK;
+}
+
+/**
+ * SCPI Callback: Deep power-down / power-up the WINC1500 chip (#334).
+ *
+ * SYST:COMM:LAN:POWer 0  -> hold WINC in shutdown (CHIP_EN low) for
+ *                           battery savings; the rest of the device
+ *                           (USB/SD streaming, ADC) keeps running.
+ * SYST:COMM:LAN:POWer 1  -> bring the WINC back up (re-init).
+ *
+ * Distinct from SYST:POWer:STATe, which standbys the *whole* device.
+ * Distinct from SYST:COMM:LAN:ENAbled, which only toggles the runtime
+ * enable flag and leaves the chip powered/idle.
+ *
+ * The deep-power-down teardown is queued via wifi_manager_PowerOff and
+ * completed by app_WifiTask; PowerOn re-inits asynchronously (~1-2 s).
+ */
+scpi_result_t SCPI_LANPowerSet(scpi_t * context) {
+    int param1;
+    if (!SCPI_ParamInt32(context, &param1, TRUE)) {
+        return SCPI_RES_ERR;
+    }
+    if (param1 != 0 && param1 != 1) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    bool ok = (param1 == 0) ? wifi_manager_PowerOff()
+                            : wifi_manager_PowerOn();
+    if (!ok) {
+        SCPI_ExecutionError(context,
+                "SYST:COMM:LAN:POWer: WiFi manager not ready");
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
 scpi_result_t SCPI_LANNetModeGet(scpi_t * context) {
     wifi_manager_settings_t * pWifiSettings = BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
     uint8_t type = pWifiSettings->networkMode;

--- a/firmware/src/services/SCPI/SCPILAN.h
+++ b/firmware/src/services/SCPI/SCPILAN.h
@@ -22,6 +22,18 @@ scpi_result_t SCPI_LANEnabledGet(scpi_t * context);
 scpi_result_t SCPI_LANEnabledSet(scpi_t * context);
 
 /**
+ * SCPI Callback: Get the WINC deep-power-down state (#334).
+ * @return SCPI_RES_OK on success SCPI_RES_ERR on error
+ */
+scpi_result_t SCPI_LANPowerGet(scpi_t * context);
+
+/**
+ * SCPI Callback: Deep power-down / power-up the WINC chip (#334).
+ * @return SCPI_RES_OK on success SCPI_RES_ERR on error
+ */
+scpi_result_t SCPI_LANPowerSet(scpi_t * context);
+
+/**
  * SCPI Callback: Get the type of LAN network
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error
  */

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -2346,6 +2346,21 @@ bool wifi_manager_PowerOff(void) {
 // SYST:COMM:LAN:ADDR? to confirm association.
 bool wifi_manager_PowerOn(void) {
     if (gStateMachineContext.pWifiSettings == NULL) return false;
+    // #637: idempotent. If the WINC is already powered and up, POWer 1 is a
+    // no-op. Re-sending INIT here would fall through the INIT handler's
+    // alreadyInitialized path and re-run WDRV_WINC_BSSConnect/APStart on the
+    // live, socket-bound chip — bypassing the #435/#437b HardReset divert
+    // (which only guards the APPLY/UpdateNetworkSettings REINIT path) and
+    // dropping/oscillating the active link. Only proceed with the re-init
+    // when the chip is actually down: deep-power-down latched, or
+    // initialized-but-not-yet-started.
+    if (!gWincDeepPowerOff &&
+        GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_INITIALIZED) &&
+        (GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED) ||
+         GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED))) {
+        LOG_I("WiFi: power-up requested but WINC already powered/up — no-op (#637)");
+        return true;
+    }
     taskENTER_CRITICAL();
     gWincDeepPowerOff = false;
     gWifiReinitDeadlineTick = 0;  // cancel any pending deferred-INIT

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1170,7 +1170,15 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 // stale deep-power-down latch so SYST:COMM:LAN:POWer? reports
                 // the true state (covers bring-up via APPLY/ENAbled, not just
                 // the dedicated PowerOn path).
-                gWincDeepPowerOff = false;
+                // #637: but only on a genuine bring-up (isEnabled==1). A
+                // concurrent SYST:COMM:LAN:POWer 0 on the higher-priority USB
+                // SCPI task sets the latch and isEnabled=0, then queues DEINIT
+                // behind this in-flight INIT; clearing unconditionally here
+                // would clobber that request so the trailing DEINIT skips the
+                // CHIP_EN/RESET_N deassert and the WINC stays powered.
+                if (pInstance->pWifiSettings->isEnabled) {
+                    gWincDeepPowerOff = false;
+                }
                 // Reset error flag on success
                 if (initErrorLogged) {
                     LOG_D("WiFi driver initialization succeeded\r\n");

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -2384,6 +2384,13 @@ bool wifi_manager_IsPoweredOff(void) {
     return gWincDeepPowerOff;
 }
 
+// #334: report the live enabled state. Read a plain aligned bool — atomic
+// on PIC32MZ; no critical section needed for a single-field read.
+bool wifi_manager_IsEnabled(void) {
+    if (gStateMachineContext.pWifiSettings == NULL) return false;
+    return gStateMachineContext.pWifiSettings->isEnabled != 0;
+}
+
 // True hardware reset of the WINC chip: disable -> DEINIT (toggles
 // CHIP_EN/RESET_N GPIOs via wifi_manager_FixWincResetState) -> after
 // 2 s settle, re-enable -> REINIT to bring the chip back up.

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -12,6 +12,7 @@
 #include "wifi_serial_bridge_interface.h"
 #include "iperf2/iperf2.h"
 #include "driver/winc/include/drv/common/nm_common.h"  // nm_reset (canonical WINC reset pulse)
+#include "wdrv_winc_gpio.h"  // WDRV_WINC_GPIOChipEnable*/Reset* (#334 deep power-down)
 #include "semphr.h"
 #include "driver/winc/include/drv/driver/m2m_wifi.h"
 
@@ -160,6 +161,17 @@ static volatile bool gTcpRxPending = false;
 // concurrency rules).  Marked volatile because it's set from any task
 // calling HardReset/Deinit and read every tick from app_WifiTask.
 static volatile TickType_t gWifiReinitDeadlineTick = 0;
+
+// #334: deep power-down latch. When true the user has requested that the
+// WINC1500 chip be held in full shutdown (CHIP_EN driven LOW) for battery
+// savings — distinct from a plain Deinit, which leaves nm_reset's final
+// CHIP_EN HIGH so the chip stays powered but idle. The DEINIT event handler
+// consults this to drive CHIP_EN/RESET_N LOW after teardown; the INIT
+// success path clears it (any bring-up implies the chip is powered again).
+// Runtime-only, scrubbed in wifi_manager_BootInit (#409). 32-bit/bool
+// reads/writes are atomic on PIC32MZ; volatile because it is written from a
+// SCPI task and read from app_WifiTask.
+static volatile bool gWincDeepPowerOff = false;
 
 // Recursive mutex serializing wifi_manager_ProcessState across callers.
 // Today app_WifiTask is the primary owner; SCPI_Reset's active pump
@@ -1154,6 +1166,11 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 }
                 sInitFailTracking = false;
                 sJamCheckDone = false;
+                // #334: the chip is powered and reachable again — clear any
+                // stale deep-power-down latch so SYST:COMM:LAN:POWer? reports
+                // the true state (covers bring-up via APPLY/ENAbled, not just
+                // the dedicated PowerOn path).
+                gWincDeepPowerOff = false;
                 // Reset error flag on success
                 if (initErrorLogged) {
                     LOG_D("WiFi driver initialization succeeded\r\n");
@@ -1970,6 +1987,18 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                 ResetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_INITIALIZED);
                 LOG_D("WiFi de-initialized and taken out of reset\r\n");
             }
+            // #334: honor a deep power-down request. wifi_manager_FixWincResetState
+            // (nm_reset) above leaves CHIP_EN HIGH — chip powered but idle. For a
+            // true low-power shutdown, override that and hold CHIP_EN + RESET_N LOW
+            // so the WINC draws only its shutdown-mode current. Done unconditionally
+            // when latched (even if the driver was never initialized) so the chip
+            // reaches the same state regardless of prior WiFi activity. Power-up
+            // (INIT via the driver's nm_reset) drives both lines back HIGH.
+            if (gWincDeepPowerOff) {
+                WDRV_WINC_GPIOChipEnableDeassert();  // CHIP_EN LOW  (full shutdown)
+                WDRV_WINC_GPIOResetAssert();         // RESET_N LOW
+                LOG_I("WiFi: WINC held in deep power-down (CHIP_EN low)");
+            }
             break;
         case WIFI_MANAGER_EVENT_UDP_SOCKET_CONNECTED:
             SetEventFlag(&pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_CONNECTED);
@@ -2121,6 +2150,7 @@ void wifi_manager_BootInit(void) {
     gTcpRxPending = false;
     gLastRssiPercentage = 0;
     gWifiReinitDeadlineTick = 0;
+    gWincDeepPowerOff = false;  // #334 — retained-RAM scrub
     gApplyInProgress = false;
     gApplyInProgressDeadlineTick = 0;
     gApplyTeardownStartTick = 0;
@@ -2283,6 +2313,52 @@ bool wifi_manager_Deinit() {
     // link.  Doing it here makes the query gates trip the moment Deinit runs.
     InvalidateStaLinkState();
     return SendEvent(WIFI_MANAGER_EVENT_DEINIT);
+}
+
+// #334: Full deep power-down of the WINC1500 chip for battery savings.
+//
+// A plain wifi_manager_Deinit() tears down the driver but nm_reset (run at
+// the tail of the DEINIT event) leaves CHIP_EN HIGH, so the chip stays
+// powered and continues drawing its idle current. PowerOff sets the
+// deep-power-down latch first, then drives the same Deinit teardown; the
+// DEINIT event handler sees the latch and holds CHIP_EN + RESET_N LOW,
+// putting the WINC in shutdown mode (minimal quiescent current).
+//
+// The rest of the device (USB/SD streaming, ADC, power management) is
+// unaffected — this only touches the WINC. Reverse with wifi_manager_PowerOn.
+//
+// Non-blocking: queues the DEINIT event. Works whether called from
+// app_WifiTask (TCP SCPI) or another task (USB CDC SCPI). The caller may
+// actively pump wifi_manager_ProcessState[NoTcpRx] to force completion, the
+// same pattern SCPI_SetPowerState uses.
+bool wifi_manager_PowerOff(void) {
+    if (gStateMachineContext.pWifiSettings == NULL) return false;
+    gWincDeepPowerOff = true;
+    LOG_I("WiFi: deep power-down requested (WINC shutdown)");
+    return wifi_manager_Deinit();
+}
+
+// #334: Bring the WINC1500 back up after a PowerOff. Clears the
+// deep-power-down latch, re-enables WiFi, and queues INIT — the driver's
+// own init path (nm_reset in nm_drv_init) drives CHIP_EN/RESET_N back HIGH
+// and re-syncs the chip, so no explicit GPIO wake is needed here. Full
+// bring-up (re-init + STA reassoc + DHCP) takes ~1-2 s+; poll
+// SYST:COMM:LAN:ADDR? to confirm association.
+bool wifi_manager_PowerOn(void) {
+    if (gStateMachineContext.pWifiSettings == NULL) return false;
+    taskENTER_CRITICAL();
+    gWincDeepPowerOff = false;
+    gWifiReinitDeadlineTick = 0;  // cancel any pending deferred-INIT
+    gStateMachineContext.pWifiSettings->isEnabled = 1;
+    taskEXIT_CRITICAL();
+    LOG_I("WiFi: power-up requested (WINC re-init)");
+    return SendEvent(WIFI_MANAGER_EVENT_INIT);
+}
+
+// #334: query the deep-power-down latch. true = WINC is (or is being) held
+// in deep power-down; false = powered/available.
+bool wifi_manager_IsPoweredOff(void) {
+    return gWincDeepPowerOff;
 }
 
 // True hardware reset of the WINC chip: disable -> DEINIT (toggles

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -218,6 +218,39 @@ extern "C" {
     bool wifi_manager_Deinit();
 
     /**
+     * @brief #334: Deep power-down the WINC1500 chip for battery savings.
+     *
+     * Unlike wifi_manager_Deinit (which leaves the chip powered-but-idle
+     * because nm_reset ends with CHIP_EN HIGH), this drives CHIP_EN and
+     * RESET_N LOW so the WINC enters shutdown mode drawing only its
+     * quiescent current. Only the WINC is affected — USB/SD streaming, ADC
+     * and power management continue running. Reverse with
+     * wifi_manager_PowerOn. Non-blocking (queues the DEINIT event).
+     *
+     * @return True on success, false if WiFi settings not initialized.
+     */
+    bool wifi_manager_PowerOff(void);
+
+    /**
+     * @brief #334: Bring the WINC1500 back up after wifi_manager_PowerOff.
+     *
+     * Clears the deep-power-down latch, re-enables WiFi and queues INIT; the
+     * driver's own init path drives CHIP_EN/RESET_N back HIGH. Full bring-up
+     * (re-init + reassoc + DHCP) takes ~1-2 s+.
+     *
+     * @return True on success, false if WiFi settings not initialized.
+     */
+    bool wifi_manager_PowerOn(void);
+
+    /**
+     * @brief #334: Query the WINC deep-power-down state.
+     *
+     * @return True if the WINC is held in deep power-down (CHIP_EN low),
+     *         false if it is powered/available.
+     */
+    bool wifi_manager_IsPoweredOff(void);
+
+    /**
      * @brief Hardware reset the WINC chip (true GPIO reset).
      *
      * Disables WiFi and queues the DEINIT event (toggles CHIP_EN /

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -251,6 +251,18 @@ extern "C" {
     bool wifi_manager_IsPoweredOff(void);
 
     /**
+     * @brief #334: Query whether WiFi is currently enabled (user setting).
+     *
+     * Reads the live pWifiSettings->isEnabled. Used by the power-state
+     * machine to remember whether to bring WiFi back up when the device
+     * leaves STANDBY (it is captured BEFORE the deep-power-down teardown,
+     * which clears isEnabled in wifi_manager_Deinit).
+     *
+     * @return True if WiFi is enabled, false if disabled or not yet init.
+     */
+    bool wifi_manager_IsEnabled(void);
+
+    /**
      * @brief Hardware reset the WINC chip (true GPIO reset).
      *
      * Disables WiFi and queues the DEINIT event (toggles CHIP_EN /


### PR DESCRIPTION
## Summary

Adds a SCPI command to fully power down the WINC1500 chip for battery savings, per #334. Distinct from the existing controls:

| Command | Effect |
|---|---|
| `SYST:COMM:LAN:POWer 0` | Hold WINC in shutdown (CHIP_EN low) — WINC-only, USB/SD streaming keeps running |
| `SYST:COMM:LAN:POWer 1` | Bring the WINC back up (re-init) |
| `SYST:COMM:LAN:POWer?` | `1` = powered/available, `0` = deep power-down |

## Why not already covered

- `SYST:COMM:LAN:ENAbled 0` only toggles the runtime enable flag; the chip stays powered/idle.
- `wifi_manager_Deinit()` tears down the driver but `nm_reset` (tail of the DEINIT event) ends with **CHIP_EN HIGH** — chip powered, still drawing idle current.
- `SYST:POWer:STATe 0` standbys the **whole device**, not just the WINC.

None of these give a WINC-only deep power-down (CHIP_EN low → shutdown-mode current) while the rest of the device keeps acquiring.

## Mechanism

- `wifi_manager_PowerOff()` sets a deep-power-down latch, then runs the normal Deinit teardown. The DEINIT event handler consults the latch and drives **CHIP_EN + RESET_N LOW** after teardown (via `WDRV_WINC_GPIOChipEnableDeassert` / `WDRV_WINC_GPIOResetAssert`), overriding `nm_reset`'s final CHIP_EN HIGH.
- `wifi_manager_PowerOn()` clears the latch, re-enables WiFi and queues INIT — the driver's own `nm_reset` (in `nm_drv_init`) drives CHIP_EN/RESET_N back HIGH and re-syncs the chip.
- The INIT-success path also clears the latch so a bring-up via `APPLy`/`ENAbled` keeps `POWer?` honest.
- Latch is runtime-only and scrubbed in `wifi_manager_BootInit` (#409 retained-RAM pattern).

Grouped under the existing LAN namespace per the lean-surface rule. No new static buffers (one `volatile bool`) — no RAM-budget impact.

## Build

NQ1 default config, XC32 v4.60, `-O3 -Werror` clean, `.production.hex` produced.

## Test

`test_334_winc_powerdown.py` (in daqifi-python-test-suite) — enable/disable SCPI round-trips complete with no error and `POWer?` reflects the commanded state. **Full current-draw verification needs an external meter / INA219 and is out of scope** (that is a bench-instrument measurement, not a SCPI round-trip).

Bench validation is **queued for the main loop** on the free USB board — this PR is BUILD-ONLY (no bench device touched).

🤖 Generated with Claude Code
https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz

---

## Added: WiFi silent in STANDBY (behavioral-predictability requirement)

Beyond the manual `SYST:COMM:LAN:POWer` command, the power-state machine now
holds the WINC in reset whenever the device is in STANDBY, so a standby unit
is RF-silent — no SSID beacon, no STA reconnect.

- `Power_UpdateState()` edge detector: transition **into** STANDBY captures
  WiFi's enabled state then calls `wifi_manager_PowerOff()` (CHIP_EN/RESET_N
  low via the `gWincDeepPowerOff` latch). Transition **out of** STANDBY calls
  `wifi_manager_PowerOn()` **only if WiFi was enabled before standby**
  (`PowerOn` force-sets `isEnabled=1`; `Deinit` inside `PowerOff` clears it,
  so the pre-standby value is captured first).
- First boot is skipped (`-1` sentinel) — the normal WiFi init owns the
  initial power-up; `PowerOff`/`PowerOn` are NULL-guarded no-ops pre-init.
- STANDBY-only: `POWERED_UP ↔ POWERED_UP_EXT_DOWN` leave WiFi untouched.
- Adds `wifi_manager_IsEnabled()` getter.

Hardware test (batch): power up with WiFi enabled → `POW:STAT 0` → confirm the
AP beacon disappears (PC scan) and `LAN:ADDRess?` goes unreachable → `POW:STAT 1`
→ WiFi returns. Repeat with WiFi disabled → stays off across the cycle.
