### PR TITLE
feat(wifi): dynamic WINC power-save based on streaming state (#29)

### DIFF
--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -584,8 +584,10 @@ void app_SystemInit() {
         daqifi_settings_LoadFactoryDeafult(DaqifiSettings_Wifi, &tmpSettings);
         daqifi_settings_SaveToNvm(&tmpSettings);
     }
-    // Move temp variable to global variables
-    tmpSettings.settings.wifi.isWifiFirmwareUpdateModeEnabled = false;
+    // Move temp variable to global variables.
+    // #29: the old force-false of the deprecated FW-update flag is gone — that
+    // slot is now powerSaveDisabled and the NVM-loaded value is meaningful
+    // (pre-#29 NVM only ever holds false there = power-save enabled).
     memcpy(&gpBoardRuntimeConfig->wifiSettings,
             &tmpSettings.settings.wifi,
             sizeof (wifi_manager_settings_t));

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5136,6 +5136,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:COMMunicate:LAN:DISPlay", .callback = SCPI_NotImplemented,},
     {.pattern = "SYSTem:COMMunicate:LAN:APPLY", .callback = SCPI_LANSettingsApply,},
     {.pattern = "SYSTem:COMMunicate:LAN:HRESet", .callback = SCPI_LANHardReset,},   // hard reset WINC (#383 recovery)
+    {.pattern = "SYSTem:COMMunicate:LAN:PSave", .callback = SCPI_LANPowerSaveSet,}, // #29 auto power-save enable
+    {.pattern = "SYSTem:COMMunicate:LAN:PSave?", .callback = SCPI_LANPowerSaveGet,},
     {.pattern = "SYSTem:COMMunicate:LAN:LOAD", .callback = SCPI_LANSettingsLoad,},
     {.pattern = "SYSTem:COMMunicate:LAN:SAVE", .callback = SCPI_LANSettingsSave,},
     {.pattern = "SYSTem:COMMunicate:LAN:FACRESET", .callback = SCPI_LANSettingsFactoryLoad,},

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -819,6 +819,11 @@ scpi_result_t SCPI_LANPowerSaveSet(scpi_t * context) {
     if (!SCPI_ParamInt32(context, &param1, TRUE)) {
         return SCPI_RES_ERR;
     }
+    if (param1 != 0 && param1 != 1) {
+        /* Match the LAN sibling setters (POWer/HIDden): documented 0|1 only. */
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
     wifi_manager_SetPowerSaveEnabled(param1 != 0);
     return SCPI_RES_OK;
 }

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -727,3 +727,32 @@ scpi_result_t SCPI_LANHostnameGet(scpi_t * context) {
     SCPI_LANStringGetImpl(context, host);
     return SCPI_RES_OK;
 }
+
+/**
+ * SCPI Callback: Enable/disable automatic WiFi power-save (#29).
+ *
+ * `SYST:COMM:LAN:PSave <0|1>` — 1 lets the WiFi manager drop the WINC into
+ * its light auto power-save mode while associated as a STA but idle; 0
+ * forces full power at all times.  Runtime-only (not persisted to NVM).
+ */
+scpi_result_t SCPI_LANPowerSaveSet(scpi_t * context) {
+    int param1;
+    if (!SCPI_ParamInt32(context, &param1, TRUE)) {
+        return SCPI_RES_ERR;
+    }
+    wifi_manager_SetPowerSaveEnabled(param1 != 0);
+    return SCPI_RES_OK;
+}
+
+/**
+ * SCPI Callback: Query WiFi power-save state (#29).
+ *
+ * Returns "<enabled>,<appliedMode>" where enabled is 0/1 and appliedMode is
+ * the WDRV_WINC_PS_MODE value currently in force (0 = full power / OFF, or
+ * -1 when the WiFi driver is not open).
+ */
+scpi_result_t SCPI_LANPowerSaveGet(scpi_t * context) {
+    SCPI_ResultInt32(context, wifi_manager_GetPowerSaveEnabled() ? 1 : 0);
+    SCPI_ResultInt32(context, wifi_manager_GetPowerSaveMode());
+    return SCPI_RES_OK;
+}

--- a/firmware/src/services/SCPI/SCPILAN.h
+++ b/firmware/src/services/SCPI/SCPILAN.h
@@ -166,6 +166,16 @@ scpi_result_t SCPI_LANFwUpdate(scpi_t * context);
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error
  */
 scpi_result_t SCPI_LANGetChipInfo(scpi_t * context);
+/**
+ * SCPI Callback: Enable/disable automatic WiFi power-save (#29).
+ * @return SCPI_RES_OK on success SCPI_RES_ERR on error
+ */
+scpi_result_t SCPI_LANPowerSaveSet(scpi_t * context);
+/**
+ * SCPI Callback: Query WiFi power-save state (#29).
+ * @return SCPI_RES_OK on success SCPI_RES_ERR on error
+ */
+scpi_result_t SCPI_LANPowerSaveGet(scpi_t * context);
 //scpi_result_t SCPI_LANAVSsidStrengthGet(scpi_t * context);
 //
 ///**

--- a/firmware/src/services/daqifi_settings.c
+++ b/firmware/src/services/daqifi_settings.c
@@ -159,7 +159,7 @@ bool daqifi_settings_LoadFactoryDeafult(DaqifiSettingsType type, DaqifiSettings*
 
             //mac address will be populated after reading from ATWINC
             wifi->networkMode = DEFAULT_WIFI_NETWORK_MODE;
-            wifi->isWifiFirmwareUpdateModeEnabled=false;
+            wifi->powerSaveDisabled = false;  /* #29: power-save on by default */
             memset(&wifi->macAddr, 0, sizeof (WDRV_WINC_MAC_ADDR));
             wifi->ipAddr.Val = inet_addr(DEFAULT_NETWORK_IP_ADDRESS);
             wifi->ipMask.Val = inet_addr(DEFAULT_NETWORK_IP_MASK);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2531,3 +2531,16 @@ bool Streaming_IsActiveOnNonWifiInterface(void) {
             iface == StreamingInterface_UsbAndSd);
 }
 
+// #29: complement of the above — true only when a streaming session is
+// enabled and its active interface is WiFi.  Read by the WiFi power-save
+// policy (app_WifiTask) to keep the WINC at full power while the WiFi data
+// path is carrying a stream.  Same volatile-view / staleness reasoning as
+// Streaming_IsActiveOnNonWifiInterface().
+bool Streaming_IsActiveOnWifiInterface(void) {
+    const volatile StreamingRuntimeConfig* cfg =
+        (const volatile StreamingRuntimeConfig*)gpRuntimeConfigStream;
+    if (cfg == NULL) return false;
+    if (!cfg->IsEnabled) return false;
+    return (cfg->ActiveInterface == StreamingInterface_WiFi);
+}
+

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -612,6 +612,15 @@ uint32_t Streaming_GetBenchmarkMode(void);
 bool Streaming_IsActiveOnNonWifiInterface(void);
 
 /**
+ * True when streaming is active AND the active interface is WiFi. The
+ * complement query to Streaming_IsActiveOnNonWifiInterface(); used by the
+ * #29 dynamic WiFi power-save policy to force full WINC power while the
+ * WiFi data path is in use. Safe to call from any context; reads plain
+ * fields with no cross-task coordination needed.
+ */
+bool Streaming_IsActiveOnWifiInterface(void);
+
+/**
  * Build channel mapping from current board config and runtime config.
  * Must be called before streaming starts (from SCPI_StartStreaming).
  * Stores mapping globally for ISR and encoder access.

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -417,6 +417,13 @@ bool Iperf2_StartUdpClient(const char* remote_ip, uint16_t remote_port,
     return true;
 }
 
+// #29: power-save policy predicate — any in-flight session holds full power.
+// gCtx.mode is volatile and enum-sized (aligned 32-bit read = atomic on
+// PIC32MZ), safe to read from app_WifiTask's policy loop.
+bool Iperf2_IsActive(void) {
+    return gCtx.mode != IPERF2_MODE_IDLE;
+}
+
 void Iperf2_Stop(void) {
     if (gCtx.mode == IPERF2_MODE_IDLE) {
         return;

--- a/firmware/src/services/wifi_services/iperf2/iperf2.h
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.h
@@ -140,6 +140,14 @@ bool Iperf2_StartTxBlast(uint16_t port, uint32_t duration_sec);
 void Iperf2_Stop(void);
 
 /**
+ * #29: true while any iperf2 session is in flight (mode != IDLE).
+ * Consumed by the WiFi power-save policy: iperf2 rides raw WINC sockets
+ * (not wifi_tcp_server), so without this predicate the WINC would stay in
+ * 802.11 power-save during a measurement and silently corrupt it.
+ */
+bool Iperf2_IsActive(void);
+
+/**
  * Snapshot the current stats — safe to call at any time.  Stats reflect
  * the most recent completed test until a new one starts.
  */

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -2593,6 +2593,28 @@ static void ApplyPowerSavePolicy(stateMachineInst_t * const pInstance) {
         return;  // no change — no HIF transaction needed
     }
 
+    // #29 fix: keep BROADCAST reception enabled under power-save.
+    // WDRV_WINC_PowerSaveSetMode has no bcast parameter -- it derives the
+    // WINC broadcast-reception flag from powerSaveDTIMInterval
+    // (m2m_wifi_set_sleep_mode's BcastEn = interval ? 1 : 0), and that field
+    // defaults to 0 -> BcastEn=0.  Per the WINC docs BcastEn=0 tells the
+    // module NOT to wake at the DTIM beacon, so an idle STA stops receiving
+    // BROADCAST traffic, blinding the device to broadcast UDP discovery
+    // (contrary to the "discovery stays responsive" contract).  Force a
+    // non-zero DTIM listen interval (1 = wake every DTIM beacon) before we
+    // sleep, so the SetMode call below transmits BcastEn=1.  Idempotent: the
+    // driver early-returns once the interval already matches (no repeat HIF);
+    // on failure we retry next loop rather than enter power-save blind.
+    if (desired != WDRV_WINC_PS_MODE_OFF &&
+        WDRV_WINC_STATUS_OK !=
+            WDRV_WINC_PowerSaveSetBeaconInterval(pInstance->wdrvHandle, 1)) {
+        if (!psSetFailedLogged) {
+            psSetFailedLogged = true;
+            LOG_E("WiFi power-save DTIM interval set rejected by WINC");
+        }
+        return;  // never enter power-save with broadcast reception disabled
+    }
+
     if (WDRV_WINC_STATUS_OK ==
             WDRV_WINC_PowerSaveSetMode(pInstance->wdrvHandle, desired)) {
         gAppliedPsMode = desired;

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -2249,6 +2249,12 @@ bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
         wifi_manager_settings_t *pRtWifi =
                 BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
         bool userEnabled = (pRtWifi != NULL && pRtWifi->isEnabled);
+        if (pRtWifi != NULL) {
+            // #29: re-seed the power-save intent from the runtime-config copy
+            // (persisted by LAN:SAVE, mirrored by the PSave setter) so a
+            // standby->powered re-init preserves the user's choice.
+            gPowerSaveEnabled = !pRtWifi->powerSaveDisabled;
+        }
         taskENTER_CRITICAL();
         gWifiReinitDeadlineTick = 0;  // cancel any pending deferred-INIT
         if (gStateMachineContext.pWifiSettings != NULL && userEnabled) {
@@ -2260,8 +2266,13 @@ bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
         }
         return true;
     }
-    if (pSettings != NULL)
+    if (pSettings != NULL) {
         gStateMachineContext.pWifiSettings = pSettings;
+        // #29: seed the power-save intent from the NVM-loaded settings
+        // (boot memcpys DaqifiSettings_Wifi into this struct; inverted flag —
+        // legacy NVM holds 0 here, so upgraded devices default to enabled).
+        gPowerSaveEnabled = !pSettings->powerSaveDisabled;
+    }
     if (gStateMachineContext.fwUpdateTaskHandle == NULL) {
         BaseType_t result = xTaskCreate(fwUpdateTask, "fwUpdateTask", 1024, NULL, 2, &gStateMachineContext.fwUpdateTaskHandle);  // Keep original — FW flash path not fully profiled
         if (result != pdPASS) {
@@ -2357,6 +2368,18 @@ void wifi_manager_SetPowerSaveEnabled(bool enabled) {
     // intent on its next iteration and re-applies the mode (disabling forces
     // full power back on within one 5 ms loop).
     gPowerSaveEnabled = enabled;
+    // #29: mirror the (inverted) opt-out into both settings copies — the
+    // runtime-config copy is what SYST:COMM:LAN:SAVE memcpys to NVM, and the
+    // state-machine copy keeps any later re-seed consistent. Plain aligned
+    // bool stores (atomic on PIC32MZ; no RMW, no critical section needed).
+    wifi_manager_settings_t *pRtWifi =
+            BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
+    if (pRtWifi != NULL) {
+        pRtWifi->powerSaveDisabled = !enabled;
+    }
+    if (gStateMachineContext.pWifiSettings != NULL) {
+        gStateMachineContext.pWifiSettings->powerSaveDisabled = !enabled;
+    }
 }
 
 bool wifi_manager_GetPowerSaveEnabled(void) {

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -87,6 +87,7 @@ static void __attribute__((unused)) ResetEventFlag(wifi_manager_stateFlag_t *pEv
 static uint8_t __attribute__((unused)) GetEventFlagStatus(wifi_manager_stateFlag_t eventFlagState, uint16_t flag);
 static bool SendEvent(wifi_manager_event_t event);
 static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * const pInstance, uint16_t event);
+static void ApplyPowerSavePolicy(stateMachineInst_t * const pInstance);
 
 extern bool wifi_tcp_server_TransmitBufferedData();
 extern size_t wifi_tcp_server_WriteBuffer(const char* data, size_t len);
@@ -153,6 +154,24 @@ static volatile TickType_t gListenSocketOpenTick = 0;
 // runs wifi_tcp_server_ProcessReceivedBuff on WifiTask's stack, then re-arms
 // recv. WINC buffers inbound TCP while we process (per WINC docs).
 static volatile bool gTcpRxPending = false;
+
+// #29 dynamic WiFi power-save.  gPowerSaveEnabled is the user intent flag
+// (default on): when true the WiFi manager is allowed to drop the WINC into
+// its light auto power-save mode while associated as a STA but idle.  It is
+// written from any task via wifi_manager_SetPowerSaveEnabled() and read on
+// app_WifiTask; a plain 32-bit-atomic bool is sufficient (a one-cycle-stale
+// read only delays the policy by one 5 ms ProcessState iteration).
+//
+// gAppliedPsMode is the last mode we actually pushed to the WINC — tracked so
+// the policy only issues a WDRV_WINC_PowerSaveSetMode HIF transaction on a
+// real transition, not every loop.  Owned exclusively by app_WifiTask.  The
+// idle mode is AUTO_MED_POWER (M2M_PS_H_AUTOMATIC): the WINC still wakes each
+// DTIM to receive beacons/broadcasts, so device discovery and inbound SCPI
+// keep working with only the ~100-300 ms wake latency documented in #29 —
+// deliberately NOT the deeper AUTO_LOW_POWER, which trades more latency for
+// marginal extra savings and is riskier for the control plane.
+static volatile bool gPowerSaveEnabled = true;
+static WDRV_WINC_PS_MODE gAppliedPsMode = WDRV_WINC_PS_MODE_OFF;
 
 // Deadline (in ticks) at which wifi_manager_ProcessState should queue
 // the deferred WIFI_MANAGER_EVENT_INIT after a HardReset.  0 = none
@@ -1168,6 +1187,11 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
             // Only open driver handle if not already open
             if (pInstance->wdrvHandle == DRV_HANDLE_INVALID) {
                 pInstance->wdrvHandle = WDRV_WINC_Open(0, 0);
+                // #29: a freshly-opened WINC boots with power-save OFF —
+                // resync our tracker so the policy re-applies from a known
+                // baseline (a stale MED tracker would otherwise skip the
+                // first re-engage after a reconnect).
+                gAppliedPsMode = WDRV_WINC_PS_MODE_OFF;
                 WDRV_WINC_EthernetAddressGet(pInstance->wdrvHandle, pInstance->pWifiSettings->macAddr.addr);
                 if (pInstance->wdrvHandle == DRV_HANDLE_INVALID) {
                     SendEvent(WIFI_MANAGER_EVENT_ERROR);
@@ -2258,6 +2282,26 @@ bool wifi_manager_IsWiFiConnected(void) {
     return (wifi_manager_GetWiFiStatus() == WIFI_STATUS_CONNECTED);
 }
 
+void wifi_manager_SetPowerSaveEnabled(bool enabled) {
+    // Plain 32-bit-atomic write; the policy on app_WifiTask picks up the new
+    // intent on its next iteration and re-applies the mode (disabling forces
+    // full power back on within one 5 ms loop).
+    gPowerSaveEnabled = enabled;
+}
+
+bool wifi_manager_GetPowerSaveEnabled(void) {
+    return gPowerSaveEnabled;
+}
+
+int wifi_manager_GetPowerSaveMode(void) {
+    if (gStateMachineContext.wdrvHandle == DRV_HANDLE_INVALID) {
+        return -1;
+    }
+    // Report the mode we last applied rather than round-tripping to the WINC,
+    // so the query is non-blocking and safe from the USB SCPI task.
+    return (int)gAppliedPsMode;
+}
+
 bool wifi_manager_Deinit() {
     if (gStateMachineContext.pWifiSettings == NULL) return false;
     // Tear down iperf2 sockets before the WINC GPIO toggle — otherwise
@@ -2502,6 +2546,65 @@ static void MaybeReconcileStaConnected(void) {
 // lifecycle/event-queue work without dispatching new TCP-arrived SCPI,
 // to prevent re-entrant SCPI_Input() on the same scpiContext when the
 // outer SCPI command itself arrived over TCP.
+// #29 dynamic WiFi power-save policy.  Runs on app_WifiTask (the owner of
+// the WINC client handle) once per normal ProcessState iteration.  Computes
+// the desired power-save mode from live WiFi + streaming state and pushes it
+// to the WINC only on a transition, so the common steady state issues no HIF
+// traffic at all.
+//
+// Full power (OFF) is the conservative default.  The light auto power-save
+// mode is requested only when EVERY one of these holds:
+//   - the feature is enabled (gPowerSaveEnabled),
+//   - we are associated as a STA (soft-AP must keep beaconing for its
+//     clients, so it must never sleep),
+//   - no TCP control-plane client is connected, and
+//   - WiFi is not the active streaming interface.
+// A WiFi stream and TCP-SCPI both run over the TCP client socket, so
+// wifi_tcp_server_HasActiveClient() alone would force full power during
+// either; the explicit Streaming_IsActiveOnWifiInterface() check is a
+// belt-and-suspenders backstop and the concrete "wire into streaming
+// start/stop" hook — a stream start/stop flips these predicates and the
+// next 5 ms iteration re-applies the correct mode.
+static void ApplyPowerSavePolicy(stateMachineInst_t * const pInstance) {
+    // Tracks whether we have already logged the current failure streak so a
+    // persistently-rejecting WINC can't flood the log at the 5 ms loop rate.
+    static bool psSetFailedLogged = false;
+
+    if (pInstance == NULL || pInstance->wdrvHandle == DRV_HANDLE_INVALID) {
+        return;
+    }
+
+    WDRV_WINC_PS_MODE desired = WDRV_WINC_PS_MODE_OFF;
+
+    bool staConnected =
+        (GetEventFlagStatus(pInstance->eventFlags,
+                            WIFI_MANAGER_STATE_FLAG_STA_CONNECTED) != 0);
+    bool apStarted =
+        (GetEventFlagStatus(pInstance->eventFlags,
+                            WIFI_MANAGER_STATE_FLAG_AP_STARTED) != 0);
+
+    if (gPowerSaveEnabled && staConnected && !apStarted &&
+        !wifi_tcp_server_HasActiveClient() &&
+        !Streaming_IsActiveOnWifiInterface()) {
+        desired = WDRV_WINC_PS_MODE_AUTO_MED_POWER;
+    }
+
+    if (desired == gAppliedPsMode) {
+        return;  // no change — no HIF transaction needed
+    }
+
+    if (WDRV_WINC_STATUS_OK ==
+            WDRV_WINC_PowerSaveSetMode(pInstance->wdrvHandle, desired)) {
+        gAppliedPsMode = desired;
+        psSetFailedLogged = false;
+        LOG_I("WiFi power-save mode -> %d", (int)desired);
+    } else if (!psSetFailedLogged) {
+        // Leave gAppliedPsMode unchanged so the next iteration retries.
+        psSetFailedLogged = true;
+        LOG_E("WiFi power-save set mode %d rejected by WINC", (int)desired);
+    }
+}
+
 static void wifi_manager_ProcessStateImpl(bool drainTcpRx) {
     wifi_manager_event_t event;
     wifi_manager_stateMachineReturnStatus_t ret;
@@ -2636,6 +2739,14 @@ static void wifi_manager_ProcessStateImpl(bool drainTcpRx) {
                 LOG_E("%s : %d : State Change Requested, but NextSate is NULL", __func__, __LINE__);
             }
         }
+    }
+
+    // #29: re-evaluate the dynamic WiFi power-save mode once per normal
+    // WifiTask iteration.  Skipped on the nested SCPI active-pump path
+    // (drainTcpRx == false) so we don't issue an extra HIF transaction in
+    // the middle of a command dispatch — the outer loop applies it.
+    if (drainTcpRx) {
+        ApplyPowerSavePolicy(&gStateMachineContext);
     }
 
     if (gProcessStateMutex != NULL) {

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -2268,10 +2268,24 @@ bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
     }
     if (pSettings != NULL) {
         gStateMachineContext.pWifiSettings = pSettings;
-        // #29: seed the power-save intent from the NVM-loaded settings
-        // (boot memcpys DaqifiSettings_Wifi into this struct; inverted flag —
-        // legacy NVM holds 0 here, so upgraded devices default to enabled).
-        gPowerSaveEnabled = !pSettings->powerSaveDisabled;
+    }
+    // #29: seed power-save intent from the RUNTIME-CONFIG copy — the single
+    // authority for the powerSaveDisabled bit (both Init seed points read it;
+    // the setter and UpdateNetworkSettings both write it). Reading the
+    // BoardData copy here instead created a two-copy asymmetry: a PSave 0 sent
+    // while the device is still in STANDBY (before this first Init runs) is
+    // written by the setter to the runtime copy only — pWifiSettings is NULL
+    // then, so its BoardData mirror is skipped — and seeding from BoardData
+    // would silently clobber that opt-out on the first power-up. Boot memcpys
+    // NVM into the runtime copy too, so it always carries the persisted value.
+    // (Adversarial-gate round-3 finding, #642.) Inverted flag: legacy NVM
+    // holds 0 -> enabled, so upgraded devices default to power-save on.
+    {
+        wifi_manager_settings_t *pRtSeed =
+                BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
+        if (pRtSeed != NULL) {
+            gPowerSaveEnabled = !pRtSeed->powerSaveDisabled;
+        }
     }
     if (gStateMachineContext.fwUpdateTaskHandle == NULL) {
         BaseType_t result = xTaskCreate(fwUpdateTask, "fwUpdateTask", 1024, NULL, 2, &gStateMachineContext.fwUpdateTaskHandle);  // Keep original — FW flash path not fully profiled
@@ -2607,14 +2621,26 @@ bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t * pSettings) {
             return false;
         }
     }
-    // #29: the settings copy above includes powerSaveDisabled, so re-seed the
-    // live intent flag — LAN:LOAD 1 / FACRESET 1 route through here and every
-    // OTHER field takes effect via the REINIT; without this line the loaded
-    // power-save choice was silently ignored until the next reboot/standby
-    // (adversarial-gate finding, #642). The rollback path above deliberately
-    // skips this: gPowerSaveEnabled was never changed, and the restored
-    // struct still matches it.
-    gPowerSaveEnabled = !gStateMachineContext.pWifiSettings->powerSaveDisabled;
+    // #29: the settings copy above includes powerSaveDisabled, so propagate it
+    // to the RUNTIME-CONFIG copy (the single authority both Init seed points
+    // read) and re-seed the live flag. LAN:LOAD 1 / FACRESET 1 route through
+    // here with a fresh NVM/factory struct; LAN:APPLY passes the runtime copy
+    // itself (self-copy, no-op). Without writing the runtime copy, a
+    // LOAD-applied opt-out took effect immediately but reverted on the next
+    // standby->powered cycle, whose re-init seeds from the (stale) runtime
+    // copy. Both adversarial-gate findings (rounds 2 and 3) are the same
+    // two-copy asymmetry; unifying on the runtime copy closes both. The
+    // REINIT-rollback path above deliberately skips this — gPowerSaveEnabled
+    // was never changed and the restored struct still matches it.
+    {
+        wifi_manager_settings_t *pRtWifi =
+                BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
+        if (pRtWifi != NULL) {
+            pRtWifi->powerSaveDisabled =
+                    gStateMachineContext.pWifiSettings->powerSaveDisabled;
+            gPowerSaveEnabled = !pRtWifi->powerSaveDisabled;
+        }
+    }
     return true;
 }
 

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -2607,6 +2607,14 @@ bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t * pSettings) {
             return false;
         }
     }
+    // #29: the settings copy above includes powerSaveDisabled, so re-seed the
+    // live intent flag — LAN:LOAD 1 / FACRESET 1 route through here and every
+    // OTHER field takes effect via the REINIT; without this line the loaded
+    // power-save choice was silently ignored until the next reboot/standby
+    // (adversarial-gate finding, #642). The rollback path above deliberately
+    // skips this: gPowerSaveEnabled was never changed, and the restored
+    // struct still matches it.
+    gPowerSaveEnabled = !gStateMachineContext.pWifiSettings->powerSaveDisabled;
     return true;
 }
 
@@ -2718,8 +2726,10 @@ static void MaybeReconcileStaConnected(void) {
 //   - the feature is enabled (gPowerSaveEnabled),
 //   - we are associated as a STA (soft-AP must keep beaconing for its
 //     clients, so it must never sleep),
-//   - no TCP control-plane client is connected, and
-//   - WiFi is not the active streaming interface.
+//   - no TCP control-plane client is connected,
+//   - WiFi is not the active streaming interface, and
+//   - no iperf2 session is in flight (raw WINC sockets — invisible to
+//     wifi_tcp_server; a dozing STA would corrupt the measurement).
 // A WiFi stream and TCP-SCPI both run over the TCP client socket, so
 // wifi_tcp_server_HasActiveClient() alone would force full power during
 // either; the explicit Streaming_IsActiveOnWifiInterface() check is a
@@ -2746,7 +2756,12 @@ static void ApplyPowerSavePolicy(stateMachineInst_t * const pInstance) {
 
     if (gPowerSaveEnabled && staConnected && !apStarted &&
         !wifi_tcp_server_HasActiveClient() &&
-        !Streaming_IsActiveOnWifiInterface()) {
+        !Streaming_IsActiveOnWifiInterface() &&
+        !Iperf2_IsActive()) {
+        // Iperf2_IsActive: iperf2 rides raw WINC sockets (own task, never
+        // wifi_tcp_server), so HasActiveClient() can't see it — without this
+        // predicate the WINC dozes through a link measurement and silently
+        // corrupts it (adversarial-gate finding, #642).
         desired = WDRV_WINC_PS_MODE_AUTO_MED_POWER;
     }
 

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -156,12 +156,16 @@ static volatile TickType_t gListenSocketOpenTick = 0;
 // recv. WINC buffers inbound TCP while we process (per WINC docs).
 static volatile bool gTcpRxPending = false;
 
-// #29 dynamic WiFi power-save.  gPowerSaveEnabled is the user intent flag
-// (default on): when true the WiFi manager is allowed to drop the WINC into
-// its light auto power-save mode while associated as a STA but idle.  It is
-// written from any task via wifi_manager_SetPowerSaveEnabled() and read on
-// app_WifiTask; a plain 32-bit-atomic bool is sufficient (a one-cycle-stale
-// read only delays the policy by one 5 ms ProcessState iteration).
+// #29 dynamic WiFi power-save.  Power-save intent (default on) has a SINGLE
+// source of truth: the runtime-config copy's inverted powerSaveDisabled bit
+// (BOARDRUNTIME_WIFI_SETTINGS — persisted by LAN:SAVE, survives Deinit, the
+// #656 authority pattern).  There is deliberately NO cached bool: every reader
+// derives from that copy via wifiPowerSaveEnabled() so no code path can leave a
+// stale mirror.  (Adversarial-gate rounds 1-4 for #642 were ALL variants of a
+// cached flag diverging from the runtime copy across the setter / boot /
+// standby-reinit / bare-LOAD/FACRESET / APPLY writers; removing the cache
+// removes the entire class.)  A one-cycle-stale read is harmless — the policy
+// re-evaluates every 5 ms ProcessState iteration on app_WifiTask.
 //
 // gAppliedPsMode is the last mode we actually pushed to the WINC — tracked so
 // the policy only issues a WDRV_WINC_PowerSaveSetMode HIF transaction on a
@@ -171,8 +175,15 @@ static volatile bool gTcpRxPending = false;
 // keep working with only the ~100-300 ms wake latency documented in #29 —
 // deliberately NOT the deeper AUTO_LOW_POWER, which trades more latency for
 // marginal extra savings and is riskier for the control plane.
-static volatile bool gPowerSaveEnabled = true;
 static WDRV_WINC_PS_MODE gAppliedPsMode = WDRV_WINC_PS_MODE_OFF;
+
+// #29: the single power-save-intent read. Derives from the runtime-config copy
+// (never NULL — indexes a static boot-init array); no cached flag to go stale.
+static bool wifiPowerSaveEnabled(void) {
+    wifi_manager_settings_t *pRt =
+            BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
+    return (pRt != NULL) && !pRt->powerSaveDisabled;
+}
 
 // Deadline (in ticks) at which wifi_manager_ProcessState should queue
 // the deferred WIFI_MANAGER_EVENT_INIT after a HardReset.  0 = none
@@ -2249,12 +2260,8 @@ bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
         wifi_manager_settings_t *pRtWifi =
                 BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
         bool userEnabled = (pRtWifi != NULL && pRtWifi->isEnabled);
-        if (pRtWifi != NULL) {
-            // #29: re-seed the power-save intent from the runtime-config copy
-            // (persisted by LAN:SAVE, mirrored by the PSave setter) so a
-            // standby->powered re-init preserves the user's choice.
-            gPowerSaveEnabled = !pRtWifi->powerSaveDisabled;
-        }
+        // #29: no power-save seed here either — the policy reads the runtime
+        // copy directly, so a standby->powered re-init already preserves it.
         taskENTER_CRITICAL();
         gWifiReinitDeadlineTick = 0;  // cancel any pending deferred-INIT
         if (gStateMachineContext.pWifiSettings != NULL && userEnabled) {
@@ -2269,24 +2276,8 @@ bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
     if (pSettings != NULL) {
         gStateMachineContext.pWifiSettings = pSettings;
     }
-    // #29: seed power-save intent from the RUNTIME-CONFIG copy — the single
-    // authority for the powerSaveDisabled bit (both Init seed points read it;
-    // the setter and UpdateNetworkSettings both write it). Reading the
-    // BoardData copy here instead created a two-copy asymmetry: a PSave 0 sent
-    // while the device is still in STANDBY (before this first Init runs) is
-    // written by the setter to the runtime copy only — pWifiSettings is NULL
-    // then, so its BoardData mirror is skipped — and seeding from BoardData
-    // would silently clobber that opt-out on the first power-up. Boot memcpys
-    // NVM into the runtime copy too, so it always carries the persisted value.
-    // (Adversarial-gate round-3 finding, #642.) Inverted flag: legacy NVM
-    // holds 0 -> enabled, so upgraded devices default to power-save on.
-    {
-        wifi_manager_settings_t *pRtSeed =
-                BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
-        if (pRtSeed != NULL) {
-            gPowerSaveEnabled = !pRtSeed->powerSaveDisabled;
-        }
-    }
+    // #29: no power-save seed here — the policy reads the runtime-config copy
+    // directly (wifiPowerSaveEnabled()), which boot already loaded from NVM.
     if (gStateMachineContext.fwUpdateTaskHandle == NULL) {
         BaseType_t result = xTaskCreate(fwUpdateTask, "fwUpdateTask", 1024, NULL, 2, &gStateMachineContext.fwUpdateTaskHandle);  // Keep original — FW flash path not fully profiled
         if (result != pdPASS) {
@@ -2378,14 +2369,13 @@ bool wifi_manager_IsWiFiConnected(void) {
 }
 
 void wifi_manager_SetPowerSaveEnabled(bool enabled) {
-    // Plain 32-bit-atomic write; the policy on app_WifiTask picks up the new
-    // intent on its next iteration and re-applies the mode (disabling forces
-    // full power back on within one 5 ms loop).
-    gPowerSaveEnabled = enabled;
-    // #29: mirror the (inverted) opt-out into both settings copies — the
-    // runtime-config copy is what SYST:COMM:LAN:SAVE memcpys to NVM, and the
-    // state-machine copy keeps any later re-seed consistent. Plain aligned
-    // bool stores (atomic on PIC32MZ; no RMW, no critical section needed).
+    // #29: write the SINGLE authority — the runtime-config copy's (inverted)
+    // powerSaveDisabled bit. The policy on app_WifiTask reads this same copy
+    // every ~5 ms and re-applies the mode (disabling forces full power back on
+    // within one loop); SYST:COMM:LAN:SAVE persists this copy to NVM. Plain
+    // aligned bool store (atomic on PIC32MZ; no RMW, no critical section).
+    // Also mirror into the state-machine copy so the two structs stay coherent
+    // for whole-struct memcpys, though nothing reads it for power-save intent.
     wifi_manager_settings_t *pRtWifi =
             BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
     if (pRtWifi != NULL) {
@@ -2397,7 +2387,7 @@ void wifi_manager_SetPowerSaveEnabled(bool enabled) {
 }
 
 bool wifi_manager_GetPowerSaveEnabled(void) {
-    return gPowerSaveEnabled;
+    return wifiPowerSaveEnabled();  // #29: single authority = runtime-config copy
 }
 
 int wifi_manager_GetPowerSaveMode(void) {
@@ -2621,24 +2611,20 @@ bool wifi_manager_UpdateNetworkSettings(wifi_manager_settings_t * pSettings) {
             return false;
         }
     }
-    // #29: the settings copy above includes powerSaveDisabled, so propagate it
-    // to the RUNTIME-CONFIG copy (the single authority both Init seed points
-    // read) and re-seed the live flag. LAN:LOAD 1 / FACRESET 1 route through
-    // here with a fresh NVM/factory struct; LAN:APPLY passes the runtime copy
-    // itself (self-copy, no-op). Without writing the runtime copy, a
-    // LOAD-applied opt-out took effect immediately but reverted on the next
-    // standby->powered cycle, whose re-init seeds from the (stale) runtime
-    // copy. Both adversarial-gate findings (rounds 2 and 3) are the same
-    // two-copy asymmetry; unifying on the runtime copy closes both. The
-    // REINIT-rollback path above deliberately skips this — gPowerSaveEnabled
-    // was never changed and the restored struct still matches it.
+    // #29: LAN:LOAD 1 / FACRESET 1 pass a fresh NVM/factory struct that this
+    // function memcpys into the state-machine (BoardData) copy — propagate its
+    // powerSaveDisabled to the RUNTIME-CONFIG copy, the single authority the
+    // power-save policy reads. LAN:APPLY passes the runtime copy itself
+    // (self-copy, no-op). No live-flag write needed — the policy derives
+    // intent from the runtime copy directly (wifiPowerSaveEnabled()). The
+    // REINIT-rollback path above returns before here, so a rolled-back apply
+    // leaves the runtime copy untouched.
     {
         wifi_manager_settings_t *pRtWifi =
                 BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
         if (pRtWifi != NULL) {
             pRtWifi->powerSaveDisabled =
                     gStateMachineContext.pWifiSettings->powerSaveDisabled;
-            gPowerSaveEnabled = !pRtWifi->powerSaveDisabled;
         }
     }
     return true;
@@ -2749,7 +2735,7 @@ static void MaybeReconcileStaConnected(void) {
 //
 // Full power (OFF) is the conservative default.  The light auto power-save
 // mode is requested only when EVERY one of these holds:
-//   - the feature is enabled (gPowerSaveEnabled),
+//   - the feature is enabled (wifiPowerSaveEnabled() — runtime-config copy),
 //   - we are associated as a STA (soft-AP must keep beaconing for its
 //     clients, so it must never sleep),
 //   - no TCP control-plane client is connected,
@@ -2780,7 +2766,7 @@ static void ApplyPowerSavePolicy(stateMachineInst_t * const pInstance) {
         (GetEventFlagStatus(pInstance->eventFlags,
                             WIFI_MANAGER_STATE_FLAG_AP_STARTED) != 0);
 
-    if (gPowerSaveEnabled && staConnected && !apStarted &&
+    if (wifiPowerSaveEnabled() && staConnected && !apStarted &&
         !wifi_tcp_server_HasActiveClient() &&
         !Streaming_IsActiveOnWifiInterface() &&
         !Iperf2_IsActive()) {

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -63,11 +63,17 @@ extern "C" {
          */
         bool isEnabled;
         /**
-         * DEPRECATED: No longer used. WiFi firmware update mode is now managed via state machine flags.
-         * Use wifi_manager_RequestWifiFirmwareUpdate() to request update and wifi_manager_IsWifiFirmwareUpdateActive() to check status.
-         * Kept for NVM compatibility - do not remove.
+         * #29: user's WiFi power-save opt-out, persisted with the LAN settings
+         * (SYST:COMM:LAN:SAVE memcpys this whole struct to NVM). INVERTED so
+         * the NVM default (0/false — also the only value pre-#29 firmware ever
+         * wrote in this slot) means power-save ENABLED: the feature ships
+         * default-on with zero NVM migration.
+         *
+         * REPURPOSES the deprecated isWifiFirmwareUpdateModeEnabled slot (same
+         * offset/size — NVM layout unchanged). That flag was dead: FW-update
+         * mode moved to state-machine flags and boot forced it false since.
          */
-        bool isWifiFirmwareUpdateModeEnabled;
+        bool powerSaveDisabled;
         /**
          * One of:
          *  WIFI_MANAGER_NETWORK_MODE_STA = 1,

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -379,6 +379,43 @@ extern "C" {
      */
     bool wifi_manager_GetBSSID(uint8_t *pBssid);
 
+    /**
+     * @brief Enable or disable automatic WiFi power-save (#29).
+     *
+     * When enabled (default), the WiFi manager automatically requests the
+     * WINC1500's light auto power-save mode while WiFi is associated as a
+     * STA but idle (no TCP control-plane client and not the active
+     * streaming interface), and restores full power the instant WiFi is
+     * needed for a TCP client or WiFi streaming.  Power-save is never
+     * engaged in soft-AP mode (the AP must beacon continuously) nor while
+     * streaming over WiFi.
+     *
+     * The policy is applied from app_WifiTask (which owns the WINC client
+     * handle); this setter only flips the intent flag — the actual
+     * WDRV_WINC_PowerSaveSetMode call happens on the next ProcessState
+     * iteration.  Runtime-only, not persisted to NVM.
+     *
+     * @param[in] enabled true to allow automatic power-save, false to force
+     *            full power at all times.
+     */
+    void wifi_manager_SetPowerSaveEnabled(bool enabled);
+
+    /**
+     * @brief Query whether automatic WiFi power-save is enabled (#29).
+     *
+     * @return true if the automatic power-save policy is allowed to engage.
+     */
+    bool wifi_manager_GetPowerSaveEnabled(void);
+
+    /**
+     * @brief Query the WINC power-save mode currently applied (#29).
+     *
+     * @return The applied WDRV_WINC_PS_MODE value as an int
+     *         (WDRV_WINC_PS_MODE_OFF == 0 at full power), or -1 if the WiFi
+     *         driver handle is not open.
+     */
+    int wifi_manager_GetPowerSaveMode(void);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/firmware/src/state/runtime/CommonRuntimeDefaults.h
+++ b/firmware/src/state/runtime/CommonRuntimeDefaults.h
@@ -110,7 +110,7 @@ _Static_assert(sizeof(DEFAULT_NETWORK_HOST_NAME) <= WIFI_MANAGER_DNS_CLIENT_MAX_
 #define COMMON_WIFI_RUNTIME_DEFAULTS \
     .wifiSettings = { \
         .isEnabled = true, \
-        .isWifiFirmwareUpdateModeEnabled = false, \
+        .powerSaveDisabled = false, /* #29: power-save on by default */ \
         .networkMode = DEFAULT_WIFI_NETWORK_MODE, \
         .securityMode = DEFAULT_WIFI_AP_SECURITY_MODE, \
         .ssid = DEFAULT_WIFI_AP_SSID, \


### PR DESCRIPTION
## Summary

Implements #29 — dynamic WiFi power-save. The WINC1500 is automatically
placed in its **light auto power-save** mode (`M2M_PS_H_AUTOMATIC` /
`WDRV_WINC_PS_MODE_AUTO_MED_POWER`) while WiFi is associated as a STA but
idle, and returned to full power the instant WiFi is needed for control or
data. Distinct from #334's manual full WINC power-down — this is a runtime
automatic light-sleep, not a chip shutdown.

The WINC driver in-tree exposes the needed API
(`WDRV_WINC_PowerSaveSetMode`, `firmware/src/config/default/driver/winc/wdrv_winc_powersave.c`
→ `m2m_wifi_set_sleep_mode`), so no BLOCKED feasibility gap.

## Policy

Applied on `app_WifiTask` (the owner of the WINC client handle) once per
`wifi_manager_ProcessState` iteration (~5 ms). A `WDRV_WINC_PowerSaveSetMode`
HIF transaction is issued **only on a real mode transition** — steady state
is silent. Power-save is requested only when **all** of:

- the feature is enabled (default on),
- associated as a **STA** (soft-AP must keep beaconing — never sleeps),
- **no TCP control-plane client** connected, and
- WiFi is **not** the active streaming interface.

Otherwise full power (`OFF`). Conservative by design: uses the light
`AUTO_MED_POWER` mode (WINC still wakes each DTIM, ~100–300 ms latency), not
the deeper `AUTO_LOW_POWER`, so discovery and TCP-SCPI stay responsive and
the control plane is never dropped.

Wired into streaming start/stop via two live predicates
(`wifi_tcp_server_HasActiveClient` + new `Streaming_IsActiveOnWifiInterface`) —
a WiFi stream start/stop flips the mode on the next loop.

## SCPI (runtime-only, not NVM-persisted)

| Command | Behavior |
|---|---|
| `SYST:COMM:LAN:PSave 0\|1` | disable / enable auto power-save (default on) |
| `SYST:COMM:LAN:PSave?` | `"<enabled>,<appliedMode>"` (mode 0=OFF, 2=light PS, -1=driver not open) |

## Build

Clean at global `-O3 -Werror` (`daqifi.X.production.hex` produced).
cppcheck baseline unchanged. No new static buffers — no RAM-budget risk.

## Test / bench plan

Suite test added (not committed here — batched by main loop):
`daqifi-python-test-suite/test_29_wifi_powersave.py` — PSave? well-formed,
enable flag round-trip, and a short USB stream with power-save ENABLED
delivering integer CSV rows (no regression; applied mode stays OFF on the
USB/idle path).

Full WiFi power-save verification (WINC actually enters light sleep + drops
measured current, discovery/TCP survive wake latency) needs a STA WiFi link
+ a current meter — **bench queued for the main loop**. On a USB board the
policy never engages (not STA-connected), so the USB board confirms the SCPI
round-trip + no streaming regression only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz

---

## 2026-07-10 update: rebased + review fixes + full hardware validation

**Rebased onto post-v3.7.1 main** (clean; interaction audit vs #637/#656 confirmed the `gAppliedPsMode` resync at `WDRV_WINC_Open` covers the deep-power-off → re-init path).

**Review fixes (from the GPT/triage findings):**
- `SYST:COMM:LAN:PSave` rejects non-0/1 with `-224` (matches `POWer`/`HIDden` siblings).
- **Default ON + NVM persistence with zero migration**: the dead `isWifiFirmwareUpdateModeEnabled` NVM slot is repurposed as `powerSaveDisabled` (same offset/size — `DaqifiSettings_Wifi` layout byte-identical). Inverted on purpose: legacy NVM only ever holds 0 there, and 0 = enabled — so upgrades and factory defaults are default-on with no migration code. The `PSave` setter mirrors into the runtime-config copy (`LAN:SAVE` memcpys that struct to NVM — persistence is free) and boot / standby-re-init seed from it (the #656 pattern).

**Hardware validation (COM12, STA on bench AP):**
| Check | Result |
|---|---|
| Default after flash | `1,2` — on + AUTO_MED engaged |
| UDP broadcast discovery under engaged PS | **3/3 responses** (DTIM/BcastEn contract) |
| TCP client connect / disconnect | `1,0` full power / `1,2` re-engaged |
| `PSave 5` | `-224 Illegal parameter value` |
| Runtime `PSave 0` across standby cycle | preserved (`0,0`) |
| `PSave 0` + `LAN:SAVE` across reboot | **survived** (`0,0`) |
| `PSave 1` + SAVE + reboot | `1,2` restored |
| WiFi PB 1ch at-cap 30 s with PS enabled | 5,176 Hz achieved, zero drops, `TcpSent==TcpConfirmed`, PS re-engaged post-stream |

**Companion regression test:** [daqifi-python-test-suite#74](https://github.com/daqifi/daqifi-python-test-suite/pull/74) — 7/7 PASS on hardware including the reboot-persistence phase.


---

## 2026-07-11 update: 5-round adversarial gate → structural fix → 8 h endurance PASS (merge candidate `010502c8`)

**Adversarial gate history** (each round's finds fixed, re-gated):
| Round | Confirmed finds | Fix |
|---|---|---|
| 1 | param validation, default-on ask | `-224` validation + NVM zero-migration repurpose |
| 2 | iperf2 dozes under PS; `LOAD` ignores PSave | `Iperf2_IsActive()` predicate; seed in `UpdateNetworkSettings` |
| 3 | pre-power-up opt-out clobbered; `LOAD` reverts on standby | unified seeding on the runtime-config copy |
| 4 | bare `LOAD`/`FACRESET` silently flip the live flag | **structural fix: deleted the cached flag entirely** — new `wifiPowerSaveEnabled()` reads the runtime-config copy's `powerSaveDisabled` bit directly; every writer is correct-by-construction |
| 5 | none (1 raw finding, refuted) | **PASS** |

Rounds 1–4 were all variants of one class — cached-flag divergence from the persisted intent — which the round-4 fix made unrepresentable. All four finds are locked in as permanent regressions (suite T8–T12).

**Functional matrix:** 12/12 PASS on COM12 (T1–T12, [suite PR #74](https://github.com/daqifi/daqifi-python-test-suite/pull/74) at `f97e2b8`), superseding the earlier 7/7 note above.

**8-hour endurance campaign** (COM12, STA on bench AP, exact merge candidate `010502c8`, `psave_endurance_20260710_162815.csv`, 456 rounds):
| Metric | Result |
|---|---|
| Discovery under engaged PS | 4,560 broadcast probes; **437/456 rounds ≥9/10 hits (95.8%)**, 19 rounds at 7–8/10, floor 7/10, zero lost-device rounds — quantifies the vendor "PS occasionally misses frames" class; avg reply 300–600 ms |
| TCP wake latency | ~70–160 ms avg per round; PS disengage-on-connect / re-engage-on-disconnect 455/456 |
| Streaming bursts (30 s at WiFi 1ch cap, every round) | 5,175–5,178 Hz, **zero drops, all 456 rounds** |
| Heap | flat 6,720–7,544 min-free band across 8 h — no leak |
| Standby cycles (every 6th round) | all passed, PS state preserved |
| Reboot + NVM persistence (every 12th round) | **38/38 persisted**; the single flagged round (r264) was the test script racing the ~20 s post-reboot WiFi rejoin — its persistence check itself passed; `+sleep` noted for the script |
| Hard resets / forced closes | 0 / 0 |

Gate PASS + 12/12 functional + endurance clean on the merge candidate: **ready for merge together with suite PR #74** (pending maintainer go).
