### PR TITLE
perf(clock): #586 PFMWS 5→4 at 252 MHz (datasheet minimum) — extensively bench-validated

### DIFF
--- a/firmware/src/config/default/clock_config.h
+++ b/firmware/src/config/default/clock_config.h
@@ -34,7 +34,7 @@
   #define DAQIFI_PBCLK_HZ     84000000UL   /* peripheral buses at PBxDIV /3 */
   #define DAQIFI_PBCLK_MHZ           84u    /* = DAQIFI_PBCLK_HZ / 1e6 */
   #define DAQIFI_PBDIV                2u    /* PBxDIVbits.PBDIV = divisor-1 → /3 */
-  #define DAQIFI_PFMWS                5u    /* flash wait states (bring-up conservative; datasheet tune-down pending) */
+  #define DAQIFI_PFMWS                4u    /* #586: datasheet+errata-#38 minimum at 252 MHz w/ ECC (raw needs 3, ECC +1); was 5 (bring-up conservative) */
 #else
   #define DAQIFI_SYSCLK_HZ   200000000UL   /* SPLL: 24 MHz POSC /3 x50 /2 */
   #define DAQIFI_PBCLK_HZ    100000000UL   /* peripheral buses at PBxDIV /2 */


### PR DESCRIPTION
Tunes the 252 MHz flash wait-states from the conservative bring-up value **5** to the datasheet+errata **minimum of 4** (raw flash needs 3 at 252 MHz → 15.9 ns fetch window; errata DS80000663 #38: ECC adds one cycle → 4). Investigation basis: #586 (doc PR #633).

## Extensive bench validation (COM12, room temp)
Flash-timing marginality manifests as intermittent instruction corruption under cache-miss-heavy, diverse code paths — so I hammered it:

| test | result |
|---|---|
| 1×T2 PB @3k / CSV @3k / JSON @2k / PB @8k | zero drops/errors |
| 4×T2 CSV @4k / PB @6k | zero drops/errors |
| **90 s sustained soak** (4×T2 CSV @4k, 3.08 MB) | zero drops/errors |
| SD-write benchmark (512 KB) | clean, 100 KB/s |
| post-stress: IDN stable, heap `HeapMinEverFree=7544`, **0 crash/fault log lines** | ✅ |

**`PFMWS=4 STRESS PASS`** — no corruption, no reset, no crash across all code paths.

## ⚠️ Caveat — margin/perf tradeoff for a human to decide
- **Benefit is small**: one fewer wait state; flash fetches are mostly 16 KB I-cache hits (errata cites <2% CPU). Real gain likely well under 1%.
- **4 is the spec-minimum with NO margin**; 5 carried one extra wait state of insurance.
- **Room-temp validated only.** A too-low wait state can fail at the temperature/voltage corner (hot / low-Vdd → slower flash) — can't rule out without a thermal chamber.

**Recommendation:** given the tiny benefit vs the catastrophic failure mode, either (a) thermal-margin soak before shipping, or (b) keep 5 as cheap insurance. I lean mildly toward **keeping 5** unless the <1% matters — but 4 is correct-per-datasheet and validated at room temp. Your call.

Refs #586, #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U7WFjps32UCAKLNfF9RQz