### PR TITLE
fix(v3.7.0): close 3 adversarial-audit findings before release

### DIFF
--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -4415,6 +4415,24 @@
         <C32Global>
         </C32Global>
       </item>
+      <item path="../src/config/default/old_hv2_bootld.ld"
+            ex="true"
+            overriding="false">
+        <C32>
+        </C32>
+        <C32-AR>
+        </C32-AR>
+        <C32-AS>
+        </C32-AS>
+        <C32-CO>
+        </C32-CO>
+        <C32-LD>
+        </C32-LD>
+        <C32CPP>
+        </C32CPP>
+        <C32Global>
+        </C32Global>
+      </item>
       <item path="../src/config/default/p32MZ2048EFM144.ld"
             ex="true"
             overriding="false">
@@ -6870,6 +6888,24 @@
         </C32Global>
       </item>
       <item path="../src/Util/StringFormatters.h" ex="false" overriding="false">
+        <C32>
+        </C32>
+        <C32-AR>
+        </C32-AR>
+        <C32-AS>
+        </C32-AS>
+        <C32-CO>
+        </C32-CO>
+        <C32-LD>
+        </C32-LD>
+        <C32CPP>
+        </C32CPP>
+        <C32Global>
+        </C32Global>
+      </item>
+      <item path="../src/config/default/old_hv2_bootld.ld"
+            ex="true"
+            overriding="false">
         <C32>
         </C32>
         <C32-AR>

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -200,6 +200,22 @@ void sd_card_manager_DataReadyCB(sd_card_manager_mode_t mode, uint8_t *pDataBuff
     const sd_card_manager_settings_t* pSet =
             (const sd_card_manager_settings_t*) BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
     const bool toTcp = (pSet != NULL) && (pSet->replyTarget == SD_CARD_REPLY_WIFI_TCP);
+
+    /* #599: a TCP-targeted async reply must reach ONLY the connection that
+     * issued the GET/LIST.  If that client disconnected (and possibly a
+     * different client has since taken the single TCP slot), writing the
+     * remaining file bytes + __END_OF_FILE__ into the new client's SCPI
+     * stream is an info leak and a parser desync.  Bail when the originating
+     * connection no longer owns the slot, and abort the SD READ so it closes
+     * the file and resets mode cleanly on its next loop iteration (the LIST
+     * path simply finishes with its remaining chunks dropped). */
+    if (toTcp && !wifi_tcp_server_ConnIsCurrent(pSet->replyGeneration)) {
+        sd_card_manager_AbortTransfer();
+        LOG_E("[SD reply] TCP client changed/gone (gen %u) - reply aborted",
+              (unsigned)pSet->replyGeneration);
+        return;
+    }
+
     size_t (*writeFn)(const char*, size_t) = toTcp ? sd_reply_write_tcp : sd_reply_write_usb;
 
     size_t transferredLength = 0;

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -229,9 +229,14 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
         memcpy(pSDCardRuntimeConfig->file, pBuff, fileLen);
         pSDCardRuntimeConfig->file[fileLen] = '\0';
     }
-    /* #598: route the async file data back to the interface that asked. */
-    pSDCardRuntimeConfig->replyTarget = wifi_tcp_server_ContextIsTcp(context)
+    /* #598: route the async file data back to the interface that asked.
+     * #599: capture the requesting TCP connection's generation so the SD
+     * reply can't leak into a different client that later inherits the slot. */
+    const bool getOverTcp = wifi_tcp_server_ContextIsTcp(context);
+    pSDCardRuntimeConfig->replyTarget = getOverTcp
             ? SD_CARD_REPLY_WIFI_TCP : SD_CARD_REPLY_USB;
+    pSDCardRuntimeConfig->replyGeneration =
+            getOverTcp ? wifi_tcp_server_GetConnGeneration() : 0u;
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_READ;
     sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
     result = SCPI_RES_OK;
@@ -283,8 +288,11 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
     // If no directory specified, the sd_card_manager will use the default from settings
     
     // Set mode to LIST_DIRECTORY and let sd_card_manager handle it
-    pSDCardRuntimeConfig->replyTarget = wifi_tcp_server_ContextIsTcp(context)
-            ? SD_CARD_REPLY_WIFI_TCP : SD_CARD_REPLY_USB;   /* #598 */
+    const bool listOverTcp = wifi_tcp_server_ContextIsTcp(context);   /* #598 */
+    pSDCardRuntimeConfig->replyTarget = listOverTcp
+            ? SD_CARD_REPLY_WIFI_TCP : SD_CARD_REPLY_USB;
+    pSDCardRuntimeConfig->replyGeneration =
+            listOverTcp ? wifi_tcp_server_GetConnGeneration() : 0u;   /* #599 */
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_LIST_DIRECTORY;
     sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
 

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -59,6 +59,13 @@ extern "C" {
         bool enable;
         sd_card_manager_mode_t mode;
         sd_card_manager_reply_target_t replyTarget;  /**< #598 */
+        /* #599: TCP connection generation captured when a WIFI_TCP reply was
+         * requested (SCPI GET/LIST).  sd_card_manager_DataReadyCB refuses to
+         * write (and aborts the transfer) if the live connection no longer
+         * matches this value, so an async GET/LIST reply cannot leak into a
+         * different client that inherited the single TCP slot.  Meaningless
+         * (and left 0) when replyTarget == SD_CARD_REPLY_USB. */
+        uint32_t replyGeneration;
         char directory[SD_CARD_MANAGER_CONF_DIR_NAME_LEN_MAX + 1];
         char file[SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX + 1];
         uint64_t maxFileSizeBytes;  // Max file size before auto-split (0 = unlimited)

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -532,8 +532,12 @@ uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
     /* Per-interface, per-format TRANSPORT cap (#524) applies to ALL variants;
      * binds CSV (byte-bound) below the ADC cap. Interface is a PARAMETER so the
      * capabilities query can compute for the detected interface w/o mutating
-     * shared state (#524 Qodo). */
-    uint32_t transportMax = Streaming_TransportMaxFreq(iface, sc->Encoding, total);
+     * shared state (#524 Qodo). The isNQ1 flag selects the 252 MHz PB refit
+     * (#595 — NQ1-only basis) vs the conservative pre-#595 PB caps for NQ2/NQ3
+     * (their wider ADC samples push more PB bytes/sample per Hz). */
+    uint32_t transportMax = Streaming_TransportMaxFreq(
+            iface, sc->Encoding, total,
+            (bc != NULL && bc->BoardVariant == 1u) ? 1u : 0u);
     if (transportMax < maxFreq) maxFreq = transportMax;
     return maxFreq;
 }

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -211,11 +211,19 @@ static inline uint32_t Streaming_SdAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2use
  * @param interface      StreamingInterface (USB / WiFi / SD / UsbAndSd)
  * @param encoding       StreamingEncoding (PB vs CSV/JSON)
  * @param totalChannels  Total enabled public ADC channels
+ * @param isNQ1          1 for NQ1 (12-bit MC12b) — use the 2026-07-05 252 MHz PB
+ *                       transport refit (#595). 0 for NQ2/NQ3 (24-bit AD7173 /
+ *                       18-bit AD7609), which keep the pre-#595 (200 MHz)
+ *                       conservative PB caps: the #595 raise was characterized on
+ *                       NQ1 only, and NQ2/NQ3 emit wider PB varints per sample, so
+ *                       the same Hz pushes more transport bytes — the NQ1-raised Hz
+ *                       cap would over-cap them and risk silent transport overflow.
  * @return transport-limited max frequency in Hz
  */
 static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
                                                   StreamingEncoding encoding,
-                                                  uint32_t totalChannels) {
+                                                  uint32_t totalChannels,
+                                                  uint32_t isNQ1) {
     if (totalChannels == 0) return STREAMING_ISR_MAX_HZ;
     /* Explicit encoding handling (Qodo): unknown encodings cap at 1 Hz so a
      * future/garbage value can never over-cap. */
@@ -238,7 +246,13 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
              * shelter under the ADC additive model and the ISR clamp). Note:
              * the additive models (fitted at 200 MHz) now bind most cells --
              * their 252 MHz re-fit is the follow-up that unlocks the rest. */
-            if (pb) { single = 22000u; A = 120000u; B =  1u; }
+            /* #595 252 MHz USB-PB raise is NQ1-only; NQ2/NQ3 keep the pre-#595
+             * (200 MHz) USB-PB curve — their wider ADC samples cost more
+             * bytes/sample, so the NQ1-raised Hz cap would over-cap them. */
+            if (pb) {
+                if (isNQ1) { single = 22000u; A = 120000u; B =  1u; }
+                else       { single = 15000u; A = 180000u; B = 10u; }
+            }
             else    { single = 15000u; A =  34000u; B =  1u; }
             break;
         case StreamingInterface_WiFi:
@@ -271,7 +285,10 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
              * soak-unproven (leaked-at-ceiling) points at 5/8/10 ch which the
              * never-over discipline penalizes below the current curve -- a
              * raise there needs a third night or the additive-model re-fit. */
-            if (pb) { single =  8000u; A = 139000u; B = 30u; }
+            /* #595 raised only the PB single-channel term (5175->8000) at 252 MHz
+             * on NQ1; NQ2/NQ3 keep 5175. The multi-channel curve was unchanged by
+             * #595, so both variants share A/(B+n). */
+            if (pb) { single = isNQ1 ? 8000u : 5175u; A = 139000u; B = 30u; }
             else    { single =  4675u; A =  20000u; B =  2u; }
             break;
         case StreamingInterface_SD:
@@ -281,7 +298,12 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
              * The SD-additive model (#574, 200 MHz fit) now binds most SD
              * cells (e.g. 1xT1 at 9852, 5xT1 at 7500) -- its re-fit is the
              * follow-up. */
-            if (pb) { single = 13000u; A =  99000u; B =  4u; }
+            /* #595 252 MHz SD-PB raise is NQ1-only; NQ2/NQ3 keep the pre-#595
+             * (200 MHz) SD-PB curve. */
+            if (pb) {
+                if (isNQ1) { single = 13000u; A =  99000u; B =  4u; }
+                else       { single =  9000u; A = 150000u; B = 15u; }
+            }
             else    { single =  7500u; A =  42000u; B = 12u; }
             break;
         case StreamingInterface_UsbAndSd:

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -644,6 +644,11 @@ static void SocketEventCallback(SOCKET socket, uint8_t messageType, void *pMessa
                     break;
                 }
                 gStateMachineContext.pTcpServerContext->client.clientSocket = pAcceptMessage->sock;
+                // #599: this connection now owns the single TCP slot.  Bump the
+                // generation so any still-in-flight async SD GET/LIST reply that
+                // was bound to the previous connection stops writing to us.
+                // Single-writer (this callback only) -> plain ++ is safe.
+                gStateMachineContext.pTcpServerContext->client.connGeneration++;
                 LOG_D("Connection from %s:%d\r\n", inet_ntop(AF_INET, &pAcceptMessage->strAddr.sin_addr.s_addr, s, sizeof (s)), pAcceptMessage->strAddr.sin_port);
                 recv(gStateMachineContext.pTcpServerContext->client.clientSocket, gStateMachineContext.pTcpServerContext->client.readBuffer, WIFI_RBUFFER_SIZE, 0);
 

--- a/firmware/src/services/wifi_services/wifi_tcp_server.c
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.c
@@ -176,6 +176,20 @@ bool wifi_tcp_server_ContextIsTcp(const scpi_t* context) {
            (context->user_context == (void*)&gpServerData->client);
 }
 
+uint32_t wifi_tcp_server_GetConnGeneration(void) {
+    return (gpServerData != NULL) ? gpServerData->client.connGeneration : 0u;
+}
+
+bool wifi_tcp_server_ConnIsCurrent(uint32_t generation) {
+    // #599: the originating connection still owns the single TCP slot only if
+    // a client is currently connected (clientSocket >= 0) AND its generation
+    // is unchanged.  A disconnect (clientSocket -> -1) or a different client
+    // taking the slot (generation bumped in SOCKET_MSG_ACCEPT) both fail this.
+    return (gpServerData != NULL) &&
+           (gpServerData->client.clientSocket >= 0) &&
+           (gpServerData->client.connGeneration == generation);
+}
+
 static size_t SCPI_TCP_Write(scpi_t * context, const char* data, size_t len) {
     // Skip retry loop if client is disconnected — no progress possible
     if (gpServerData == NULL || gpServerData->client.clientSocket < 0) {
@@ -336,6 +350,7 @@ void wifi_tcp_server_Initialize(wifi_tcp_server_context_t *pServerData) {
         gpServerData->client.wifiWriteBufferRejectedBytes = 0;
         gpServerData->client.inflightHead = 0;
         gpServerData->client.inflightTail = 0;
+        gpServerData->client.connGeneration = 0;
         for (uint8_t i = 0; i < WIFI_TCP_MAX_IN_FLIGHT; i++) {
             gpServerData->client.inflightSizes[i] = 0;
         }

--- a/firmware/src/services/wifi_services/wifi_tcp_server.h
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.h
@@ -99,6 +99,15 @@ typedef struct s_tcpClientContext
     volatile uint16_t inflightSizes[WIFI_TCP_MAX_IN_FLIGHT];
     volatile uint8_t inflightHead;
     volatile uint8_t inflightTail;
+
+    /** #599: monotonically-increasing accepted-connection counter.  Bumped
+     *  once per SOCKET_MSG_ACCEPT that installs a client (single writer:
+     *  SocketEventCallback on the WINC driver task — same pattern as
+     *  acceptRefused/acceptFails, so a plain ++ is safe; the 32-bit read is
+     *  atomic).  Lets an in-flight async SD GET/LIST reply verify it still
+     *  targets the connection that issued it, so a later client inheriting
+     *  the single slot can never receive it. */
+    volatile uint32_t connGeneration;
 } wifi_tcp_server_clientContext_t;
 
 /**
@@ -153,6 +162,17 @@ size_t wifi_tcp_server_WriteBuffer(const char* data, size_t len);
 
 /** #598: true when the given SCPI context is the WiFi TCP console's. */
 bool wifi_tcp_server_ContextIsTcp(const scpi_t* context);
+
+/** #599: current accepted-connection generation (0 if no client has ever
+ *  been accepted).  Captured at SD GET/LIST time to bind an async reply. */
+uint32_t wifi_tcp_server_GetConnGeneration(void);
+
+/** #599: true only if a client is currently connected AND its generation
+ *  equals `generation` — i.e. the originating connection still owns the
+ *  single TCP slot.  False after that client disconnects, or once a
+ *  different client has taken the slot.  Backpressure (buffer full while the
+ *  same client stays connected) does NOT flip this false. */
+bool wifi_tcp_server_ConnIsCurrent(uint32_t generation);
 
 /**
  * Swap the WiFi TCP circular write buffer to pool-managed memory.


### PR DESCRIPTION
The **adversarial pre-merge gate** (qodo-cycle §3.5) over the v3.7.0 release delta surfaced three real issues the 2-hour dual-board soak could not (it only used `default`/USB and never disconnected mid-GET). All three are fixed here; the fix diff was re-run through the gate → **PASS, 0 findings**.

### #1 — Nq1/Nq3 build configs flipped standalone→bootloader-linked (`configurations.xml`)
An accidental MPLAB re-save (`911862c6`, bundled into #601 with no linker-script mention) dropped the `old_hv2_bootld.ld` exclusion from the **Nq1/Nq3** configs, so `make CONF=Nq1/Nq3` emitted a bootloader-offset hex → PICkit-flashing standalone gave a **non-running device**. `default` was untouched, so **the shipped release artifact was always correct**. Restored the exclusion in both configs (source + regenerated `Makefile-Nq1.mk` verified standalone).

### #2 — SD-GET/LIST-over-TCP client leak (#599)
An async `SYST:STOR:SD:GET/LIS?` routed through a single per-device `replyTarget` with **no connection identity**. If client A disconnected mid-transfer and client B inherited the one TCP slot, A's remaining file bytes + `__END_OF_FILE__` leaked into B's SCPI stream (info-leak + parser desync). Fix: stamp each accepted connection with a `connGeneration` (single-writer, bumped in `SOCKET_MSG_ACCEPT`), capture it at GET/LIST, and abort the transfer in `DataReadyCB` when the originating connection no longer owns the slot. USB path and single-client happy path unchanged.

### #595 — 252 MHz PB transport-cap raise not variant-gated
The #595/#600 PB refit was measured on **NQ1 only** but applied to all variants, raising NQ2/NQ3 SD/WiFi PB caps 44–55% onto an un-characterized basis (silent-loss risk). Gate the raised PB coefficients to NQ1 via an `isNQ1` param to `Streaming_TransportMaxFreq`; NQ2/NQ3 keep the pre-#595 conservative caps until re-characterized. NQ1 caps unchanged (bench-confirmed 8788 Hz for 1×T1).

**Validation:** `default` builds clean; NQ1 regression clean; adversarial gate re-run on this diff = PASS. #2's 2-client behavior and #595's NQ2/NQ3 protection are not NQ1-benchable — noted honestly. Separately flagged (pre-existing): the Nq1/Nq3 configs also lack the libscpi include path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)