### PR TITLE
fix(wifi): #656 honor isEnabled on standby->powered re-init

### DIFF
--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -2213,13 +2213,27 @@ bool wifi_manager_Init(wifi_manager_settings_t * pSettings) {
         if (pSettings != NULL) {
             gStateMachineContext.pWifiSettings = pSettings;
         }
-        if (gStateMachineContext.pWifiSettings != NULL) {
-            taskENTER_CRITICAL();
-            gWifiReinitDeadlineTick = 0;  // cancel any pending deferred-INIT
+        /* #656: honor the user's enable setting on the standby->powered
+         * re-init.  The state-machine copy (gpBoardData->wifiSettings) had its
+         * isEnabled zeroed by the standby Deinit, so the authoritative
+         * "user wants WiFi" bit is the runtime-config copy — written by the
+         * ENAbled setter / NVM boot-load, untouched by Deinit.  Only re-arm and
+         * drive the FSM back through INIT when WiFi is actually enabled; a
+         * user-disabled device then stays quiet across the power cycle, matching
+         * the cold-boot ENTRY gate (line ~1018).  Cancel any pending
+         * deferred-INIT regardless (matches the existing teardown semantics). */
+        wifi_manager_settings_t *pRtWifi =
+                BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS);
+        bool userEnabled = (pRtWifi != NULL && pRtWifi->isEnabled);
+        taskENTER_CRITICAL();
+        gWifiReinitDeadlineTick = 0;  // cancel any pending deferred-INIT
+        if (gStateMachineContext.pWifiSettings != NULL && userEnabled) {
             gStateMachineContext.pWifiSettings->isEnabled = 1;
-            taskEXIT_CRITICAL();
         }
-        SendEvent(WIFI_MANAGER_EVENT_INIT);
+        taskEXIT_CRITICAL();
+        if (userEnabled) {
+            SendEvent(WIFI_MANAGER_EVENT_INIT);
+        }
         return true;
     }
     if (pSettings != NULL)


### PR DESCRIPTION
## Problem
A user-disabled WiFi module re-broadcast its soft-AP on every `SYST:POWer:STATe 0`→`1` cycle (`ENAbled?`=0 but `ADDR?`=192.168.1.1). Found during #637 hardware validation.

## Root cause
`app_WifiTask` re-calls `wifi_manager_Init` on every return to POWERED_UP (app_freertos.c:294). Because the event queue already exists, this takes the **re-init branch** (wifi_manager.c:2204-2224), which **unconditionally** `isEnabled=1` + `SendEvent(INIT)` — bypassing the MainState ENTRY `isEnabled` gate (line ~1018) and restarting BSSConnect/APStart even when the user disabled WiFi. The state-machine copy `gpBoardData->wifiSettings.isEnabled` can't be trusted here: the standby `Deinit` zeros it.

## Fix
Gate the re-init on the **authoritative runtime-config copy** `BoardRunTimeConfig_Get(BOARDRUNTIME_WIFI_SETTINGS)->isEnabled` — written by the ENAbled setter (SCPILAN.c:194) + NVM boot-load (app_freertos.c:589), untouched by `Deinit`. Re-arm + INIT only when the user has WiFi enabled.

- **Cold boot** unaffected — first `Init` (`gEventQH==NULL`) still runs the ENTRY gate.
- **Enabled** flow unaffected — re-arms + INITs as before.

## Validation
Adversarial gate PASS (0 findings). Hardware (COM12):
- Enabled standby-cycle → WiFi restores (`ADDR?`=192.168.1.1). ✅
- **Disabled standby-cycle → stays off** (`ADDR?` unreachable; was 192.168.1.1). ✅ the fix
- Re-enable (`ENA 1`+`APPLY`) → WiFi comes back. ✅

Fixes #656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)