### PR TITLE
fix(scpi): #612 validate SD:CRC filename (close the deferred CRC site)

### DIFF
--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -261,6 +261,10 @@ scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         return SCPI_RES_ERR;
     }
+    if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612: CRC was the deferred site (post-#610-merge) */
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
     memcpy(pSDCardRuntimeConfig->file, pBuff, fileLen);
     pSDCardRuntimeConfig->file[fileLen] = '\0';
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_COMPUTE_CRC;


### PR DESCRIPTION
## Problem
`SYST:STOR:SD:CRC` copied its filename with only a length check — missing the `SD_ValidatePathParam()` guard that GET/LIST/DELETE/rename already apply (4 sites). The validator's own comment names CRC as a traversal risk. This is #615's "CRC site gets the guard post-#610-merge" follow-up that fell through. `../../x` passed the length check and reached the FatFS path builder (read-only CRC → info-disclosure/traversal, not destructive).

## Fix
Apply the same validator + error path as the other four SD filename sites.

## Validation
Build clean; ran in the overnight v3.7.1 candidate soak (8 h, no regressions). Quick CRC-traversal-reject test on hardware pending with the final candidate flash.

Found by codex review of the v3.7.1 window. Refs #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)