### PR TITLE
perf(streaming): lower SD CSV cap A 42000->36000 (soak-safe 10ch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -593,7 +593,7 @@ The firmware computes a maximum safe streaming frequency as a `min()` of an **AD
 |-----------|----:|----:|----:|
 | USB    | 15000 / 15000 | 180000/(10+n) | 34000/(1+n) |
 | WiFi   | 5175 / 4675   | 139000/(30+n) | min(20000/(2+n), 3050) |
-| SD     | 9000 / 7500   | 150000/(15+n) | 42000/(12+n) |
+| SD     | 9000 / 7500   | 150000/(15+n) | 36000/(12+n) |
 | USB+SD | 8000 / 8000   | 66000/(6+n)   | 15000/(0+n) |
 
 **Fit basis (normative — the zero-loss sweep subset the F3 coefficients derive from, Hz):**

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -304,7 +304,14 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
                 if (isNQ1) { single = 13000u; A =  99000u; B =  4u; }
                 else       { single =  9000u; A = 150000u; B = 15u; }
             }
-            else    { single =  7500u; A =  42000u; B = 12u; }
+            /* SD CSV A 42000->36000 (2026-07-09): the 8 h freeze-aware soak
+             * dropped SD bytes at the 10ch cap (5T1+5T2 @ 1909 = 42000/22) in
+             * 2/7 rounds -- byte-rate-limited (sdDrop, no wedge). sdDrop scales
+             * with the high-channel byte-rate asymptote (~A*bytes/sample), so
+             * lowering A pulls the many-channel ceiling under the SD write
+             * limit (10ch 1909->1636, ~14% margin) while the clean low-channel
+             * cells only gain headroom. Single-channel (7500) unaffected. */
+            else    { single =  7500u; A =  36000u; B = 12u; }
             break;
         case StreamingInterface_UsbAndSd:
             if (pb) { single =  8000u; A =  66000u; B =  6u; }


### PR DESCRIPTION
## Problem
The 8 h freeze-aware at-cap soak (v3.7.1 validation) dropped SD bytes at the SD CSV **10 ch** cap (5T1+5T2 @ 1909 Hz = 42000/22) in **2 of 7 rounds** — `sdDrop` (SD-write byte-rate limit), no wedge, qd=0, ~0.07% loss. By the soak-safe-caps standard the cap is marginally over-aggressive for that config.

## Fix (one number)
SD CSV `A`: 42000 → 36000. `sdDrop` scales with the high-channel byte-rate asymptote (~`A × bytes/sample`), so lowering `A` pulls the many-channel ceiling under the SD write limit while the clean low-channel cells only gain headroom:
- 10 ch: 1909 → **1636** (~14% margin)
- single-channel (7500) unaffected
- applies to all variants (SD write speed is variant-independent)

CLAUDE.md fit-table updated.

## Validation
Hardware (COM12): SD-only at-cap soak at the new 1636 cap — [pending, in progress].

Found during v3.7.1 overnight validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)