### PR TITLE
feat(wifi): TCP console idle-timeout — connect-and-never-send guard (#663)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2838,6 +2838,7 @@ static scpi_result_t SCPI_ClearStreamStats(scpi_t * context) {
         pTcp->clientForceClosed = 0;
         pTcp->listenReopens = 0;
         pTcp->listenHardResets = 0;
+        pTcp->client.idleClosed = 0;  // #676: idle-timeout closes (sibling listener-health counter)
         taskEXIT_CRITICAL();
     }
     // Reset SD write metrics
@@ -2986,6 +2987,7 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
         // #560/#475 Opt 0 — listener-health observability
         uint32_t socketOpenFails = 0, listenFails = 0, acceptFails = 0, acceptRefused = 0;
         uint32_t clientForceClosed = 0, listenReopens = 0, listenHardResets = 0, listenState = 0;
+        uint32_t idleClosed = 0;  // #676
         wifi_tcp_server_context_t* pTcp = wifi_manager_GetTcpServerContext();
         if (pTcp != NULL) {
             // Atomic snapshot of 64-bit counters (not atomic on 32-bit PIC32MZ)
@@ -3009,6 +3011,7 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
             clientForceClosed = pTcp->clientForceClosed;
             listenReopens = pTcp->listenReopens;
             listenHardResets = pTcp->listenHardResets;
+            idleClosed = pTcp->client.idleClosed;  // #676
             listenState = (pTcp->serverSocket >= 0) ? 1u : 0u;  // 0=closed, 1=open (2=suspect reserved for Opt 2 watchdog)
             taskEXIT_CRITICAL();
         }
@@ -3048,6 +3051,7 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
         scpi_printf(context, "WifiClientForceClosed=%u\r\n", (unsigned)clientForceClosed);
         scpi_printf(context, "WifiListenReopens=%u\r\n", (unsigned)listenReopens);
         scpi_printf(context, "WifiListenHardResets=%u\r\n", (unsigned)listenHardResets);
+        scpi_printf(context, "WifiIdleClosed=%u\r\n", (unsigned)idleClosed);  // #663/#676
     }
     scpi_printf(context, "UsbBytesSent=%llu\r\n", (unsigned long long)UsbCdc_GetWireBytesSent());
     scpi_printf(context, "SdDroppedBytes=%u\r\n", (unsigned)s.sdDroppedBytes);

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5319,6 +5319,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:COMMunicate:LAN:HRESet", .callback = SCPI_LANHardReset,},   // hard reset WINC (#383 recovery)
     {.pattern = "SYSTem:COMMunicate:LAN:PSave", .callback = SCPI_LANPowerSaveSet,}, // #29 auto power-save enable
     {.pattern = "SYSTem:COMMunicate:LAN:PSave?", .callback = SCPI_LANPowerSaveGet,},
+    {.pattern = "SYSTem:COMMunicate:LAN:IDLEtimeout", .callback = SCPI_LANIdleTimeoutSet,}, // #663 TCP console idle timeout (s, 0=off)
+    {.pattern = "SYSTem:COMMunicate:LAN:IDLEtimeout?", .callback = SCPI_LANIdleTimeoutGet,},
     {.pattern = "SYSTem:COMMunicate:LAN:LOAD", .callback = SCPI_LANSettingsLoad,},
     {.pattern = "SYSTem:COMMunicate:LAN:SAVE", .callback = SCPI_LANSettingsSave,},
     {.pattern = "SYSTem:COMMunicate:LAN:FACRESET", .callback = SCPI_LANSettingsFactoryLoad,},

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -854,7 +854,12 @@ scpi_result_t SCPI_LANIdleTimeoutSet(scpi_t * context) {
     if (!SCPI_ParamInt32(context, &param1, TRUE)) {
         return SCPI_RES_ERR;
     }
-    if (param1 < 0) {
+    // #676 gate: bound the range. seconds * configTICK_RATE_HZ (1000) is a
+    // 32-bit tick multiply, so values >= ~4.29M s silently wrap (and multiples
+    // of 2^29 s wrap to exactly 0 = "disabled", inverting the query). Cap at a
+    // generous 24 h — far beyond any real console idle timeout — mirroring the
+    // bounded SCPI_SetTransportGrace setter. 0 = off.
+    if (param1 < 0 || param1 > SYST_LAN_IDLE_TIMEOUT_MAX_SEC) {
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         return SCPI_RES_ERR;
     }

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -840,3 +840,30 @@ scpi_result_t SCPI_LANPowerSaveGet(scpi_t * context) {
     SCPI_ResultInt32(context, wifi_manager_GetPowerSaveMode());
     return SCPI_RES_OK;
 }
+
+/**
+ * SCPI Callback: Set the TCP console idle timeout in seconds (#663).
+ *
+ * A connected TCP console client with no RX or TX for this long is closed
+ * (connect-and-never-send DoS guard). 0 disables the watchdog. Runtime-only.
+ * A streaming client is continuously TX-active, so it is never idle and is
+ * never torn down by this timeout.
+ */
+scpi_result_t SCPI_LANIdleTimeoutSet(scpi_t * context) {
+    int param1;
+    if (!SCPI_ParamInt32(context, &param1, TRUE)) {
+        return SCPI_RES_ERR;
+    }
+    if (param1 < 0) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    wifi_manager_SetConsoleIdleTimeout((uint32_t)param1);
+    return SCPI_RES_OK;
+}
+
+/** SCPI Callback: Query the TCP console idle timeout in seconds (0=off, #663). */
+scpi_result_t SCPI_LANIdleTimeoutGet(scpi_t * context) {
+    SCPI_ResultUInt32(context, wifi_manager_GetConsoleIdleTimeout());
+    return SCPI_RES_OK;
+}

--- a/firmware/src/services/SCPI/SCPILAN.h
+++ b/firmware/src/services/SCPI/SCPILAN.h
@@ -201,6 +201,12 @@ scpi_result_t SCPI_LANPowerSaveSet(scpi_t * context);
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error
  */
 scpi_result_t SCPI_LANPowerSaveGet(scpi_t * context);
+/**
+ * SCPI Callback: Set/query the TCP console idle timeout in seconds (#663).
+ * 0 disables. @return SCPI_RES_OK on success SCPI_RES_ERR on error
+ */
+scpi_result_t SCPI_LANIdleTimeoutSet(scpi_t * context);
+scpi_result_t SCPI_LANIdleTimeoutGet(scpi_t * context);
 //scpi_result_t SCPI_LANAVSsidStrengthGet(scpi_t * context);
 //
 ///**

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -192,6 +192,17 @@ static bool wifiPowerSaveEnabled(void) {
 // calling HardReset/Deinit and read every tick from app_WifiTask.
 static volatile TickType_t gWifiReinitDeadlineTick = 0;
 
+// #663: TCP console idle-timeout deadline, in ticks. A connected client with
+// no RX or TX for this long is closed (connect-and-never-send DoS; #387/#560
+// listener-wedge class). Default 300 s — generous, since a legitimate headless
+// logger streams (constant TX → never idle) or polls; a pure-idle console with
+// no traffic for minutes is the DoS case. 0 = disabled. Runtime-only (resets
+// to default on reboot). 32-bit reads/writes atomic on PIC32MZ; written from a
+// SCPI task, read every WifiTask iteration.
+#define WIFI_CONSOLE_IDLE_TIMEOUT_DEFAULT_SEC 300u
+static volatile TickType_t gConsoleIdleDeadlineTicks =
+        WIFI_CONSOLE_IDLE_TIMEOUT_DEFAULT_SEC * configTICK_RATE_HZ;
+
 // #334: deep power-down latch. When true the user has requested that the
 // WINC1500 chip be held in full shutdown (CHIP_EN driven LOW) for battery
 // savings — distinct from a plain Deinit, which leaves nm_reset's final
@@ -686,6 +697,7 @@ static void SocketEventCallback(SOCKET socket, uint8_t messageType, void *pMessa
                     break;
                 }
                 gStateMachineContext.pTcpServerContext->client.clientSocket = pAcceptMessage->sock;
+                gStateMachineContext.pTcpServerContext->client.lastActivityTick = xTaskGetTickCount(); // #663: start the idle clock at connect
                 // #599: this connection now owns the single TCP slot.  Bump the
                 // generation so any still-in-flight async SD GET/LIST reply that
                 // was bound to the previous connection stops writing to us.
@@ -721,6 +733,7 @@ static void SocketEventCallback(SOCKET socket, uint8_t messageType, void *pMessa
                 // we call recv() again, so missing this tick's re-arm is
                 // safe.
                 gStateMachineContext.pTcpServerContext->client.readBufferLength = pRecvMessage->s16BufferSize;
+                gStateMachineContext.pTcpServerContext->client.lastActivityTick = xTaskGetTickCount(); // #663: RX activity resets the idle clock
                 gTcpRxPending = true;
 
             } else {
@@ -2815,6 +2828,43 @@ static void ApplyPowerSavePolicy(stateMachineInst_t * const pInstance) {
     }
 }
 
+// #663: TCP console idle-timeout watchdog. Runs once per normal WifiTask
+// ProcessState iteration (under gProcessStateMutex, drainTcpRx path only).
+// Closes a client that has had no RX or TX for gConsoleIdleDeadlineTicks —
+// the connect-and-never-send DoS. Safe against the #452 close-races-streaming
+// hazard two ways: (1) a streaming client is continuously TX-active so its
+// lastActivityTick keeps advancing → never idle; (2) the explicit
+// !Streaming_IsActiveOnWifiInterface() gate. Closing sets clientSocket=-1 and
+// the still-listening serverSocket auto-accepts the next client (same path as
+// a normal disconnect — no manual re-listen).
+static void wifi_manager_ServiceConsoleIdleTimeout(void)
+{
+    if (gConsoleIdleDeadlineTicks == 0) return;                 // disabled
+    if (gStateMachineContext.pTcpServerContext == NULL) return;
+    if (!wifi_tcp_server_HasActiveClient()) return;             // no client
+    if (Streaming_IsActiveOnWifiInterface()) return;            // never touch a live stream
+
+    TickType_t idle = xTaskGetTickCount() -
+                      gStateMachineContext.pTcpServerContext->client.lastActivityTick;
+    if (idle > gConsoleIdleDeadlineTicks) {
+        LOG_I("TCP: console idle %us > %us deadline — closing (connect-and-never-send guard, #663)",
+              (unsigned)(idle / configTICK_RATE_HZ),
+              (unsigned)(gConsoleIdleDeadlineTicks / configTICK_RATE_HZ));
+        gStateMachineContext.pTcpServerContext->client.idleClosed++;
+        wifi_tcp_server_CloseClientSocket();
+    }
+}
+
+// #663: runtime setter/getter for the console idle timeout (seconds; 0=off).
+void wifi_manager_SetConsoleIdleTimeout(uint32_t seconds)
+{
+    gConsoleIdleDeadlineTicks = (TickType_t)seconds * configTICK_RATE_HZ;
+}
+uint32_t wifi_manager_GetConsoleIdleTimeout(void)
+{
+    return (uint32_t)(gConsoleIdleDeadlineTicks / configTICK_RATE_HZ);
+}
+
 static void wifi_manager_ProcessStateImpl(bool drainTcpRx) {
     wifi_manager_event_t event;
     wifi_manager_stateMachineReturnStatus_t ret;
@@ -2957,6 +3007,7 @@ static void wifi_manager_ProcessStateImpl(bool drainTcpRx) {
     // the middle of a command dispatch — the outer loop applies it.
     if (drainTcpRx) {
         ApplyPowerSavePolicy(&gStateMachineContext);
+        wifi_manager_ServiceConsoleIdleTimeout();  // #663: connect-and-never-send guard
     }
 
     if (gProcessStateMutex != NULL) {

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -2844,8 +2844,15 @@ static void wifi_manager_ServiceConsoleIdleTimeout(void)
     if (!wifi_tcp_server_HasActiveClient()) return;             // no client
     if (Streaming_IsActiveOnWifiInterface()) return;            // never touch a live stream
 
-    TickType_t idle = xTaskGetTickCount() -
-                      gStateMachineContext.pTcpServerContext->client.lastActivityTick;
+    // #676 gate: capture lastActivityTick FIRST, then read the current tick, so
+    // the elapsed subtraction can never underflow. If we read `now` first and a
+    // concurrent RX/TX (WINC driver or send path) stamped a newer tick before
+    // we read lastActivityTick, `now - last` would wrap to ~0xFFFFFFFF and
+    // spuriously close a just-active client. Reading `last` first guarantees
+    // now >= last (ticks are monotonic), so `idle` is a true non-negative
+    // elapsed (correct across the 32-bit rollover, the standard FreeRTOS idiom).
+    TickType_t last = gStateMachineContext.pTcpServerContext->client.lastActivityTick;
+    TickType_t idle = xTaskGetTickCount() - last;
     if (idle > gConsoleIdleDeadlineTicks) {
         LOG_I("TCP: console idle %us > %us deadline — closing (connect-and-never-send guard, #663)",
               (unsigned)(idle / configTICK_RATE_HZ),

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -696,8 +696,15 @@ static void SocketEventCallback(SOCKET socket, uint8_t messageType, void *pMessa
                     }
                     break;
                 }
+                // #676 gate: stamp the idle clock BEFORE publishing clientSocket.
+                // The watchdog gates on HasActiveClient (clientSocket>=0); if we
+                // set clientSocket first, it could preempt between the two stores,
+                // see a live socket with the *previous* connection's stale tick
+                // (idle if the device sat client-less > deadline), and close the
+                // brand-new client. Stamping first makes a live socket always
+                // carry a fresh tick.
+                gStateMachineContext.pTcpServerContext->client.lastActivityTick = xTaskGetTickCount();
                 gStateMachineContext.pTcpServerContext->client.clientSocket = pAcceptMessage->sock;
-                gStateMachineContext.pTcpServerContext->client.lastActivityTick = xTaskGetTickCount(); // #663: start the idle clock at connect
                 // #599: this connection now owns the single TCP slot.  Bump the
                 // generation so any still-in-flight async SD GET/LIST reply that
                 // was bound to the previous connection stops writing to us.

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -2860,7 +2860,15 @@ static void wifi_manager_ServiceConsoleIdleTimeout(void)
     // elapsed (correct across the 32-bit rollover, the standard FreeRTOS idiom).
     TickType_t last = gStateMachineContext.pTcpServerContext->client.lastActivityTick;
     TickType_t idle = xTaskGetTickCount() - last;
-    if (idle > gConsoleIdleDeadlineTicks) {
+    // #676 Qodo: re-read lastActivityTick and only close if it is UNCHANGED
+    // since our snapshot (optimistic concurrency). An RX/TX from the WINC driver
+    // / send path stamps a newer tick; if one landed between the snapshot and
+    // here, the client just became active — skip the close so a near-boundary
+    // active client is not falsely disconnected. The residual window (a stamp
+    // after this re-read) is a couple of instructions and self-heals via the
+    // client's immediate reconnect. The read is a 32-bit aligned atomic.
+    if (idle > gConsoleIdleDeadlineTicks &&
+        gStateMachineContext.pTcpServerContext->client.lastActivityTick == last) {
         LOG_I("TCP: console idle %us > %us deadline — closing (connect-and-never-send guard, #663)",
               (unsigned)(idle / configTICK_RATE_HZ),
               (unsigned)(gConsoleIdleDeadlineTicks / configTICK_RATE_HZ));

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -467,6 +467,17 @@ extern "C" {
     bool wifi_manager_GetPowerSaveEnabled(void);
 
     /**
+     * @brief Set the TCP console idle timeout (#663). A connected client with
+     *        no RX or TX for this long is closed (connect-and-never-send DoS).
+     * @param seconds Idle deadline in seconds; 0 disables the watchdog.
+     *        Runtime-only (resets to the default on reboot).
+     */
+    void wifi_manager_SetConsoleIdleTimeout(uint32_t seconds);
+
+    /** @brief Query the TCP console idle timeout in seconds (0 = disabled). */
+    uint32_t wifi_manager_GetConsoleIdleTimeout(void);
+
+    /**
      * @brief Query the WINC power-save mode currently applied (#29).
      *
      * @return The applied WDRV_WINC_PS_MODE value as an int

--- a/firmware/src/services/wifi_services/wifi_manager.h
+++ b/firmware/src/services/wifi_services/wifi_manager.h
@@ -466,11 +466,16 @@ extern "C" {
      */
     bool wifi_manager_GetPowerSaveEnabled(void);
 
+    /** #663/#676: max settable console idle timeout (seconds). Bounds the
+     *  SCPI setter so seconds * configTICK_RATE_HZ cannot overflow 32-bit
+     *  ticks. 24 h is far beyond any real idle-timeout need; 0 = off. */
+    #define SYST_LAN_IDLE_TIMEOUT_MAX_SEC 86400u
+
     /**
      * @brief Set the TCP console idle timeout (#663). A connected client with
      *        no RX or TX for this long is closed (connect-and-never-send DoS).
-     * @param seconds Idle deadline in seconds; 0 disables the watchdog.
-     *        Runtime-only (resets to the default on reboot).
+     * @param seconds Idle deadline in seconds (0 = off, max
+     *        SYST_LAN_IDLE_TIMEOUT_MAX_SEC). Runtime-only (resets on reboot).
      */
     void wifi_manager_SetConsoleIdleTimeout(uint32_t seconds);
 

--- a/firmware/src/services/wifi_services/wifi_tcp_server.c
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.c
@@ -134,6 +134,7 @@ static bool TcpServerFlush() {
         gpServerData->client.tcpInFlight++;
         taskEXIT_CRITICAL();
         gpServerData->client.writeBufferLength = 0;
+        gpServerData->client.lastActivityTick = xTaskGetTickCount(); // #663: TX keeps a streaming client non-idle
         funRet = true;
     } else if (sockRet == SOCK_ERR_BUFFER_FULL) {
         // WINC module buffer full - return false without blocking
@@ -351,6 +352,7 @@ void wifi_tcp_server_Initialize(wifi_tcp_server_context_t *pServerData) {
         gpServerData->client.inflightHead = 0;
         gpServerData->client.inflightTail = 0;
         gpServerData->client.connGeneration = 0;
+        gpServerData->client.lastActivityTick = xTaskGetTickCount(); // #663 (idleClosed persists across connections — not reset)
         for (uint8_t i = 0; i < WIFI_TCP_MAX_IN_FLIGHT; i++) {
             gpServerData->client.inflightSizes[i] = 0;
         }
@@ -522,6 +524,25 @@ static inline void DrainPendingBufferReset(void) {
 // is actively connected. Returns true when a client socket is open.
 bool wifi_tcp_server_HasActiveClient(void) {
     return (gpServerData != NULL) && (gpServerData->client.clientSocket >= 0);
+}
+
+// #663: last RX/TX activity tick on the connected client (0 if none). Plain
+// aligned read of a volatile TickType_t — atomic on PIC32MZ.
+TickType_t wifi_tcp_server_GetLastActivityTick(void) {
+    return (gpServerData != NULL) ? gpServerData->client.lastActivityTick : 0;
+}
+
+// #663: stamp activity "now". No-op with no client. Single 32-bit store —
+// atomic on PIC32MZ; callers are the send path (streaming/WifiTask) and the
+// RX/ACCEPT handlers (WINC driver task).
+void wifi_tcp_server_StampActivity(void) {
+    if (gpServerData != NULL && gpServerData->client.clientSocket >= 0) {
+        gpServerData->client.lastActivityTick = xTaskGetTickCount();
+    }
+}
+
+uint32_t wifi_tcp_server_GetIdleClosedCount(void) {
+    return (gpServerData != NULL) ? gpServerData->client.idleClosed : 0;
 }
 
 // #367 diagnostics: bytes queued in the WiFi TCP write circular buffer

--- a/firmware/src/services/wifi_services/wifi_tcp_server.c
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.c
@@ -526,25 +526,6 @@ bool wifi_tcp_server_HasActiveClient(void) {
     return (gpServerData != NULL) && (gpServerData->client.clientSocket >= 0);
 }
 
-// #663: last RX/TX activity tick on the connected client (0 if none). Plain
-// aligned read of a volatile TickType_t — atomic on PIC32MZ.
-TickType_t wifi_tcp_server_GetLastActivityTick(void) {
-    return (gpServerData != NULL) ? gpServerData->client.lastActivityTick : 0;
-}
-
-// #663: stamp activity "now". No-op with no client. Single 32-bit store —
-// atomic on PIC32MZ; callers are the send path (streaming/WifiTask) and the
-// RX/ACCEPT handlers (WINC driver task).
-void wifi_tcp_server_StampActivity(void) {
-    if (gpServerData != NULL && gpServerData->client.clientSocket >= 0) {
-        gpServerData->client.lastActivityTick = xTaskGetTickCount();
-    }
-}
-
-uint32_t wifi_tcp_server_GetIdleClosedCount(void) {
-    return (gpServerData != NULL) ? gpServerData->client.idleClosed : 0;
-}
-
 // #367 diagnostics: bytes queued in the WiFi TCP write circular buffer
 // that haven't been drained to send() yet. Streaming_Stop snapshots this
 // to reconcile the accounting gap.

--- a/firmware/src/services/wifi_services/wifi_tcp_server.h
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.h
@@ -108,6 +108,19 @@ typedef struct s_tcpClientContext
      *  targets the connection that issued it, so a later client inheriting
      *  the single slot can never receive it. */
     volatile uint32_t connGeneration;
+
+    /** #663: tick of the last RX or TX activity on this connection. Stamped at
+     *  ACCEPT, on every SOCKET_MSG_RECV, and on every successful send(). The
+     *  console idle-timeout watchdog (wifi_manager) closes a client that has
+     *  had no RX *or* TX for the configured deadline — the connect-and-never-
+     *  send DoS. Because a streaming client is continuously TX-active it is
+     *  never idle by this definition, so streaming is never torn down. */
+    volatile TickType_t lastActivityTick;
+
+    /** #663 health counter: connections closed by the idle-timeout watchdog
+     *  (single writer: app_WifiTask ProcessState). Sibling of acceptRefused/
+     *  acceptFails for #560-style listener observability. */
+    uint32_t idleClosed;
 } wifi_tcp_server_clientContext_t;
 
 /**
@@ -189,6 +202,19 @@ void wifi_tcp_server_SetWriteBuffer(uint8_t* buf, uint32_t size);
  * plane is in use.
  */
 bool wifi_tcp_server_HasActiveClient(void);
+
+/**
+ * #663: tick of the last RX/TX activity on the connected client (0 if none).
+ * Read by the console idle-timeout watchdog in wifi_manager_ProcessState.
+ */
+TickType_t wifi_tcp_server_GetLastActivityTick(void);
+
+/** #663: stamp the connected client's activity tick "now" (RX or TX). No-op if
+ *  no client. Called from the send path and the RX/ACCEPT handlers. */
+void wifi_tcp_server_StampActivity(void);
+
+/** #663: count of clients closed by the idle-timeout watchdog. */
+uint32_t wifi_tcp_server_GetIdleClosedCount(void);
 
 /**
  * Returns the current count of bytes sitting in the WiFi TCP write

--- a/firmware/src/services/wifi_services/wifi_tcp_server.h
+++ b/firmware/src/services/wifi_services/wifi_tcp_server.h
@@ -204,19 +204,6 @@ void wifi_tcp_server_SetWriteBuffer(uint8_t* buf, uint32_t size);
 bool wifi_tcp_server_HasActiveClient(void);
 
 /**
- * #663: tick of the last RX/TX activity on the connected client (0 if none).
- * Read by the console idle-timeout watchdog in wifi_manager_ProcessState.
- */
-TickType_t wifi_tcp_server_GetLastActivityTick(void);
-
-/** #663: stamp the connected client's activity tick "now" (RX or TX). No-op if
- *  no client. Called from the send path and the RX/ACCEPT handlers. */
-void wifi_tcp_server_StampActivity(void);
-
-/** #663: count of clients closed by the idle-timeout watchdog. */
-uint32_t wifi_tcp_server_GetIdleClosedCount(void);
-
-/**
  * Returns the current count of bytes sitting in the WiFi TCP write
  * circular buffer (queued for send() but not yet drained).
  * Used by Streaming_Stop to capture session-end "tail" bytes for the


### PR DESCRIPTION
## Problem

The `:9760` SCPI-over-TCP console had **no idle/connect timeout** — a client that connects and never sends holds the single console slot indefinitely (connect-and-never-send DoS, #387/#560 listener-wedge class; iperf2 already models a connect deadline).

## Design

A per-connection `lastActivityTick` is stamped at **ACCEPT**, on every **RX** (`SOCKET_MSG_RECV`), and on every successful **TX** (`send()`). A watchdog in `wifi_manager_ProcessState` (once per normal WifiTask iteration, under `gProcessStateMutex`, alongside the #29 power-save policy) closes a client idle — **no RX *or* TX** — beyond the deadline.

**Key safety property:** a streaming client is continuously TX-active, so its tick keeps advancing → it is *never* idle → streaming is never torn down. This avoids the **#452 close-races-streaming** corruption by construction; an explicit `!Streaming_IsActiveOnWifiInterface()` gate is belt-and-suspenders. Closing sets `clientSocket=-1` and the still-listening `serverSocket` **auto-accepts** the next client (same path as a normal disconnect — no manual re-listen), so there is **no listener wedge**.

## SCPI (lean — extends the LAN namespace)

```
SYST:COMM:LAN:IDLEtimeout <sec>   # 0 = off, default 300 s, runtime-only
SYST:COMM:LAN:IDLEtimeout?
```
Health counter `client.idleClosed` (sibling of `acceptRefused`/`acceptFails`).

## Validation

**Hardware 4/4** on COM12 + STA (Tesla, 192.168.1.156), 2026-07-11:
| | scenario | result |
|---|---|---|
| S1 | connect-and-never-send | closed after the deadline ✓ |
| S3 | fresh client after idle-close | accepted — **no listener wedge** ✓ |
| S2 | active client (periodic traffic) | stays open past 2× deadline ✓ |
| S4 | streaming client (43,890 B, TX-active, zero RX) | **not closed** ✓ |

SCPI surface: default 300, set/get, 0=off, negative → −224. cppcheck clean (matches baseline). Regression test: [daqifi-python-test-suite#78](https://github.com/daqifi/daqifi-python-test-suite/pull/78).

Fixes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)