### PR TITLE
fix(scpi): validate CONF:ADC:CHAN channel before uint8_t truncation (#678)

### DIFF
--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -151,6 +151,28 @@ scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
     if (SCPI_ParamInt32(context, &param2, FALSE)) {
         // Single-channel form: (channel, state). NOT a bitmask — the one-arg
         // form CONF:ADC:CHAN <mask> is the bitmask path (see #630).
+
+        // #678: validate the FULL parsed channel id against the settable-channel
+        // range BEFORE the (uint8_t) cast below. Without this, a value >= 256 is
+        // truncated mod-256 and can alias onto a valid user channel (256->0,
+        // 257->1, ...), silently mutating it and returning OK. The #630 guard
+        // does not catch it because it checks the RESOLVED index, which is
+        // downstream of the truncation. Same truncation-before-validation class
+        // that #653/#671 fixed for DIO (DIO_SingleChannelIndexValid): reject the
+        // raw value up front, no state change. This guard is inside the two-arg
+        // branch only — the one-arg <mask> form legitimately uses the full int as
+        // a bitmask (up to 0xFFFF). maxUserChannel matches the mask path below
+        // (NQ3: 0-7, others: 0-15).
+        uint8_t maxUserChannel = (pBoardConfig->BoardVariant == 3) ? 7 : 15;
+        if (param1 < 0 || param1 > maxUserChannel) {
+            LOG_E("CONF:ADC:CHAN: channel %d out of range (settable user channels "
+                  "0..%u). The two-arg form is <channel>,<state>; use the one-arg "
+                  "<mask> form to enable channels by bitmask.",
+                  param1, (unsigned) maxUserChannel);
+            SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+            return SCPI_RES_ERR;
+        }
+
         size_t channelIndex = ADC_FindChannelIndex((uint8_t) param1);
 
         // #630: bounds-check BEFORE dereferencing. ADC_FindChannelIndex returns


### PR DESCRIPTION
## Problem
`SCPI_ADCChanEnableSet`'s two-arg `(channel,state)` path cast the channel argument to `uint8_t` **before** the channel lookup, so an out-of-range channel `>= 256` was truncated mod-256 and could alias onto a valid user channel (`256→0`, `257→1`, … `271→15`), **silently disabling/enabling that channel and returning `OK`**.

The #630 bounds guard did **not** catch it — it checks the *resolved* index (`ADC_FindChannelIndex((uint8_t)param1)`), which is downstream of the truncation. So `#630` closed the OOB *read* but left the truncation-alias hole open. This is the **same truncation-before-validation class that #653/#671 fixed for DIO** (`DIO_SingleChannelIndexValid`), not carried over to ADC.

### Repro (pre-fix)
With streaming stopped and ch0 enabled: `CONF:ADC:CHAN 256,0` → ch0 silently disabled, `OK` returned. Expected: rejected, no state change.

## Fix
Validate the **full parsed `param1`** against the settable-channel range (`0..15` NQ1/NQ2, `0..7` NQ3 — same `maxUserChannel` the one-arg mask path uses) **before** the `(uint8_t)` cast, in the **two-arg branch only**. Reject with `SCPI_ERROR_DATA_OUT_OF_RANGE` + a `LOG_E` discoverability hint, no state change.

- The one-arg `<mask>` form is untouched — it legitimately uses the full int as a bitmask (up to `0xFFFF`), so the guard is scoped inside the two-arg branch.
- The downstream `#630` resolved-index guard and the variant switch's range checks are **kept as defense-in-depth** on this SCPI input boundary (intentional redundancy, not dead code).

Low severity: no memory corruption (the #630 guard already prevents the OOB read), recoverable, visible via `CONF:ADC:CHAN?`. But a real correctness hole and an incomplete #630 fix.

## Provenance
Surfaced by the **cross-vendor Codex (GPT-5.x) adversary** newly wired into the qodo-cycle pre-merge gate (run against the merged #630 diff as a validation of the new `auditEngine:"both"` default), independently CONFIRMED by the Claude opus refute-skeptic against the source.

## Test
Companion regression test `test_678_adc_chan_truncation.py` in daqifi/daqifi-python-test-suite#79 — asserts `256,0`/`260,0`/`512,1` are rejected with the victim channel intact (FAILs on pre-#678 firmware), the reject logs a hint, and the one-arg mask form still applies. **Bench run queued** (no device attached at authoring).

## Build
Clean under `-Werror -Wall` at global `-O3` (default config, XC32 v4.60).

Fixes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)