### PR TITLE
fix(wifi): snapshot idle-timeout deadline once — close double-read TOCTOU (#677)

### DIFF
--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -2846,7 +2846,17 @@ static void ApplyPowerSavePolicy(stateMachineInst_t * const pInstance) {
 // a normal disconnect — no manual re-listen).
 static void wifi_manager_ServiceConsoleIdleTimeout(void)
 {
-    if (gConsoleIdleDeadlineTicks == 0) return;                 // disabled
+    // #677: snapshot the volatile deadline ONCE so the disabled-guard and the
+    // deadline compare below both use a single consistent value. Reading the
+    // global twice let a concurrent SYST:COMM:LAN:IDLEtimeout 0 (SCPI on USB
+    // pri 7, preempting this WiFi-task pri 2 code) land between the two reads:
+    // pass the disabled-guard while it was still e.g. 300s, then compare `idle`
+    // against a freshly-stored 0 and close a console the operator just disabled
+    // the watchdog for — the opposite of intent. The aligned 32-bit TickType_t
+    // load is atomic (no torn read), so this is a double-read TOCTOU, not a
+    // tear; caching in a local resolves it. Consistent with the #676 hardening.
+    const TickType_t deadline = gConsoleIdleDeadlineTicks;      // single read
+    if (deadline == 0) return;                                  // disabled
     if (gStateMachineContext.pTcpServerContext == NULL) return;
     if (!wifi_tcp_server_HasActiveClient()) return;             // no client
     if (Streaming_IsActiveOnWifiInterface()) return;            // never touch a live stream
@@ -2867,11 +2877,11 @@ static void wifi_manager_ServiceConsoleIdleTimeout(void)
     // active client is not falsely disconnected. The residual window (a stamp
     // after this re-read) is a couple of instructions and self-heals via the
     // client's immediate reconnect. The read is a 32-bit aligned atomic.
-    if (idle > gConsoleIdleDeadlineTicks &&
+    if (idle > deadline &&
         gStateMachineContext.pTcpServerContext->client.lastActivityTick == last) {
         LOG_I("TCP: console idle %us > %us deadline — closing (connect-and-never-send guard, #663)",
               (unsigned)(idle / configTICK_RATE_HZ),
-              (unsigned)(gConsoleIdleDeadlineTicks / configTICK_RATE_HZ));
+              (unsigned)(deadline / configTICK_RATE_HZ));
         gStateMachineContext.pTcpServerContext->client.idleClosed++;
         wifi_tcp_server_CloseClientSocket();
     }


### PR DESCRIPTION
## Problem
`wifi_manager_ServiceConsoleIdleTimeout()` read the `volatile gConsoleIdleDeadlineTicks` **twice** — the disabled-guard (`if (deadline == 0) return;`) and the deadline compare (`if (idle > deadline …)`). A concurrent `SYST:COMM:LAN:IDLEtimeout 0` (SCPI on **`app_USBDeviceTask` pri 7**, preempting the watchdog on **`app_WifiTask` pri 2**) landing **between the two reads** could:
1. pass the disabled-guard while the value was still e.g. `300000`, then
2. compare `idle` against a freshly-stored `0` → `idle > 0` true for any idle ≥ 1 tick → **close the idle console the operator just disabled the watchdog for** — the opposite of intent, plus a nonsensical `console idle Ns > 0s deadline` log line.

This is a **double-read TOCTOU** (two clean atomic reads that differ), *not* a torn read — per the PIC32MZ rule an aligned 32-bit `TickType_t` load is atomic. A TCP-delivered disable runs same-task on the WiFi task and cannot preempt; the **USB path is the only reachable racer**.

## Fix
Snapshot the deadline into a `const TickType_t deadline` local at function entry and use that single value for both the guard and the compare/log. One consistent snapshot → the decision can't straddle a concurrent write. Consistent with the #676 optimistic-concurrency hardening already in this function.

## Impact — low
Self-limited: the streaming gate guarantees the victim is an **idle** client (no data loss), the still-listening server auto-accepts its immediate reconnect, and it fires only in a couple-instruction window, only once (the watchdog is disabled thereafter). No crash/wedge/corruption/security impact.

## Provenance
Surfaced by the **cross-vendor Codex (GPT-5.x) adversary** newly wired into the qodo-cycle pre-merge gate (run against the merged #663 diff, commit `475a737d`), independently CONFIRMED by the Claude opus refute-skeptic (which corrected the initial "torn snapshot" mislabel to "double-read TOCTOU" and set severity low).

## Test
Companion regression test `test_677_idle_timeout_toctou.py` in daqifi/daqifi-python-test-suite#79 — deterministic D1/D2 (feature works; disabled stays open past 2× deadline) plus a best-effort R1 race probe that toggles the timeout `non-zero<->0` over USB while an idle console exists (can catch the TOCTOU on old firmware, always green on fixed). SKIPs cleanly if not associated. **Bench run queued** (no device attached at authoring).

## Build
Clean under `-Werror -Wall` at global `-O3` (default config, XC32 v4.60).

Fixes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)