### PR TITLE
perf(streaming): #662 batch-pop — encode N samples per encoder wake

### DIFF
--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2178,10 +2178,32 @@ void streaming_Task(void) {
         // #662 batch-pop: encode up to STREAMING_BATCH_MAX samples back-to-back
         // into `buffer`, accumulating framed messages, then a SINGLE output
         // write below of the whole batch. Availability + room are re-checked
-        // every iteration (the pri-9 deferred task may enqueue concurrently);
-        // the MIN_ROOM guard guarantees the encoder has space so a 0 return is
-        // unambiguously empty-queue/failure, never truncation. At steady state
-        // (queue depth 1) this is a batch of 1 — identical to the pre-#662 path.
+        // every iteration (the pri-9 deferred task may enqueue concurrently).
+        // At steady state (queue depth 1) this is a batch of 1 — identical to
+        // the pre-#662 path.
+        //
+        // The batch total is bounded by BOTH the encoder buffer AND the smallest
+        // ACTIVE transport ring's free space (#686 review): the transport writes
+        // below are all-or-nothing, and a single write larger than a ring's
+        // capacity can NEVER succeed (even on an empty ring), so an over-large
+        // batch would retry to the 10 s timeout and drop the whole batch — total
+        // loss on a small ring (e.g. WiFi min 1400). Free size is a safe bound:
+        // nothing writes these rings until after this loop, so the snapshot only
+        // grows. The FIRST message is always encoded (drain the queue; one framed
+        // message fits any legal ring, exactly as pre-#662); ADDITIONAL messages
+        // are added only while packetSize keeps MIN_ROOM within every active ring.
+        size_t batchXportFree = bufferSize;
+        switch (pRunTimeStreamConf->ActiveInterface) {
+            case StreamingInterface_USB:      batchXportFree = usbSize; break;
+            case StreamingInterface_WiFi:     batchXportFree = wifiSize; break;
+            case StreamingInterface_SD:       batchXportFree = sdSize; break;
+            case StreamingInterface_UsbAndSd:
+                batchXportFree = (usbSize < sdSize) ? usbSize : sdSize; break;
+            default: break;
+        }
+        if (hasSD && sdSize < batchXportFree) {
+            batchXportFree = sdSize;         // SD-logging override also writes SD
+        }
         packetSize = 0;
         for (uint32_t batchIdx = 0; batchIdx < STREAMING_BATCH_MAX; batchIdx++) {
             bool ainNow = !AInSampleList_IsEmpty();
@@ -2189,8 +2211,18 @@ void streaming_Task(void) {
             if (!ainNow && !dioNow) {
                 break;                       // queue drained — normal batch end
             }
-            if ((bufferSize - packetSize) < STREAMING_BATCH_MIN_ROOM) {
-                break;                       // flush what we have; no guaranteed room
+            // First message always encoded (drain the queue); additional
+            // messages must keep MIN_ROOM within the encoder buffer AND the
+            // smallest active transport ring, so the single all-or-nothing write
+            // below always fits its ring. Addition (not subtraction) avoids
+            // size_t underflow when a transport ring is momentarily full (free=0).
+            if (batchIdx > 0) {
+                if ((bufferSize - packetSize) < STREAMING_BATCH_MIN_ROOM) {
+                    break;                   // no encoder-buffer room
+                }
+                if ((packetSize + STREAMING_BATCH_MIN_ROOM) > batchXportFree) {
+                    break;                   // would overflow the smallest active ring
+                }
             }
 
             nanopbFlag.Size = 0;

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1976,13 +1976,27 @@ void Streaming_UpdateState(void) {
  * @note This function will return early if streaming is disabled or there is no data to process.
  */
 
+// #662 batch-pop: per encoder wake, encode up to STREAMING_BATCH_MAX samples
+// back-to-back into one buffer, then a SINGLE output write of the concatenated
+// framed messages. Amortizes the per-wake output-write + size-query overhead
+// across N samples. Each encoder call pops one sample and emits a self-framed
+// unit (PB length-delimited / CSV row / JSON object), so concatenating N is
+// byte-identical to N separate writes — invisible to clients (no wire-format
+// change). Bounded so a backlog can't monopolize the encoder or delay the
+// output write beyond N samples' worth. STREAMING_BATCH_MIN_ROOM is a
+// conservative worst-case single-message size: the batch stops before an
+// encode that isn't guaranteed to fit, so a 0 encoder return unambiguously
+// means empty-queue/failure rather than truncation.
+#define STREAMING_BATCH_MAX      8u
+#define STREAMING_BATCH_MIN_ROOM 1024u
+
 void streaming_Task(void) {
     // Enable FPU context saving for this task (required for ADC voltage conversion)
     portTASK_USES_FLOATING_POINT();
 
      TickType_t xBlockTime = portMAX_DELAY;
     NanopbFlagsArray nanopbFlag;
-    size_t usbSize, wifiSize, sdSize, maxSize;
+    size_t usbSize, wifiSize, sdSize;
     /* #371/#372: USB/WiFi gates moved to ActiveInterface checks at the
      * write sites — hasUsb / hasWifi are no longer consulted, removed
      * from the per-iteration switch.  hasSD is still consulted by the SD
@@ -2161,91 +2175,94 @@ void streaming_Task(void) {
         // whichever outputs have space, and discarded if none do.
         // Previously used min(128, output_free) which caused CSV 16ch
         // encoder failures when USB buffer was full (128 < row size ~172).
-        maxSize = bufferSize;
-
-        nanopbFlag.Size = 0;
-
-        nanopbFlag.Data[nanopbFlag.Size++] = DaqifiOutMessage_msg_time_stamp_tag;
-
-        if (AINDataAvailable) {
-            nanopbFlag.Data[nanopbFlag.Size++] = DaqifiOutMessage_analog_in_data_tag;
-        }
-        if (DIODataAvailable) {
-            nanopbFlag.Data[nanopbFlag.Size++] = DaqifiOutMessage_digital_data_tag;
-            nanopbFlag.Data[nanopbFlag.Size++] = DaqifiOutMessage_digital_port_dir_tag;
-        }
-
+        // #662 batch-pop: encode up to STREAMING_BATCH_MAX samples back-to-back
+        // into `buffer`, accumulating framed messages, then a SINGLE output
+        // write below of the whole batch. Availability + room are re-checked
+        // every iteration (the pri-9 deferred task may enqueue concurrently);
+        // the MIN_ROOM guard guarantees the encoder has space so a 0 return is
+        // unambiguously empty-queue/failure, never truncation. At steady state
+        // (queue depth 1) this is a batch of 1 — identical to the pre-#662 path.
         packetSize = 0;
-        if (nanopbFlag.Size > 0) {
-            DioProbe_PulseStart(8);  /* probe 8: encode duration */
-            if(pRunTimeStreamConf->Encoding == Streaming_Csv){
-                DIO_TIMING_TEST_WRITE_STATE(1);
-                packetSize = csv_Encode(pBoardData, &nanopbFlag, (uint8_t *) buffer, maxSize);
-                DIO_TIMING_TEST_WRITE_STATE(0);
+        for (uint32_t batchIdx = 0; batchIdx < STREAMING_BATCH_MAX; batchIdx++) {
+            bool ainNow = !AInSampleList_IsEmpty();
+            bool dioNow = !DIOSampleList_IsEmpty(&pBoardData->DIOSamples);
+            if (!ainNow && !dioNow) {
+                break;                       // queue drained — normal batch end
             }
-            else if (pRunTimeStreamConf->Encoding == Streaming_Json) {
+            if ((bufferSize - packetSize) < STREAMING_BATCH_MIN_ROOM) {
+                break;                       // flush what we have; no guaranteed room
+            }
+
+            nanopbFlag.Size = 0;
+            nanopbFlag.Data[nanopbFlag.Size++] = DaqifiOutMessage_msg_time_stamp_tag;
+            if (ainNow) {
+                nanopbFlag.Data[nanopbFlag.Size++] = DaqifiOutMessage_analog_in_data_tag;
+            }
+            if (dioNow) {
+                nanopbFlag.Data[nanopbFlag.Size++] = DaqifiOutMessage_digital_data_tag;
+                nanopbFlag.Data[nanopbFlag.Size++] = DaqifiOutMessage_digital_port_dir_tag;
+            }
+
+            uint8_t *encPtr = (uint8_t *) buffer + packetSize;
+            size_t encRoom = bufferSize - packetSize;
+            size_t encoded = 0;
+            DioProbe_PulseStart(8);  /* probe 8: encode duration */
+            if (pRunTimeStreamConf->Encoding == Streaming_Csv) {
                 DIO_TIMING_TEST_WRITE_STATE(1);
-                packetSize = Json_Encode(pBoardData, &nanopbFlag, (uint8_t *) buffer, maxSize);
+                encoded = csv_Encode(pBoardData, &nanopbFlag, encPtr, encRoom);
+                DIO_TIMING_TEST_WRITE_STATE(0);
+            } else if (pRunTimeStreamConf->Encoding == Streaming_Json) {
+                DIO_TIMING_TEST_WRITE_STATE(1);
+                encoded = Json_Encode(pBoardData, &nanopbFlag, encPtr, encRoom);
                 DIO_TIMING_TEST_WRITE_STATE(0);
             } else {
                 DIO_TIMING_TEST_WRITE_STATE(1);
 #if PB_PROFILE_COUNTERS
                 uint32_t pbStart = _CP0_GET_COUNT();
-                packetSize = Nanopb_EncodeStreamingFast(pBoardData, &nanopbFlag, (uint8_t *) buffer, maxSize);
+                encoded = Nanopb_EncodeStreamingFast(pBoardData, &nanopbFlag, encPtr, encRoom);
                 uint32_t pbCycles = _CP0_GET_COUNT() - pbStart;
                 taskENTER_CRITICAL();
                 gStreamStats.pbEncodeCycles += pbCycles;
                 if (pbCycles > gStreamStats.pbEncodeMaxCycles) {
                     gStreamStats.pbEncodeMaxCycles = pbCycles;
                 }
-                if (packetSize > 0) {
-                    gStreamStats.pbEncodeBytesOut += packetSize;
+                if (encoded > 0) {
+                    gStreamStats.pbEncodeBytesOut += encoded;
                 }
                 taskEXIT_CRITICAL();
 #else
-                packetSize = Nanopb_EncodeStreamingFast(pBoardData, &nanopbFlag, (uint8_t *) buffer, maxSize);
+                encoded = Nanopb_EncodeStreamingFast(pBoardData, &nanopbFlag, encPtr, encRoom);
 #endif
                 DIO_TIMING_TEST_WRITE_STATE(0);
             }
             DioProbe_PulseEnd(8);
-        }
-        if (packetSize == 0 && nanopbFlag.Size > 0 && (AINDataAvailable || DIODataAvailable)) {
-            // #484: shutdown race.  If Streaming_Stop ran between the
-            // IsEnabled check at the top of this loop iteration and the
-            // encoder invocation, the encoder runs against partially
-            // torn-down state (pool freed, sample queue drained,
-            // encoder buffer pointer about to be cleared) and returns
-            // packetSize=0.  That's not a real encoder failure — the
-            // operator asked us to stop.  Verified empirically (n=20,
-            // 5 s vs 30 s test streams both fire EF at ~50 % regardless
-            // of stream duration → fires at Stop, not mid-stream).
-            // Skip the failure bookkeeping ONLY (don't `continue`) so any
-            // post-encoder cleanup or future code below still runs.
-            if (pRunTimeStreamConf->IsEnabled) {
-                bool pastGrace = Streaming_PastStartupGrace();
-                // Each encoder pops exactly 1 sample per call. On failure that
-                // sample is freed back to the pool but its data is lost (#297).
-                // Counting 1 per failure avoids the race condition where the
-                // higher-priority deferred ISR task pushes new samples between
-                // queue depth reads, making a delta approach inaccurate.
-                // Count for both AIN and DIO encoder failures — any sample type
-                // consumed by a failed encode is lost.
-                // #483: also bump Steady subset when past the 3 s startup grace.
-                // Single critical section covers all counters and the QUES bit
-                // so a concurrent Streaming_GetStats snapshot sees them coherently.
-                taskENTER_CRITICAL();
-                gStreamStats.encoderFailures++;
-                gStreamStats.encoderDroppedSamples++;
-                if (pastGrace) {
-                    gStreamStats.encoderFailuresSteady++;
-                    gStreamStats.encoderDroppedSamplesSteady++;
+
+            if (encoded == 0) {
+                // The queue was non-empty (checked above) with guaranteed room,
+                // yet the encoder produced nothing → a real encoder failure OR
+                // the #484 shutdown race (Streaming_Stop ran mid-iteration and
+                // the encoder saw partially torn-down state — verified empirically
+                // to fire at Stop, not mid-stream). Account exactly one lost
+                // sample (each encode pops exactly one, #297) and stop the batch.
+                // #483: bump the Steady subset when past the 3 s startup grace.
+                if (pRunTimeStreamConf->IsEnabled) {
+                    bool pastGrace = Streaming_PastStartupGrace();
+                    taskENTER_CRITICAL();
+                    gStreamStats.encoderFailures++;
+                    gStreamStats.encoderDroppedSamples++;
+                    if (pastGrace) {
+                        gStreamStats.encoderFailuresSteady++;
+                        gStreamStats.encoderDroppedSamplesSteady++;
+                    }
+                    gQuesBits |= QUES_BIT_ENCODER_FAIL;
+                    taskEXIT_CRITICAL();
+                    LOG_E_SESSION(LOG_SESSION_ENCODER_SAMPLE_LOSS,
+                        "Streaming: encoder failure lost 1 sample");
+                    LOG_E_SESSION(LOG_SESSION_ENCODER_FAIL, "Streaming: Encoder failure detected");
                 }
-                gQuesBits |= QUES_BIT_ENCODER_FAIL;
-                taskEXIT_CRITICAL();
-                LOG_E_SESSION(LOG_SESSION_ENCODER_SAMPLE_LOSS,
-                    "Streaming: encoder failure lost 1 sample");
-                LOG_E_SESSION(LOG_SESSION_ENCODER_FAIL, "Streaming: Encoder failure detected");
+                break;
             }
+            packetSize += encoded;
         }
         if (packetSize > 0) {
             taskENTER_CRITICAL();


### PR DESCRIPTION
## What

`streaming_Task` encoded exactly one sample per wake (one encoder call + one output write per notify). This amortizes the per-wake overhead: per encoder wake it now encodes up to `STREAMING_BATCH_MAX` (8) samples back-to-back into one buffer, then does a **single** output write of the concatenated framed messages.

**Wire-invisible.** Each encoder call still pops one sample and emits a self-framed unit (PB length-delimited / CSV row / JSON object), so concatenating N is byte-identical to the N separate writes the client already parses — no wire-format change, works for PB/CSV/JSON, no client change. Composes with #238 (batched PB messages) as the ticket notes.

## Correctness

- Batch loop **re-checks AIN/DIO availability every iteration** (the pri-9 deferred ISR task enqueues concurrently) and stops on: queue drained, the `STREAMING_BATCH_MAX` bound, or `< STREAMING_BATCH_MIN_ROOM` (1024 B) buffer left.
- The room floor **guarantees the encoder has space**, so a 0 return is unambiguously empty-queue/failure (never truncation), and keeps `packetSize <= bufferSize` (no overflow).
- Per-sample encoder-failure accounting (#297/#483/#484) preserved.
- At steady state (queue depth 1) it is a **batch of 1 — identical to the pre-#662 path**; batching engages only under backlog (near-cap / bursty-write), where the amortized single write helps most. Notify semantics unchanged (`pdFALSE`), preserving catch-up behavior.

## Validation (COM3 · DAQiFi,Nq1,7E2898F46200E8A7 · 252 MHz firmware · 2026-07-14)

- Builds clean at `-O3 -Werror`.
- **Zero firmware loss while batching engaged to depth 3–4** (8ch@3kHz SD: 32,854 samples; 1ch@5kHz SD: 14,752 samples; `SamplePoolMaxUsed` 3–4, `EncoderDropped=0`, `QueueDropped=0`).
- Companion test [`test_662_batch_pop_integrity.py`](https://github.com/daqifi/daqifi-python-test-suite/pull) (test-suite branch `perf/662-batch-pop`): **2/2 PASS** — zero cross-channel drift `[0,0,0,0,0,0,0,0]` across 105k samples at batch depth 3, 99.977% exact counter match (24/105176 at the USB-capture noise floor), firmware zero loss.

## Caveat

The **deterministic** SD-download counter verify was blocked by a separate `SD:GET` anomaly found during this work: the file is present at 175,598 B (per `SD:LIST`) but `SD:GET` returns 0–43 B. That is **not a #662 regression** (streaming/write path is clean) — it's an SD *read* issue, tracked separately for isolation. The cross-channel-drift signal used above is capture-noise-immune (a split row corrupts all its channels together, leaving inter-channel drift at 0), so it stands independently of the SD path.

Closes #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)