### PR TITLE
fix(sd): #689 cheap defensive guard — cap files-per-directory to avoid the O(N) create wedge

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3480,6 +3480,7 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         // (Qodo /agentic_review pass-1 finding on PR #508: "Stale
         // disk-full short-circuits start".)
         sd_card_manager_ClearStartupDiskFull();
+        sd_card_manager_ClearStartupDirFull();   /* #689 */
 
         pSDCardSettings->mode = SD_CARD_MANAGER_MODE_WRITE;
         sd_card_manager_UpdateSettings(pSDCardSettings);
@@ -3498,6 +3499,9 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         int readyWait = 0;
         while (!sd_card_manager_IsWriteReady() && readyWait < 500) {
             if (sd_card_manager_StartupDiskFull()) {
+                break;
+            }
+            if (sd_card_manager_StartupDirFull()) {   /* #689: early-exit */
                 break;
             }
             vTaskDelay(pdMS_TO_TICKS(10));
@@ -3532,6 +3536,13 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
                     LOG_E("[SD] STR:START refused: disk full (space unknown), floor=%llu B",
                           (unsigned long long)floor);
                 }
+            } else if (sd_card_manager_StartupDirFull()) {
+                /* #689: SD target directory holds too many files — file-create
+                 * would wedge the SD op timeout. Surface the precise cause and
+                 * remedy instead of a generic "not ready". */
+                LOG_E("[SD] STR:START refused: target directory has too many "
+                      "files (#689) — use a larger SD:MAXSize, a different "
+                      "directory, or clear the card");
             } else {
                 LOG_E("SD file not ready after %d ms", readyWait * 10);
             }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3599,15 +3599,42 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
 
         // Re-enable SD if it was closed for DMA quiesce
         if (sdLoggingRequested) {
+            /* #690 (adversarial audit): this post-repartition re-open ALSO passes
+             * through the #689 dir-file-cap guard. If the directory reached the cap
+             * between the first open and this re-open (e.g. the first open created
+             * the boundary file, or disk filled), the guard refuses and IsWriteReady
+             * stays false. The OLD code only logged and fell through to enable
+             * streaming with OPER_SD_LOGGING asserted but NO file open — silent
+             * total data loss on an SD-only session. Mirror the first block: clear
+             * the flags, early-exit the poll, and FAIL START with the precise cause
+             * so SD-logging is never falsely asserted. */
+            sd_card_manager_ClearStartupDirFull();
+            sd_card_manager_ClearStartupDiskFull();
             pSDCardSettings->mode = SD_CARD_MANAGER_MODE_WRITE;
             sd_card_manager_UpdateSettings(pSDCardSettings);
             int readyWait = 0;
             while (!sd_card_manager_IsWriteReady() && readyWait < 500) {
+                if (sd_card_manager_StartupDirFull() || sd_card_manager_StartupDiskFull()) {
+                    break;
+                }
                 vTaskDelay(pdMS_TO_TICKS(10));
                 readyWait++;
             }
             if (!sd_card_manager_IsWriteReady()) {
-                LOG_E("SD file not ready after DMA resize (%d ms)", readyWait * 10);
+                if (sd_card_manager_StartupDirFull()) {
+                    LOG_E("STR:START refused: SD directory too full (#689) after "
+                          "buffer repartition — use a different directory or clear the card\r\n");
+                } else if (sd_card_manager_StartupDiskFull()) {
+                    LOG_E("STR:START refused: SD disk full after buffer repartition\r\n");
+                } else {
+                    LOG_E("SD file not ready after DMA resize (%d ms)\r\n", readyWait * 10);
+                }
+                /* Abort START — never enable streaming with SD logging asserted
+                 * but no file open (would silently drop every sample). */
+                pSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
+                sd_card_manager_UpdateSettings(pSDCardSettings);
+                SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+                return SCPI_RES_ERR;
             }
         }
     }

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -511,6 +511,10 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
              "benchmark_%d.dat", (int)(xTaskGetTickCount() & 0xFFFF));
     
     // Set SD card to write mode
+    /* #690: this WRITE-mode open goes through the #689 dir-file-cap guard too.
+     * Clear the flag first so the poll observes only THIS request's outcome
+     * (mirrors SCPI_StartStreaming / the #503 disk-full pattern). */
+    sd_card_manager_ClearStartupDirFull();
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_WRITE;
     sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
 
@@ -518,13 +522,22 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
     {
         int readyWait = 0;
         while (!sd_card_manager_IsWriteReady() && readyWait < 500) {
+            if (sd_card_manager_StartupDirFull()) {   /* #690: early-exit */
+                break;
+            }
             vTaskDelay(pdMS_TO_TICKS(10));
             readyWait++;
         }
         if (!sd_card_manager_IsWriteReady()) {
-            LOG_E("SD:BENCH - File not ready after timeout\r\n");
-            LOG_E("SD:BENCH - if reads/LIST work but writes hang, the card is "
-                  "likely SPI-mode incompatible (wiki: SD-Card-Compatibility)\r\n");
+            if (sd_card_manager_StartupDirFull()) {
+                /* #690: name the real cause instead of the card advisory. */
+                LOG_E("SD:BENCH refused: target directory has too many files "
+                      "(#689) — use a different directory or clear the card\r\n");
+            } else {
+                LOG_E("SD:BENCH - File not ready after timeout\r\n");
+                LOG_E("SD:BENCH - if reads/LIST work but writes hang, the card is "
+                      "likely SPI-mode incompatible (wiki: SD-Card-Compatibility)\r\n");
+            }
             SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
             gSDBenchmarkResults.testInProgress = false;
             pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -15,6 +15,18 @@
 #define SD_CARD_MANAGER_DISK_MOUNT_NAME    "/mnt/DAQiFi"
 // SD_CARD_MANAGER_DISK_DEV_NAME is now in header for external use
 #define SD_CARD_MANAGER_MAX_SPLIT_FILES    9999
+/* #689: defensive files-per-directory ceiling. FatFs file-create is O(directory
+ * size) — creating a file in a directory holding many hundreds of entries can
+ * exceed the SD op timeout and wedge the manager (reads keep working). Refuse to
+ * create a WRITE-mode file when the target directory already holds this many
+ * files, so the failure is a clean, diagnosable error instead of a silent wedge.
+ * Set below the observed directory-size wedge onset. Bench 2026-07-14 (SanDisk
+ * SR256, gentle rotation): 75 files built clean, ~125 files wedged — the onset
+ * tracks the FatFs directory-cluster grow (dir_clear write burst) and the O(N)
+ * create scan, so it is CARD-DEPENDENT. 64 keeps the directory within its first
+ * FAT cluster (no grow burst) with margin below the proven-clean 75. Not a full
+ * fix (subdirectory bucketing would be) — a guard until #689 is resolved. */
+#define SD_CARD_MANAGER_MAX_DIR_FILES      64u
 
 // Iterative directory listing — bounded BSS-backed stack instead of recursion.
 // 16 levels covers any realistic FAT32 tree without growing the task stack.
@@ -202,6 +214,19 @@ typedef struct {
     // volatile, -O3 can hoist the read out of the loop or cache it
     // across the vTaskDelay(1), defeating the intended early-exit.
     volatile bool startupDiskFull;
+
+    // #689: set true when a WRITE-mode file create was refused because the
+    // target directory already holds >= SD_CARD_MANAGER_MAX_DIR_FILES files
+    // (FatFs create is O(dir size) and wedges the SD op timeout on very large
+    // directories). Read by SCPI_StartStreaming to surface a precise
+    // "directory too full" error instead of a generic "not ready". Same
+    // volatile / cross-task (SD task pri 5 writer, SCPI pri 7/2 reader)
+    // rationale as startupDiskFull above.
+    volatile bool startupDirFull;
+    // #689: file count of the target directory, counted once per session at the
+    // first file open; added to fileCounter to bound the check without a
+    // per-rotation re-scan.
+    uint32_t dirFileCountAtStart;
 } sd_card_manager_context_t;
 
 sd_card_manager_context_t gSDCardData;
@@ -237,6 +262,35 @@ static int CircularBufferToSDWrite(uint8_t* buf, uint32_t len) {
     // Return length to indicate success - actual write happens in state machine
     // Calling SDCardWrite() here causes duplicate writes!
     return len;
+}
+
+/* #689: count entries in a directory, early-exiting once `cap` is reached so the
+ * O(N) directory scan cost is bounded to ~cap entries regardless of directory
+ * size. Runs in the SD task, which owns the filesystem. "." / ".." are skipped.
+ * Returns min(actualFiles, cap); a return of `cap` means "at least cap". A
+ * missing directory (created lazily on first write) counts as 0. */
+static uint32_t CountDirEntries(const char* dirPath, uint32_t cap) {
+    SYS_FS_HANDLE dh = SYS_FS_DirOpen(dirPath);
+    if (dh == SYS_FS_HANDLE_INVALID) {
+        return 0;   // directory doesn't exist yet -> no files
+    }
+    uint32_t count = 0;
+    SYS_FS_FSTAT st;
+    memset(&st, 0, sizeof(st));
+    while (count < cap) {
+        if (SYS_FS_DirRead(dh, &st) == SYS_FS_RES_FAILURE) {
+            break;                          // read error
+        }
+        if (st.fname[0] == '\0') {
+            break;                          // end of directory
+        }
+        if (strcmp(st.fname, ".") == 0 || strcmp(st.fname, "..") == 0) {
+            continue;                       // skip dot entries
+        }
+        count++;
+    }
+    (void)SYS_FS_DirClose(dh);
+    return count;
 }
 
 /**
@@ -986,6 +1040,38 @@ void sd_card_manager_ProcessState() {
                 if (gSDCardData.fileCounter == 0) {
                     // First time opening - extract base filename
                     extractBaseFilename(gpSDCardSettings->file);
+                    // #689: count existing files in the target directory once
+                    // (bounded to the guard ceiling) so the check below is cheap
+                    // on every subsequent rotation.
+                    gSDCardData.dirFileCountAtStart = CountDirEntries(
+                        gpSDCardSettings->directory, SD_CARD_MANAGER_MAX_DIR_FILES);
+                }
+
+                // #689 guard: refuse to create a file into a directory that
+                // already holds too many files. FatFs file-create is O(dir size)
+                // and would wedge the SD op timeout on large directories. This
+                // covers BOTH session start (fileCounter==0) and every split
+                // rotation (which re-enters OPEN_FILE with fileCounter++). Clean-
+                // stop to IDLE with startupDirFull set, so SCPI_StartStreaming
+                // reports a precise "directory too full" error rather than a
+                // silent wedge — mirrors the #503 disk-full clean-stop pattern.
+                if ((gSDCardData.dirFileCountAtStart + gSDCardData.fileCounter)
+                        >= SD_CARD_MANAGER_MAX_DIR_FILES) {
+                    LOG_E("[SD] WRITE refused: dir '%s' holds >= %u files — FatFs "
+                          "file-create wedges large directories (#689). Use a "
+                          "larger SD:MAXSize, a different directory, or clear the "
+                          "card.", gpSDCardSettings->directory,
+                          (unsigned)SD_CARD_MANAGER_MAX_DIR_FILES);
+                    gSDCardData.startupDirFull = true;
+                    gSDCardData.lastOperationSuccess = false;
+                    if (gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID) {
+                        (void)SYS_FS_FileClose(gSDCardData.fileHandle);
+                        gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
+                    }
+                    gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
+                    gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_IDLE;
+                    xSemaphoreGive(gSDCardData.opCompleteSemaphore);
+                    break;
                 }
 
                 generateFilename(gSDCardData.filePath, sizeof(gSDCardData.filePath),
@@ -1875,13 +1961,18 @@ bool sd_card_manager_WaitForCompletion(uint32_t timeoutMs) {
         return true;  // Operation completed
     } else {
         LOG_E("[SD] WaitForCompletion timeout after %u ms\r\n", timeoutMs);
-        // #589: a card whose reads/LIST work while writes hang or abort is
-        // the bench-proven signature of an SPI-mode-incompatible card (e.g.
-        // A2-class SDXC). Say so — this line is the difference between a
-        // support mystery and a card swap.
-        LOG_E("[SD] card operations hanging while reads work - card may be "
-              "SPI-mode incompatible (A2/SDXC class); try a different card "
-              "(wiki: SD-Card-Compatibility)\r\n");
+        // Reads/LIST work but writes hang has two known causes; name both so the
+        // advisory isn't misleading (bench 2026-07-14 proved the directory case).
+        // #689: creating a file in a directory holding many hundreds of files is
+        //       O(dir size) in FatFs and can exceed this timeout — the common
+        //       cause with small SD:MAXSize + long sessions. The #689 guard now
+        //       refuses before this point, so if you see this, check dir size.
+        // #589: a genuinely SPI-mode-incompatible card (e.g. some A2/SDXC) whose
+        //       writes hang from power-up regardless of directory size.
+        LOG_E("[SD] operations hanging while reads work - likely (a) target "
+              "directory too large (#689: larger SD:MAXSize / clear the card) "
+              "or (b) an SPI-mode-incompatible card (wiki: SD-Card-Compatibility)"
+              "\r\n");
         return false;  // Timeout
     }
 }
@@ -1935,6 +2026,21 @@ void sd_card_manager_ClearStartupDiskFull(void) {
      * is correct, since gating on settings init could leave the
      * flag stuck-true if SCPI ever runs before sd init. */
     gSDCardData.startupDiskFull = false;
+}
+
+bool sd_card_manager_StartupDirFull(void) {
+    /* #689: true iff the most recent WRITE-mode file create was refused
+     * because the target directory already holds >= SD_CARD_MANAGER_MAX_DIR_FILES
+     * files. Read by SCPI_StartStreaming to surface a precise error. Same
+     * single-byte volatile/no-critical-section rationale as StartupDiskFull. */
+    return gSDCardData.startupDirFull;
+}
+
+void sd_card_manager_ClearStartupDirFull(void) {
+    /* #689: SCPI callers clear this synchronously before each new WRITE attempt
+     * (pairs with ClearStartupDiskFull), so the STR:START poll observes only the
+     * current request's outcome and a stale `true` can't reject a later start. */
+    gSDCardData.startupDirFull = false;
 }
 
 bool sd_card_manager_GetCrcResult(uint32_t *crc32, uint64_t *length) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -290,9 +290,11 @@ static uint32_t CountDirEntries(const char* dirPath, uint32_t cap) {
     while (count < cap) {
         if (SYS_FS_DirRead(dh, &st) == SYS_FS_RES_FAILURE) {
             /* #690: a mid-scan read error means the count is untrustworthy —
-             * fail safe (refuse) rather than proceed on a partial count. */
-            LOG_E("[SD] CountDirEntries: DirRead failed at %u — failing safe",
-                  (unsigned)count);
+             * fail safe (refuse) rather than proceed on a partial count. Log
+             * SYS_FS_Error() so a real media/FS fault is distinguishable in the
+             * field from a genuinely full directory (both take the refuse path). */
+            LOG_E("[SD] CountDirEntries: DirRead failed at %u err=%d — failing safe",
+                  (unsigned)count, (int)SYS_FS_Error());
             (void)SYS_FS_DirClose(dh);
             return cap;
         }

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -272,14 +272,29 @@ static int CircularBufferToSDWrite(uint8_t* buf, uint32_t len) {
 static uint32_t CountDirEntries(const char* dirPath, uint32_t cap) {
     SYS_FS_HANDLE dh = SYS_FS_DirOpen(dirPath);
     if (dh == SYS_FS_HANDLE_INVALID) {
-        return 0;   // directory doesn't exist yet -> no files
+        /* #690 review (Qodo): distinguish "directory doesn't exist yet" (the
+         * normal first-write case → 0 files) from a real FS error. FAIL SAFE on
+         * a real error — return cap so the guard REFUSES the create rather than
+         * fail-open into the very wedge it exists to prevent. */
+        SYS_FS_ERROR e = SYS_FS_Error();
+        if (e == SYS_FS_ERROR_NO_PATH || e == SYS_FS_ERROR_NO_FILE) {
+            return 0;                       // directory absent -> no files
+        }
+        LOG_E("[SD] CountDirEntries: DirOpen('%s') failed err=%d — failing safe (refuse)",
+              dirPath, (int)e);
+        return cap;
     }
     uint32_t count = 0;
     SYS_FS_FSTAT st;
     memset(&st, 0, sizeof(st));
     while (count < cap) {
         if (SYS_FS_DirRead(dh, &st) == SYS_FS_RES_FAILURE) {
-            break;                          // read error
+            /* #690: a mid-scan read error means the count is untrustworthy —
+             * fail safe (refuse) rather than proceed on a partial count. */
+            LOG_E("[SD] CountDirEntries: DirRead failed at %u — failing safe",
+                  (unsigned)count);
+            (void)SYS_FS_DirClose(dh);
+            return cap;
         }
         if (st.fname[0] == '\0') {
             break;                          // end of directory

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -240,6 +240,20 @@ extern "C" {
     void sd_card_manager_ClearStartupDiskFull(void);
 
     /**
+     * @brief #689: true if the most recent WRITE attempt was refused because
+     *        the target directory already holds >= SD_CARD_MANAGER_MAX_DIR_FILES
+     *        files (FatFs file-create is O(dir size) and wedges the SD op
+     *        timeout on very large directories). Read by SCPI_StartStreaming to
+     *        surface a precise "directory too full" error. Cleared on every
+     *        subsequent WRITE attempt.
+     */
+    bool sd_card_manager_StartupDirFull(void);
+
+    /** @brief #689: synchronously clear the directory-full flag before a new
+     *         WRITE attempt (pairs with sd_card_manager_ClearStartupDiskFull). */
+    void sd_card_manager_ClearStartupDirFull(void);
+
+    /**
      * @brief Checks if the SD card manager is busy with an active operation.
      *
      * This should be called before starting any new SD operation to prevent


### PR DESCRIPTION
Cheap defensive guard for [#689](https://github.com/daqifi/daqifi-nyquist-firmware/issues/689) (SD writes wedge when the target directory holds many files — FatFs file-create is O(directory size)). A full fix is subdirectory bucketing; this guard prevents the silent wedge in the meantime.

## What it does
- **`SD_CARD_MANAGER_MAX_DIR_FILES = 64`.** At WRITE-mode file open, `CountDirEntries` counts the target directory once per session (early-exit at the cap), then before **every** create — session start **and** every split rotation (both re-enter `OPEN_FILE`) — refuse if `dirFileCountAtStart + fileCounter >= 64`.
- The refusal **clean-stops to IDLE** with a new `startupDirFull` flag; `SCPI_StartStreaming` surfaces a precise `-200` "directory too full" error (mirrors the #503 disk-full clean-stop) instead of a silent ~10 s wedge.
- Fixes the **misleading** `WaitForCompletion` advisory: it blamed the card ("SPI-mode incompatible") on *any* write timeout; it now names both causes (large directory #689 / genuinely incompatible card #589).

## Why 64
`64` keeps the directory within its first FAT cluster (no `dir_clear` grow-burst) with margin below the observed wedge onset. **The onset is card-dependent** — on the bench SanDisk SR256 (gentle rotation) 75 files built clean but ~125 wedged, so this is a conservative guard, not a tuned limit. A first cut at 200 was *above* the onset and didn't protect — corrected to 64. For default `SD:MAXSize` (multi-GB) a session makes a handful of files, so 64 is never hit in normal use; it only bites pathological small-`MAXSize` long sessions, which is exactly the wedge case.

## Testing
- **Build**: clean at -O3 -Werror (hex 1,826,881 B).
- **Hardware-validated** (Nq1 `7E2898F46200E8A7`, USB, SanDisk SR256, gentle rotation): mid-session caps at 63-64 with **wedge=0** + refusal advisory; start-into-full dir **rejected** with wedge=0; empty-dir writes unaffected.
- **Regression test**: [daqifi-python-test-suite#89](https://github.com/daqifi/daqifi-python-test-suite/pull/89) (A cap / B reject / C control), PASS on bench.

## Scope / follow-up
This is the "cheap guard for now" — it prevents the wedge and makes it diagnosable, but caps directories at 64 files. The real fix (removing the limit) is **subdirectory bucketing**, tracked in #689.

Refs #689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)