### PR TITLE
feat(wifi): #58 mDNS responder diagnostics + recvfrom self-heal

### DIFF
--- a/firmware/src/Util/Logger.h
+++ b/firmware/src/Util/Logger.h
@@ -181,6 +181,7 @@ extern "C" {
         LOG_ONCE_USB_TRANSPARENT_DECLINE, /**< UsbCdc.c: transparent-mode read CB declined a buffer — dropped to avoid un-arming the CDC read (#575); one-shot so a persistently-declining CB can't flood */
         LOG_ONCE_BRIDGE_RX_OVERFLOW,      /**< wifi_serial_bridge_interface.c: transparent RX ring full — bytes dropped instead of wrapped (silent wrap corrupted WINC images mid-flash, #WINC-recovery) */
         LOG_ONCE_BIT_SD_BACKOFF,          /**< drv_sdspi.c: detect-poll backoff engaged after 10 card-absent polls (#589 P1) */
+        LOG_ONCE_MDNS_ARM_FAIL,           /**< mdns_responder.c: recvfrom re-arm failed — responder deaf until ServiceHealth() re-opens (#58) */
         /* Add new entries above this line */
         LOG_ONCE_COUNT                     /**< Must be <= 32 */
     } LogOnceBit_t;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5413,6 +5413,7 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:COMMunicate:LAN:FACRESET", .callback = SCPI_LANSettingsFactoryLoad,},
     //
     {.pattern = "SYSTem:COMMunicate:LAN:GETChipInfo?", .callback = SCPI_LANGetChipInfo,},
+    {.pattern = "SYSTem:COMMunicate:LAN:MDNS?", .callback = SCPI_LANMdnsDiagGet,},  // #58 mDNS diagnostics
     // ADC
     {.pattern = "MEASure:VOLTage:DC?", .callback = SCPI_ADCVoltageGet,},
     {.pattern = "ENAble:VOLTage:DC", .callback = SCPI_ADCChanEnableSet,},

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -21,6 +21,8 @@
 #include "wdrv_winc_client_api.h"
 #include "services/daqifi_settings.h"
 #include "services/wifi_services/wifi_manager.h"
+#include "services/wifi_services/mdns_responder.h"   // #58: mDNS diagnostics
+#include "services/SCPI/SCPIInterface.h"              // #58: shared response buffer
 #include "services/sd_card_services/sd_card_manager.h"
 
 
@@ -715,6 +717,32 @@ scpi_result_t SCPI_LANGetChipInfo(scpi_t * context) {
     return SCPI_LANStringGetImpl(
             context,
             jsonChar);
+}
+
+/* #58: mDNS responder diagnostics. Reports whether the responder is still
+ * receiving/answering queries (recvArmed + rx/match/resp counters) and how many
+ * times the self-heal has re-opened a deaf socket (armFail/heal) — answerable
+ * on-device, independent of host-side mDNS tooling (unreliable on multi-homed
+ * hosts). Uses the shared response buffer (JSON can approach 256 B). */
+scpi_result_t SCPI_LANMdnsDiagGet(scpi_t * context) {
+    mdns_diag_t d;
+    mdns_responder_GetDiag(&d);
+    char *buf = (char *)SCPI_ResponseBuf_Take();
+    if (buf == NULL) {
+        return SCPI_RES_ERR;
+    }
+    snprintf(buf, 512,
+             "{\"Active\":%d,\"RecvArmed\":%d,\"Rx\":%lu,\"Match\":%lu,\"Resp\":%lu,"
+             "\"ArmFail\":%lu,\"Heal\":%lu,\"LastArmRc\":%d,"
+             "\"Instance\":\"%s\",\"Host\":\"%s\"}\n",
+             (int)d.active, (int)d.recvArmed,
+             (unsigned long)d.rxCount, (unsigned long)d.matchCount,
+             (unsigned long)d.respCount, (unsigned long)d.armFailCount,
+             (unsigned long)d.healCount, (int)d.lastArmRc,
+             d.instance, d.host);
+    scpi_result_t r = SCPI_LANStringGetImpl(context, buf);
+    SCPI_ResponseBuf_Give();
+    return r;
 }
 
 scpi_result_t SCPI_LANSettingsSave(scpi_t * context) {

--- a/firmware/src/services/SCPI/SCPILAN.h
+++ b/firmware/src/services/SCPI/SCPILAN.h
@@ -192,6 +192,14 @@ scpi_result_t SCPI_LANFwUpdate(scpi_t * context);
  */
 scpi_result_t SCPI_LANGetChipInfo(scpi_t * context);
 /**
+ * SCPI Callback: mDNS responder diagnostics (#58). Returns a JSON snapshot of
+ * the responder's receive/answer counters + self-heal state so a wedge is
+ * observable on-device (SYST:COMM:LAN:MDNS?).
+ * @param context
+ * @return SCPI_RES_OK on success, SCPI_RES_ERR on error
+ */
+scpi_result_t SCPI_LANMdnsDiagGet(scpi_t * context);
+/**
  * SCPI Callback: Enable/disable automatic WiFi power-save (#29).
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error
  */

--- a/firmware/src/services/wifi_services/mdns_responder.c
+++ b/firmware/src/services/wifi_services/mdns_responder.c
@@ -338,9 +338,11 @@ static bool mdns_send_response(void) {
     dst.sin_family = AF_INET;
     dst.sin_port = _htons(MDNS_PORT);
     dst.sin_addr.s_addr = _htonl(MDNS_MCAST_ADDR_HOST);
-    sendto(gMdns.sock, resp, (uint16_t)n, 0,
-           (struct sockaddr *)&dst, sizeof(dst));
-    return true;
+    /* #692: only count the response if sendto() accepted it — respCount then
+     * tracks accepted sends, not attempts. sendto returns sint16 (SOCK_ERR_*). */
+    int16_t sc = sendto(gMdns.sock, resp, (uint16_t)n, 0,
+                        (struct sockaddr *)&dst, sizeof(dst));
+    return (sc == SOCK_ERR_NO_ERROR);
 }
 
 static void copy_str(char *dst, size_t dstSize, const char *src) {
@@ -495,6 +497,11 @@ void mdns_responder_GetDiag(mdns_diag_t *out) {
         return;
     }
     memset(out, 0, sizeof(*out));
+    /* #692: coherent point-in-time snapshot — the counters are updated from the
+     * WINC-callback and WifiTask contexts, so take them together under a short
+     * critical section (infrequent SCPI-path query; the string copies are of
+     * post-Start-constant names). */
+    taskENTER_CRITICAL();
     out->active       = gMdns.active;
     out->recvArmed    = gMdns.recvArmed;
     out->rxCount      = gMdns.rxCount;
@@ -505,6 +512,7 @@ void mdns_responder_GetDiag(mdns_diag_t *out) {
     out->lastArmRc    = gMdns.lastArmRc;
     copy_str(out->instance, sizeof(out->instance), gMdns.instanceFqdn);
     copy_str(out->host, sizeof(out->host), gMdns.hostFqdn);
+    taskEXIT_CRITICAL();
 }
 
 void mdns_responder_UpdateIp(uint32_t ipAddrNetworkOrder) {

--- a/firmware/src/services/wifi_services/mdns_responder.c
+++ b/firmware/src/services/wifi_services/mdns_responder.c
@@ -77,6 +77,10 @@ typedef struct {
     char hostFqdn[24];       /* "daqifi-xxxx.local"             */
     uint8_t rxBuf[MDNS_RX_BUF_SIZE];
     /* ---- #58 diagnostics + self-heal ---- */
+    bool     wantRun;        /* intent to run: Start sets, Stop clears. ServiceHealth
+                              * gates on this so a stale needsReopen store from a
+                              * WINC callback preempted by an intentional Stop
+                              * (DEINIT teardown) can't resurrect the responder (#692). */
     bool     recvArmed;      /* a recvfrom is currently outstanding */
     bool     needsReopen;    /* a recv re-arm failed -> ServiceHealth must recover */
     uint16_t healCooldown;   /* ServiceHealth iterations to skip before next re-open */
@@ -409,6 +413,7 @@ bool mdns_responder_Start(const mdns_identity_t *id) {
     gMdns.lastArmRc = 0;
     gMdns.healCooldown = 0u;
     gMdns.needsReopen = false;
+    gMdns.wantRun = true;             /* self-heal is now permitted for this session */
 
     if (!mdns_open_socket()) {
         /* Initial open failed to queue — let ServiceHealth() retry it from the
@@ -472,13 +477,22 @@ static void mdns_close_socket(void) {
 }
 
 void mdns_responder_Stop(void) {
-    /* Real teardown (STA disconnect / AP entry): clear the heal request so
-     * ServiceHealth() won't resurrect the socket after we intentionally close. */
+    /* Real teardown (STA disconnect / AP entry / DEINIT): clear the intent to
+     * run FIRST, then the heal request + socket. wantRun is the authority
+     * ServiceHealth() checks, so even if a WINC-callback bind/recvfrom-fail path
+     * was preempted here and later writes needsReopen=true, ServiceHealth won't
+     * resurrect a deliberately-stopped responder (#692 adversarial audit). */
+    gMdns.wantRun = false;
     gMdns.needsReopen = false;
     mdns_close_socket();
 }
 
 void mdns_responder_ServiceHealth(void) {
+    if (!gMdns.wantRun) {
+        return;                           /* never started, or intentionally stopped:
+                                           * ignore any stale needsReopen set by a
+                                           * WINC callback that raced Stop (#692). */
+    }
     /* Rate-limit re-open attempts so a persistently-failing socket can't thrash
      * the WINC every WifiTask iteration. */
     if (gMdns.healCooldown > 0u) {
@@ -486,7 +500,7 @@ void mdns_responder_ServiceHealth(void) {
         return;
     }
     if (!gMdns.needsReopen) {
-        return;                           /* healthy (or intentionally stopped) */
+        return;                           /* healthy */
     }
     /* A recvfrom re-arm (or the initial open) failed -> the responder is deaf
      * while the device stays associated. Re-open from this WifiTask context —

--- a/firmware/src/services/wifi_services/mdns_responder.c
+++ b/firmware/src/services/wifi_services/mdns_responder.c
@@ -47,6 +47,11 @@
 #define MDNS_TX_BUF_SIZE    384u
 #define MDNS_NAME_MAX       160u
 
+/* Self-heal cooldown: after a re-open attempt, skip this many ServiceHealth()
+ * calls before trying again, so a persistently-failing socket can't thrash the
+ * WINC with socket()/bind() every WifiTask iteration (~5 ms). 200 ≈ 1 s. */
+#define MDNS_HEAL_COOLDOWN_ITERS   200u
+
 typedef struct {
     SOCKET   sock;
     bool     active;
@@ -60,9 +65,22 @@ typedef struct {
     char instanceFqdn[64];   /* "<instance>._daqifi._tcp.local" */
     char hostFqdn[24];       /* "daqifi-xxxx.local"             */
     uint8_t rxBuf[MDNS_RX_BUF_SIZE];
+    /* ---- #58 diagnostics + self-heal ---- */
+    bool     recvArmed;      /* a recvfrom is currently outstanding */
+    bool     needsReopen;    /* a recv re-arm failed -> ServiceHealth must recover */
+    uint16_t healCooldown;   /* ServiceHealth iterations to skip before next re-open */
+    uint32_t rxCount;
+    uint32_t matchCount;
+    uint32_t respCount;
+    uint32_t armFailCount;
+    uint32_t healCount;
+    int8_t   lastArmRc;
 } mdns_state_t;
 
 static mdns_state_t gMdns = { .sock = -1, .active = false };
+
+/* Forward decl: shared socket open+bind used by Start and the self-heal. */
+static bool mdns_open_socket(void);
 
 /* ----- small wire-write helpers (network / big-endian) ------------------- */
 
@@ -269,20 +287,40 @@ static bool query_matches(const uint8_t *rx, size_t len) {
 
 /* ----- socket lifecycle -------------------------------------------------- */
 
+/* Arm one recvfrom. #58: the return was previously ignored — if it fails
+ * synchronously (WINC HIF queue full under heavy streaming load), no further
+ * SOCKET_MSG_RECVFROM ever arrives and the responder goes permanently deaf
+ * while still "active" and associated. Capture the rc, mark the socket
+ * un-armed, and flag needsReopen so ServiceHealth() (WifiTask) recovers it. */
 static void mdns_arm_recv(void) {
-    if (gMdns.sock >= 0) {
-        recvfrom(gMdns.sock, gMdns.rxBuf, sizeof(gMdns.rxBuf), 0);
+    if (gMdns.sock < 0) {
+        gMdns.recvArmed = false;
+        return;
+    }
+    int8_t rc = recvfrom(gMdns.sock, gMdns.rxBuf, sizeof(gMdns.rxBuf), 0);
+    gMdns.lastArmRc = rc;
+    if (rc == SOCK_ERR_NO_ERROR) {
+        gMdns.recvArmed = true;
+    } else {
+        gMdns.recvArmed = false;
+        gMdns.needsReopen = true;
+        gMdns.armFailCount++;
+        /* Static string only — LOG_E_ONCE's ISR branch passes fmt with no args.
+         * The rc is in gMdns.lastArmRc, reported by SYST:COMM:LAN:MDNS?. */
+        LOG_E_ONCE(LOG_ONCE_MDNS_ARM_FAIL,
+                   "[mDNS] recvfrom re-arm failed - self-heal will re-open (see MDNS? ArmFail/LastArmRc)");
     }
 }
 
-static void mdns_send_response(void) {
+/* Returns true if a datagram was handed to sendto() (for respCount). */
+static bool mdns_send_response(void) {
     if (gMdns.id.ipAddr == 0u) {
-        return;                           /* no DHCP lease yet — stay silent */
+        return false;                     /* no DHCP lease yet — stay silent */
     }
     uint8_t resp[MDNS_TX_BUF_SIZE];       /* stack (WINC task) — not BSS */
     size_t n = build_response(resp);
     if (n == 0u || n > SOCKET_BUFFER_MAX_LENGTH) {
-        return;
+        return false;
     }
     struct sockaddr_in dst;
     memset(&dst, 0, sizeof(dst));
@@ -291,6 +329,7 @@ static void mdns_send_response(void) {
     dst.sin_addr.s_addr = _htonl(MDNS_MCAST_ADDR_HOST);
     sendto(gMdns.sock, resp, (uint16_t)n, 0,
            (struct sockaddr *)&dst, sizeof(dst));
+    return true;
 }
 
 static void copy_str(char *dst, size_t dstSize, const char *src) {
@@ -338,10 +377,38 @@ bool mdns_responder_Start(const mdns_identity_t *id) {
     snprintf(gMdns.instanceFqdn, sizeof(gMdns.instanceFqdn),
              "DAQiFi-%02X%02X.%s", a, b, MDNS_SERVICE_TYPE);
 
+    /* #58: fresh session — reset diagnostics counters (self-heals, which call
+     * mdns_open_socket() directly, deliberately preserve them). */
+    gMdns.rxCount = 0u;
+    gMdns.matchCount = 0u;
+    gMdns.respCount = 0u;
+    gMdns.armFailCount = 0u;
+    gMdns.healCount = 0u;
+    gMdns.lastArmRc = 0;
+    gMdns.healCooldown = 0u;
+    gMdns.needsReopen = false;
+
+    if (!mdns_open_socket()) {
+        /* Initial open failed to queue — let ServiceHealth() retry it from the
+         * WifiTask context rather than staying silent until the next reconnect. */
+        gMdns.needsReopen = true;
+        return false;
+    }
+    LOG_I("[mDNS] starting: %s on %s", gMdns.instanceFqdn, gMdns.hostFqdn);
+    return true;
+}
+
+/* Open + bind the UDP socket using the already-stored gMdns identity. Shared
+ * by Start (first open) and ServiceHealth (self-heal re-open). On success the
+ * socket is bound-pending; SOCKET_MSG_BIND then joins the group + arms recv.
+ * Leaves gMdns.active/sock consistent on every path. */
+static bool mdns_open_socket(void) {
+    gMdns.recvArmed = false;
     gMdns.sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (gMdns.sock < 0) {
         LOG_E("[mDNS] socket() failed: %d", gMdns.sock);
         gMdns.sock = -1;
+        gMdns.active = false;
         return false;
     }
 
@@ -361,14 +428,17 @@ bool mdns_responder_Start(const mdns_identity_t *id) {
         LOG_E("[mDNS] bind() failed to queue: sock=%d rc=%d", gMdns.sock, (int)bindRc);
         (void)shutdown(gMdns.sock);  /* best-effort cleanup — rc intentionally ignored */
         gMdns.sock = -1;
+        gMdns.active = false;
         return false;
     }
     gMdns.active = true;
-    LOG_I("[mDNS] starting: %s on %s", gMdns.instanceFqdn, gMdns.hostFqdn);
     return true;
 }
 
-void mdns_responder_Stop(void) {
+/* Drop the multicast group + close the socket, leaving sock/active/recvArmed
+ * consistent. Does NOT touch needsReopen — used by BOTH the public Stop (real
+ * teardown) and the self-heal re-open, which manage needsReopen themselves. */
+static void mdns_close_socket(void) {
     if (gMdns.sock >= 0) {
         uint32_t grp = _htonl(MDNS_MCAST_ADDR_HOST);
         setsockopt(gMdns.sock, SOL_SOCKET, IP_DROP_MEMBERSHIP, &grp, sizeof(grp));
@@ -376,6 +446,54 @@ void mdns_responder_Stop(void) {
     }
     gMdns.sock = -1;
     gMdns.active = false;
+    gMdns.recvArmed = false;
+}
+
+void mdns_responder_Stop(void) {
+    /* Real teardown (STA disconnect / AP entry): clear the heal request so
+     * ServiceHealth() won't resurrect the socket after we intentionally close. */
+    gMdns.needsReopen = false;
+    mdns_close_socket();
+}
+
+void mdns_responder_ServiceHealth(void) {
+    /* Rate-limit re-open attempts so a persistently-failing socket can't thrash
+     * the WINC every WifiTask iteration. */
+    if (gMdns.healCooldown > 0u) {
+        gMdns.healCooldown--;
+        return;
+    }
+    if (!gMdns.needsReopen) {
+        return;                           /* healthy (or intentionally stopped) */
+    }
+    /* A recvfrom re-arm (or the initial open) failed -> the responder is deaf
+     * while the device stays associated. Re-open from this WifiTask context —
+     * the same context Start/Stop already run in, so no new HIF re-entrancy
+     * hazard vs. re-arming recvfrom directly from here. */
+    gMdns.healCooldown = MDNS_HEAL_COOLDOWN_ITERS;
+    mdns_close_socket();
+    if (mdns_open_socket()) {
+        gMdns.needsReopen = false;        /* SOCKET_MSG_BIND will re-arm recv */
+        gMdns.healCount++;
+    }
+    /* else: open still failing -> needsReopen stays set, retried after cooldown */
+}
+
+void mdns_responder_GetDiag(mdns_diag_t *out) {
+    if (out == NULL) {
+        return;
+    }
+    memset(out, 0, sizeof(*out));
+    out->active       = gMdns.active;
+    out->recvArmed    = gMdns.recvArmed;
+    out->rxCount      = gMdns.rxCount;
+    out->matchCount   = gMdns.matchCount;
+    out->respCount    = gMdns.respCount;
+    out->armFailCount = gMdns.armFailCount;
+    out->healCount    = gMdns.healCount;
+    out->lastArmRc    = gMdns.lastArmRc;
+    copy_str(out->instance, sizeof(out->instance), gMdns.instanceFqdn);
+    copy_str(out->host, sizeof(out->host), gMdns.hostFqdn);
 }
 
 void mdns_responder_UpdateIp(uint32_t ipAddrNetworkOrder) {
@@ -411,14 +529,18 @@ void mdns_responder_HandleSocketEvent(SOCKET sock, uint8_t msgType, void *pvMsg)
     case SOCKET_MSG_RECVFROM: {
         tstrSocketRecvMsg *pRx = (tstrSocketRecvMsg *)pvMsg;
         if (pRx != NULL && pRx->pu8Buffer != NULL && pRx->s16BufferSize > 0) {
+            gMdns.rxCount++;              /* #58 diag: a datagram was delivered */
             /* Use the WINC event's own buffer pointer (== gMdns.rxBuf, the
              * buffer we armed recvfrom with) rather than the global — more
              * idiomatic and robust to any future buffer indirection. */
             if (query_matches(pRx->pu8Buffer, (size_t)pRx->s16BufferSize)) {
-                mdns_send_response();
+                gMdns.matchCount++;
+                if (mdns_send_response()) {
+                    gMdns.respCount++;
+                }
             }
         }
-        mdns_arm_recv();                  /* always re-arm */
+        mdns_arm_recv();                  /* always re-arm (return-checked, #58) */
         break;
     }
     case SOCKET_MSG_SENDTO:

--- a/firmware/src/services/wifi_services/mdns_responder.c
+++ b/firmware/src/services/wifi_services/mdns_responder.c
@@ -63,6 +63,15 @@
  * WINC with socket()/bind() every WifiTask iteration (~5 ms). 200 ≈ 1 s. */
 #define MDNS_HEAL_COOLDOWN_ITERS   200u
 
+/* Bind-pending watchdog (#692 audit): if the socket opened (active) but the
+ * SOCKET_MSG_BIND completion never arrives to arm the recv — a silently dropped
+ * async completion, which produces no explicit failure event — force a reopen
+ * after this many ServiceHealth iterations so the "active but deaf" wedge is
+ * covered on the no-signal path too. Generous (~5 s at the ~5 ms ProcessState
+ * cadence; longer under streaming load) so a merely-slow bind never false-fires
+ * — a normal bind arms the recv in well under 1 s. */
+#define MDNS_BIND_PENDING_MAX_ITERS 1000u
+
 typedef struct {
     SOCKET   sock;
     bool     active;
@@ -84,6 +93,8 @@ typedef struct {
     bool     recvArmed;      /* a recvfrom is currently outstanding */
     bool     needsReopen;    /* a recv re-arm failed -> ServiceHealth must recover */
     uint16_t healCooldown;   /* ServiceHealth iterations to skip before next re-open */
+    uint16_t bindPendingTicks; /* ServiceHealth iterations spent active-but-not-armed
+                                * (bind-completion watchdog, #692 audit) */
     uint32_t rxCount;
     uint32_t matchCount;
     uint32_t respCount;
@@ -431,6 +442,7 @@ bool mdns_responder_Start(const mdns_identity_t *id) {
  * Leaves gMdns.active/sock consistent on every path. */
 static bool mdns_open_socket(void) {
     gMdns.recvArmed = false;
+    gMdns.bindPendingTicks = 0u;      /* fresh bind attempt — restart the watchdog */
     gMdns.sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (gMdns.sock < 0) {
         LOG_E("[mDNS] socket() failed: %d", gMdns.sock);
@@ -492,6 +504,18 @@ void mdns_responder_ServiceHealth(void) {
         return;                           /* never started, or intentionally stopped:
                                            * ignore any stale needsReopen set by a
                                            * WINC callback that raced Stop (#692). */
+    }
+    /* Bind-completion watchdog (#692 audit): a socket that opened (active) but
+     * never armed its recv means the SOCKET_MSG_BIND completion was dropped by
+     * the WINC without an explicit failure event — no needsReopen signal is
+     * produced. Force a reopen after the grace period so the "active but deaf"
+     * wedge is recovered on this no-signal path too. Reset once armed. */
+    if (gMdns.active && !gMdns.recvArmed && !gMdns.needsReopen) {
+        if (++gMdns.bindPendingTicks >= MDNS_BIND_PENDING_MAX_ITERS) {
+            gMdns.needsReopen = true;     /* stuck bind -> fall through to reopen */
+        }
+    } else {
+        gMdns.bindPendingTicks = 0u;
     }
     /* Rate-limit re-open attempts so a persistently-failing socket can't thrash
      * the WINC every WifiTask iteration. */

--- a/firmware/src/services/wifi_services/mdns_responder.c
+++ b/firmware/src/services/wifi_services/mdns_responder.c
@@ -14,6 +14,17 @@
 #include <stdio.h>
 #include "socket.h"
 #include "Util/Logger.h"
+#include "FreeRTOS.h"
+#include "task.h"        /* taskENTER_CRITICAL — shared diagnostic-counter RMW (#692) */
+
+/* #58 / Qodo #692: the diagnostic counters are effectively single-writer per
+ * field, but they are read by GetDiag and reset by Start from other task
+ * contexts, and the RECVFROM counters run in the WINC-callback task while the
+ * heal counters run in WifiTask. Protect every read-modify-write per the
+ * project atomicity rule + compliance rule 68846 (PR #223 precedent). Plain
+ * bool/32-bit stores (recvArmed, needsReopen, lastArmRc) are atomic and need
+ * no guard. */
+#define MDNS_RMW(stmt_) do { taskENTER_CRITICAL(); stmt_; taskEXIT_CRITICAL(); } while (0)
 
 /* mDNS well-known group + port. 224.0.0.251 = 0xE00000FB. */
 #define MDNS_MCAST_ADDR_HOST   0xE00000FBu   /* host byte order */
@@ -304,7 +315,7 @@ static void mdns_arm_recv(void) {
     } else {
         gMdns.recvArmed = false;
         gMdns.needsReopen = true;
-        gMdns.armFailCount++;
+        MDNS_RMW(gMdns.armFailCount++);
         /* Static string only — LOG_E_ONCE's ISR branch passes fmt with no args.
          * The rc is in gMdns.lastArmRc, reported by SYST:COMM:LAN:MDNS?. */
         LOG_E_ONCE(LOG_ONCE_MDNS_ARM_FAIL,
@@ -460,7 +471,7 @@ void mdns_responder_ServiceHealth(void) {
     /* Rate-limit re-open attempts so a persistently-failing socket can't thrash
      * the WINC every WifiTask iteration. */
     if (gMdns.healCooldown > 0u) {
-        gMdns.healCooldown--;
+        MDNS_RMW(gMdns.healCooldown--);
         return;
     }
     if (!gMdns.needsReopen) {
@@ -474,7 +485,7 @@ void mdns_responder_ServiceHealth(void) {
     mdns_close_socket();
     if (mdns_open_socket()) {
         gMdns.needsReopen = false;        /* SOCKET_MSG_BIND will re-arm recv */
-        gMdns.healCount++;
+        MDNS_RMW(gMdns.healCount++);
     }
     /* else: open still failing -> needsReopen stays set, retried after cooldown */
 }
@@ -521,22 +532,29 @@ void mdns_responder_HandleSocketEvent(SOCKET sock, uint8_t msgType, void *pvMsg)
             setsockopt(gMdns.sock, SOL_SOCKET, IP_ADD_MEMBERSHIP, &grp, sizeof(grp));
             mdns_arm_recv();
         } else {
-            LOG_E("[mDNS] bind failed");
-            mdns_responder_Stop();
+            /* Async bind failure is a transient WINC/HIF condition, NOT an
+             * intentional teardown — calling the public Stop() would clear
+             * needsReopen and permanently disable the self-heal this PR adds
+             * (#692). Close the socket and schedule a rate-limited re-open so
+             * ServiceHealth() recovers it, same as a recvfrom re-arm failure. */
+            LOG_E("[mDNS] bind failed — scheduling self-heal retry");
+            mdns_close_socket();
+            gMdns.needsReopen = true;
+            gMdns.healCooldown = MDNS_HEAL_COOLDOWN_ITERS;
         }
         break;
     }
     case SOCKET_MSG_RECVFROM: {
         tstrSocketRecvMsg *pRx = (tstrSocketRecvMsg *)pvMsg;
         if (pRx != NULL && pRx->pu8Buffer != NULL && pRx->s16BufferSize > 0) {
-            gMdns.rxCount++;              /* #58 diag: a datagram was delivered */
+            MDNS_RMW(gMdns.rxCount++);    /* #58 diag: a datagram was delivered */
             /* Use the WINC event's own buffer pointer (== gMdns.rxBuf, the
              * buffer we armed recvfrom with) rather than the global — more
              * idiomatic and robust to any future buffer indirection. */
             if (query_matches(pRx->pu8Buffer, (size_t)pRx->s16BufferSize)) {
-                gMdns.matchCount++;
+                MDNS_RMW(gMdns.matchCount++);
                 if (mdns_send_response()) {
-                    gMdns.respCount++;
+                    MDNS_RMW(gMdns.respCount++);
                 }
             }
         }

--- a/firmware/src/services/wifi_services/mdns_responder.c
+++ b/firmware/src/services/wifi_services/mdns_responder.c
@@ -547,18 +547,23 @@ void mdns_responder_GetDiag(mdns_diag_t *out) {
     /* #692: coherent point-in-time snapshot — the counters are updated from the
      * WINC-callback and WifiTask contexts, so take them together under a short
      * critical section (infrequent SCPI-path query; the string copies are of
-     * post-Start-constant names). */
+     * post-Start-constant names). Honor the header contract: when the responder
+     * is INACTIVE the snapshot stays zeroed (the memset above) rather than
+     * leaking stale prior-session counters/names (#692 audit). The deaf-wedge
+     * state is still active=true, so this doesn't hide it. */
     taskENTER_CRITICAL();
-    out->active       = gMdns.active;
-    out->recvArmed    = gMdns.recvArmed;
-    out->rxCount      = gMdns.rxCount;
-    out->matchCount   = gMdns.matchCount;
-    out->respCount    = gMdns.respCount;
-    out->armFailCount = gMdns.armFailCount;
-    out->healCount    = gMdns.healCount;
-    out->lastArmRc    = gMdns.lastArmRc;
-    copy_str(out->instance, sizeof(out->instance), gMdns.instanceFqdn);
-    copy_str(out->host, sizeof(out->host), gMdns.hostFqdn);
+    out->active = gMdns.active;
+    if (gMdns.active) {
+        out->recvArmed    = gMdns.recvArmed;
+        out->rxCount      = gMdns.rxCount;
+        out->matchCount   = gMdns.matchCount;
+        out->respCount    = gMdns.respCount;
+        out->armFailCount = gMdns.armFailCount;
+        out->healCount    = gMdns.healCount;
+        out->lastArmRc    = gMdns.lastArmRc;
+        copy_str(out->instance, sizeof(out->instance), gMdns.instanceFqdn);
+        copy_str(out->host, sizeof(out->host), gMdns.hostFqdn);
+    }
     taskEXIT_CRITICAL();
 }
 

--- a/firmware/src/services/wifi_services/mdns_responder.c
+++ b/firmware/src/services/wifi_services/mdns_responder.c
@@ -346,13 +346,22 @@ static bool mdns_send_response(void) {
 }
 
 static void copy_str(char *dst, size_t dstSize, const char *src) {
+    if (dstSize == 0u) {
+        return;
+    }
     if (src == NULL) {
         dst[0] = '\0';
         return;
     }
-    size_t n = strlen(src);
-    if (n >= dstSize) {
-        n = dstSize - 1u;
+    /* #692: bound the scan to dstSize — never run strlen() past the source
+     * buffer. GetDiag may copy gMdns.instanceFqdn/hostFqdn while Start is
+     * mid-snprintf on them (higher-prio USB SCPI preempts WifiTask), so the
+     * source can be transiently unterminated; an unbounded strlen would read
+     * past the array (UB). dst and the FQDN sources are the same size, so this
+     * also truncates identity strings exactly as before. */
+    size_t n = 0u;
+    while (n < (dstSize - 1u) && src[n] != '\0') {
+        n++;
     }
     memcpy(dst, src, n);
     dst[n] = '\0';
@@ -547,8 +556,12 @@ void mdns_responder_HandleSocketEvent(SOCKET sock, uint8_t msgType, void *pvMsg)
              * ServiceHealth() recovers it, same as a recvfrom re-arm failure. */
             LOG_E("[mDNS] bind failed — scheduling self-heal retry");
             mdns_close_socket();
+            /* Set ONLY needsReopen (a single atomic store), exactly like the
+             * recvfrom re-arm failure path: ServiceHealth() does a prompt first
+             * re-open and sets the cooldown itself for subsequent retries.
+             * Setting healCooldown here too was a second, non-atomic store that
+             * raced ServiceHealth's cooldown check (Qodo #692 pass 3). */
             gMdns.needsReopen = true;
-            gMdns.healCooldown = MDNS_HEAL_COOLDOWN_ITERS;
         }
         break;
     }

--- a/firmware/src/services/wifi_services/mdns_responder.h
+++ b/firmware/src/services/wifi_services/mdns_responder.h
@@ -34,6 +34,22 @@ extern "C" {
 /** The TCP service port advertised in the SRV record (SCPI TCP console). */
 #define MDNS_SERVICE_PORT   9760u
 
+/** On-device diagnostics snapshot (#58). Lets `SYST:COMM:LAN:MDNS?` report
+ *  whether the responder is still receiving/answering queries — independent of
+ *  host-side mDNS tooling, which is unreliable on multi-homed test hosts. */
+typedef struct {
+    bool     active;        /**< responder owns a live socket */
+    bool     recvArmed;     /**< a recvfrom is currently armed (false = deaf) */
+    uint32_t rxCount;       /**< inbound datagrams delivered to the responder */
+    uint32_t matchCount;    /**< queries that matched our service/host */
+    uint32_t respCount;     /**< responses sent */
+    uint32_t armFailCount;  /**< recvfrom re-arm failures (the wedge signal) */
+    uint32_t healCount;     /**< self-heal socket re-opens performed */
+    int8_t   lastArmRc;     /**< rc of the most recent recvfrom re-arm */
+    char     instance[64];  /**< advertised instance FQDN */
+    char     host[24];      /**< advertised host FQDN */
+} mdns_diag_t;
+
 /** Runtime identity + TXT metadata for the advertised service. Strings are
  *  copied into the responder at Start; caller-owned buffers need not persist. */
 typedef struct {
@@ -87,6 +103,21 @@ bool mdns_responder_OwnsSocket(SOCKET sock);
  * @param sock the socket, @param msgType SOCKET_MSG_*, @param pvMsg WINC payload.
  */
 void mdns_responder_HandleSocketEvent(SOCKET sock, uint8_t msgType, void *pvMsg);
+
+/**
+ * Periodic self-heal (#58). Call from WifiTask's ProcessState loop (same
+ * context that Start/Stop already run in — NOT the WINC callback context, so
+ * no new HIF re-entrancy hazard). If the responder is active but its recvfrom
+ * re-arm has failed (it would otherwise be permanently deaf while still
+ * "active" — the observed long-run silence), this re-opens the socket using
+ * the stored identity so it recovers. Rate-limited internally; a no-op when
+ * healthy or inactive. Safe to call every iteration.
+ */
+void mdns_responder_ServiceHealth(void);
+
+/** Copy the current diagnostics snapshot (#58). Never fails; zeros @p out
+ *  when the responder is inactive. */
+void mdns_responder_GetDiag(mdns_diag_t *out);
 
 #ifdef __cplusplus
 }

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -3081,6 +3081,7 @@ static void wifi_manager_ProcessStateImpl(bool drainTcpRx) {
     if (drainTcpRx) {
         ApplyPowerSavePolicy(&gStateMachineContext);
         wifi_manager_ServiceConsoleIdleTimeout();  // #663: connect-and-never-send guard
+        mdns_responder_ServiceHealth();            // #58: re-open a deaf mDNS socket
     }
 
     if (gProcessStateMutex != NULL) {


### PR DESCRIPTION
## Summary
Adds **on-device observability** and a **targeted self-heal** to the #345 mDNS responder.

The responder is purely reactive and previously **ignored the return of its `recvfrom` re-arm** (`mdns_arm_recv`). If a re-arm fails synchronously — WINC HIF queue full under heavy streaming load — no further `SOCKET_MSG_RECVFROM` arrives and the responder goes **permanently deaf while still "active" and associated**. That failure mode is invisible to host-side mDNS tooling (itself unreliable on multi-homed hosts).

## Changes
- **Return-checked `mdns_arm_recv()`** — captures the rc, marks the socket un-armed, flags `needsReopen`, counts `armFailCount`. Static-string `LOG_E_ONCE` (rc is in the diagnostics, not the format string — ISR-branch requirement).
- **Self-heal** `mdns_responder_ServiceHealth()` — called every WifiTask `ProcessState` iteration (the *same* context `Start`/`Stop` already run in, so **no new HIF re-entrancy hazard** vs. re-arming `recvfrom` cross-context). Re-opens a deaf socket via the shared `mdns_open_socket()` using the stored identity; rate-limited (~1 re-open/s) so a persistently-failing socket can't thrash the WINC; a failed re-open keeps `needsReopen` set to retry. No-op (early return) in the healthy/stopped case, so **no socket ops from WifiTask during normal operation**.
- **Diagnostics** `SYST:COMM:LAN:MDNS?` → JSON `{Active, RecvArmed, Rx, Match, Resp, ArmFail, Heal, LastArmRc, Instance, Host}` (uses the shared response buffer). Makes a wedge **observable on-device**, independent of host tooling.

## Motivation
Unverified long-run observation (2026-07-15): a device's mDNS responder went silent to zeroconf over a ~2 h WiFi-active soak while staying associated/healthy (streaming clean, heap flat). The observation was **confounded** (dual-homed bench host, flaky unit WiFi), so this ships the observability to *settle* it plus a defensive fix for the most plausible mechanism. Startup discovery, heap, and streaming were all already fine.

## Build
Clean at `-O3 -Werror` (hex +3.7 KB). No new cppcheck findings expected.

## Test plan
- `daqifi-python-test-suite` `test_58_mdns_diagnostics.py` (companion PR): asserts `MDNS?` JSON shape, `Active`+`RecvArmed`, and that a zeroconf discovery bumps the **on-device** `Rx`/`Match`/`Resp` counters. Fails on pre-#58 firmware (`-113`).
- Hardware validation pending (flash a bench unit, STA on Tesla, run `test_58`).

## Docs
SCPI wiki updated with the `SYST:COMM:LAN:MDNS?` row.

Refs #58, #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)