### PR TITLE
feat(spi): #665 user SPI1 master on the DIO terminal

### DIFF
--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -336,6 +336,9 @@
         <logicalFolder name="UI" displayName="UI" projectFiles="true">
           <itemPath>../src/HAL/UI/UI.h</itemPath>
         </logicalFolder>
+        <logicalFolder name="UserSpi" displayName="UserSpi" projectFiles="true">
+          <itemPath>../src/HAL/UserSpi/UserSpi.h</itemPath>
+        </logicalFolder>
         <itemPath>../src/HAL/DIO.h</itemPath>
         <itemPath>../src/HAL/ADC.h</itemPath>
         <itemPath>../src/HAL/DioProbe.h</itemPath>
@@ -923,6 +926,9 @@
         </logicalFolder>
         <logicalFolder name="UI" displayName="UI" projectFiles="true">
           <itemPath>../src/HAL/UI/UI.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="UserSpi" displayName="UserSpi" projectFiles="true">
+          <itemPath>../src/HAL/UserSpi/UserSpi.c</itemPath>
         </logicalFolder>
         <itemPath>../src/HAL/DIO.c</itemPath>
         <itemPath>../src/HAL/ADC.c</itemPath>

--- a/firmware/src/HAL/DIO.c
+++ b/firmware/src/HAL/DIO.c
@@ -93,17 +93,18 @@ bool DIO_ClaimChannel(uint8_t channel, DioChannelOwner_t owner) {
     if (channel >= MAX_DIO_CHANNEL || owner == DIO_OWNER_NONE) {
         return false;
     }
-    /* The debug probe has an exclusive claim that predates the registry. */
-    if (DioProbe_IsChannelOwned(channel)) {
-        return false;
-    }
     bool ok = false;
     taskENTER_CRITICAL();
-    DioChannelOwner_t cur = (DioChannelOwner_t)gDioOwner[channel];
-    if (cur == DIO_OWNER_NONE || cur == owner) {
-        gDioOwner[channel] = (uint8_t)owner;
-        gDioOwnedMask |= (uint16_t)(1u << channel);
-        ok = true;
+    /* Test the probe claim and the peripheral owner together inside the
+     * critical section so probe-assign (one SCPI interface) and a peripheral
+     * claim (the other) can't race between the check and the store. */
+    if (!DioProbe_IsChannelOwned(channel)) {
+        DioChannelOwner_t cur = (DioChannelOwner_t)gDioOwner[channel];
+        if (cur == DIO_OWNER_NONE || cur == owner) {
+            gDioOwner[channel] = (uint8_t)owner;
+            gDioOwnedMask |= (uint16_t)(1u << channel);
+            ok = true;
+        }
     }
     taskEXIT_CRITICAL();
     return ok;
@@ -260,6 +261,13 @@ bool DIO_WriteStateAll(void) {
 }
 
 bool DIO_WriteStateSingle(uint8_t dataIndex) {
+    /* Bounds-guard the array indexing below. DIO_ChannelBlocked only rejects
+     * indices >= MAX_DIO_CHANNEL, so a caller passing a value in
+     * [DIOChannels.Size, MAX_DIO_CHANNEL) (e.g. channel 15 under the 15-entry
+     * DIO_TIMING_TEST config) would otherwise read past the table. */
+    if (gpBoardConfig == NULL || dataIndex >= gpBoardConfig->DIOChannels.Size) {
+        return false;
+    }
     /* Probe or a peripheral (SPI/I2C/UART/...) owns this channel and
      * drives its TRIS/LAT exclusively. Skipping here is the primary
      * isolation point; for the probe, scope-signal purity depends on it,

--- a/firmware/src/HAL/DIO.c
+++ b/firmware/src/HAL/DIO.c
@@ -466,7 +466,13 @@ void DIO_StreamingTrigger(DIOSample* latest, DIOSampleList* streamingSamples) {
         if (gpRuntimeBoardConfig->DIOGlobalEnable &&
                 gpRuntimeBoardConfig->StreamingConfig.IsEnabled) {
             DIOSample streamingSample;
-            streamingSample.Mask = 0xFFFF;
+            /* Use the mask DIO_ReadSampleByMask actually populated, not a
+             * hardcoded 0xFFFF: it has probe- and peripheral-owned (SPI/#665)
+             * channels stripped, so a JSON consumer sees those bus pins as
+             * NOT-valid rather than as a genuine logic-0 DIO reading (their
+             * Values bit is left 0). With nothing owned this equals 0xFFFF, so
+             * normal DIO streaming is unchanged. */
+            streamingSample.Mask = latest->Mask;
             streamingSample.Values = latest->Values;
             streamingSample.Timestamp = latest->Timestamp;
             if (!DIOSampleList_PushBack(

--- a/firmware/src/HAL/DIO.c
+++ b/firmware/src/HAL/DIO.c
@@ -90,7 +90,15 @@ static volatile uint16_t gDioOwnedMask = 0;
 static volatile uint8_t  gDioOwner[MAX_DIO_CHANNEL] = {0};
 
 bool DIO_ClaimChannel(uint8_t channel, DioChannelOwner_t owner) {
-    if (channel >= MAX_DIO_CHANNEL || owner == DIO_OWNER_NONE) {
+    /* Bound against the actual board channel count, not just the gDioOwner
+     * array size — a channel index in [DIOChannels.Size, MAX_DIO_CHANNEL) is a
+     * valid array slot but not a real board pin, so claiming it would register
+     * ownership of a non-existent channel. Size is always <= MAX_DIO_CHANNEL by
+     * board-config construction, so this is also a strict array-bounds guard.
+     * Matches the DIO_WriteStateSingle guard added in this PR. */
+    if (gpBoardConfig == NULL ||
+        channel >= gpBoardConfig->DIOChannels.Size ||
+        owner == DIO_OWNER_NONE) {
         return false;
     }
     bool ok = false;

--- a/firmware/src/HAL/DIO.c
+++ b/firmware/src/HAL/DIO.c
@@ -95,10 +95,14 @@ bool DIO_ClaimChannel(uint8_t channel, DioChannelOwner_t owner) {
     }
     bool ok = false;
     taskENTER_CRITICAL();
-    /* Test the probe claim and the peripheral owner together inside the
-     * critical section so probe-assign (one SCPI interface) and a peripheral
-     * claim (the other) can't race between the check and the store. */
-    if (!DioProbe_IsChannelOwned(channel)) {
+    /* Test the probe claim, PWM-active state, AND the peripheral owner together
+     * inside the critical section. PWM does not take a registry entry (it uses
+     * the IsPwmActive flag), so a claim that ignored IsPwmActive could steal a
+     * pin a concurrent PWM enable just activated on the other SCPI interface,
+     * then overwrite its PPS mux — a silent cross-feature corruption. Reading
+     * IsPwmActive here (paired with DIO_PWMWriteStateSingle refusing to program
+     * a registry-owned pin) makes SPI-vs-PWM arbitration race-free both ways. */
+    if (!DioProbe_IsChannelOwned(channel) && !DIO_IsPwmActive(channel)) {
         DioChannelOwner_t cur = (DioChannelOwner_t)gDioOwner[channel];
         if (cur == DIO_OWNER_NONE || cur == owner) {
             gDioOwner[channel] = (uint8_t)owner;

--- a/firmware/src/HAL/DIO.c
+++ b/firmware/src/HAL/DIO.c
@@ -348,6 +348,13 @@ bool DIO_ReadSampleByMask(DIOSample* sample, uint32_t mask) {
 }
 
 bool DIO_PWMWriteStateSingle(uint8_t dataIndex) {
+    /* Bounds-guard the table indexing below (same rationale as
+     * DIO_WriteStateSingle): DIO_ChannelBlocked only rejects >= MAX_DIO_CHANNEL,
+     * so an index in [DIOChannels.Size, MAX_DIO_CHANNEL) would read past the
+     * board table. SCPI callers validate, but keep the HAL self-protecting. */
+    if (gpBoardConfig == NULL || dataIndex >= gpBoardConfig->DIOChannels.Size) {
+        return false;
+    }
     if (DIO_ChannelBlocked(dataIndex)) {
         return false;
     }
@@ -374,6 +381,10 @@ bool DIO_PWMWriteStateSingle(uint8_t dataIndex) {
 }
 
 bool DIO_PWMDutyCycleSetSingle(uint8_t dataIndex) {
+    /* Bounds-guard the table indexing below — see DIO_WriteStateSingle. */
+    if (gpBoardConfig == NULL || dataIndex >= gpBoardConfig->DIOChannels.Size) {
+        return false;
+    }
     if (DIO_ChannelBlocked(dataIndex)) {
         return false;
     }
@@ -390,6 +401,10 @@ bool DIO_PWMDutyCycleSetSingle(uint8_t dataIndex) {
 }
 
 bool DIO_PWMFrequencySet(uint8_t dataIndex) {
+    /* Bounds-guard the table indexing below — see DIO_WriteStateSingle. */
+    if (gpBoardConfig == NULL || dataIndex >= gpBoardConfig->DIOChannels.Size) {
+        return false;
+    }
     if (DIO_ChannelBlocked(dataIndex)) {
         return false;
     }

--- a/firmware/src/HAL/DIO.c
+++ b/firmware/src/HAL/DIO.c
@@ -9,6 +9,8 @@
 
 #include "configuration.h"
 #include "definitions.h"
+#include "FreeRTOS.h"
+#include "task.h"
 #include "state/runtime/BoardRuntimeConfig.h"
 #include "state/board/BoardConfig.h"
 #include "TimerApi/TimerApi.h"
@@ -73,6 +75,146 @@ void DIO_ProbeReleasePair(uint8_t channel) {
     SetGpioDir(dio->EnableChannel, dio->EnableBitPos, 1);
 }
 
+/* ---------------------------------------------------------------------
+ * DIO channel ownership registry (#664 shared foundation)
+ * ---------------------------------------------------------------------
+ * gDioOwnedMask is the fast-path bitmask consulted per streaming tick and
+ * in the read filter; gDioOwner[] carries the owner id for error naming.
+ * Written from task context (SCPI / peripheral HAL) under a critical
+ * section; the mask is read from the streaming task and the DIO write
+ * paths (a single aligned 16-bit load is atomic on PIC32MZ). The DIO
+ * debug probe (DioProbe) is a separate, higher-priority owner class with
+ * its own tear-safe mask — DIO_ChannelBlocked ORs the two.
+ * --------------------------------------------------------------------- */
+static volatile uint16_t gDioOwnedMask = 0;
+static volatile uint8_t  gDioOwner[MAX_DIO_CHANNEL] = {0};
+
+bool DIO_ClaimChannel(uint8_t channel, DioChannelOwner_t owner) {
+    if (channel >= MAX_DIO_CHANNEL || owner == DIO_OWNER_NONE) {
+        return false;
+    }
+    /* The debug probe has an exclusive claim that predates the registry. */
+    if (DioProbe_IsChannelOwned(channel)) {
+        return false;
+    }
+    bool ok = false;
+    taskENTER_CRITICAL();
+    DioChannelOwner_t cur = (DioChannelOwner_t)gDioOwner[channel];
+    if (cur == DIO_OWNER_NONE || cur == owner) {
+        gDioOwner[channel] = (uint8_t)owner;
+        gDioOwnedMask |= (uint16_t)(1u << channel);
+        ok = true;
+    }
+    taskEXIT_CRITICAL();
+    return ok;
+}
+
+void DIO_ReleaseChannel(uint8_t channel, DioChannelOwner_t owner) {
+    if (channel >= MAX_DIO_CHANNEL) {
+        return;
+    }
+    taskENTER_CRITICAL();
+    if ((DioChannelOwner_t)gDioOwner[channel] == owner) {
+        gDioOwner[channel] = (uint8_t)DIO_OWNER_NONE;
+        gDioOwnedMask &= (uint16_t)~(1u << channel);
+    }
+    taskEXIT_CRITICAL();
+}
+
+DioChannelOwner_t DIO_GetChannelOwner(uint8_t channel) {
+    if (channel >= MAX_DIO_CHANNEL) {
+        return DIO_OWNER_NONE;
+    }
+    return (DioChannelOwner_t)gDioOwner[channel];
+}
+
+const char* DIO_ChannelOwnerName(DioChannelOwner_t owner) {
+    switch (owner) {
+        case DIO_OWNER_SPI:     return "SPI";
+        case DIO_OWNER_I2C:     return "I2C";
+        case DIO_OWNER_UART:    return "UART";
+        case DIO_OWNER_ONEWIRE: return "1-Wire";
+        case DIO_OWNER_IC:      return "InputCapture";
+        case DIO_OWNER_CLOCK:   return "Clock";
+        default:                return "none";
+    }
+}
+
+bool DIO_ChannelBlocked(uint8_t channel) {
+    if (channel >= MAX_DIO_CHANNEL) {
+        return false;
+    }
+    if (DioProbe_IsChannelOwned(channel)) {
+        return true;
+    }
+    return (gDioOwnedMask & (uint16_t)(1u << channel)) != 0;
+}
+
+const char* DIO_ChannelBlockedReason(uint8_t channel) {
+    if (channel >= MAX_DIO_CHANNEL) {
+        return NULL;
+    }
+    if (DioProbe_IsChannelOwned(channel)) {
+        return "DIO probe";
+    }
+    DioChannelOwner_t owner = (DioChannelOwner_t)gDioOwner[channel];
+    return (owner == DIO_OWNER_NONE) ? NULL : DIO_ChannelOwnerName(owner);
+}
+
+bool DIO_IsPwmActive(uint8_t channel) {
+    if (gpRuntimeBoardConfig == NULL ||
+        channel >= gpRuntimeBoardConfig->DIOChannels.Size) {
+        return false;
+    }
+    return gpRuntimeBoardConfig->DIOChannels.Data[channel].IsPwmActive;
+}
+
+/* ---------------------------------------------------------------------
+ * Peripheral pin electrical setup (#664 shared foundation)
+ * See the header for the SN74LVC2G241 buffer / 100K read-path model.
+ * --------------------------------------------------------------------- */
+bool DIO_SetChannelPeripheralOutput(uint8_t channel) {
+    if (gpBoardConfig == NULL || channel >= gpBoardConfig->DIOChannels.Size) {
+        return false;
+    }
+    const DIOConfig* dio = &gpBoardConfig->DIOChannels.Data[channel];
+    /* Data pin -> output (driven by the mapped peripheral or DIO_DriveChannel). */
+    SetGpioDir(dio->DataChannel, dio->DataBitPos, 0);
+    /* External buffer enabled: it drives the terminal at +5V_D. */
+    WriteGpioPin(dio->EnableChannel, dio->EnableBitPos, !dio->EnableInverted);
+    SetGpioDir(dio->EnableChannel, dio->EnableBitPos, 0);
+    return true;
+}
+
+bool DIO_SetChannelPeripheralInput(uint8_t channel) {
+    if (gpBoardConfig == NULL || channel >= gpBoardConfig->DIOChannels.Size) {
+        return false;
+    }
+    const DIOConfig* dio = &gpBoardConfig->DIOChannels.Data[channel];
+    /* Data pin -> input: reads the terminal through the 100K series R. */
+    SetGpioDir(dio->DataChannel, dio->DataBitPos, 1);
+    /* External buffer disabled: terminal high-Z so the slave can drive it. */
+    WriteGpioPin(dio->EnableChannel, dio->EnableBitPos, dio->EnableInverted);
+    SetGpioDir(dio->EnableChannel, dio->EnableBitPos, 0);
+    return true;
+}
+
+bool DIO_DriveChannel(uint8_t channel, bool level) {
+    if (gpBoardConfig == NULL || channel >= gpBoardConfig->DIOChannels.Size) {
+        return false;
+    }
+    const DIOConfig* dio = &gpBoardConfig->DIOChannels.Data[channel];
+    WriteGpioPin(dio->DataChannel, dio->DataBitPos, level ? 1 : 0);
+    return true;
+}
+
+void DIO_RestoreChannel(uint8_t channel) {
+    /* Re-apply the runtime-configured state. The caller must have released
+     * its claim first, else DIO_WriteStateSingle short-circuits on the
+     * still-blocked channel. */
+    (void)DIO_WriteStateSingle(channel);
+}
+
 bool DIO_InitHardware(const tBoardConfig *pInitBoardConfiguration,
         const tBoardRuntimeConfig *pInitBoardRuntimeConfig) {
     bool enableInverted;
@@ -118,10 +260,11 @@ bool DIO_WriteStateAll(void) {
 }
 
 bool DIO_WriteStateSingle(uint8_t dataIndex) {
-    /* Probe owns this channel — the debug probe drives TRIS/LAT
-     * exclusively. Skipping here is the primary isolation point;
-     * signal purity on the scope depends on it. */
-    if (DioProbe_IsChannelOwned(dataIndex)) {
+    /* Probe or a peripheral (SPI/I2C/UART/...) owns this channel and
+     * drives its TRIS/LAT exclusively. Skipping here is the primary
+     * isolation point; for the probe, scope-signal purity depends on it,
+     * and for a peripheral it prevents the DIO path stomping the bus. */
+    if (DIO_ChannelBlocked(dataIndex)) {
         return true;
     }
     bool enableInverted = gpBoardConfig->DIOChannels.Data[ dataIndex ].EnableInverted;
@@ -156,10 +299,11 @@ bool DIO_WriteStateSingle(uint8_t dataIndex) {
 }
 
 bool DIO_ReadSampleByMask(DIOSample* sample, uint32_t mask) {
-    /* Filter out probe-owned channels — their toggle waveform is
-     * debug artifact, not user data. Including them in the stream
-     * would mislead the consumer reading DIO samples. */
-    mask = DioProbe_FilterReadMask(mask);
+    /* Filter out probe-owned channels (their toggle waveform is a debug
+     * artifact, not user data) and peripheral-claimed channels (SPI/I2C/
+     * UART bus lines, not DIO logic levels) — including either would
+     * mislead the consumer reading DIO samples. */
+    mask = DioProbe_FilterReadMask(mask) & ~(uint32_t)gDioOwnedMask;
     sample->Mask = mask;
     sample->Values = 0;
     // Set module trigger timestamp
@@ -184,7 +328,7 @@ bool DIO_ReadSampleByMask(DIOSample* sample, uint32_t mask) {
 }
 
 bool DIO_PWMWriteStateSingle(uint8_t dataIndex) {
-    if (DioProbe_IsChannelOwned(dataIndex)) {
+    if (DIO_ChannelBlocked(dataIndex)) {
         return false;
     }
     bool enableInverted = gpBoardConfig->DIOChannels.Data[ dataIndex ].EnableInverted;
@@ -210,7 +354,7 @@ bool DIO_PWMWriteStateSingle(uint8_t dataIndex) {
 }
 
 bool DIO_PWMDutyCycleSetSingle(uint8_t dataIndex) {
-    if (DioProbe_IsChannelOwned(dataIndex)) {
+    if (DIO_ChannelBlocked(dataIndex)) {
         return false;
     }
     uint8_t pwmDriverInstance = gpBoardConfig->DIOChannels.Data[ dataIndex ].PwmOcmpId;
@@ -226,7 +370,7 @@ bool DIO_PWMDutyCycleSetSingle(uint8_t dataIndex) {
 }
 
 bool DIO_PWMFrequencySet(uint8_t dataIndex) {
-    if (DioProbe_IsChannelOwned(dataIndex)) {
+    if (DIO_ChannelBlocked(dataIndex)) {
         return false;
     }
 
@@ -272,9 +416,10 @@ void DIO_StreamingTrigger(DIOSample* latest, DIOSampleList* streamingSamples) {
 
     // Write DIO values
     for (i = 0; i < DIOChruntimeConfig->Size; ++i) {
-        /* Skip probe-owned channels at the loop level to avoid the
-         * call overhead. DIO_WriteStateSingle also guards internally. */
-        if (DioProbe_IsChannelOwned((uint8_t)i)) {
+        /* Skip probe- or peripheral-owned channels at the loop level to
+         * avoid the call overhead. DIO_WriteStateSingle also guards
+         * internally. */
+        if (DIO_ChannelBlocked((uint8_t)i)) {
             continue;
         }
         DIO_WriteStateSingle(i);

--- a/firmware/src/HAL/DIO.h
+++ b/firmware/src/HAL/DIO.h
@@ -116,6 +116,93 @@ bool DIO_PWMDutyCycleSetSingle(uint8_t dataIndex);
  */
 bool DIO_PWMFrequencySet(uint8_t dataIndex);
 
+/* ---------------------------------------------------------------------
+ * DIO channel ownership registry (#664 shared foundation)
+ * ---------------------------------------------------------------------
+ * A general claim/release layer so peripheral features built on the user
+ * DIO terminal (SPI #665, I2C #15, UART #16, 1-Wire #669, ...) can reserve
+ * the pins they drive. A claimed channel is skipped by the DIO streaming
+ * write path and rejected by the SCPI DIO:PORt / PWM setters (which name
+ * the owner). This generalizes the probe-specific DioProbe_IsChannelOwned
+ * into a multi-owner registry; the DIO debug probe keeps its own tear-safe
+ * fast path and is treated here as an additional, higher-priority owner
+ * class (see DIO_ChannelBlocked / DIO_ChannelBlockedReason).
+ * --------------------------------------------------------------------- */
+
+/*! Peripheral that has claimed a DIO channel. */
+typedef enum {
+    DIO_OWNER_NONE = 0,   //!< unclaimed by a peripheral
+    DIO_OWNER_SPI,        //!< user SPI1 master (#665)
+    DIO_OWNER_I2C,        //!< user I2C hub (#15)
+    DIO_OWNER_UART,       //!< user UART (#16)
+    DIO_OWNER_ONEWIRE,    //!< user 1-Wire master (#669)
+    DIO_OWNER_IC,         //!< input capture / edge events (#666/#667)
+    DIO_OWNER_CLOCK,      //!< clock output (#668)
+} DioChannelOwner_t;
+
+/*! Claim a DIO channel for a peripheral. Fails if the index is out of
+ *  range, the DIO debug probe owns the channel, or it is already claimed
+ *  by a *different* peripheral (idempotent for the same owner). Thread-safe
+ *  (task-context critical section).
+ *  @return true if the channel is now owned by @p owner. */
+bool DIO_ClaimChannel(uint8_t channel, DioChannelOwner_t owner);
+
+/*! Release a channel previously claimed via DIO_ClaimChannel. No-op unless
+ *  the channel is currently owned by @p owner (a peripheral cannot release
+ *  another peripheral's claim). */
+void DIO_ReleaseChannel(uint8_t channel, DioChannelOwner_t owner);
+
+/*! Current peripheral owner of a channel (DIO_OWNER_NONE if not claimed by
+ *  a peripheral). Does not report DIO-probe ownership. */
+DioChannelOwner_t DIO_GetChannelOwner(uint8_t channel);
+
+/*! Human-readable owner name for SCPI error messages ("SPI", "I2C", ...). */
+const char* DIO_ChannelOwnerName(DioChannelOwner_t owner);
+
+/*! True if a channel is unavailable for normal DIO use — owned by the
+ *  debug probe OR claimed by a peripheral. Hot-path helper used by the DIO
+ *  write/read/streaming paths. */
+bool DIO_ChannelBlocked(uint8_t channel);
+
+/*! Why a channel is blocked, as a static string for error messages, or
+ *  NULL if it is free for normal DIO use. */
+const char* DIO_ChannelBlockedReason(uint8_t channel);
+
+/*! True if PWM (output-compare) is currently active on a channel. Lets a
+ *  peripheral reject a pin-claim rather than silently leaving the OC output
+ *  driving the pad. */
+bool DIO_IsPwmActive(uint8_t channel);
+
+/* ---------------------------------------------------------------------
+ * Peripheral pin electrical setup (#664 shared foundation)
+ * ---------------------------------------------------------------------
+ * The DIO terminal channel is one unidirectional SN74LVC2G241 buffer half:
+ * enable(OE) active => the PIC pin drives the terminal at the +5V_D rail;
+ * enable inactive => terminal high-Z and the PIC pin reads the terminal
+ * through a 100K series resistor (input mode). These helpers apply that
+ * model for a claimed channel so SPI/UART/I2C don't each re-derive the
+ * buffer polarity. Call only on a channel already claimed by the caller.
+ * --------------------------------------------------------------------- */
+
+/*! Data pin -> output, external buffer enabled (drives the terminal). Used
+ *  for peripheral outputs: SPI SCK/MOSI/CS, UART TX. The data pin's value
+ *  is driven either by the mapped peripheral (SCK/MOSI) or by
+ *  DIO_DriveChannel (a software CS). */
+bool DIO_SetChannelPeripheralOutput(uint8_t channel);
+
+/*! Data pin -> input, external buffer disabled (terminal high-Z; the pin
+ *  reads the terminal through the 100K series resistor). Used for
+ *  peripheral inputs: SPI MISO, UART RX. */
+bool DIO_SetChannelPeripheralInput(uint8_t channel);
+
+/*! Drive a peripheral-output channel's data pin (e.g. a software CS line).
+ *  Only meaningful after DIO_SetChannelPeripheralOutput on @p channel. */
+bool DIO_DriveChannel(uint8_t channel, bool level);
+
+/*! Restore a channel to its runtime-configured DIO state. Call after
+ *  releasing a peripheral claim so the normal DIO path resumes cleanly. */
+void DIO_RestoreChannel(uint8_t channel);
+
 
 
 #ifdef  DIO_TIMING_TEST

--- a/firmware/src/HAL/DioProbe.c
+++ b/firmware/src/HAL/DioProbe.c
@@ -165,6 +165,22 @@ bool DioProbe_AssignToChannel(uint8_t probeId, uint8_t channel,
      * the second arrival sees the first's bit set and rejects. */
     taskENTER_CRITICAL();
     prev_ch = slot->channel;
+    /* Refuse a channel a peripheral (SPI/#665, future I2C/UART/...) has claimed
+     * — the mirror of DIO_ClaimChannel refusing a probe-owned pin. Checked
+     * inside the CS so it's atomic vs a concurrent DIO_ClaimChannel on the
+     * other SCPI task. UNCONDITIONAL (unlike the probe-vs-probe check below,
+     * which allows re-assigning your own slot's channel): a peripheral owner is
+     * never the probe, so if one exists the probe must not take the pin even if
+     * this slot's prev_ch already equals it — otherwise SYST:DIOProbe:MODE/ROUTe
+     * onto an SPI-owned pin drives it (asserting CS outside a transfer,
+     * corrupting the slave) and creates dual ownership. */
+    DioChannelOwner_t periphOwner = DIO_GetChannelOwner(channel);
+    if (periphOwner != DIO_OWNER_NONE) {
+        taskEXIT_CRITICAL();
+        LOG_E("DioProbe: channel %u owned by %s",
+              (unsigned)channel, DIO_ChannelOwnerName(periphOwner));
+        return false;
+    }
     if (prev_ch != channel && (gDioProbeOwnedMask & (1u << channel)) != 0u) {
         taskEXIT_CRITICAL();
         LOG_E("DioProbe: channel %u already owned by another probe",

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -414,11 +414,17 @@ static bool spi_TransferLocked(const uint8_t* tx, uint8_t* rx, uint16_t len) {
     }
 
     if (!ok) {
-        /* Per-byte timeout (SCK not toggling): drain any partial RX and clear
-         * the overflow flag so the next transfer starts from a clean FIFO. The
-         * drain is bounded — if SPIRBF were stuck set (hardware fault) an
-         * unbounded loop would hang the caller; the RX FIFO holds only a few
-         * bytes, so a small cap is ample. */
+        /* Per-byte timeout (SCK not toggling): reset the module so the next
+         * transfer starts from a clean slate. Toggling ON=0→1 flushes the shift
+         * register and FIFOs if SCK halted mid-byte — otherwise the next
+         * spi_XferByte (which only writes SPI1BUF, it does not re-init) could
+         * clock out residual bits. MSTEN/CKP/CKE/BRG live in SPI1CON/SPI1BRG and
+         * persist across the ON toggle, so no reconfigure is needed. Then clear
+         * the (sticky) overflow flag and bounded-drain any residual RX — bounded
+         * so a stuck SPIRBF from a hardware fault can't hang the caller; the RX
+         * FIFO holds only a few bytes, so a small cap is ample. */
+        SPI1CONCLR = _SPI1CON_ON_MASK;
+        SPI1CONSET = _SPI1CON_ON_MASK;
         SPI1STATCLR = _SPI1STAT_SPIROV_MASK;
         uint32_t drainGuard = 32u;
         while (((SPI1STAT & _SPI1STAT_SPIRBF_MASK) != 0U) && (drainGuard-- > 0U)) {

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -14,6 +14,8 @@
 #include "UserSpi.h"
 #include "configuration.h"
 #include "definitions.h"
+#include "FreeRTOS.h"
+#include "semphr.h"
 #include "HAL/DIO.h"
 #include "Util/Logger.h"
 
@@ -39,6 +41,24 @@ static UserSpiConfig_t gCfg;
 static bool            gHaveConfig = false;
 static bool            gEnabled    = false;
 static uint32_t        gActualBaud = 0;
+
+/* Serializes the public API. SPI SCPI commands can be dispatched from both the
+ * USB SCPI task (pri 7) and the WiFi TCP SCPI task (pri 2), so config/enable/
+ * transfer must not interleave on the single shared SPI1 peripheral. Statically
+ * allocated (configSUPPORT_STATIC_ALLOCATION), lazily created on first use. */
+static SemaphoreHandle_t gSpiMutex = NULL;
+static StaticSemaphore_t gSpiMutexBuf;
+
+static SemaphoreHandle_t spi_Mutex(void) {
+    if (gSpiMutex == NULL) {
+        taskENTER_CRITICAL();
+        if (gSpiMutex == NULL) {   /* re-check: another task may have won the race */
+            gSpiMutex = xSemaphoreCreateMutexStatic(&gSpiMutexBuf);
+        }
+        taskEXIT_CRITICAL();
+    }
+    return gSpiMutex;
+}
 
 static void spi_CfgconUnlockedWrite(uint32_t val);
 
@@ -118,11 +138,17 @@ static uint32_t spi_ComputeBrg(uint32_t baudHz, uint32_t* actualOut) {
 /* Map / unmap SDO1 + SDI1 through PPS. Clears RPD1R so the dedicated SCK1
  * (not a remappable output) is the only driver on RD1/DIO0. */
 static void spi_ApplyPps(bool enable) {
-    /* PPS registers are gated by CFGCON.IOLOCK. Open it (DMA-suspended unlock),
-     * write the PPS map directly while it's open, then close it. DIO0/RD1: drop
+    /* PPS registers (RPnR outputs, SDI1R input) are gated by CFGCON.IOLOCK.
+     * Run the whole open -> PPS writes -> close sequence as ONE interrupt-
+     * disabled block so it is indivisible: no other task's PPS/SYSKEY work
+     * (PWM output remap, a future DIO peripheral) can interleave, and IOLOCK
+     * is never left open to a preemptor. The nested spi_CfgconUnlockedWrite
+     * calls also disable interrupts, but restore to the already-disabled
+     * state captured here, so interrupts stay off throughout. DIO0/RD1: drop
      * the remappable-output mux so the dedicated SCK1 owns the pad. */
-    spi_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_IOLOCK_MASK);
+    uint32_t st = __builtin_disable_interrupts();
 
+    spi_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_IOLOCK_MASK);
     RPD1R = 0U;
     volatile uint32_t *mosiRpr = spi_MosiRprAddr(gCfg.mosiDio);
     if (mosiRpr != NULL) {
@@ -130,8 +156,9 @@ static void spi_ApplyPps(bool enable) {
     }
     SDI1R = (enable && gCfg.misoDio != USER_SPI_PIN_NONE)
                 ? spi_MisoSdi1rValue(gCfg.misoDio) : 0U;
-
     spi_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_IOLOCK_MASK);
+
+    __builtin_mtc0(12, 0, st);
 }
 
 /* Perform a SYSKEY-unlocked write to CFGCON — the only SYSKEY-gated register
@@ -200,7 +227,7 @@ static bool spi_XferByte(uint8_t txByte, uint8_t* rxByte) {
 // Section: public API
 // *****************************************************************************
 
-bool UserSpi_Configure(const UserSpiConfig_t* cfg, const char** err) {
+static bool spi_ConfigureLocked(const UserSpiConfig_t* cfg, const char** err) {
     const char* why = NULL;
     if (cfg == NULL) {
         why = "null config";
@@ -245,21 +272,13 @@ bool UserSpi_Configure(const UserSpiConfig_t* cfg, const char** err) {
     return true;
 }
 
-bool UserSpi_GetConfig(UserSpiConfig_t* out) {
-    if (out == NULL || !gHaveConfig) {
-        return false;
-    }
-    *out = gCfg;
-    return true;
-}
-
 /* True if a pin is unavailable to claim — owned by the probe/another
  * peripheral, or currently driving a PWM output. */
 static bool spi_PinInUse(uint8_t dio) {
     return (DIO_ChannelBlockedReason(dio) != NULL) || DIO_IsPwmActive(dio);
 }
 
-bool UserSpi_Enable(const char** err) {
+static bool spi_EnableLocked(const char** err) {
     if (!gHaveConfig) {
         if (err != NULL) { *err = "no SPI config set"; }
         return false;
@@ -328,7 +347,7 @@ bool UserSpi_Enable(const char** err) {
     return true;
 }
 
-bool UserSpi_Disable(void) {
+static bool spi_DisableLocked(void) {
     if (!gEnabled) {
         return true;
     }
@@ -360,7 +379,7 @@ bool UserSpi_IsEnabled(void) {
     return gEnabled;
 }
 
-bool UserSpi_Transfer(const uint8_t* tx, uint8_t* rx, uint16_t len) {
+static bool spi_TransferLocked(const uint8_t* tx, uint8_t* rx, uint16_t len) {
     if (!gEnabled || len == 0u || len > USER_SPI_MAX_FRAME) {
         return false;
     }
@@ -392,4 +411,58 @@ bool UserSpi_Transfer(const uint8_t* tx, uint8_t* rx, uint16_t len) {
 
 uint32_t UserSpi_GetActualBaud(void) {
     return gEnabled ? gActualBaud : 0u;
+}
+
+// *****************************************************************************
+// Section: public API mutex wrappers
+//
+// The SPI SCPI commands can be dispatched concurrently from the USB SCPI task
+// (pri 7) and the WiFi TCP SCPI task (pri 2). These thin wrappers serialize
+// every operation that touches the config, the shared SPI1 peripheral, or the
+// PPS/PMD reconfiguration, so the two interfaces cannot interleave. The inner
+// *_Locked functions keep their early-return structure; the single take/give
+// here avoids sprinkling gives across every exit path. IsEnabled/GetActualBaud
+// stay lock-free — each is a single aligned 32-bit read (atomic on PIC32MZ).
+// *****************************************************************************
+
+bool UserSpi_Configure(const UserSpiConfig_t* cfg, const char** err) {
+    xSemaphoreTake(spi_Mutex(), portMAX_DELAY);
+    bool r = spi_ConfigureLocked(cfg, err);
+    xSemaphoreGive(gSpiMutex);
+    return r;
+}
+
+bool UserSpi_GetConfig(UserSpiConfig_t* out) {
+    if (out == NULL) {
+        return false;
+    }
+    xSemaphoreTake(spi_Mutex(), portMAX_DELAY);
+    bool r = false;
+    if (gHaveConfig) {
+        *out = gCfg;
+        r = true;
+    }
+    xSemaphoreGive(gSpiMutex);
+    return r;
+}
+
+bool UserSpi_Enable(const char** err) {
+    xSemaphoreTake(spi_Mutex(), portMAX_DELAY);
+    bool r = spi_EnableLocked(err);
+    xSemaphoreGive(gSpiMutex);
+    return r;
+}
+
+bool UserSpi_Disable(void) {
+    xSemaphoreTake(spi_Mutex(), portMAX_DELAY);
+    bool r = spi_DisableLocked();
+    xSemaphoreGive(gSpiMutex);
+    return r;
+}
+
+bool UserSpi_Transfer(const uint8_t* tx, uint8_t* rx, uint16_t len) {
+    xSemaphoreTake(spi_Mutex(), portMAX_DELAY);
+    bool r = spi_TransferLocked(tx, rx, len);
+    xSemaphoreGive(gSpiMutex);
+    return r;
 }

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -413,9 +413,13 @@ static bool spi_TransferLocked(const uint8_t* tx, uint8_t* rx, uint16_t len) {
 
     if (!ok) {
         /* Per-byte timeout (SCK not toggling): drain any partial RX and clear
-         * the overflow flag so the next transfer starts from a clean FIFO. */
+         * the overflow flag so the next transfer starts from a clean FIFO. The
+         * drain is bounded — if SPIRBF were stuck set (hardware fault) an
+         * unbounded loop would hang the caller; the RX FIFO holds only a few
+         * bytes, so a small cap is ample. */
         SPI1STATCLR = _SPI1STAT_SPIROV_MASK;
-        while ((SPI1STAT & _SPI1STAT_SPIRBF_MASK) != 0U) {
+        uint32_t drainGuard = 32u;
+        while (((SPI1STAT & _SPI1STAT_SPIRBF_MASK) != 0U) && (drainGuard-- > 0U)) {
             (void)SPI1BUF;
         }
     }

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -337,8 +337,11 @@ static bool spi_EnableLocked(const char** err) {
         DIO_SetChannelPeripheralInput(gCfg.misoDio);
     }
     if (gCfg.csDio != USER_SPI_PIN_NONE) {
+        /* Latch CS idle-high BEFORE enabling the output buffer, so the terminal
+         * never sees a brief active-low assertion if the pin's prior LAT was
+         * low (a spurious select to the slave). */
+        DIO_DriveChannel(gCfg.csDio, true);
         DIO_SetChannelPeripheralOutput(gCfg.csDio);
-        DIO_DriveChannel(gCfg.csDio, true);   /* CS idle high (deasserted) */
     }
 
     spi_SetPmd(true);    /* power the SPI1 module before touching its SFRs */

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -1,0 +1,395 @@
+/**
+ * @file UserSpi.c
+ * @brief User SPI1 master on the DIO terminal (#665). See UserSpi.h.
+ *
+ * Hand-rolled SPI1 PLIB per the no-MCC policy: a minimal polled 8-bit
+ * master. PPS values are taken from the PIC32MZ2048EFM144 DFP
+ * (PIC32MZ-EF_DFP 1.5.173): SDO1 output code = 5 (RP<pin>R=5), SDI1 is a
+ * group-1 input (SDI1R = the pin's RPn code: RPF1=4, RPG1=12, RPC1=10),
+ * and SCK1 is a fixed (non-remappable) function on RD1/DIO0.
+ */
+#define LOG_LVL     LOG_LEVEL_ERROR
+#define LOG_MODULE  LOG_MODULE_GENERAL
+
+#include "UserSpi.h"
+#include "configuration.h"
+#include "definitions.h"
+#include "HAL/DIO.h"
+#include "Util/Logger.h"
+
+/* SPI1 source clock = PBCLK2. Post-#487 the peripheral bus runs at
+ * SYSCLK/3 = 84 MHz (see the Clock Tree in CLAUDE.md). SPI_CLK =
+ * PBCLK2 / (2*(BRG+1)). */
+#define USER_SPI_PBCLK_HZ   84000000UL
+
+/* Per-byte polled-transfer spin bound. Sized to cover the slowest byte
+ * (8 bits at USER_SPI_MIN_BAUD_HZ ~= 1.3 ms) with wide margin at the
+ * 252 MHz core; a real transfer at the 100 kHz default completes in ~80 us.
+ * A timeout here means SCK is not toggling (hardware/config fault). */
+#define USER_SPI_XFER_TIMEOUT   2000000UL
+
+/* Max bytes per SYST:COMM:SPI:TRANsfer? frame (matches the SCPI hex cap). */
+#define USER_SPI_MAX_FRAME      256u
+
+// *****************************************************************************
+// Section: module state
+// *****************************************************************************
+
+static UserSpiConfig_t gCfg;
+static bool            gHaveConfig = false;
+static bool            gEnabled    = false;
+static uint32_t        gActualBaud = 0;
+
+static void spi_CfgconUnlockedWrite(uint32_t val);
+
+// *****************************************************************************
+// Section: PPS capability maps (verified DFP values)
+// *****************************************************************************
+
+/* MOSI: DIO channels whose pin can output SDO1 (RP<pin>R = 5). */
+static bool spi_MosiCapable(uint8_t dio) {
+    switch (dio) {
+        case 2: case 4: case 5: case 6: case 7: case 14: case 15:
+            return true;
+        default:
+            return false;
+    }
+}
+
+/* MISO: DIO channels whose pin is a group-1 SDI1 input, and the SDI1R
+ * value that selects them. Returns 0xFF for non-capable channels. */
+static uint8_t spi_MisoSdi1rValue(uint8_t dio) {
+    switch (dio) {
+        case 5:  return 4u;   /* RPF1 */
+        case 7:  return 12u;  /* RPG1 */
+        case 15: return 10u;  /* RPC1 */
+        default: return 0xFFu;
+    }
+}
+
+/* Address of a MOSI-capable DIO's SDO1 output-select register (NULL if the
+ * channel can't be MOSI). The caller writes 5 (SDO1) or 0 (no-connect). */
+static volatile uint32_t* spi_MosiRprAddr(uint8_t dio) {
+    switch (dio) {
+        case 2:  return &RPD3R;  /* RD3 */
+        case 4:  return &RPF0R;  /* RF0 */
+        case 5:  return &RPF1R;  /* RF1 */
+        case 6:  return &RPG0R;  /* RG0 */
+        case 7:  return &RPG1R;  /* RG1 */
+        case 14: return &RPE5R;  /* RE5 */
+        case 15: return &RPC1R;  /* RC1 */
+        default: return NULL;
+    }
+}
+
+// *****************************************************************************
+// Section: helpers
+// *****************************************************************************
+
+static uint8_t spi_Reverse8(uint8_t b) {
+    b = (uint8_t)(((b & 0xF0u) >> 4) | ((b & 0x0Fu) << 4));
+    b = (uint8_t)(((b & 0xCCu) >> 2) | ((b & 0x33u) << 2));
+    b = (uint8_t)(((b & 0xAAu) >> 1) | ((b & 0x55u) << 1));
+    return b;
+}
+
+/* Compute the BRG for a requested baud (same rounding as the Harmony SPI
+ * PLIBs) and the actual resulting SCK. */
+static uint32_t spi_ComputeBrg(uint32_t baudHz, uint32_t* actualOut) {
+    uint32_t src = USER_SPI_PBCLK_HZ;
+    uint32_t brg = ((src / baudHz) / 2u);
+    brg = (brg == 0u) ? 0u : (brg - 1u);
+    uint32_t baudHigh = src / (2u * (brg + 1u));
+    uint32_t baudLow  = src / (2u * (brg + 2u));
+    uint32_t errHigh  = (baudHigh > baudHz) ? (baudHigh - baudHz) : (baudHz - baudHigh);
+    uint32_t errLow   = (baudHz > baudLow)  ? (baudHz - baudLow)  : (baudLow - baudHz);
+    if (errHigh > errLow) {
+        brg++;
+    }
+    if (brg > 8191u) {
+        brg = 8191u;
+    }
+    if (actualOut != NULL) {
+        *actualOut = src / (2u * (brg + 1u));
+    }
+    return brg;
+}
+
+/* Map / unmap SDO1 + SDI1 through PPS. Clears RPD1R so the dedicated SCK1
+ * (not a remappable output) is the only driver on RD1/DIO0. */
+static void spi_ApplyPps(bool enable) {
+    /* PPS registers are gated by CFGCON.IOLOCK. Open it (DMA-suspended unlock),
+     * write the PPS map directly while it's open, then close it. DIO0/RD1: drop
+     * the remappable-output mux so the dedicated SCK1 owns the pad. */
+    spi_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_IOLOCK_MASK);
+
+    RPD1R = 0U;
+    volatile uint32_t *mosiRpr = spi_MosiRprAddr(gCfg.mosiDio);
+    if (mosiRpr != NULL) {
+        *mosiRpr = enable ? 5U : 0U;    /* SDO1=5, else no-connect */
+    }
+    SDI1R = (enable && gCfg.misoDio != USER_SPI_PIN_NONE)
+                ? spi_MisoSdi1rValue(gCfg.misoDio) : 0U;
+
+    spi_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_IOLOCK_MASK);
+}
+
+/* Perform a SYSKEY-unlocked write to CFGCON — the only SYSKEY-gated register
+ * the SPI feature touches, to toggle IOLOCK (PPS) / PMDLOCK (module power).
+ *
+ * This only reconfigures at runtime because IOL1WAY / PMDL1WAY are OFF (see
+ * config words in initialization.c); with the default one-way locks the plib
+ * init consumes the single allowed change and every later unlock is silently
+ * ignored. Interrupts are masked for the unlock so an ISR SFR access can't
+ * land between the key writes and the protected store and disarm the window
+ * (the same idiom plib_nvm.c uses for its runtime NVMKEY unlocks). */
+static void spi_CfgconUnlockedWrite(uint32_t val) {
+    uint32_t st = __builtin_disable_interrupts();
+    SYSKEY = 0x00000000U;
+    SYSKEY = 0xAA996655U;
+    SYSKEY = 0x556699AAU;
+    CFGCON = val;
+    SYSKEY = 0x33333333U;
+    __builtin_mtc0(12, 0, st);
+}
+
+/* Power the SPI1 module (clear its PMD bit). SPI1 is otherwise PMD-gated OFF
+ * (Harmony's CLK_Initialize disables unused peripherals) so every SPI1 SFR
+ * write is ignored. Clearing CFGCON.PMDLOCK opens PMD5 for a direct write. */
+static void spi_SetPmd(bool enable) {
+    spi_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_PMDLOCK_MASK);
+    if (enable) {
+        PMD5CLR = _PMD5_SPI1MD_MASK;
+    } else {
+        PMD5SET = _PMD5_SPI1MD_MASK;
+    }
+    spi_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_PMDLOCK_MASK);
+}
+
+static void spi_Spi1Init(void) {
+    uint8_t mode = gCfg.mode;
+    /* CKP = CPOL; CKE is inverted vs CPHA on PIC32. */
+    bool ckp = (mode & 0x2u) != 0u;
+    bool cke = (mode & 0x1u) == 0u;
+
+    SPI1CON = 0;                                   /* stop, reset, ON=0 */
+    (void)SPI1BUF;                                 /* drain RX */
+    SPI1STATCLR = _SPI1STAT_SPIROV_MASK;
+    SPI1BRG = spi_ComputeBrg(gCfg.baudHz, &gActualBaud);
+
+    uint32_t con = _SPI1CON_MSTEN_MASK;            /* master, 8-bit, ENHBUF=0 */
+    if (ckp) { con |= _SPI1CON_CKP_MASK; }
+    if (cke) { con |= _SPI1CON_CKE_MASK; }
+    SPI1CON = con;
+    SPI1CONSET = _SPI1CON_ON_MASK;
+}
+
+static bool spi_XferByte(uint8_t txByte, uint8_t* rxByte) {
+    SPI1BUF = txByte;
+    uint32_t guard = USER_SPI_XFER_TIMEOUT;
+    while ((SPI1STAT & _SPI1STAT_SPIRBF_MASK) == 0U) {
+        if (--guard == 0U) {
+            return false;
+        }
+    }
+    *rxByte = (uint8_t)SPI1BUF;
+    return true;
+}
+
+// *****************************************************************************
+// Section: public API
+// *****************************************************************************
+
+bool UserSpi_Configure(const UserSpiConfig_t* cfg, const char** err) {
+    const char* why = NULL;
+    if (cfg == NULL) {
+        why = "null config";
+    } else if (cfg->mode > 3u) {
+        why = "mode must be 0..3";
+    } else if (cfg->baudHz < USER_SPI_MIN_BAUD_HZ || cfg->baudHz > USER_SPI_MAX_BAUD_HZ) {
+        why = "baud out of range (6k..42M Hz)";
+    } else if (cfg->mosiDio != USER_SPI_PIN_NONE && !spi_MosiCapable(cfg->mosiDio)) {
+        why = "MOSI must be DIO 2,4,5,6,7,14,15";
+    } else if (cfg->misoDio != USER_SPI_PIN_NONE && spi_MisoSdi1rValue(cfg->misoDio) == 0xFFu) {
+        why = "MISO must be DIO 5,7,15";
+    } else if (cfg->csDio != USER_SPI_PIN_NONE && cfg->csDio >= 16u) {
+        why = "CS DIO out of range";
+    } else if (cfg->mosiDio == USER_SPI_PIN_NONE && cfg->misoDio == USER_SPI_PIN_NONE) {
+        why = "at least one of MOSI/MISO required";
+    }
+
+    /* Collisions: SCK is DIO0; no two roles may share a pin. */
+    if (why == NULL) {
+        uint8_t m = cfg->mosiDio, s = cfg->misoDio, c = cfg->csDio;
+        if (m == USER_SPI_SCK_DIO || s == USER_SPI_SCK_DIO || c == USER_SPI_SCK_DIO) {
+            why = "DIO0 is reserved for SCK";
+        } else if (m != USER_SPI_PIN_NONE && (m == s || m == c)) {
+            why = "MOSI pin collides with MISO/CS";
+        } else if (s != USER_SPI_PIN_NONE && s == c) {
+            why = "MISO pin collides with CS";
+        }
+    }
+
+    if (why != NULL) {
+        if (err != NULL) { *err = why; }
+        return false;
+    }
+
+    if (gEnabled) {
+        if (err != NULL) { *err = "disable SPI before reconfiguring"; }
+        return false;
+    }
+
+    gCfg = *cfg;
+    gHaveConfig = true;
+    return true;
+}
+
+bool UserSpi_GetConfig(UserSpiConfig_t* out) {
+    if (out == NULL || !gHaveConfig) {
+        return false;
+    }
+    *out = gCfg;
+    return true;
+}
+
+/* True if a pin is unavailable to claim — owned by the probe/another
+ * peripheral, or currently driving a PWM output. */
+static bool spi_PinInUse(uint8_t dio) {
+    return (DIO_ChannelBlockedReason(dio) != NULL) || DIO_IsPwmActive(dio);
+}
+
+bool UserSpi_Enable(const char** err) {
+    if (!gHaveConfig) {
+        if (err != NULL) { *err = "no SPI config set"; }
+        return false;
+    }
+    if (gEnabled) {
+        return true;
+    }
+
+    /* Pre-check every needed pin before claiming any, so a failure leaves
+     * nothing half-claimed. */
+    if (spi_PinInUse(USER_SPI_SCK_DIO)) {
+        if (err != NULL) { *err = "SCK/DIO0 in use (probe or PWM ch0) — free it first"; }
+        return false;
+    }
+    if (gCfg.mosiDio != USER_SPI_PIN_NONE && spi_PinInUse(gCfg.mosiDio)) {
+        if (err != NULL) { *err = "MOSI pin in use (probe/peripheral/PWM)"; }
+        return false;
+    }
+    if (gCfg.misoDio != USER_SPI_PIN_NONE && spi_PinInUse(gCfg.misoDio)) {
+        if (err != NULL) { *err = "MISO pin in use (probe/peripheral/PWM)"; }
+        return false;
+    }
+    if (gCfg.csDio != USER_SPI_PIN_NONE && spi_PinInUse(gCfg.csDio)) {
+        if (err != NULL) { *err = "CS pin in use (probe/peripheral/PWM)"; }
+        return false;
+    }
+
+    /* Claim in order; unwind on any (racing) failure. */
+    uint8_t claimed[4];
+    int nClaimed = 0;
+    #define SPI_TRY_CLAIM(ch) do {                                   \
+        if (!DIO_ClaimChannel((ch), DIO_OWNER_SPI)) {                \
+            while (nClaimed > 0) {                                   \
+                DIO_ReleaseChannel(claimed[--nClaimed], DIO_OWNER_SPI); \
+            }                                                        \
+            if (err != NULL) { *err = "pin claim failed (raced)"; }  \
+            return false;                                            \
+        }                                                            \
+        claimed[nClaimed++] = (ch);                                  \
+    } while (0)
+
+    SPI_TRY_CLAIM(USER_SPI_SCK_DIO);
+    if (gCfg.mosiDio != USER_SPI_PIN_NONE) { SPI_TRY_CLAIM(gCfg.mosiDio); }
+    if (gCfg.misoDio != USER_SPI_PIN_NONE) { SPI_TRY_CLAIM(gCfg.misoDio); }
+    if (gCfg.csDio  != USER_SPI_PIN_NONE)  { SPI_TRY_CLAIM(gCfg.csDio); }
+    #undef SPI_TRY_CLAIM
+
+    /* PPS map, then set buffer directions, then start SPI1. */
+    spi_ApplyPps(true);
+
+    DIO_SetChannelPeripheralOutput(USER_SPI_SCK_DIO);
+    if (gCfg.mosiDio != USER_SPI_PIN_NONE) {
+        DIO_SetChannelPeripheralOutput(gCfg.mosiDio);
+    }
+    if (gCfg.misoDio != USER_SPI_PIN_NONE) {
+        DIO_SetChannelPeripheralInput(gCfg.misoDio);
+    }
+    if (gCfg.csDio != USER_SPI_PIN_NONE) {
+        DIO_SetChannelPeripheralOutput(gCfg.csDio);
+        DIO_DriveChannel(gCfg.csDio, true);   /* CS idle high (deasserted) */
+    }
+
+    spi_SetPmd(true);    /* power the SPI1 module before touching its SFRs */
+    spi_Spi1Init();
+    gEnabled = true;
+    return true;
+}
+
+bool UserSpi_Disable(void) {
+    if (!gEnabled) {
+        return true;
+    }
+    SPI1CON = 0;               /* SPI1 off (module stays PMD-powered from boot) */
+    spi_ApplyPps(false);       /* unmap SDO1/SDI1, leave RPD1R cleared */
+
+    /* Release claims, then restore each channel's runtime DIO state. */
+    DIO_ReleaseChannel(USER_SPI_SCK_DIO, DIO_OWNER_SPI);
+    DIO_RestoreChannel(USER_SPI_SCK_DIO);
+    if (gCfg.mosiDio != USER_SPI_PIN_NONE) {
+        DIO_ReleaseChannel(gCfg.mosiDio, DIO_OWNER_SPI);
+        DIO_RestoreChannel(gCfg.mosiDio);
+    }
+    if (gCfg.misoDio != USER_SPI_PIN_NONE) {
+        DIO_ReleaseChannel(gCfg.misoDio, DIO_OWNER_SPI);
+        DIO_RestoreChannel(gCfg.misoDio);
+    }
+    if (gCfg.csDio != USER_SPI_PIN_NONE) {
+        DIO_ReleaseChannel(gCfg.csDio, DIO_OWNER_SPI);
+        DIO_RestoreChannel(gCfg.csDio);
+    }
+
+    gEnabled = false;
+    gActualBaud = 0;
+    return true;
+}
+
+bool UserSpi_IsEnabled(void) {
+    return gEnabled;
+}
+
+bool UserSpi_Transfer(const uint8_t* tx, uint8_t* rx, uint16_t len) {
+    if (!gEnabled || len == 0u || len > USER_SPI_MAX_FRAME) {
+        return false;
+    }
+
+    bool haveCs = (gCfg.csDio != USER_SPI_PIN_NONE);
+    if (haveCs) {
+        DIO_DriveChannel(gCfg.csDio, false);   /* assert (active low) */
+    }
+
+    bool ok = true;
+    for (uint16_t i = 0; i < len; ++i) {
+        uint8_t t = (tx != NULL) ? tx[i] : 0xFFu;
+        if (gCfg.lsbFirst) { t = spi_Reverse8(t); }
+        uint8_t r = 0;
+        if (!spi_XferByte(t, &r)) {
+            ok = false;
+            break;
+        }
+        if (rx != NULL) {
+            rx[i] = gCfg.lsbFirst ? spi_Reverse8(r) : r;
+        }
+    }
+
+    if (haveCs) {
+        DIO_DriveChannel(gCfg.csDio, true);    /* deassert */
+    }
+    return ok;
+}
+
+uint32_t UserSpi_GetActualBaud(void) {
+    return gEnabled ? gActualBaud : 0u;
+}

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -343,6 +343,14 @@ static bool spi_EnableLocked(const char** err) {
     /* PPS map, then set buffer directions, then start SPI1. */
     spi_ApplyPps(true);
 
+    /* Pre-drive SCK to its CKP idle level BEFORE enabling its output buffer, so
+     * the terminal never sees a spurious clock edge when spi_Spi1Init drives SCK
+     * to idle below. SCK (DIO0/RD1) is exposed as a LAT-driven GPIO output while
+     * SPI1 is still OFF, so a prior LAT differing from the CKP idle would glitch
+     * the pad at ON=1 — and a no-CS slave (csDio=-1) with CS tied active would
+     * clock that edge as a bit, slipping the first frame. Mirror of the CS idle
+     * pre-drive below; CKP = mode bit 1 (idle high when set). */
+    DIO_DriveChannel(USER_SPI_SCK_DIO, (gCfg.mode & 0x2u) != 0u);
     DIO_SetChannelPeripheralOutput(USER_SPI_SCK_DIO);
     if (gCfg.mosiDio != USER_SPI_PIN_NONE) {
         DIO_SetChannelPeripheralOutput(gCfg.mosiDio);

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -184,6 +184,10 @@ static void spi_CfgconUnlockedWrite(uint32_t val) {
  * (Harmony's CLK_Initialize disables unused peripherals) so every SPI1 SFR
  * write is ignored. Clearing CFGCON.PMDLOCK opens PMD5 for a direct write. */
 static void spi_SetPmd(bool enable) {
+    /* Indivisible like spi_ApplyPps: whole open -> PMD write -> close in one
+     * interrupt-disabled block so no other task's SYSKEY/PMD work interleaves
+     * and PMDLOCK is never left open to a preemptor. */
+    uint32_t st = __builtin_disable_interrupts();
     spi_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_PMDLOCK_MASK);
     if (enable) {
         PMD5CLR = _PMD5_SPI1MD_MASK;
@@ -191,6 +195,7 @@ static void spi_SetPmd(bool enable) {
         PMD5SET = _PMD5_SPI1MD_MASK;
     }
     spi_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_PMDLOCK_MASK);
+    __builtin_mtc0(12, 0, st);
 }
 
 static void spi_Spi1Init(void) {
@@ -403,6 +408,15 @@ static bool spi_TransferLocked(const uint8_t* tx, uint8_t* rx, uint16_t len) {
         }
         if (rx != NULL) {
             rx[i] = gCfg.lsbFirst ? spi_Reverse8(r) : r;
+        }
+    }
+
+    if (!ok) {
+        /* Per-byte timeout (SCK not toggling): drain any partial RX and clear
+         * the overflow flag so the next transfer starts from a clean FIFO. */
+        SPI1STATCLR = _SPI1STAT_SPIROV_MASK;
+        while ((SPI1STAT & _SPI1STAT_SPIRBF_MASK) != 0U) {
+            (void)SPI1BUF;
         }
     }
 

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -249,6 +249,14 @@ static bool spi_ConfigureLocked(const UserSpiConfig_t* cfg, const char** err) {
         why = "mode must be 0..3";
     } else if (cfg->baudHz < USER_SPI_MIN_BAUD_HZ || cfg->baudHz > USER_SPI_MAX_BAUD_HZ) {
         why = "baud out of range (6k..42M Hz)";
+    } else if (cfg->baudHz < (USER_SPI_PBCLK_HZ / (2u * 8192u))) {
+        /* Below the BRG-saturation SCK floor at this PBCLK: the 13-bit BRG
+         * clamps at 8191, so a lower request would be met with a SCK ABOVE it
+         * (overclock). Reject here so spi_ComputeBrg's "achieved <= requested"
+         * contract always holds. On the 84 MHz build the floor (~5.1 kHz) is
+         * below the 6 kHz min above, so this only bites the 100 MHz legacy
+         * clock (floor ~6.1 kHz). */
+        why = "baud below the PBCLK SCK floor";
     } else if (cfg->mosiDio != USER_SPI_PIN_NONE && !spi_MosiCapable(cfg->mosiDio)) {
         why = "MOSI must be DIO 2,4,5,6,7,14,15";
     } else if (cfg->misoDio != USER_SPI_PIN_NONE && spi_MisoSdi1rValue(cfg->misoDio) == 0xFFu) {
@@ -409,7 +417,8 @@ static bool spi_TransferLocked(const uint8_t* tx, uint8_t* rx, uint16_t len) {
         return false;
     }
 
-    bool haveCs = (gCfg.csDio != USER_SPI_PIN_NONE);
+    bool haveCs   = (gCfg.csDio  != USER_SPI_PIN_NONE);
+    bool haveMiso = (gCfg.misoDio != USER_SPI_PIN_NONE);
     if (haveCs) {
         DIO_DriveChannel(gCfg.csDio, false);   /* assert (active low) */
     }
@@ -424,7 +433,11 @@ static bool spi_TransferLocked(const uint8_t* tx, uint8_t* rx, uint16_t len) {
             break;
         }
         if (rx != NULL) {
-            rx[i] = gCfg.lsbFirst ? spi_Reverse8(r) : r;
+            /* On a MOSI-only (write-only) bus no MISO pin is configured, yet
+             * SDI1R still selects a real PPS pin (input PPS has no no-connect
+             * encoding) whose read-back is arbitrary noise. Report the
+             * documented 0x00 for the no-MISO case instead of that pin's level. */
+            rx[i] = haveMiso ? (gCfg.lsbFirst ? spi_Reverse8(r) : r) : 0u;
         }
     }
 

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -16,13 +16,15 @@
 #include "definitions.h"
 #include "FreeRTOS.h"
 #include "semphr.h"
+#include "clock_config.h"
 #include "HAL/DIO.h"
 #include "Util/Logger.h"
 
-/* SPI1 source clock = PBCLK2. Post-#487 the peripheral bus runs at
- * SYSCLK/3 = 84 MHz (see the Clock Tree in CLAUDE.md). SPI_CLK =
- * PBCLK2 / (2*(BRG+1)). */
-#define USER_SPI_PBCLK_HZ   84000000UL
+/* SPI1 source clock = PBCLK2, taken from the project's single-source clock
+ * config so it tracks the DAQIFI_SYSCLK_252 toggle (84 MHz at 252 MHz sysclk,
+ * 100 MHz on the legacy 200 MHz build) rather than hardcoding one profile.
+ * SPI_CLK = PBCLK2 / (2*(BRG+1)). */
+#define USER_SPI_PBCLK_HZ   DAQIFI_PBCLK_HZ
 
 /* Per-byte polled-transfer spin bound. Sized to cover the slowest byte
  * (8 bits at USER_SPI_MIN_BAUD_HZ ~= 1.3 ms) with wide margin at the

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -119,15 +119,22 @@ static uint8_t spi_Reverse8(uint8_t b) {
  * PLIBs) and the actual resulting SCK. */
 static uint32_t spi_ComputeBrg(uint32_t baudHz, uint32_t* actualOut) {
     uint32_t src = USER_SPI_PBCLK_HZ;
-    uint32_t brg = ((src / baudHz) / 2u);
-    brg = (brg == 0u) ? 0u : (brg - 1u);
-    uint32_t baudHigh = src / (2u * (brg + 1u));
-    uint32_t baudLow  = src / (2u * (brg + 2u));
-    uint32_t errHigh  = (baudHigh > baudHz) ? (baudHigh - baudHz) : (baudHz - baudHigh);
-    uint32_t errLow   = (baudHz > baudLow)  ? (baudHz - baudLow)  : (baudLow - baudHz);
-    if (errHigh > errLow) {
-        brg++;
+    /* Round the SPI clock DOWN, never up: the achieved SCK must not exceed the
+     * requested baud. spi_ConfigureLocked validates only the *requested* rate
+     * against USER_SPI_MAX_BAUD_HZ, so a round-to-nearest that lands above the
+     * request would silently overclock a slave rated for the requested max
+     * (data corruption). SCK = src / (2*(BRG+1)), so the smallest divisor
+     * giving SCK <= baud is ceil(src / (2*baud)) = BRG+1. baudHz is validated
+     * >= USER_SPI_MIN_BAUD_HZ upstream, so 2*baud never overflows uint32 (baud
+     * <= 42 MHz) and is non-zero. The BRG clamp only bites below the hardware
+     * SCK floor (~5.1 kHz at 84 MHz), which the 6 kHz min baud keeps requests
+     * above — so actual <= baud always holds. */
+    uint32_t twoBaud = 2u * baudHz;
+    uint32_t divisor = (src + twoBaud - 1u) / twoBaud;   /* ceil(src / (2*baud)) */
+    if (divisor == 0u) {
+        divisor = 1u;
     }
+    uint32_t brg = divisor - 1u;
     if (brg > 8191u) {
         brg = 8191u;
     }

--- a/firmware/src/HAL/UserSpi/UserSpi.h
+++ b/firmware/src/HAL/UserSpi/UserSpi.h
@@ -1,0 +1,106 @@
+/**
+ * @file UserSpi.h
+ * @brief User SPI1 master on the DIO terminal (#665, part of epic #664).
+ *
+ * Exposes the otherwise-unused SPI1 peripheral as a general-purpose master
+ * on the 16-pin user DIO terminal so digital sensors / MCUs / SBCs can be
+ * driven with `SYST:COMM:SPI:*`.
+ *
+ * Pin model (verified against the DFP PPS tables and DIO.SchDoc):
+ *   - SCK  = DIO0 (RD1) — SCK1 is a fixed/dedicated SPI1 function, not PPS
+ *            remappable. Enabling SPI1 master drives it; the competing
+ *            RPD1R output mux (PWM ch0 / OC1) is cleared so only SCK1 drives.
+ *   - MOSI = SDO1, PPS output — one of DIO {2,4,5,6,7,14,15} (RP<pin>R = 5).
+ *   - MISO = SDI1, PPS input (group 1 only) — one of DIO {5,7,15}
+ *            (SDI1R = the pin's RPn code).
+ *   - CS   = any free DIO driven as a software GPIO (active low), or none.
+ *
+ * Electrical: outputs (SCK/MOSI/CS) swing at the +5V_D buffer rail (mind
+ * 3.3 V-only slaves). MISO returns through the terminal's 100K series read
+ * resistor (~1-2 us RC), so full-duplex reads are bounded to roughly
+ * 100-500 kHz SCK regardless of the requested baud — write-only devices can
+ * clock faster. This driver ships the mechanism; the client picks the rate.
+ *
+ * Transfers are polled and bounded (no ISR) — sufficient for the
+ * command/response sensors this targets. The pins are claimed through the
+ * DIO ownership registry (DIO_ClaimChannel), so streaming and DIO:PORt
+ * won't stomp the bus and PWM on an overlapping channel is refused.
+ */
+#ifndef USER_SPI_H
+#define USER_SPI_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** SCK is always DIO0 (fixed SCK1). */
+#define USER_SPI_SCK_DIO    0u
+/** Sentinel for an unused MOSI/MISO/CS data line. */
+#define USER_SPI_PIN_NONE   0xFFu
+
+/** Default SCK when a config omits a baud (RC-safe for MISO reads). */
+#define USER_SPI_DEFAULT_BAUD_HZ   100000u
+
+/** Requested-baud bounds. Silicon max is 42 MHz (BRG=0); the practical
+ *  floor is PBCLK2/(2*8192). The client is responsible for staying within
+ *  the MISO RC limit when a MISO pin is used. */
+#define USER_SPI_MIN_BAUD_HZ   6000u
+#define USER_SPI_MAX_BAUD_HZ   42000000u
+
+/** Immutable-per-session SPI configuration. */
+typedef struct {
+    uint8_t  mosiDio;   /**< MOSI DIO channel, or USER_SPI_PIN_NONE */
+    uint8_t  misoDio;   /**< MISO DIO channel, or USER_SPI_PIN_NONE */
+    uint8_t  csDio;     /**< active-low CS DIO channel, or USER_SPI_PIN_NONE */
+    uint32_t baudHz;    /**< requested SCK frequency */
+    uint8_t  mode;      /**< SPI mode 0..3 (CPOL/CPHA) */
+    bool     lsbFirst;  /**< true = LSB-first (software bit-reversed) */
+} UserSpiConfig_t;
+
+/**
+ * Validate and store a configuration. Does NOT touch hardware — apply it
+ * with UserSpi_Enable. Rejected (returns false, with a reason in @p err if
+ * non-NULL) if a pin is out of range, MOSI/MISO is not PPS-capable for that
+ * role, pins collide, the mode is >3, or the baud is out of range.
+ * @param cfg configuration to validate/store (copied internally).
+ * @param err optional out: static reason string on failure.
+ */
+bool UserSpi_Configure(const UserSpiConfig_t* cfg, const char** err);
+
+/** Copy the current stored configuration. @return false if none set yet. */
+bool UserSpi_GetConfig(UserSpiConfig_t* out);
+
+/**
+ * Apply the stored configuration: claim the pins, PPS-map SDO1/SDI1, clear
+ * the SCK output-mux contention, set the buffer directions, and start SPI1.
+ * Fails (returns false, reason in @p err) if no config is set, a pin is
+ * already owned/probe-claimed, or PWM is active on a needed channel.
+ */
+bool UserSpi_Enable(const char** err);
+
+/** Stop SPI1, unmap PPS, release the pins, and restore their DIO state. */
+bool UserSpi_Disable(void);
+
+/** True while SPI1 is enabled and owns its pins. */
+bool UserSpi_IsEnabled(void);
+
+/**
+ * Full-duplex transfer of @p len bytes. CS (if configured) is asserted for
+ * the whole frame. @p rx may be NULL (write-only) or alias @p tx (in place);
+ * @p tx may be NULL (read-only — 0xFF clocked out). MISO with no slave reads
+ * 0x00 (terminal pulled down through 180K).
+ * @return false on a per-byte hardware timeout or if not enabled.
+ */
+bool UserSpi_Transfer(const uint8_t* tx, uint8_t* rx, uint16_t len);
+
+/** Actual SCK frequency after BRG rounding (0 if not enabled). */
+uint32_t UserSpi_GetActualBaud(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USER_SPI_H */

--- a/firmware/src/Util/StreamingBufferPool.c
+++ b/firmware/src/Util/StreamingBufferPool.c
@@ -8,8 +8,12 @@
 
 /* Static pool array — lives in BSS, not heap. No fragmentation risk,
  * no malloc, no fatal hook. Size must fit in RAM alongside .data,
- * FreeRTOS heap (75KB), and coherent pool (92KB). */
-#define STATIC_POOL_SIZE (194U * 1024U)
+ * FreeRTOS heap (75KB), and coherent pool (92KB).
+ * Trimmed 1KB from 194KB (#665) to make room for the DIO-peripheral epic's
+ * static footprint (SPI1 mutex + DIO ownership registry) — the device was at
+ * the RAM edge and the extra statics overflowed the main stack region. 1KB is
+ * ~13 samples off the stream-time partition; negligible to throughput. */
+#define STATIC_POOL_SIZE ((194U * 1024U) - 1024U)
 static uint8_t gPoolStorage[STATIC_POOL_SIZE];
 
 /* The overcommit fallback below carves these four minimums and expects the

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -116,9 +116,9 @@
 // Note: Define ENABLE_ICSP_REALTIME_LOG=1 in project settings to enable debug logging
 // REJECT MCC MERGE ATTEMPTS TO REPLACE THIS CONDITIONAL LOGIC!
 #if defined(ENABLE_ICSP_REALTIME_LOG) && (ENABLE_ICSP_REALTIME_LOG == 1)
-    #pragma config PGL1WAY =    OFF  // Allow multiple Peripheral Pin Select reconfigurations
+    #pragma config PGL1WAY =    OFF  // Allow multiple Permission Group Lock reconfigurations
     #pragma config PMDL1WAY =   OFF  // Allow multiple Peripheral Module Disable reconfigurations
-    #pragma config IOL1WAY =    OFF  // Allow multiple I/O lock reconfigurations
+    #pragma config IOL1WAY =    OFF  // Allow multiple I/O (PPS) lock reconfigurations
     #warning "Config lock bits disabled for ICSP logging - DO NOT RELEASE TO PRODUCTION"
 #else
     // #664/#665: user digital-sensor peripherals on the DIO terminal need

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -121,9 +121,14 @@
     #pragma config IOL1WAY =    OFF  // Allow multiple I/O lock reconfigurations
     #warning "Config lock bits disabled for ICSP logging - DO NOT RELEASE TO PRODUCTION"
 #else
-    #pragma config PGL1WAY =    ON   // Peripheral Pin Select one-way lock
-    #pragma config PMDL1WAY =   ON   // Peripheral Module Disable one-way lock
-    #pragma config IOL1WAY =    ON   // I/O one-way lock
+    // #664/#665: user digital-sensor peripherals on the DIO terminal need
+    // RUNTIME PPS + PMD reconfiguration (remap SDO1/SDI1, power SPI1, etc.).
+    // The one-way locks would freeze both after the plib init, so they are
+    // OFF. The DIO ownership registry (HAL/DIO.c) gates which subsystem may
+    // touch each pin, replacing the coarse one-way-lock security posture.
+    #pragma config PGL1WAY =    OFF  // Allow multiple Peripheral Pin Select reconfigurations
+    #pragma config PMDL1WAY =   OFF  // Allow multiple Peripheral Module Disable reconfigurations
+    #pragma config IOL1WAY =    OFF  // Allow multiple I/O lock reconfigurations
 #endif
 #pragma config FUSBIDIO =   OFF
 

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -122,11 +122,13 @@
     #warning "Config lock bits disabled for ICSP logging - DO NOT RELEASE TO PRODUCTION"
 #else
     // #664/#665: user digital-sensor peripherals on the DIO terminal need
-    // RUNTIME PPS + PMD reconfiguration (remap SDO1/SDI1, power SPI1, etc.).
-    // The one-way locks would freeze both after the plib init, so they are
-    // OFF. The DIO ownership registry (HAL/DIO.c) gates which subsystem may
-    // touch each pin, replacing the coarse one-way-lock security posture.
-    #pragma config PGL1WAY =    OFF  // Allow multiple Peripheral Pin Select reconfigurations
+    // RUNTIME reconfiguration of PPS (IOLOCK) and peripheral power (PMDLOCK) —
+    // remap SDO1/SDI1, power SPI1, etc. — which the one-way locks would freeze
+    // after the plib init. We don't rely on these locks as a security boundary,
+    // so this is just: relax the two the feature needs and leave the unrelated
+    // PGL1WAY (permission-group lock) at its default. Which subsystem may drive
+    // each pin is gated by the DIO ownership registry (HAL/DIO.c).
+    #pragma config PGL1WAY =    ON   // unrelated to PPS/PMD — left at default
     #pragma config PMDL1WAY =   OFF  // Allow multiple Peripheral Module Disable reconfigurations
     #pragma config IOL1WAY =    OFF  // Allow multiple I/O lock reconfigurations
 #endif

--- a/firmware/src/services/SCPI/SCPIDIO.c
+++ b/firmware/src/services/SCPI/SCPIDIO.c
@@ -32,7 +32,7 @@ static scpi_result_t SCPI_GPIOSingleDirectionSet(uint8_t id, bool isInput);
  * @param mask A mask where each bit corresponds to the pin with the given id (BIT(1) == PIN(1))
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error
  */
-static scpi_result_t SCPI_GPIOMultiDirectionSet(uint32_t mask);
+static scpi_result_t SCPI_GPIOMultiDirectionSet(scpi_t * context, uint32_t mask);
 
 /**
  * Gets the direction of a single GPIO pin
@@ -62,7 +62,7 @@ static scpi_result_t SCPI_GPIOSingleStateSet(uint8_t id, bool value);
  * @param mask A mask where each bit corresponds to the pin with the given id (BIT(1) == PIN(1))
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error
  */
-static scpi_result_t SCPI_GPIOMultiStateSet(uint32_t mask);
+static scpi_result_t SCPI_GPIOMultiStateSet(scpi_t * context, uint32_t mask);
 
 /**
  * Gets the value of a single GPIO pin
@@ -133,7 +133,7 @@ scpi_result_t SCPI_GPIODirectionSet(scpi_t * context)
 
     if (!SCPI_ParamInt32(context, &param2, FALSE))
     {
-        return SCPI_GPIOMultiDirectionSet((uint32_t)~param1); // Interpret the input as a bit mask (invert because 1=output but we use isInput as the test)
+        return SCPI_GPIOMultiDirectionSet(context, (uint32_t)~param1); // Interpret the input as a bit mask (invert because 1=output but we use isInput as the test)
     }
     else
     {
@@ -197,7 +197,7 @@ scpi_result_t SCPI_GPIOStateSet(scpi_t * context)
 
     if (!SCPI_ParamInt32(context, &param2, FALSE))
     {
-        return SCPI_GPIOMultiStateSet((uint32_t)param1); // Interpret the input as a bit mask
+        return SCPI_GPIOMultiStateSet(context, (uint32_t)param1); // Interpret the input as a bit mask
     }
     else
     {
@@ -431,12 +431,8 @@ static scpi_result_t SCPI_GPIOSingleDirectionSet(uint8_t id, bool isInput)
     {
         return SCPI_RES_ERR;
     }
-    /* Skip probe/peripheral-owned channels — the mask form (DIO:PORT:DIR
-     * <mask>) reaches here without the single-channel ownership guard. */
-    if (DIO_ChannelBlocked(id))
-    {
-        return SCPI_RES_OK;
-    }
+    /* Pure writer: ownership is enforced by both callers (see
+     * SCPI_GPIOSingleStateSet) — a blocked channel never reaches here. */
     pRunTimeDIOChannels->Data[id].IsInput = isInput;
     if (!DIO_WriteStateSingle(id))
     {
@@ -446,24 +442,43 @@ static scpi_result_t SCPI_GPIOSingleDirectionSet(uint8_t id, bool isInput)
     return SCPI_RES_OK;
 }
 
-static scpi_result_t SCPI_GPIOMultiDirectionSet(uint32_t mask)
+static scpi_result_t SCPI_GPIOMultiDirectionSet(scpi_t * context, uint32_t mask)
 {
     size_t i = 0;
     scpi_result_t result = SCPI_RES_OK;
-    
-    DIORuntimeArray * pRunTimeDIOChannels = BoardRunTimeConfig_Get(         
+    uint32_t blockedMask = 0;
+
+    DIORuntimeArray * pRunTimeDIOChannels = BoardRunTimeConfig_Get(
                         BOARDRUNTIMECONFIG_DIO_CHANNELS);
-    
+
     // Obviously, this breaks down if we have more than 32 channels
-    for (i=0; i<pRunTimeDIOChannels->Size; ++i) 
+    for (i=0; i<pRunTimeDIOChannels->Size; ++i)
     {
+        /* Skip probe/peripheral-owned pins (see SCPI_GPIOMultiStateSet) — never
+         * stomp an owner's direction, and report the skip rather than silently
+         * succeeding. */
+        if (DIO_ChannelBlocked(i))
+        {
+            blockedMask |= (uint32_t)(1u << i);
+            continue;
+        }
         bool isInput = (mask & (1 << i));
         if (SCPI_GPIOSingleDirectionSet(i, isInput) == SCPI_RES_ERR)
         {
             result = SCPI_RES_ERR;
         }
     }
-    
+
+    if (blockedMask != 0)
+    {
+        char msg[72];
+        snprintf(msg, sizeof(msg),
+                 "DIO:DIR mask: skipped owned channels 0x%04X (in use by SPI/probe)",
+                 (unsigned)blockedMask);
+        SCPI_ExecutionError(context, msg);
+        result = SCPI_RES_ERR;
+    }
+
     return result;
 }
 
@@ -519,15 +534,10 @@ static scpi_result_t SCPI_GPIOSingleStateSet(uint8_t id, bool value)
     {
         return SCPI_RES_ERR;
     }
-    /* Skip a channel owned by the probe or a peripheral (SPI/#665, ...). The
-     * mask form (DIO:PORT:STATe <mask>) reaches here WITHOUT the per-channel
-     * ownership guard the single-channel form applies upstream; silently
-     * rewriting an owned CS/data pin's runtime Value would surface as the
-     * wrong level once the owner releases the pin (DIO_RestoreChannel). */
-    if (DIO_ChannelBlocked(id))
-    {
-        return SCPI_RES_OK;
-    }
+    /* Pure writer: ownership is enforced by both callers — the single form
+     * (SCPI_GPIOStateSet) rejects blocked channels upstream and names the
+     * owner; the mask form (SCPI_GPIOMultiStateSet) skips them before calling
+     * here. So a blocked channel never reaches this point. */
     pRunTimeDIOChannels->Data[id].Value = value;
     if (!DIO_WriteStateSingle(id))
     {
@@ -538,24 +548,48 @@ static scpi_result_t SCPI_GPIOSingleStateSet(uint8_t id, bool value)
 }
  
 
-static scpi_result_t SCPI_GPIOMultiStateSet(uint32_t mask)
+static scpi_result_t SCPI_GPIOMultiStateSet(scpi_t * context, uint32_t mask)
 {
     size_t i = 0;
     scpi_result_t result = SCPI_RES_OK;
-    
-    DIORuntimeArray * pRunTimeDIOChannels = BoardRunTimeConfig_Get(         
+    uint32_t blockedMask = 0;
+
+    DIORuntimeArray * pRunTimeDIOChannels = BoardRunTimeConfig_Get(
                         BOARDRUNTIMECONFIG_DIO_CHANNELS);
-    
+
     // Obviously, this breaks down if we have more than 32 channels
-    for (i=0; i<pRunTimeDIOChannels->Size; ++i) 
+    for (i=0; i<pRunTimeDIOChannels->Size; ++i)
     {
+        /* The mask form bypasses the per-channel ownership guard the single
+         * form applies upstream. Skip probe/peripheral-owned pins (SPI/#665) so
+         * we never stomp their runtime Value, but record them — the command
+         * must NOT silently succeed while ignoring claimed pins (contract:
+         * DIO:PORt setters reject claimed channels). */
+        if (DIO_ChannelBlocked(i))
+        {
+            blockedMask |= (uint32_t)(1u << i);
+            continue;
+        }
         bool value = (mask & (1 << i));
         if (SCPI_GPIOSingleStateSet(i, value) == SCPI_RES_ERR)
         {
             result = SCPI_RES_ERR;
         }
     }
-    
+
+    if (blockedMask != 0)
+    {
+        /* Push ONE execution error per command (not per channel) naming the
+         * skipped pins — surfaces via SYST:ERR? like the single form, and can't
+         * flood the log on a repeated mask poll. */
+        char msg[72];
+        snprintf(msg, sizeof(msg),
+                 "DIO:STATE mask: skipped owned channels 0x%04X (in use by SPI/probe)",
+                 (unsigned)blockedMask);
+        SCPI_ExecutionError(context, msg);
+        result = SCPI_RES_ERR;
+    }
+
     return result;
 }
 

--- a/firmware/src/services/SCPI/SCPIDIO.c
+++ b/firmware/src/services/SCPI/SCPIDIO.c
@@ -168,7 +168,10 @@ scpi_result_t SCPI_GPIODirectionGet(scpi_t * context)
     else
     {
         bool result = false;
+        /* Reject a read of an owned pin the same way the setter dispatch does —
+         * consistent with SCPI_GPIODirectionSet (see SCPI_GPIOStateGet). */
         if (!DIO_SingleChannelIndexValid(context, param1) ||  // #671: reject before truncation
+            SCPI_DioChannelBlocked(context, param1, "DIO:DIR?") ||
             SCPI_GPIOSingleDirectionGet((uint8_t)param1, &result) == SCPI_RES_ERR)
         {
             retCode = SCPI_RES_ERR;
@@ -232,7 +235,13 @@ scpi_result_t SCPI_GPIOStateGet(scpi_t * context)
     else
     {
         bool result = false;
+        /* Reject a read of an owned pin (SPI/probe/...) the same way the setter
+         * dispatch does — an owned bus line has no meaningful DIO logic level,
+         * and the read path strips it to 0, misreporting a driven-high pin
+         * (e.g. an idle-high CS) as 0. Error + name the owner (a config problem,
+         * per the SCPI data-visibility rule), consistent with SCPI_GPIOStateSet. */
         if (!DIO_SingleChannelIndexValid(context, param1) ||  // #671: reject before truncation
+            SCPI_DioChannelBlocked(context, param1, "DIO:STATE?") ||
             SCPI_GPIOSingleStateGet((uint8_t)param1, &result) == SCPI_RES_ERR)
         {
             retCode = SCPI_RES_ERR;

--- a/firmware/src/services/SCPI/SCPIDIO.c
+++ b/firmware/src/services/SCPI/SCPIDIO.c
@@ -606,29 +606,33 @@ static scpi_result_t SCPI_PWMSingleStateSet(uint8_t id, bool value)
         return SCPI_RES_ERR;
     }
     /* Snapshot so a blocked write rolls BOTH fields back to their pre-call
-     * state (not just IsPwmActive). */
+     * state (not just IsPwmActive). The whole transition — the transient
+     * Value/IsPwmActive write, the hardware program, and any rollback — runs in
+     * one critical section so a concurrent DIO_ClaimChannel on the other SCPI
+     * interface (USB pri 7 can preempt WiFi pri 2 mid-sequence) can never
+     * observe a transient IsPwmActive that this call later rolls back. Pairs
+     * with the critical section in DIO_ClaimChannel to make SPI-vs-PWM
+     * arbitration atomic in both directions (the fields are an RMW on a struct
+     * that claim reads — the project atomicity rule requires the guard).
+     * DIO_PWMWriteStateSingle is bounded register work (OCMP enable/disable +
+     * PPS remap, no loops/delays), so the section stays short (~1-2 us). */
+    taskENTER_CRITICAL();
     bool prevValue = pRunTimeDIOChannels->Data[id].Value;
     bool prevPwm   = pRunTimeDIOChannels->Data[id].IsPwmActive;
-    if(value){
-        pRunTimeDIOChannels->Data[id].Value=1;
-        pRunTimeDIOChannels->Data[id].IsPwmActive=1;
-    }
-    else{
-        pRunTimeDIOChannels->Data[id].Value=0;
-        pRunTimeDIOChannels->Data[id].IsPwmActive=0;
-    }
-    if (!DIO_PWMWriteStateSingle(id))
-    {
+    pRunTimeDIOChannels->Data[id].Value       = value ? 1 : 0;
+    pRunTimeDIOChannels->Data[id].IsPwmActive = value ? 1 : 0;
+    bool applied = DIO_PWMWriteStateSingle(id);
+    if (!applied) {
         /* Blocked — e.g. the pin was claimed by a peripheral (SPI) in a
          * concurrent cross-interface race, so DIO_PWMWriteStateSingle refused
          * to reprogram it. Roll BOTH runtime fields back: a lying IsPwmActive
          * would block the channel's DIO restore + later claims, and a stale
          * Value would drive an unintended static level once the block clears
          * and DIO_WriteStateSingle resumes for this channel. */
-        pRunTimeDIOChannels->Data[id].Value = prevValue;
+        pRunTimeDIOChannels->Data[id].Value       = prevValue;
         pRunTimeDIOChannels->Data[id].IsPwmActive = prevPwm;
-        return SCPI_RES_ERR;
     }
-    return SCPI_RES_OK;
+    taskEXIT_CRITICAL();
+    return applied ? SCPI_RES_OK : SCPI_RES_ERR;
 }
 

--- a/firmware/src/services/SCPI/SCPIDIO.c
+++ b/firmware/src/services/SCPI/SCPIDIO.c
@@ -602,6 +602,12 @@ static scpi_result_t SCPI_PWMSingleStateSet(uint8_t id, bool value)
     }
     if (!DIO_PWMWriteStateSingle(id))
     {
+        /* Blocked — e.g. the pin was claimed by a peripheral (SPI) in a
+         * concurrent cross-interface race, so DIO_PWMWriteStateSingle refused
+         * to reprogram it. Don't leave IsPwmActive lying set for a channel PWM
+         * isn't actually driving (it would also wrongly block that channel's
+         * normal DIO restore and a later peripheral claim). */
+        pRunTimeDIOChannels->Data[id].IsPwmActive = 0;
         return SCPI_RES_ERR;
     }
     return SCPI_RES_OK;

--- a/firmware/src/services/SCPI/SCPIDIO.c
+++ b/firmware/src/services/SCPI/SCPIDIO.c
@@ -471,10 +471,15 @@ static scpi_result_t SCPI_GPIOMultiDirectionSet(scpi_t * context, uint32_t mask)
 
     if (blockedMask != 0)
     {
-        char msg[72];
+        /* Name the ACTUAL owner of the first skipped channel (registry has
+         * SPI/I2C/UART/1-Wire/... + probe) rather than a fixed string. */
+        uint8_t firstCh = (uint8_t)__builtin_ctz(blockedMask);
+        const char* owner = DIO_ChannelBlockedReason(firstCh);
+        char msg[112];
         snprintf(msg, sizeof(msg),
-                 "DIO:DIR mask: skipped owned channels 0x%04X (in use by SPI/probe)",
-                 (unsigned)blockedMask);
+                 "DIO:DIR mask: skipped owned channels 0x%04X (ch %u in use by %s)",
+                 (unsigned)blockedMask, (unsigned)firstCh,
+                 owner ? owner : "peripheral/probe");
         SCPI_ExecutionError(context, msg);
         result = SCPI_RES_ERR;
     }
@@ -582,10 +587,16 @@ static scpi_result_t SCPI_GPIOMultiStateSet(scpi_t * context, uint32_t mask)
         /* Push ONE execution error per command (not per channel) naming the
          * skipped pins — surfaces via SYST:ERR? like the single form, and can't
          * flood the log on a repeated mask poll. */
-        char msg[72];
+        /* Name the ACTUAL owner of the first skipped channel (registry has
+         * SPI/I2C/UART/1-Wire/... + probe) rather than a fixed string;
+         * blockedMask lists every skipped channel for follow-up. */
+        uint8_t firstCh = (uint8_t)__builtin_ctz(blockedMask);
+        const char* owner = DIO_ChannelBlockedReason(firstCh);
+        char msg[112];
         snprintf(msg, sizeof(msg),
-                 "DIO:STATE mask: skipped owned channels 0x%04X (in use by SPI/probe)",
-                 (unsigned)blockedMask);
+                 "DIO:STATE mask: skipped owned channels 0x%04X (ch %u in use by %s)",
+                 (unsigned)blockedMask, (unsigned)firstCh,
+                 owner ? owner : "peripheral/probe");
         SCPI_ExecutionError(context, msg);
         result = SCPI_RES_ERR;
     }

--- a/firmware/src/services/SCPI/SCPIDIO.c
+++ b/firmware/src/services/SCPI/SCPIDIO.c
@@ -18,7 +18,6 @@
 #include "state/board/BoardConfig.h"
 #include "state/runtime/BoardRuntimeConfig.h"
 #include "HAL/DIO.h"
-#include "HAL/DioProbe.h"
 #include "../../HAL/TimerApi/TimerApi.h"
 /**
  * Sets the GPIO direction for a single pin
@@ -108,6 +107,22 @@ static bool DIO_SingleChannelIndexValid(scpi_t *context, int channel)
     return false;
 }
 
+/* If @p channel is owned by the DIO probe or claimed by a peripheral
+ * (SPI/I2C/UART/...), push a SCPI execution error naming the owner and
+ * return true. The caller should then return SCPI_RES_ERR. Returns false
+ * if the channel is free for normal DIO/PWM control. (#664 ownership) */
+static bool SCPI_DioChannelBlocked(scpi_t * context, int channel, const char * op)
+{
+    const char* owner = DIO_ChannelBlockedReason((uint8_t)channel);
+    if (owner == NULL) {
+        return false;
+    }
+    char msg[64];
+    snprintf(msg, sizeof(msg), "%s: DIO ch %d in use by %s", op, channel, owner);
+    SCPI_ExecutionError(context, msg);
+    return true;
+}
+
 scpi_result_t SCPI_GPIODirectionSet(scpi_t * context)
 {
     int param1, param2;
@@ -125,8 +140,7 @@ scpi_result_t SCPI_GPIODirectionSet(scpi_t * context)
         if (!DIO_SingleChannelIndexValid(context, param1)) {
             return SCPI_RES_ERR; // #671: reject before (uint8_t) truncation
         }
-        if (DioProbe_IsChannelOwned((uint8_t)param1)) {
-            SCPI_ExecutionError(context, "DIO:DIR: channel owned by DIO probe");
+        if (SCPI_DioChannelBlocked(context, param1, "DIO:DIR")) {
             return SCPI_RES_ERR;
         }
         return SCPI_GPIOSingleDirectionSet((uint8_t)param1, !(bool)param2); // Interpret the input as a bit/direction pair (invert because 1=output but we use isInput as the test)
@@ -190,8 +204,7 @@ scpi_result_t SCPI_GPIOStateSet(scpi_t * context)
         if (!DIO_SingleChannelIndexValid(context, param1)) {
             return SCPI_RES_ERR; // #671: reject before (uint8_t) truncation
         }
-        if (DioProbe_IsChannelOwned((uint8_t)param1)) {
-            SCPI_ExecutionError(context, "DIO:STATE: channel owned by DIO probe");
+        if (SCPI_DioChannelBlocked(context, param1, "DIO:STATE")) {
             return SCPI_RES_ERR;
         }
         return SCPI_GPIOSingleStateSet((uint8_t)param1, (bool)param2); // Interpret the input as a bit/direction pair
@@ -277,8 +290,7 @@ scpi_result_t SCPI_PWMChannelEnableSet (scpi_t * context){
     if (!DIO_SingleChannelIndexValid(context, param1)) {
         return SCPI_RES_ERR; // #671: reject before (uint8_t) truncation
     }
-    if (DioProbe_IsChannelOwned((uint8_t)param1)) {
-        SCPI_ExecutionError(context, "DIO:PWM:ENA: channel owned by DIO probe");
+    if (SCPI_DioChannelBlocked(context, param1, "DIO:PWM:ENA")) {
         return SCPI_RES_ERR;
     }
 
@@ -329,8 +341,7 @@ scpi_result_t SCPI_PWMChannelFrequencySet(scpi_t * context){
         SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
         return SCPI_RES_ERR;
     }
-    if (DioProbe_IsChannelOwned((uint8_t)param1)) {
-        SCPI_ExecutionError(context, "DIO:PWM:FREQ: channel owned by DIO probe");
+    if (SCPI_DioChannelBlocked(context, param1, "DIO:PWM:FREQ")) {
         return SCPI_RES_ERR;
     }
     //only timer 3 is driving all the pwm so, channel independent frequency cannot be generated
@@ -381,8 +392,7 @@ scpi_result_t SCPI_PWMChannelDUTYSet(scpi_t * context){
     if(param2>100){
         return SCPI_RES_ERR;
     }
-    if (DioProbe_IsChannelOwned((uint8_t)param1)) {
-        SCPI_ExecutionError(context, "DIO:PWM:DUTY: channel owned by DIO probe");
+    if (SCPI_DioChannelBlocked(context, param1, "DIO:PWM:DUTY")) {
         return SCPI_RES_ERR;
     }
 

--- a/firmware/src/services/SCPI/SCPIDIO.c
+++ b/firmware/src/services/SCPI/SCPIDIO.c
@@ -592,6 +592,10 @@ static scpi_result_t SCPI_PWMSingleStateSet(uint8_t id, bool value)
     {
         return SCPI_RES_ERR;
     }
+    /* Snapshot so a blocked write rolls BOTH fields back to their pre-call
+     * state (not just IsPwmActive). */
+    bool prevValue = pRunTimeDIOChannels->Data[id].Value;
+    bool prevPwm   = pRunTimeDIOChannels->Data[id].IsPwmActive;
     if(value){
         pRunTimeDIOChannels->Data[id].Value=1;
         pRunTimeDIOChannels->Data[id].IsPwmActive=1;
@@ -604,10 +608,12 @@ static scpi_result_t SCPI_PWMSingleStateSet(uint8_t id, bool value)
     {
         /* Blocked — e.g. the pin was claimed by a peripheral (SPI) in a
          * concurrent cross-interface race, so DIO_PWMWriteStateSingle refused
-         * to reprogram it. Don't leave IsPwmActive lying set for a channel PWM
-         * isn't actually driving (it would also wrongly block that channel's
-         * normal DIO restore and a later peripheral claim). */
-        pRunTimeDIOChannels->Data[id].IsPwmActive = 0;
+         * to reprogram it. Roll BOTH runtime fields back: a lying IsPwmActive
+         * would block the channel's DIO restore + later claims, and a stale
+         * Value would drive an unintended static level once the block clears
+         * and DIO_WriteStateSingle resumes for this channel. */
+        pRunTimeDIOChannels->Data[id].Value = prevValue;
+        pRunTimeDIOChannels->Data[id].IsPwmActive = prevPwm;
         return SCPI_RES_ERR;
     }
     return SCPI_RES_OK;

--- a/firmware/src/services/SCPI/SCPIDIO.c
+++ b/firmware/src/services/SCPI/SCPIDIO.c
@@ -431,13 +431,18 @@ static scpi_result_t SCPI_GPIOSingleDirectionSet(uint8_t id, bool isInput)
     {
         return SCPI_RES_ERR;
     }
-    
+    /* Skip probe/peripheral-owned channels — the mask form (DIO:PORT:DIR
+     * <mask>) reaches here without the single-channel ownership guard. */
+    if (DIO_ChannelBlocked(id))
+    {
+        return SCPI_RES_OK;
+    }
     pRunTimeDIOChannels->Data[id].IsInput = isInput;
     if (!DIO_WriteStateSingle(id))
     {
         return SCPI_RES_ERR;
     }
-    
+
     return SCPI_RES_OK;
 }
 
@@ -507,20 +512,28 @@ static scpi_result_t SCPI_GPIOMultiDirectionGet(uint32_t* mask)
 
 static scpi_result_t SCPI_GPIOSingleStateSet(uint8_t id, bool value)
 {
-    DIORuntimeArray * pRunTimeDIOChannels = BoardRunTimeConfig_Get(         
+    DIORuntimeArray * pRunTimeDIOChannels = BoardRunTimeConfig_Get(
                         BOARDRUNTIMECONFIG_DIO_CHANNELS);
-    
+
     if ( id >= pRunTimeDIOChannels->Size)
     {
         return SCPI_RES_ERR;
     }
-    
+    /* Skip a channel owned by the probe or a peripheral (SPI/#665, ...). The
+     * mask form (DIO:PORT:STATe <mask>) reaches here WITHOUT the per-channel
+     * ownership guard the single-channel form applies upstream; silently
+     * rewriting an owned CS/data pin's runtime Value would surface as the
+     * wrong level once the owner releases the pin (DIO_RestoreChannel). */
+    if (DIO_ChannelBlocked(id))
+    {
+        return SCPI_RES_OK;
+    }
     pRunTimeDIOChannels->Data[id].Value = value;
     if (!DIO_WriteStateSingle(id))
     {
         return SCPI_RES_ERR;
     }
-    
+
     return SCPI_RES_OK;
 }
  

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5414,6 +5414,12 @@ static const scpi_command_t scpi_commands[] = {
     //
     {.pattern = "SYSTem:COMMunicate:LAN:GETChipInfo?", .callback = SCPI_LANGetChipInfo,},
     {.pattern = "SYSTem:COMMunicate:LAN:MDNS?", .callback = SCPI_LANMdnsDiagGet,},  // #58 mDNS diagnostics
+    // User SPI1 master on the DIO terminal (#665, epic #664)
+    {.pattern = "SYSTem:COMMunicate:SPI:CONFig", .callback = SCPI_SpiConfigSet,},
+    {.pattern = "SYSTem:COMMunicate:SPI:CONFig?", .callback = SCPI_SpiConfigGet,},
+    {.pattern = "SYSTem:COMMunicate:SPI:ENAble", .callback = SCPI_SpiEnableSet,},
+    {.pattern = "SYSTem:COMMunicate:SPI:ENAble?", .callback = SCPI_SpiEnableGet,},
+    {.pattern = "SYSTem:COMMunicate:SPI:TRANsfer?", .callback = SCPI_SpiTransfer,},
     // ADC
     {.pattern = "MEASure:VOLTage:DC?", .callback = SCPI_ADCVoltageGet,},
     {.pattern = "ENAble:VOLTage:DC", .callback = SCPI_ADCChanEnableSet,},

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -768,7 +768,18 @@ scpi_result_t SCPI_SpiConfigSet(scpi_t * context) {
         !SCPI_ParamInt32(context, &mode, TRUE)) {
         return SCPI_RES_ERR;   /* libscpi already pushed a parse error */
     }
-    (void)SCPI_ParamInt32(context, &order, FALSE);
+    /* Optional order param: if it is SUPPLIED it must be a valid integer, else
+     * reject the whole config. The old (void)SCPI_ParamInt32 discarded the
+     * parse result, so a bad 6th token (e.g. ...,0,BOGUS) pushed a DATA_TYPE
+     * error yet still committed the config with the default order. Mirror the
+     * SCPI_Parameter(FALSE)+SCPI_ParamToInt32 idiom used elsewhere. */
+    scpi_parameter_t orderParam;
+    if (SCPI_Parameter(context, &orderParam, FALSE)) {
+        if (!SCPI_ParamToInt32(context, &orderParam, &order)) {
+            return SCPI_RES_ERR;   /* present but not an integer (error already pushed) */
+        }
+    }
+    /* else: absent -> keep the MSB-first default (order = 0). */
 
     /* Reject out-of-range pin indices before the uint8_t narrowing so a
      * value like 258 can't alias onto DIO2. Negative = unused line. */
@@ -882,6 +893,17 @@ scpi_result_t SCPI_SpiTransfer(scpi_t * context) {
     const char* p = NULL;
     size_t len = 0;
     if (!SCPI_ParamCharacters(context, &p, &len, TRUE)) {
+        return SCPI_RES_ERR;
+    }
+    /* Exactly one (quoted) hex arg — reject any trailing parameter BEFORE we
+     * clock anything. Without this, unquoted comma-separated bytes
+     * ("TRAN? 9F,00,00") consume only 9F here and shift that truncated frame to
+     * the slave before libscpi rejects the leftover ",00,00". The documented
+     * form is one quoted token, e.g. "9F0000" (spi_ParseHex tolerates commas
+     * inside it). */
+    scpi_parameter_t extra;
+    if (SCPI_Parameter(context, &extra, FALSE)) {
+        SCPI_ExecutionError(context, "SPI:TRAN: one quoted hex arg only (e.g. \"9F0000\")");
         return SCPI_RES_ERR;
     }
     if (!UserSpi_IsEnabled()) {

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -895,16 +895,21 @@ scpi_result_t SCPI_SpiTransfer(scpi_t * context) {
     if (!SCPI_ParamCharacters(context, &p, &len, TRUE)) {
         return SCPI_RES_ERR;
     }
-    /* Exactly one (quoted) hex arg — reject any trailing parameter BEFORE we
-     * clock anything. Without this, unquoted comma-separated bytes
-     * ("TRAN? 9F,00,00") consume only 9F here and shift that truncated frame to
-     * the slave before libscpi rejects the leftover ",00,00". The documented
-     * form is one quoted token, e.g. "9F0000" (spi_ParseHex tolerates commas
-     * inside it). */
+    /* Exactly one (quoted) hex arg — reject ANY trailing token BEFORE we clock
+     * anything, else a truncated frame reaches the slave before the error
+     * surfaces. Two malformed shapes: comma-separated ("TRAN? 9F,00,00") parses
+     * a 2nd parameter (SCPI_Parameter returns TRUE); space-separated
+     * ("TRAN? \"9F\" 00") is an INVALID_SEPARATOR (SCPI_Parameter returns FALSE
+     * but queues an error — so also check SCPI_ParamErrorOccurred). The
+     * documented form is one quoted token, e.g. "9F0000" (spi_ParseHex tolerates
+     * commas inside it). */
     scpi_parameter_t extra;
     if (SCPI_Parameter(context, &extra, FALSE)) {
         SCPI_ExecutionError(context, "SPI:TRAN: one quoted hex arg only (e.g. \"9F0000\")");
         return SCPI_RES_ERR;
+    }
+    if (SCPI_ParamErrorOccurred(context)) {
+        return SCPI_RES_ERR;   /* trailing token with an invalid separator (error already queued) */
     }
     if (!UserSpi_IsEnabled()) {
         SCPI_ExecutionError(context, "SPI not enabled");

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -785,7 +785,7 @@ scpi_result_t SCPI_SpiConfigSet(scpi_t * context) {
     cfg.mosiDio  = spi_ScpiPinToDio(mosi);
     cfg.misoDio  = spi_ScpiPinToDio(miso);
     cfg.csDio    = spi_ScpiPinToDio(cs);
-    cfg.baudHz   = (baud <= 0) ? 0u : (uint32_t)baud;
+    cfg.baudHz   = (baud <= 0) ? USER_SPI_DEFAULT_BAUD_HZ : (uint32_t)baud;  /* 0/neg = safe default */
     cfg.mode     = (uint8_t)mode;
     cfg.lsbFirst = (order != 0);
 

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -23,6 +23,7 @@
 #include "services/wifi_services/wifi_manager.h"
 #include "services/wifi_services/mdns_responder.h"   // #58: mDNS diagnostics
 #include "services/SCPI/SCPIInterface.h"              // #58: shared response buffer
+#include "HAL/UserSpi/UserSpi.h"                      // #665: user SPI1 master
 #include "services/sd_card_services/sd_card_manager.h"
 
 
@@ -743,6 +744,184 @@ scpi_result_t SCPI_LANMdnsDiagGet(scpi_t * context) {
     scpi_result_t r = SCPI_LANStringGetImpl(context, buf);
     SCPI_ResponseBuf_Give();
     return r;
+}
+
+// =========================================================================
+// User SPI1 master (#665, epic #664) — SYST:COMM:SPI:*
+// =========================================================================
+
+/* Map a signed SCPI pin argument to a DIO channel or the "none" sentinel.
+ * Negative = unused line; anything > 15 is rejected by the caller to avoid
+ * a uint8_t truncation-alias (cf. #678). */
+static uint8_t spi_ScpiPinToDio(int32_t v) {
+    return (v < 0) ? USER_SPI_PIN_NONE : (uint8_t)v;
+}
+
+scpi_result_t SCPI_SpiConfigSet(scpi_t * context) {
+    int32_t mosi, miso, cs, baud, mode;
+    int32_t order = 0;   /* optional, default MSB-first */
+
+    if (!SCPI_ParamInt32(context, &mosi, TRUE) ||
+        !SCPI_ParamInt32(context, &miso, TRUE) ||
+        !SCPI_ParamInt32(context, &cs,   TRUE) ||
+        !SCPI_ParamInt32(context, &baud, TRUE) ||
+        !SCPI_ParamInt32(context, &mode, TRUE)) {
+        return SCPI_RES_ERR;   /* libscpi already pushed a parse error */
+    }
+    (void)SCPI_ParamInt32(context, &order, FALSE);
+
+    /* Reject out-of-range pin indices before the uint8_t narrowing so a
+     * value like 258 can't alias onto DIO2. Negative = unused line. */
+    if (mosi > 15 || miso > 15 || cs > 15) {
+        SCPI_ExecutionError(context, "SPI pin index out of range (-1..15)");
+        return SCPI_RES_ERR;
+    }
+    if (mode < 0 || mode > 3) {
+        SCPI_ExecutionError(context, "SPI mode must be 0..3");
+        return SCPI_RES_ERR;
+    }
+
+    UserSpiConfig_t cfg;
+    cfg.mosiDio  = spi_ScpiPinToDio(mosi);
+    cfg.misoDio  = spi_ScpiPinToDio(miso);
+    cfg.csDio    = spi_ScpiPinToDio(cs);
+    cfg.baudHz   = (baud <= 0) ? 0u : (uint32_t)baud;
+    cfg.mode     = (uint8_t)mode;
+    cfg.lsbFirst = (order != 0);
+
+    const char* err = NULL;
+    if (!UserSpi_Configure(&cfg, &err)) {
+        SCPI_ExecutionError(context, (err != NULL) ? err : "invalid SPI config");
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
+scpi_result_t SCPI_SpiConfigGet(scpi_t * context) {
+    UserSpiConfig_t cfg;
+    if (!UserSpi_GetConfig(&cfg)) {
+        SCPI_ExecutionError(context, "no SPI config set");
+        return SCPI_RES_ERR;
+    }
+    char *buf = (char *)SCPI_ResponseBuf_Take();
+    if (buf == NULL) {
+        return SCPI_RES_ERR;
+    }
+    int mosi = (cfg.mosiDio == USER_SPI_PIN_NONE) ? -1 : (int)cfg.mosiDio;
+    int miso = (cfg.misoDio == USER_SPI_PIN_NONE) ? -1 : (int)cfg.misoDio;
+    int cs   = (cfg.csDio   == USER_SPI_PIN_NONE) ? -1 : (int)cfg.csDio;
+    snprintf(buf, SCPI_RESPONSE_BUF_SIZE,
+             "{\"Sck\":0,\"Mosi\":%d,\"Miso\":%d,\"Cs\":%d,\"Baud\":%lu,"
+             "\"Mode\":%d,\"LsbFirst\":%d,\"Enabled\":%d,\"ActualBaud\":%lu}\n",
+             mosi, miso, cs, (unsigned long)cfg.baudHz,
+             (int)cfg.mode, (int)cfg.lsbFirst,
+             (int)UserSpi_IsEnabled(), (unsigned long)UserSpi_GetActualBaud());
+    /* SCPI_ResultMnemonic emits the JSON raw (no SCPI string-quoting), so
+     * clients get parseable JSON — matching the mDNS diagnostic convention. */
+    SCPI_ResultMnemonic(context, buf);
+    SCPI_ResponseBuf_Give();
+    return SCPI_RES_OK;
+}
+
+scpi_result_t SCPI_SpiEnableSet(scpi_t * context) {
+    int32_t on;
+    if (!SCPI_ParamInt32(context, &on, TRUE)) {
+        return SCPI_RES_ERR;
+    }
+    const char* err = NULL;
+    bool ok = (on != 0) ? UserSpi_Enable(&err) : UserSpi_Disable();
+    if (!ok) {
+        SCPI_ExecutionError(context, (err != NULL) ? err : "SPI enable failed");
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
+scpi_result_t SCPI_SpiEnableGet(scpi_t * context) {
+    SCPI_ResultInt32(context, UserSpi_IsEnabled() ? 1 : 0);
+    return SCPI_RES_OK;
+}
+
+/* Parse a hex byte string (tolerant of quotes, spaces, commas, underscores
+ * and an optional 0x prefix) into @p out. Requires an even, non-zero count
+ * of hex digits and at most @p maxOut bytes. */
+static bool spi_ParseHex(const char* p, size_t len, uint8_t* out,
+                         uint16_t maxOut, uint16_t* nOut) {
+    uint16_t n = 0;
+    int hi = -1;   /* pending high nibble, -1 = none */
+    size_t i = 0;
+    if (len >= 2u && p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) {
+        i = 2u;
+    }
+    for (; i < len; ++i) {
+        char c = p[i];
+        if (c == ' ' || c == '\t' || c == '_' || c == ',' || c == '"') {
+            continue;
+        }
+        int v;
+        if (c >= '0' && c <= '9')      { v = c - '0'; }
+        else if (c >= 'a' && c <= 'f') { v = c - 'a' + 10; }
+        else if (c >= 'A' && c <= 'F') { v = c - 'A' + 10; }
+        else { return false; }
+        if (hi < 0) {
+            hi = v;
+        } else {
+            if (n >= maxOut) { return false; }
+            out[n++] = (uint8_t)(((uint8_t)hi << 4) | (uint8_t)v);
+            hi = -1;
+        }
+    }
+    if (hi >= 0 || n == 0u) {
+        return false;   /* odd nibble count or empty */
+    }
+    *nOut = n;
+    return true;
+}
+
+scpi_result_t SCPI_SpiTransfer(scpi_t * context) {
+    const char* p = NULL;
+    size_t len = 0;
+    if (!SCPI_ParamCharacters(context, &p, &len, TRUE)) {
+        return SCPI_RES_ERR;
+    }
+    if (!UserSpi_IsEnabled()) {
+        SCPI_ExecutionError(context, "SPI not enabled");
+        return SCPI_RES_ERR;
+    }
+
+    /* Carve tx/rx/out regions out of the shared 2048B response buffer so we
+     * never put a >=256B scratch array on the (small) WifiTask stack. */
+    uint8_t *buf = SCPI_ResponseBuf_Take();
+    if (buf == NULL) {
+        return SCPI_RES_ERR;
+    }
+    uint8_t *tx  = buf;             /* [0..255]   */
+    uint8_t *rx  = buf + 256;       /* [256..511] */
+    char    *out = (char *)(buf + 512);  /* [512..2047] */
+
+    uint16_t n = 0;
+    if (!spi_ParseHex(p, len, tx, 256u, &n)) {
+        SCPI_ResponseBuf_Give();
+        SCPI_ExecutionError(context, "SPI:TRAN: bad hex (even digits, <=256 bytes)");
+        return SCPI_RES_ERR;
+    }
+    if (!UserSpi_Transfer(tx, rx, n)) {
+        SCPI_ResponseBuf_Give();
+        SCPI_ExecutionError(context, "SPI transfer timeout");
+        return SCPI_RES_ERR;
+    }
+
+    static const char hexd[] = "0123456789ABCDEF";
+    for (uint16_t i = 0; i < n; ++i) {
+        out[2 * i]     = hexd[(rx[i] >> 4) & 0x0Fu];
+        out[2 * i + 1] = hexd[rx[i] & 0x0Fu];
+    }
+    out[2 * n] = '\0';
+
+    /* Raw hex, no SCPI quoting, so the client parses MISO bytes directly. */
+    SCPI_ResultMnemonic(context, out);
+    SCPI_ResponseBuf_Give();
+    return SCPI_RES_OK;
 }
 
 scpi_result_t SCPI_LANSettingsSave(scpi_t * context) {

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -757,6 +757,24 @@ static uint8_t spi_ScpiPinToDio(int32_t v) {
     return (v < 0) ? USER_SPI_PIN_NONE : (uint8_t)v;
 }
 
+/* True if the SCPI line has an unconsumed trailing token after the expected
+ * parameters — a real extra parameter (comma-separated: SCPI_Parameter returns
+ * TRUE) or an invalid separator (space-separated: SCPI_Parameter returns FALSE
+ * but queues an error). libscpi only flags a trailing token AFTER the callback
+ * returns, so every SPI SETTER must call this and bail BEFORE applying any side
+ * effect (pin claims, PPS/PMD, clocking, config store) — a rejected command
+ * must not leave hardware or config changed (e.g. `SPI:ENA 1,0` would otherwise
+ * leave SPI enabled). Pushes an execution error for the extra-parameter case;
+ * SCPI_Parameter already queued one for the invalid-separator case. */
+static bool spi_RejectTrailingParam(scpi_t* context) {
+    scpi_parameter_t extra;
+    if (SCPI_Parameter(context, &extra, FALSE)) {
+        SCPI_ExecutionError(context, "unexpected trailing parameter");
+        return true;
+    }
+    return SCPI_ParamErrorOccurred(context);
+}
+
 scpi_result_t SCPI_SpiConfigSet(scpi_t * context) {
     int32_t mosi, miso, cs, baud, mode;
     int32_t order = 0;   /* optional, default MSB-first */
@@ -780,6 +798,10 @@ scpi_result_t SCPI_SpiConfigSet(scpi_t * context) {
         }
     }
     /* else: absent -> keep the MSB-first default (order = 0). */
+
+    if (spi_RejectTrailingParam(context)) {
+        return SCPI_RES_ERR;   /* a rejected CONFig must not store the config */
+    }
 
     /* Reject out-of-range pin indices before the uint8_t narrowing so a
      * value like 258 can't alias onto DIO2. Negative = unused line. */
@@ -839,6 +861,9 @@ scpi_result_t SCPI_SpiEnableSet(scpi_t * context) {
     if (!SCPI_ParamInt32(context, &on, TRUE)) {
         return SCPI_RES_ERR;
     }
+    if (spi_RejectTrailingParam(context)) {
+        return SCPI_RES_ERR;   /* a rejected ENAble must not claim pins / power SPI1 */
+    }
     const char* err = NULL;
     bool ok = (on != 0) ? UserSpi_Enable(&err) : UserSpi_Disable();
     if (!ok) {
@@ -895,21 +920,12 @@ scpi_result_t SCPI_SpiTransfer(scpi_t * context) {
     if (!SCPI_ParamCharacters(context, &p, &len, TRUE)) {
         return SCPI_RES_ERR;
     }
-    /* Exactly one (quoted) hex arg — reject ANY trailing token BEFORE we clock
-     * anything, else a truncated frame reaches the slave before the error
-     * surfaces. Two malformed shapes: comma-separated ("TRAN? 9F,00,00") parses
-     * a 2nd parameter (SCPI_Parameter returns TRUE); space-separated
-     * ("TRAN? \"9F\" 00") is an INVALID_SEPARATOR (SCPI_Parameter returns FALSE
-     * but queues an error — so also check SCPI_ParamErrorOccurred). The
-     * documented form is one quoted token, e.g. "9F0000" (spi_ParseHex tolerates
-     * commas inside it). */
-    scpi_parameter_t extra;
-    if (SCPI_Parameter(context, &extra, FALSE)) {
-        SCPI_ExecutionError(context, "SPI:TRAN: one quoted hex arg only (e.g. \"9F0000\")");
+    /* Exactly one (quoted) hex arg — reject any trailing token (comma- OR
+     * space-separated) BEFORE we clock anything, else a truncated frame reaches
+     * the slave before the error surfaces. The documented form is one quoted
+     * token, e.g. "9F0000" (spi_ParseHex tolerates commas inside it). */
+    if (spi_RejectTrailingParam(context)) {
         return SCPI_RES_ERR;
-    }
-    if (SCPI_ParamErrorOccurred(context)) {
-        return SCPI_RES_ERR;   /* trailing token with an invalid separator (error already queued) */
     }
     if (!UserSpi_IsEnabled()) {
         SCPI_ExecutionError(context, "SPI not enabled");

--- a/firmware/src/services/SCPI/SCPILAN.h
+++ b/firmware/src/services/SCPI/SCPILAN.h
@@ -199,6 +199,21 @@ scpi_result_t SCPI_LANGetChipInfo(scpi_t * context);
  * @return SCPI_RES_OK on success, SCPI_RES_ERR on error
  */
 scpi_result_t SCPI_LANMdnsDiagGet(scpi_t * context);
+/* ---------------------------------------------------------------------
+ * User SPI1 master on the DIO terminal (#665, epic #664). SYST:COMM:SPI:*.
+ * Hosted here as the SYST:COMM namespace home until the epic's I2C/UART
+ * children justify a dedicated SCPIComm translation unit.
+ * --------------------------------------------------------------------- */
+/*! SCPI: SYST:COMM:SPI:CONFig <mosiDio|-1>,<misoDio|-1>,<csDio|-1>,<baud>,<mode 0-3>[,<order 0=MSB|1=LSB>] */
+scpi_result_t SCPI_SpiConfigSet(scpi_t * context);
+/*! SCPI: SYST:COMM:SPI:CONFig? -> JSON of the stored SPI config + state. */
+scpi_result_t SCPI_SpiConfigGet(scpi_t * context);
+/*! SCPI: SYST:COMM:SPI:ENAble <0|1> -> apply/tear down the SPI master. */
+scpi_result_t SCPI_SpiEnableSet(scpi_t * context);
+/*! SCPI: SYST:COMM:SPI:ENAble? -> 1 if the SPI master is active. */
+scpi_result_t SCPI_SpiEnableGet(scpi_t * context);
+/*! SCPI: SYST:COMM:SPI:TRANsfer? <hex> -> full-duplex transfer, MISO as hex. */
+scpi_result_t SCPI_SpiTransfer(scpi_t * context);
 /**
  * SCPI Callback: Enable/disable automatic WiFi power-save (#29).
  * @return SCPI_RES_OK on success SCPI_RES_ERR on error


### PR DESCRIPTION
## What

First feature of the **digital-sensor epic #664**: a **user SPI1 master on the 16-pin DIO terminal**, exposed via `SYST:COMM:SPI:*`, so sensors / MCUs / SBCs can be driven from the terminal.

- **SCK** = DIO0 (fixed SCK1) · **MOSI** = SDO1 via PPS (DIO 2/4/5/6/7/14/15) · **MISO** = SDI1 via PPS (DIO 5/7/15) · **CS** = any free DIO as software GPIO.
- PPS values are V-class from the PIC32MZ2048EFM144 DFP (SDO1=5, SDI1R RPF1=4/RPG1=12/RPC1=10).

### SCPI (lean — 3 commands)
```
SYST:COMM:SPI:CONFig <mosiDio|-1>,<misoDio|-1>,<csDio|-1>,<baud>,<mode 0-3>[,<order 0=MSB|1=LSB>]
SYST:COMM:SPI:CONFig?          -> JSON {Sck,Mosi,Miso,Cs,Baud,Mode,LsbFirst,Enabled,ActualBaud}
SYST:COMM:SPI:ENAble <0|1> / ?
SYST:COMM:SPI:TRANsfer? <hex>  -> full-duplex; CS asserted around the frame; MISO bytes returned as hex
```

## Shared foundation (every #664 child reuses this)

- **DIO channel ownership registry** (`DIO_ClaimChannel`/`ReleaseChannel`/`GetChannelOwner`/name) generalizing the probe-specific ownership. DIO write/read/streaming paths skip owned channels; `DIO:PORt` and PWM setters **reject** claimed channels and name the owner (detail via `SYST:LOG?`, per the errors-go-to-log rule).
- **Peripheral pin-buffer helpers** (`DIO_SetChannelPeripheral{Output,Input}`) encoding the SN74LVC2G241 enable / high-Z read-through-100K model.

## Config-word change (⚠️ security posture)

`IOL1WAY` / `PMDL1WAY` / `PGL1WAY` one-way locks set **OFF** in the production build. The epic requires **runtime** PPS/PMD reconfiguration; the one-way locks freeze both after the plib init, so with them ON every runtime unlock is silently ignored (root-caused after ~25 reflash cycles — verified via register readback). The **DIO ownership registry** provides the access control the coarse one-way lock otherwise gave. The firmware already toggles these OFF for ICSP-debug builds. **Owner-approved.**

## Testing

Hardware-validated on Nq1 (COM3): **23/23** checks — config validation (bad pins/mode/DIO0-collision/uint8-alias), clean JSON, the SPI↔PWM/probe ownership matrix, and **real MISO transfers** (`TRAN? 9F -> 00` — the bus clocks and reads the pin through its 180K pull-down; no hardware timeout).

Companion regression test: **`test_665_user_spi.py`** in `daqifi-python-test-suite` ([test/665-user-spi](https://github.com/daqifi/daqifi-python-test-suite/tree/test/665-user-spi)) — passes native on COM3, fails on pre-#665 firmware. Physical MOSI↔MISO **loopback** (`--loopback`) is queued for when a jumper is on the bench.

## Notes
- SPI1 was unused; hand-rolled polled master per the no-MCC policy.
- The `NQ3` MPLAB config has a **pre-existing** (unrelated) build defect — missing `libscpi` include path — that fails on files this PR doesn't touch; `default`/Nq1 builds clean at -O3 -Werror.

Closes #665 · Refs #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)
