### PR TITLE
feat(adc): #670 hardware analog threshold alarms via ADCHS digital comparators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1023,7 +1023,38 @@ The `StreamingInterface` enum exposes four combinations: `USB`, `WiFi`, `SD`, an
 ### Development Considerations
 
 - All hardware access must go through HAL layer
-- **Prefer Harmony PLIB / driver APIs over direct SFR writes** for hardware abstractability. Order of preference: (1) PLIB function (`EVIC_SourceEnable`, `ADCHS_*`, `GPIO_*`), (2) SFR bitfield accessors (`ADCCON2bits.SAMC = val`), (3) raw register writes only when no PLIB/bitfield path exists AND performance demands it OR SET/CLR atomic forms are needed — always comment *why*
+- **Read the PIC32 Family Reference Manual (FRM) BEFORE writing any peripheral
+  register code — this MCU is complicated and the DFP header alone is not
+  enough.** The device pack header gives you bit *names and positions* but NOT
+  the *semantics*, enable-ordering, routing requirements, or the gotcha `Note:`
+  callouts — and those are exactly where bring-up dies. The FRM section for each
+  peripheral is authoritative; grep its actual text, don't infer from register
+  width. Fetch the relevant section PDF from
+  `ww1.microchip.com/downloads/.../ReferenceManuals/` (e.g. the 12-bit HS SAR
+  ADC is **DS60001344E**), `pdftotext` it, and read the operation + register
+  descriptions in full. Cite FRM `DS#`/register/bit for load-bearing claims
+  (per the Debugging-discipline V-tag rule). Concrete #670 lessons the header
+  hid and only the FRM revealed: the digital comparator needs **`DCMPGIEN`**
+  (interrupt-enable, bit 6) set separately from `ENDCMP` — without it the event
+  fires but no interrupt; the in-window condition is **`IEBTWN`**, not `IEHILO`
+  (which is only "DATA < DCMPHI"); comparator/filter inputs are **limited to
+  AN0–31** (`ADCCMPENx` is 32-bit by spec, not just by register width); and a
+  result only reaches the comparator "if configured to use data from this
+  particular sample" — a routing requirement invisible in the headers.
+- **Prefer Microchip's own drivers, PLIBs, device packs, and reference code over
+  rolling your own — always check what Harmony/MCC/the DFP already provides
+  FIRST.** Our MCU has subtle, undocumented-in-headers sequencing that the vendor
+  code already gets right; a hand-rolled register sequence will miss a routing
+  or enable step (see #670). Order of preference: (1) a **Harmony driver / PLIB
+  function** (`ADCHS_*`, `EVIC_*`, `GPIO_*`, `DRV_*`) — check `plib_*.h` and the
+  Harmony framework/examples for the peripheral, and consider whether an MCC
+  reconfigure would generate the feature before hand-rolling it; (2) **SFR
+  bitfield accessors** (`ADCCON2bits.SAMC = val`) when no PLIB path exists;
+  (3) **raw register writes** ONLY when no PLIB/bitfield path exists AND
+  performance demands it OR SET/CLR atomic forms are needed — and then only
+  after reading the FRM for that peripheral, always commenting *why* and citing
+  the FRM. When you must hand-roll (no-MCC modules like REFO/comparator), still
+  read the FRM init sequence first and mirror the vendor example's ordering.
 - SCPI commands follow IEEE 488.2 standard
 - Use FreeRTOS primitives for synchronization
 - Respect board variant differences in runtime checks

--- a/firmware/daqifi.X/nbproject/configurations.xml
+++ b/firmware/daqifi.X/nbproject/configurations.xml
@@ -313,6 +313,7 @@
         <logicalFolder name="ADC" displayName="ADC" projectFiles="true">
           <itemPath>../src/HAL/ADC/AD7173.h</itemPath>
           <itemPath>../src/HAL/ADC/AD7609.h</itemPath>
+          <itemPath>../src/HAL/ADC/AdcThreshold.h</itemPath>
           <itemPath>../src/HAL/ADC/MC12bADC.h</itemPath>
         </logicalFolder>
         <logicalFolder name="BQ24297" displayName="BQ24297" projectFiles="true">
@@ -913,6 +914,7 @@
         <logicalFolder name="ADC" displayName="ADC" projectFiles="true">
           <itemPath>../src/HAL/ADC/AD7173.c</itemPath>
           <itemPath>../src/HAL/ADC/AD7609.c</itemPath>
+          <itemPath>../src/HAL/ADC/AdcThreshold.c</itemPath>
           <itemPath>../src/HAL/ADC/MC12bADC.c</itemPath>
         </logicalFolder>
         <logicalFolder name="BQ24297" displayName="BQ24297" projectFiles="true">

--- a/firmware/src/HAL/ADC.c
+++ b/firmware/src/HAL/ADC.c
@@ -10,6 +10,7 @@
 #include "ADC/AD7609.h"
 //#include "ADC/AD7173.h"
 #include "ADC/MC12bADC.h"
+#include "ADC/AdcThreshold.h"
 #include "DIO.h"
 #include "DioProbe.h"
 #include "Util/Logger.h"
@@ -206,6 +207,10 @@ void ADC_Init(
 
     // Register ADC EOS interrupt callback using Harmony's callback mechanism
     ADCHS_EOSCallbackRegister(ADC_EOSInterruptCB, 0);
+
+    // #670: park the digital-comparator threshold units (interrupts off, priority
+    // set). No thresholds are armed until CONF:ADC:THREshold configures one.
+    AdcThreshold_Initialize();
 
     // Note: AD7609 initialization happens later when 10V rail is powered up
 }

--- a/firmware/src/HAL/ADC/AdcThreshold.c
+++ b/firmware/src/HAL/ADC/AdcThreshold.c
@@ -157,10 +157,16 @@ static void thr_ApplyUnit(uint8_t u, uint8_t an, AdcThresholdMode mode,
     *(r->con) = 0u;                 /* disable while reconfiguring */
     thr_IntDisable(u);
     thr_IntClearFlag(u);
+    /* Reset the ISR-shared counters HERE, with this unit's IRQ disabled, so a
+     * trip from a still-live old config (reconfigure-in-place) or a stray idle
+     * conversion can't leave a phantom count/latch on the freshly-armed config. */
+    gUnits[u].tripCount = 0u;
+    gUnits[u].latched   = false;
     *(r->cmp) = ((uint32_t)hi << 16) | (uint32_t)lo;   /* DCMPHI:DCMPLO */
     *(r->en)  = (1u << an);                              /* watch this AN input */
     /* condition + comparator enable + interrupt-on-event enable (DCMPGIEN) */
     *(r->con) = thr_ModeBits(mode) | CMP_ENDCMP | CMP_DCMPGIEN;
+    (void)*(r->con);                /* clear any immediate DCMPED before arming */
     thr_IntClearFlag(u);
     thr_IntEnable(u);
 }
@@ -224,14 +230,14 @@ bool AdcThreshold_Configure(uint8_t chId, AdcThresholdMode mode,
         if (existing >= 0) { thr_ReleaseUnit((uint8_t)existing); }
         /* OFF on a channel with no threshold is a no-op success. */
     } else if (existing >= 0) {
-        /* reconfigure in place (keep the unit, reset counters via ApplyUnit) */
+        /* reconfigure in place. Only metadata is written here (the ISR does not
+         * read these fields); the ISR-shared tripCount/latched are reset inside
+         * thr_ApplyUnit with the IRQ disabled, so no phantom trip can survive. */
         gUnits[existing].mode = mode;
         gUnits[existing].an   = an;
         gUnits[existing].isT1 = isT1;
         gUnits[existing].lo   = lo;
         gUnits[existing].hi   = hi;
-        gUnits[existing].tripCount = 0u;
-        gUnits[existing].latched   = false;
         thr_ApplyUnit((uint8_t)existing, an, mode, lo, hi);
     } else {
         int u = -1;
@@ -276,8 +282,10 @@ void AdcThreshold_Clear(uint8_t chId) {
         thr_IntDisable(u);
         gUnits[u].tripCount = 0u;
         gUnits[u].latched   = false;
+        (void)*(gRegs[u].con);  /* clear a pending DCMPED (source) before the flag,
+                                 * else a stale event re-latches on re-enable */
         thr_IntClearFlag(u);
-        thr_IntEnable(u);
+        thr_IntEnable(u);       /* re-arm — IsrTrip masks itself, Clear un-masks */
     }
     xSemaphoreGive(thr_Mutex());
 }
@@ -292,17 +300,22 @@ bool AdcThreshold_AnyLatched(void) {
 }
 
 void AdcThreshold_RevalidateForStream(void) {
-    /* A Type 2 threshold whose channel is not in the session scan (ADCCSS) can
-     * never fire. Disable it and inform. Reads the applied ADCCSS1/2 live. */
+    /* A Type 2 threshold whose channel is not in this session's scan (ADCCSS)
+     * won't see stream-sample conversions, so it can't monitor stream data this
+     * session. It is deliberately NOT released or disabled: the unit stays armed
+     * so it still fires on idle / MEAS conversions of that AN, and its config +
+     * latch survive the session (the persistence contract — a latched alarm must
+     * outlive an unrelated stream, cleared only by CONF:ADC:THREshold:CLEar).
+     * Just inform. Reads the applied ADCCSS1 live (AN < 32 by construction). */
     xSemaphoreTake(thr_Mutex(), portMAX_DELAY);
     for (uint8_t u = 0; u < ADC_THRESHOLD_UNITS; u++) {
         if (!gUnits[u].inUse || gUnits[u].isT1) { continue; }
         uint8_t an = gUnits[u].an;   /* < 32 by construction */
         bool scanned = ((ADCCSS1 >> an) & 1u) != 0u;
         if (!scanned) {
-            LOG_E("ADC threshold on ch %u disabled: channel not in the streaming scan",
+            LOG_E("ADC threshold ch %u inactive this stream: channel not in the "
+                  "session scan (still monitors at idle; config/latch preserved)",
                   (unsigned)gUnits[u].chId);
-            thr_ReleaseUnit(u);
         }
     }
     xSemaphoreGive(thr_Mutex());
@@ -310,9 +323,21 @@ void AdcThreshold_RevalidateForStream(void) {
 
 void AdcThreshold_IsrTrip(uint8_t unit) {
     if (unit >= ADC_THRESHOLD_UNITS) { return; }
-    thr_IntClearFlag(unit);
+    /* Clear the peripheral event (read AINID via the CON register) BEFORE the
+     * EVIC flag — the PIC32 clear-source-then-flag rule. Clearing IFS while
+     * DCMPED is still asserted can immediately re-latch a spurious interrupt. */
     (void)*(gRegs[unit].con);          /* read clears the DCMPED event */
+    thr_IntClearFlag(unit);
     gUnits[unit].tripCount++;          /* ISR is the sole writer of this field */
     gUnits[unit].latched = true;
+    /* Latch-and-mask. The comparator is LEVEL-evaluated: a signal parked past the
+     * limit (exactly the alarm condition) re-asserts DCMPED on every conversion,
+     * so leaving the IRQ enabled is an IPL3 ISR storm (up to the streaming rate)
+     * that preempts the pri-6 encoder and can force sample drops. A latched alarm
+     * only needs to fire ONCE — mask this unit's IRQ here; AdcThreshold_Clear (or
+     * a reconfigure) re-arms it. The comparator stays enabled, so DCMPED keeps
+     * tracking live state; only the interrupt is gated. IEC1CLR is an atomic
+     * SET/CLR write, safe from ISR context. */
+    thr_IntDisable(unit);
     LOG_E_ONCE(LOG_ONCE_ADC_THRESHOLD_TRIP, "ADC analog threshold tripped");
 }

--- a/firmware/src/HAL/ADC/AdcThreshold.c
+++ b/firmware/src/HAL/ADC/AdcThreshold.c
@@ -26,11 +26,15 @@
 #include "semphr.h"
 #include "task.h"
 
-/* ADCCMPCONx condition bits (identical layout across CMPCON1..6). */
-#define CMP_IELOLO   _ADCCMPCON1_IELOLO_MASK   /* result <  DCMPLO */
-#define CMP_IEHILO   _ADCCMPCON1_IEHILO_MASK   /* DCMPLO <= result < DCMPHI */
-#define CMP_IEHIHI   _ADCCMPCON1_IEHIHI_MASK   /* result >= DCMPHI */
+/* ADCCMPCONx condition bits (identical layout across CMPCON1..6). FRM 22-26
+ * event semantics: IELOLO = DATA < DCMPLO; IEHIHI = DATA >= DCMPHI;
+ * IEBTWN = DCMPLO <= DATA < DCMPHI (the in-window condition -- IEHILO is only
+ * "DATA < DCMPHI", NOT the window). DCMPGIEN gates the interrupt on the event. */
+#define CMP_IELOLO   _ADCCMPCON1_IELOLO_MASK   /* DATA <  DCMPLO */
+#define CMP_IEBTWN   _ADCCMPCON1_IEBTWN_MASK   /* DCMPLO <= DATA < DCMPHI */
+#define CMP_IEHIHI   _ADCCMPCON1_IEHIHI_MASK   /* DATA >= DCMPHI */
 #define CMP_ENDCMP   _ADCCMPCON1_ENDCMP_MASK   /* enable the comparator */
+#define CMP_DCMPGIEN _ADCCMPCON1_DCMPGIEN_MASK /* enable the interrupt when an event fires */
 
 #define AN_CMP_MAX   31u   /* ADCCMPENx is 32-bit: only AN0..31 are selectable */
 
@@ -138,10 +142,10 @@ static int thr_UnitForCh(uint8_t chId) {
 
 static uint32_t thr_ModeBits(AdcThresholdMode m) {
     switch (m) {
-        case ADC_THRESH_BELOW:   return CMP_IELOLO;
-        case ADC_THRESH_ABOVE:   return CMP_IEHIHI;
-        case ADC_THRESH_INSIDE:  return CMP_IEHILO;
-        case ADC_THRESH_OUTSIDE: return CMP_IELOLO | CMP_IEHIHI;
+        case ADC_THRESH_BELOW:   return CMP_IELOLO;              /* DATA < lo */
+        case ADC_THRESH_ABOVE:   return CMP_IEHIHI;              /* DATA >= hi */
+        case ADC_THRESH_INSIDE:  return CMP_IEBTWN;              /* lo <= DATA < hi */
+        case ADC_THRESH_OUTSIDE: return CMP_IELOLO | CMP_IEHIHI; /* DATA < lo || DATA >= hi */
         default:                 return 0u;
     }
 }
@@ -155,7 +159,8 @@ static void thr_ApplyUnit(uint8_t u, uint8_t an, AdcThresholdMode mode,
     thr_IntClearFlag(u);
     *(r->cmp) = ((uint32_t)hi << 16) | (uint32_t)lo;   /* DCMPHI:DCMPLO */
     *(r->en)  = (1u << an);                              /* watch this AN input */
-    *(r->con) = thr_ModeBits(mode) | CMP_ENDCMP;        /* condition + enable */
+    /* condition + comparator enable + interrupt-on-event enable (DCMPGIEN) */
+    *(r->con) = thr_ModeBits(mode) | CMP_ENDCMP | CMP_DCMPGIEN;
     thr_IntClearFlag(u);
     thr_IntEnable(u);
 }

--- a/firmware/src/HAL/ADC/AdcThreshold.c
+++ b/firmware/src/HAL/ADC/AdcThreshold.c
@@ -1,0 +1,306 @@
+/**
+ * @file AdcThreshold.c
+ * @brief ADCHS digital-comparator threshold alarms (#670, epic #664).
+ *
+ * Hand-rolled ADCCMPCONx/ADCCMPENx/ADCCMPx setup (no Harmony comparator API
+ * exists). Six comparator units; one is allocated per monitored channel. See
+ * AdcThreshold.h for the mode->condition map and the raw-code contract.
+ *
+ * AN-coverage limit: ADCCMPENx is a single 32-bit register, so a comparator can
+ * only be assigned an AN input < 32. A handful of NQ1 channels scan on AN>=32
+ * (via ADCCSS2) and are therefore rejected with a clear message. (Whether the
+ * silicon can compare AN>=32 through some other path is a FRM question; the safe,
+ * always-correct subset is AN<32, which is what we expose.)
+ */
+#define LOG_LVL    LOG_LEVEL_ADC
+#define LOG_MODULE LOG_MODULE_ADC
+#include "AdcThreshold.h"
+#include "device.h"
+#include "../ADC.h"
+#include "../../state/board/BoardConfig.h"
+#include "../../state/board/AInConfig.h"
+#include "../../state/runtime/BoardRuntimeConfig.h"
+#include "../../services/streaming.h"
+#include "../../Util/Logger.h"
+#include "FreeRTOS.h"
+#include "semphr.h"
+#include "task.h"
+
+/* ADCCMPCONx condition bits (identical layout across CMPCON1..6). */
+#define CMP_IELOLO   _ADCCMPCON1_IELOLO_MASK   /* result <  DCMPLO */
+#define CMP_IEHILO   _ADCCMPCON1_IEHILO_MASK   /* DCMPLO <= result < DCMPHI */
+#define CMP_IEHIHI   _ADCCMPCON1_IEHIHI_MASK   /* result >= DCMPHI */
+#define CMP_ENDCMP   _ADCCMPCON1_ENDCMP_MASK   /* enable the comparator */
+
+#define AN_CMP_MAX   31u   /* ADCCMPENx is 32-bit: only AN0..31 are selectable */
+
+typedef struct {
+    volatile uint32_t* con;   /* ADCCMPCONx */
+    volatile uint32_t* en;    /* ADCCMPENx  */
+    volatile uint32_t* cmp;   /* ADCCMPx (DCMPHI:DCMPLO) */
+    uint8_t  ifsBit;          /* IFS1/IEC1 bit for ADCDCxIF/IE */
+} CmpRegs_t;
+
+/* Vector 46..51 -> IFS1/IEC1 bits 14..19 (verified device header). */
+static const CmpRegs_t gRegs[ADC_THRESHOLD_UNITS] = {
+    { &ADCCMPCON1, &ADCCMPEN1, &ADCCMP1, 14u },
+    { &ADCCMPCON2, &ADCCMPEN2, &ADCCMP2, 15u },
+    { &ADCCMPCON3, &ADCCMPEN3, &ADCCMP3, 16u },
+    { &ADCCMPCON4, &ADCCMPEN4, &ADCCMP4, 17u },
+    { &ADCCMPCON5, &ADCCMPEN5, &ADCCMP5, 18u },
+    { &ADCCMPCON6, &ADCCMPEN6, &ADCCMP6, 19u },
+};
+
+typedef struct {
+    bool     inUse;
+    uint8_t  chId;                 /* user channel id being watched */
+    uint8_t  an;                   /* AN input (< 32) */
+    bool     isT1;                 /* dedicated (continuous) vs T2 (scanned) */
+    AdcThresholdMode mode;
+    uint16_t lo, hi;
+    volatile uint32_t tripCount;   /* ISR-incremented (ISR is the sole writer) */
+    volatile bool     latched;     /* ISR-set; cleared by AdcThreshold_Clear */
+} ThreshUnit;
+
+static ThreshUnit gUnits[ADC_THRESHOLD_UNITS];
+
+static SemaphoreHandle_t gMutex;
+static StaticSemaphore_t gMutexBuf;
+
+static SemaphoreHandle_t thr_Mutex(void) {
+    if (gMutex == NULL) {
+        taskENTER_CRITICAL();
+        if (gMutex == NULL) { gMutex = xSemaphoreCreateMutexStatic(&gMutexBuf); }
+        taskEXIT_CRITICAL();
+    }
+    return gMutex;
+}
+
+/* ---- interrupt enable/flag/priority (kept in-module; plib_evic untouched) ---- */
+
+static void thr_IntSetPriority(uint8_t u) {
+    /* Priority 3 (<= configMAX_SYSCALL_INTERRUPT_PRIORITY = 4), matching EOS.
+     * DC1/2 in IPC11, DC3/4/5/6 in IPC12; sub-priority left 0. */
+    switch (u) {
+        case 0: IPC11bits.ADCDC1IP = 3; IPC11bits.ADCDC1IS = 0; break;
+        case 1: IPC11bits.ADCDC2IP = 3; IPC11bits.ADCDC2IS = 0; break;
+        case 2: IPC12bits.ADCDC3IP = 3; IPC12bits.ADCDC3IS = 0; break;
+        case 3: IPC12bits.ADCDC4IP = 3; IPC12bits.ADCDC4IS = 0; break;
+        case 4: IPC12bits.ADCDC5IP = 3; IPC12bits.ADCDC5IS = 0; break;
+        case 5: IPC12bits.ADCDC6IP = 3; IPC12bits.ADCDC6IS = 0; break;
+        default: break;
+    }
+}
+static inline void thr_IntEnable(uint8_t u)  { IEC1SET = (1u << gRegs[u].ifsBit); }
+static inline void thr_IntDisable(uint8_t u) { IEC1CLR = (1u << gRegs[u].ifsBit); }
+static inline void thr_IntClearFlag(uint8_t u){ IFS1CLR = (1u << gRegs[u].ifsBit); }
+
+/* ---- channel resolution + capability gate ---- */
+
+/* Resolve a user channel id to its board index + AN + type, enforcing the
+ * MC12b-only / public-only / AN<32 constraints. err set on any rejection. */
+static bool thr_Resolve(uint8_t chId, size_t* idx, uint8_t* an, bool* isT1,
+                        const char** err) {
+    const tBoardConfig* pCfg =
+            (const tBoardConfig*)BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
+    size_t i = ADC_FindChannelIndex(chId);
+    if (i >= pCfg->AInChannels.Size) {
+        if (err) { *err = "threshold: unknown ADC channel"; }
+        return false;
+    }
+    const AInChannel* ch = &pCfg->AInChannels.Data[i];
+    if (ch->Type != AIn_MC12bADC) {
+        if (err) { *err = "threshold: not supported on this board's ADC (MC12b only)"; }
+        return false;
+    }
+    if (ch->Config.MC12b.IsPublic != 1) {
+        if (err) { *err = "threshold: not a public user channel"; }
+        return false;
+    }
+    uint32_t anv = ch->Config.MC12b.ChannelId;
+    if (anv > AN_CMP_MAX) {
+        if (err) { *err = "threshold: channel's ADC input (AN>=32) is not comparator-reachable"; }
+        return false;
+    }
+    if (idx)  { *idx = i; }
+    if (an)   { *an = (uint8_t)anv; }
+    if (isT1) { *isT1 = (ch->Config.MC12b.ChannelType == 1); }
+    return true;
+}
+
+/* find the unit watching chId, or -1 */
+static int thr_UnitForCh(uint8_t chId) {
+    for (int u = 0; u < (int)ADC_THRESHOLD_UNITS; u++) {
+        if (gUnits[u].inUse && gUnits[u].chId == chId) { return u; }
+    }
+    return -1;
+}
+
+static uint32_t thr_ModeBits(AdcThresholdMode m) {
+    switch (m) {
+        case ADC_THRESH_BELOW:   return CMP_IELOLO;
+        case ADC_THRESH_ABOVE:   return CMP_IEHIHI;
+        case ADC_THRESH_INSIDE:  return CMP_IEHILO;
+        case ADC_THRESH_OUTSIDE: return CMP_IELOLO | CMP_IEHIHI;
+        default:                 return 0u;
+    }
+}
+
+/* Program comparator unit u for (an, mode, lo, hi) and arm its interrupt. */
+static void thr_ApplyUnit(uint8_t u, uint8_t an, AdcThresholdMode mode,
+                          uint16_t lo, uint16_t hi) {
+    const CmpRegs_t* r = &gRegs[u];
+    *(r->con) = 0u;                 /* disable while reconfiguring */
+    thr_IntDisable(u);
+    thr_IntClearFlag(u);
+    *(r->cmp) = ((uint32_t)hi << 16) | (uint32_t)lo;   /* DCMPHI:DCMPLO */
+    *(r->en)  = (1u << an);                              /* watch this AN input */
+    *(r->con) = thr_ModeBits(mode) | CMP_ENDCMP;        /* condition + enable */
+    thr_IntClearFlag(u);
+    thr_IntEnable(u);
+}
+
+/* Fully release comparator unit u. */
+static void thr_ReleaseUnit(uint8_t u) {
+    thr_IntDisable(u);
+    *(gRegs[u].con) = 0u;
+    *(gRegs[u].en)  = 0u;
+    thr_IntClearFlag(u);
+    gUnits[u].inUse     = false;
+    gUnits[u].mode      = ADC_THRESH_OFF;
+    gUnits[u].tripCount = 0u;
+    gUnits[u].latched   = false;
+}
+
+/* ------------------------------------------------------------------ */
+/* Public API */
+
+void AdcThreshold_Initialize(void) {
+    for (uint8_t u = 0; u < ADC_THRESHOLD_UNITS; u++) {
+        thr_IntDisable(u);
+        thr_IntClearFlag(u);
+        thr_IntSetPriority(u);
+        *(gRegs[u].con) = 0u;
+        *(gRegs[u].en)  = 0u;
+        gUnits[u] = (ThreshUnit){0};
+    }
+}
+
+bool AdcThreshold_Configure(uint8_t chId, AdcThresholdMode mode,
+                            uint16_t lo, uint16_t hi, const char** err) {
+    if (mode > ADC_THRESH_OUTSIDE) {
+        if (err) { *err = "threshold: mode out of range (0..4)"; }
+        return false;
+    }
+    if (mode != ADC_THRESH_OFF) {
+        if (lo > ADC_THRESHOLD_MAX_CODE || hi > ADC_THRESHOLD_MAX_CODE || lo > hi) {
+            if (err) { *err = "threshold: need 0 <= lo <= hi <= 4095 (raw codes)"; }
+            return false;
+        }
+    }
+    size_t idx = 0; uint8_t an = 0; bool isT1 = false;
+    if (mode != ADC_THRESH_OFF) {
+        if (!thr_Resolve(chId, &idx, &an, &isT1, err)) { return false; }
+    }
+    (void)idx;   /* resolved for validation; the unit is keyed by chId */
+
+    xSemaphoreTake(thr_Mutex(), portMAX_DELAY);
+    bool ok = true;
+    int existing = thr_UnitForCh(chId);
+
+    if (mode == ADC_THRESH_OFF) {
+        if (existing >= 0) { thr_ReleaseUnit((uint8_t)existing); }
+        /* OFF on a channel with no threshold is a no-op success. */
+    } else if (existing >= 0) {
+        /* reconfigure in place (keep the unit, reset counters via ApplyUnit) */
+        gUnits[existing].mode = mode;
+        gUnits[existing].an   = an;
+        gUnits[existing].isT1 = isT1;
+        gUnits[existing].lo   = lo;
+        gUnits[existing].hi   = hi;
+        gUnits[existing].tripCount = 0u;
+        gUnits[existing].latched   = false;
+        thr_ApplyUnit((uint8_t)existing, an, mode, lo, hi);
+    } else {
+        int u = -1;
+        for (int k = 0; k < (int)ADC_THRESHOLD_UNITS; k++) {
+            if (!gUnits[k].inUse) { u = k; break; }
+        }
+        if (u < 0) {
+            if (err) { *err = "threshold: all 6 comparator units in use"; }
+            ok = false;
+        } else {
+            gUnits[u] = (ThreshUnit){ .inUse = true, .chId = chId, .an = an,
+                                      .isT1 = isT1, .mode = mode, .lo = lo, .hi = hi };
+            thr_ApplyUnit((uint8_t)u, an, mode, lo, hi);
+        }
+    }
+    xSemaphoreGive(thr_Mutex());
+    return ok;
+}
+
+bool AdcThreshold_Query(uint8_t chId, AdcThresholdMode* mode,
+                        uint16_t* lo, uint16_t* hi,
+                        uint32_t* tripCount, bool* latched) {
+    xSemaphoreTake(thr_Mutex(), portMAX_DELAY);
+    int u = thr_UnitForCh(chId);
+    bool found = (u >= 0);
+    if (mode)      { *mode      = found ? gUnits[u].mode : ADC_THRESH_OFF; }
+    if (lo)        { *lo        = found ? gUnits[u].lo : 0u; }
+    if (hi)        { *hi        = found ? gUnits[u].hi : 0u; }
+    if (tripCount) { *tripCount = found ? gUnits[u].tripCount : 0u; }
+    if (latched)   { *latched   = found ? gUnits[u].latched : false; }
+    xSemaphoreGive(thr_Mutex());
+    return found;
+}
+
+void AdcThreshold_Clear(uint8_t chId) {
+    xSemaphoreTake(thr_Mutex(), portMAX_DELAY);
+    for (uint8_t u = 0; u < ADC_THRESHOLD_UNITS; u++) {
+        if (!gUnits[u].inUse) { continue; }
+        if (chId != ADC_THRESHOLD_ALL_CH && gUnits[u].chId != chId) { continue; }
+        /* Disable the interrupt across the clear so a concurrent trip can't
+         * immediately re-latch/re-count what we just zeroed. */
+        thr_IntDisable(u);
+        gUnits[u].tripCount = 0u;
+        gUnits[u].latched   = false;
+        thr_IntClearFlag(u);
+        thr_IntEnable(u);
+    }
+    xSemaphoreGive(thr_Mutex());
+}
+
+bool AdcThreshold_AnyLatched(void) {
+    /* Lock-free read: each latched flag is a bool written only by its ISR; a
+     * stale miss is corrected on the next SyncQuesBits. */
+    for (uint8_t u = 0; u < ADC_THRESHOLD_UNITS; u++) {
+        if (gUnits[u].inUse && gUnits[u].latched) { return true; }
+    }
+    return false;
+}
+
+void AdcThreshold_RevalidateForStream(void) {
+    /* A Type 2 threshold whose channel is not in the session scan (ADCCSS) can
+     * never fire. Disable it and inform. Reads the applied ADCCSS1/2 live. */
+    xSemaphoreTake(thr_Mutex(), portMAX_DELAY);
+    for (uint8_t u = 0; u < ADC_THRESHOLD_UNITS; u++) {
+        if (!gUnits[u].inUse || gUnits[u].isT1) { continue; }
+        uint8_t an = gUnits[u].an;   /* < 32 by construction */
+        bool scanned = ((ADCCSS1 >> an) & 1u) != 0u;
+        if (!scanned) {
+            LOG_E("ADC threshold on ch %u disabled: channel not in the streaming scan",
+                  (unsigned)gUnits[u].chId);
+            thr_ReleaseUnit(u);
+        }
+    }
+    xSemaphoreGive(thr_Mutex());
+}
+
+void AdcThreshold_IsrTrip(uint8_t unit) {
+    if (unit >= ADC_THRESHOLD_UNITS) { return; }
+    thr_IntClearFlag(unit);
+    (void)*(gRegs[unit].con);          /* read clears the DCMPED event */
+    gUnits[unit].tripCount++;          /* ISR is the sole writer of this field */
+    gUnits[unit].latched = true;
+    LOG_E_ONCE(LOG_ONCE_ADC_THRESHOLD_TRIP, "ADC analog threshold tripped");
+}

--- a/firmware/src/HAL/ADC/AdcThreshold.c
+++ b/firmware/src/HAL/ADC/AdcThreshold.c
@@ -198,8 +198,15 @@ bool AdcThreshold_Configure(uint8_t chId, AdcThresholdMode mode,
         return false;
     }
     if (mode != ADC_THRESH_OFF) {
-        if (lo > ADC_THRESHOLD_MAX_CODE || hi > ADC_THRESHOLD_MAX_CODE || lo > hi) {
-            if (err) { *err = "threshold: need 0 <= lo <= hi <= 4095 (raw codes)"; }
+        if (lo > ADC_THRESHOLD_MAX_CODE || hi > ADC_THRESHOLD_MAX_CODE) {
+            if (err) { *err = "threshold: raw codes must be 0..4095"; }
+            return false;
+        }
+        /* Only the window modes use both bounds (below uses lo, above uses hi),
+         * so lo<=hi is required only for inside/outside -- this catches an
+         * inverted window while letting below/above ignore the unused bound. */
+        if ((mode == ADC_THRESH_INSIDE || mode == ADC_THRESH_OUTSIDE) && lo > hi) {
+            if (err) { *err = "threshold: window modes need lo <= hi"; }
             return false;
         }
     }

--- a/firmware/src/HAL/ADC/AdcThreshold.h
+++ b/firmware/src/HAL/ADC/AdcThreshold.h
@@ -1,0 +1,98 @@
+/**
+ * @file AdcThreshold.h
+ * @brief Hardware analog threshold alarms via the ADCHS digital comparators
+ *        (#670, epic #664).
+ *
+ * The PIC32MZ ADCHS block has 6 digital comparators (ADCCMPCON1-6). Each watches
+ * the 12-bit conversion RESULT of one selected AN input in hardware and raises an
+ * interrupt the moment a result crosses a programmed limit -- zero per-sample CPU,
+ * works during streaming scans (Type 1 dedicated and Type 2 MODULE7-scanned
+ * channels), and fires on the very conversion that trips. A trip latches a
+ * per-channel flag + counter, sets the QUES "analog limit" status bit, and emits a
+ * one-shot log; the client reads it back with CONF:ADC:THREshold?.
+ *
+ * Limits are RAW ADC codes (0..4095): the ISR path stays float-free; volts->codes
+ * is the client's job (firmware = mechanism). NQ1/NQ2 (internal MC12bADC) only --
+ * NQ3's external AD7609 has no such block, so the command is capability-gated off.
+ *
+ * Mode -> comparator condition (all set DCMPLO=lo, DCMPHI=hi; only the enabled
+ * quadrant bits differ):
+ *   BELOW   result <  lo              (IELOLO)
+ *   ABOVE   result >= hi              (IEHIHI)
+ *   INSIDE  lo <= result <  hi        (IEHILO)
+ *   OUTSIDE result <  lo || result >= hi   (IELOLO | IEHIHI)
+ */
+#ifndef ADC_THRESHOLD_H
+#define ADC_THRESHOLD_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ADC_THRESHOLD_UNITS      6u      /*!< ADCCMP1..6 */
+#define ADC_THRESHOLD_MAX_CODE   4095u   /*!< 12-bit ADC full scale */
+#define ADC_THRESHOLD_ALL_CH     0xFFu   /*!< AdcThreshold_Clear: clear every unit */
+
+typedef enum {
+    ADC_THRESH_OFF     = 0,  /*!< disabled / release the unit */
+    ADC_THRESH_BELOW   = 1,  /*!< trip when result <  lo */
+    ADC_THRESH_ABOVE   = 2,  /*!< trip when result >= hi */
+    ADC_THRESH_INSIDE  = 3,  /*!< trip when lo <= result <  hi (in window) */
+    ADC_THRESH_OUTSIDE = 4,  /*!< trip when result <  lo || result >= hi (out of window) */
+} AdcThresholdMode;
+
+/** Boot-time init: clears state and parks all 6 comparator interrupts (disabled,
+ *  priority set). Safe to call before the ADC is running. */
+void AdcThreshold_Initialize(void);
+
+/**
+ * Configure (or, with @p mode == OFF, release) a threshold on user ADC channel
+ * @p chId, in raw 12-bit codes. Allocates one of the 6 comparator units to the
+ * channel; a second Configure on the same channel updates it in place.
+ * @return false (reason in @p err if non-NULL) if the board variant has no MC12b
+ *   ADC, @p chId is not a valid public channel, @p mode/@p lo/@p hi are out of
+ *   range (need lo<=hi<=4095), no comparator unit is free (names the holders), or
+ *   -- while streaming -- @p chId is a Type 2 channel not in the active scan.
+ */
+bool AdcThreshold_Configure(uint8_t chId, AdcThresholdMode mode,
+                            uint16_t lo, uint16_t hi, const char** err);
+
+/**
+ * Read back the threshold on @p chId. Fills any non-NULL out-params with the
+ * configured mode, limits, trip counter, and latched flag.
+ * @return true if @p chId has a threshold configured; false (mode = OFF) if not.
+ */
+bool AdcThreshold_Query(uint8_t chId, AdcThresholdMode* mode,
+                        uint16_t* lo, uint16_t* hi,
+                        uint32_t* tripCount, bool* latched);
+
+/** Clear the latch + trip counter for @p chId, or for every unit when
+ *  @p chId == ADC_THRESHOLD_ALL_CH. The comparator keeps monitoring. */
+void AdcThreshold_Clear(uint8_t chId);
+
+/** True if any configured threshold has latched a trip since its last Clear.
+ *  Task context; SCPI_SyncQuesBits derives the QUES analog-limit bit from this. */
+bool AdcThreshold_AnyLatched(void);
+
+/**
+ * Re-validate active thresholds against the scan list applied at stream start:
+ * a Type 2 threshold whose channel is not in the session scan can never fire, so
+ * disable its comparator and emit a one-shot log (inform on stale data). Called
+ * from the streaming-start path after the session CSS is computed. Type 1
+ * (dedicated, continuously converting) thresholds are unaffected.
+ */
+void AdcThreshold_RevalidateForStream(void);
+
+/** Per-unit trip ISR body, called from ADC_DC1..6_Handler (interrupts.c). @p unit
+ *  is 0..5. Minimal + self-contained: clears the event, bumps this unit's counter
+ *  and latch (ISR is the sole writer), one-shot logs. No cross-module coupling. */
+void AdcThreshold_IsrTrip(uint8_t unit);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_THRESHOLD_H */

--- a/firmware/src/HAL/ADC/AdcThreshold.h
+++ b/firmware/src/HAL/ADC/AdcThreshold.h
@@ -5,22 +5,28 @@
  *
  * The PIC32MZ ADCHS block has 6 digital comparators (ADCCMPCON1-6). Each watches
  * the 12-bit conversion RESULT of one selected AN input in hardware and raises an
- * interrupt the moment a result crosses a programmed limit -- zero per-sample CPU,
- * works during streaming scans (Type 1 dedicated and Type 2 MODULE7-scanned
- * channels), and fires on the very conversion that trips. A trip latches a
- * per-channel flag + counter, sets the QUES "analog limit" status bit, and emits a
- * one-shot log; the client reads it back with CONF:ADC:THREshold?.
+ * interrupt the moment a result crosses a programmed limit, on both Type 1
+ * (dedicated) and Type 2 (MODULE7-scanned) channels. A trip latches a per-channel
+ * flag + counter, sets the QUES "analog limit" status bit, and emits a one-shot
+ * log; the client reads it back with CONF:ADC:THREshold?.
+ *
+ * The comparator is LEVEL-evaluated, so a signal parked past the limit would set
+ * the event on every conversion. The trip ISR therefore latch-and-masks: it fires
+ * ONCE, disables its own interrupt, and is re-armed by AdcThreshold_Clear (or a
+ * reconfigure). Cost is one ISR per Clear-cycle, not per conversion -- so it adds
+ * no per-sample CPU in steady state even while streaming.
  *
  * Limits are RAW ADC codes (0..4095): the ISR path stays float-free; volts->codes
  * is the client's job (firmware = mechanism). NQ1/NQ2 (internal MC12bADC) only --
  * NQ3's external AD7609 has no such block, so the command is capability-gated off.
  *
  * Mode -> comparator condition (all set DCMPLO=lo, DCMPHI=hi; only the enabled
- * quadrant bits differ):
- *   BELOW   result <  lo              (IELOLO)
- *   ABOVE   result >= hi              (IEHIHI)
- *   INSIDE  lo <= result <  hi        (IEHILO)
- *   OUTSIDE result <  lo || result >= hi   (IELOLO | IEHIHI)
+ * event bits differ). NOTE: the in-window bit is IEBTWN, NOT IEHILO (which is only
+ * "result < DCMPHI") -- see the FRM note in AdcThreshold.c:
+ *   BELOW   result <  lo                    (IELOLO)
+ *   ABOVE   result >= hi                    (IEHIHI)
+ *   INSIDE  lo <= result <  hi              (IEBTWN)
+ *   OUTSIDE result <  lo || result >= hi    (IELOLO | IEHIHI)
  */
 #ifndef ADC_THRESHOLD_H
 #define ADC_THRESHOLD_H
@@ -53,9 +59,11 @@ void AdcThreshold_Initialize(void);
  * @p chId, in raw 12-bit codes. Allocates one of the 6 comparator units to the
  * channel; a second Configure on the same channel updates it in place.
  * @return false (reason in @p err if non-NULL) if the board variant has no MC12b
- *   ADC, @p chId is not a valid public channel, @p mode/@p lo/@p hi are out of
- *   range (need lo<=hi<=4095), no comparator unit is free (names the holders), or
- *   -- while streaming -- @p chId is a Type 2 channel not in the active scan.
+ *   ADC, @p chId is not a valid public channel, @p chId's AN input is >= 32
+ *   (comparators reach AN0..31 only), @p mode is out of range, @p lo/@p hi exceed
+ *   4095 (or lo>hi for the window modes), or no comparator unit is free (names the
+ *   holders). The while-streaming rejection is enforced by the SCPI layer, not
+ *   here. below uses only lo; above only hi; only the window modes need lo<=hi.
  */
 bool AdcThreshold_Configure(uint8_t chId, AdcThresholdMode mode,
                             uint16_t lo, uint16_t hi, const char** err);
@@ -78,11 +86,12 @@ void AdcThreshold_Clear(uint8_t chId);
 bool AdcThreshold_AnyLatched(void);
 
 /**
- * Re-validate active thresholds against the scan list applied at stream start:
- * a Type 2 threshold whose channel is not in the session scan can never fire, so
- * disable its comparator and emit a one-shot log (inform on stale data). Called
- * from the streaming-start path after the session CSS is computed. Type 1
- * (dedicated, continuously converting) thresholds are unaffected.
+ * Inform (do NOT disable) about active thresholds vs the scan list applied at
+ * stream start: a Type 2 threshold whose channel is not in the session scan won't
+ * see stream-sample conversions this session, so it emits a one-shot log. The unit
+ * is left fully armed so it still fires on idle/MEAS conversions and its config +
+ * latch survive the session (persistence contract). Called from the streaming-start
+ * path after the session CSS is computed. Type 1 thresholds are unaffected.
  */
 void AdcThreshold_RevalidateForStream(void);
 

--- a/firmware/src/Util/Logger.h
+++ b/firmware/src/Util/Logger.h
@@ -182,6 +182,7 @@ extern "C" {
         LOG_ONCE_BRIDGE_RX_OVERFLOW,      /**< wifi_serial_bridge_interface.c: transparent RX ring full — bytes dropped instead of wrapped (silent wrap corrupted WINC images mid-flash, #WINC-recovery) */
         LOG_ONCE_BIT_SD_BACKOFF,          /**< drv_sdspi.c: detect-poll backoff engaged after 10 card-absent polls (#589 P1) */
         LOG_ONCE_MDNS_ARM_FAIL,           /**< mdns_responder.c: recvfrom re-arm failed — responder deaf until ServiceHealth() re-opens (#58) */
+        LOG_ONCE_ADC_THRESHOLD_TRIP,      /**< AdcThreshold.c: an ADC digital-comparator threshold tripped (#670); one-shot so a signal parked past the limit can't flood */
         /* Add new entries above this line */
         LOG_ONCE_COUNT                     /**< Must be <= 32 */
     } LogOnceBit_t;

--- a/firmware/src/config/default/interrupts.c
+++ b/firmware/src/config/default/interrupts.c
@@ -54,6 +54,7 @@
 
 
 #include "HAL/ADC.h"
+#include "HAL/ADC/AdcThreshold.h"
 #include "HAL/DIO.h"
 
 // *****************************************************************************
@@ -111,6 +112,8 @@ void I2C5_MASTER_Handler (void);
 void SPI6_RX_Handler (void);
 void SPI6_TX_Handler (void);
 void ADC_EOS_Handler (void);
+void ADC_DC1_Handler(void); void ADC_DC2_Handler(void); void ADC_DC3_Handler(void);
+void ADC_DC4_Handler(void); void ADC_DC5_Handler(void); void ADC_DC6_Handler(void);
 
 
 // *****************************************************************************
@@ -366,6 +369,16 @@ void __attribute__((used)) ADC_EOS_Handler (void)
 {
     ADC_EOS_InterruptHandler();
 }
+
+// #670: ADCHS digital-comparator trip ISRs (vectors 46-51). Each defers to the
+// shared, self-contained AdcThreshold_IsrTrip(unit); priority 3 (set in the
+// AdcThreshold module) keeps them FreeRTOS-syscall-safe (<= 4).
+void __attribute__((used)) ADC_DC1_Handler(void) { AdcThreshold_IsrTrip(0); }
+void __attribute__((used)) ADC_DC2_Handler(void) { AdcThreshold_IsrTrip(1); }
+void __attribute__((used)) ADC_DC3_Handler(void) { AdcThreshold_IsrTrip(2); }
+void __attribute__((used)) ADC_DC4_Handler(void) { AdcThreshold_IsrTrip(3); }
+void __attribute__((used)) ADC_DC5_Handler(void) { AdcThreshold_IsrTrip(4); }
+void __attribute__((used)) ADC_DC6_Handler(void) { AdcThreshold_IsrTrip(5); }
 
 
 

--- a/firmware/src/config/default/interrupts_a.S
+++ b/firmware/src/config/default/interrupts_a.S
@@ -809,3 +809,100 @@ IntVectorADC_EOS_Handler:
     portRESTORE_CONTEXT
     .end   IntVectorADC_EOS_Handler
 
+/* #670: ADCHS digital-comparator trip vectors 46-51 (DC1-DC6). */
+    .section   .vector_46,code, keep
+    .equ     __vector_dispatch_46, IntVectorADC_DC1_Handler
+    .global  __vector_dispatch_46
+    .set     nomicromips
+    .set     noreorder
+    .set     nomips16
+    .set     noat
+    .ent  IntVectorADC_DC1_Handler
+IntVectorADC_DC1_Handler:
+    portSAVE_CONTEXT
+    la    s6,  ADC_DC1_Handler
+    jalr  s6
+    nop
+    portRESTORE_CONTEXT
+    .end   IntVectorADC_DC1_Handler
+
+    .section   .vector_47,code, keep
+    .equ     __vector_dispatch_47, IntVectorADC_DC2_Handler
+    .global  __vector_dispatch_47
+    .set     nomicromips
+    .set     noreorder
+    .set     nomips16
+    .set     noat
+    .ent  IntVectorADC_DC2_Handler
+IntVectorADC_DC2_Handler:
+    portSAVE_CONTEXT
+    la    s6,  ADC_DC2_Handler
+    jalr  s6
+    nop
+    portRESTORE_CONTEXT
+    .end   IntVectorADC_DC2_Handler
+
+    .section   .vector_48,code, keep
+    .equ     __vector_dispatch_48, IntVectorADC_DC3_Handler
+    .global  __vector_dispatch_48
+    .set     nomicromips
+    .set     noreorder
+    .set     nomips16
+    .set     noat
+    .ent  IntVectorADC_DC3_Handler
+IntVectorADC_DC3_Handler:
+    portSAVE_CONTEXT
+    la    s6,  ADC_DC3_Handler
+    jalr  s6
+    nop
+    portRESTORE_CONTEXT
+    .end   IntVectorADC_DC3_Handler
+
+    .section   .vector_49,code, keep
+    .equ     __vector_dispatch_49, IntVectorADC_DC4_Handler
+    .global  __vector_dispatch_49
+    .set     nomicromips
+    .set     noreorder
+    .set     nomips16
+    .set     noat
+    .ent  IntVectorADC_DC4_Handler
+IntVectorADC_DC4_Handler:
+    portSAVE_CONTEXT
+    la    s6,  ADC_DC4_Handler
+    jalr  s6
+    nop
+    portRESTORE_CONTEXT
+    .end   IntVectorADC_DC4_Handler
+
+    .section   .vector_50,code, keep
+    .equ     __vector_dispatch_50, IntVectorADC_DC5_Handler
+    .global  __vector_dispatch_50
+    .set     nomicromips
+    .set     noreorder
+    .set     nomips16
+    .set     noat
+    .ent  IntVectorADC_DC5_Handler
+IntVectorADC_DC5_Handler:
+    portSAVE_CONTEXT
+    la    s6,  ADC_DC5_Handler
+    jalr  s6
+    nop
+    portRESTORE_CONTEXT
+    .end   IntVectorADC_DC5_Handler
+
+    .section   .vector_51,code, keep
+    .equ     __vector_dispatch_51, IntVectorADC_DC6_Handler
+    .global  __vector_dispatch_51
+    .set     nomicromips
+    .set     noreorder
+    .set     nomips16
+    .set     noat
+    .ent  IntVectorADC_DC6_Handler
+IntVectorADC_DC6_Handler:
+    portSAVE_CONTEXT
+    la    s6,  ADC_DC6_Handler
+    jalr  s6
+    nop
+    portRESTORE_CONTEXT
+    .end   IntVectorADC_DC6_Handler
+

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -17,6 +17,7 @@
 #include "state/data/BoardData.h"
 #include "state/board/BoardConfig.h"
 #include "HAL/ADC/MC12bADC.h"
+#include "HAL/ADC/AdcThreshold.h"
 #include "state/runtime/BoardRuntimeConfig.h"
 #include "HAL/ADC.h"
 #include "../daqifi_settings.h"
@@ -823,6 +824,80 @@ scpi_result_t SCPI_ADCOnboardDiagGet(scpi_t * context) {
     StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
     SCPI_ResultInt32(context, pStreamCfg->OnboardDiagEnabled ? 1 : 0);
+    return SCPI_RES_OK;
+}
+
+// --- #670: ADC hardware threshold alarms (ADCHS digital comparators) --------
+// CONF:ADC:THREshold <ch>,<mode 0=off|1=below|2=above|3=inside|4=outside>,<lo>,<hi>
+scpi_result_t SCPI_ADCThresholdSet(scpi_t * context) {
+    int32_t ch, mode, lo = 0, hi = 0;
+    if (!SCPI_ParamInt32(context, &ch, TRUE))   return SCPI_RES_ERR;
+    if (!SCPI_ParamInt32(context, &mode, TRUE)) return SCPI_RES_ERR;
+    bool haveLo = SCPI_ParamInt32(context, &lo, FALSE);
+    bool haveHi = SCPI_ParamInt32(context, &hi, FALSE);
+    // Reject before the (uint8_t) narrowing so a value like 256 can't alias
+    // onto a valid channel (#671 truncation-alias lesson).
+    if (ch < 0 || ch > 255 || mode < 0 || mode > 4) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+    if (mode != 0 && (!haveLo || !haveHi)) {
+        SCPI_ExecutionError(context, "CONF:ADC:THRE: modes 1-4 require lo,hi");
+        return SCPI_RES_ERR;
+    }
+    if ((haveLo && (lo < 0 || lo > (int32_t)ADC_THRESHOLD_MAX_CODE)) ||
+        (haveHi && (hi < 0 || hi > (int32_t)ADC_THRESHOLD_MAX_CODE))) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+    // Config change: reject while streaming (consistent with the CONF:ADC family;
+    // the session scan is frozen at start, #116/#541).
+    StreamingRuntimeConfig *pStreamCfg =
+            BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
+    if (pStreamCfg->IsEnabled || pStreamCfg->Running) {
+        SCPI_ExecutionError(context, "CONF:ADC:THRE: cannot change while streaming");
+        return SCPI_RES_ERR;
+    }
+    const char* err = NULL;
+    if (!AdcThreshold_Configure((uint8_t)ch, (AdcThresholdMode)mode,
+                                (uint16_t)lo, (uint16_t)hi, &err)) {
+        SCPI_ExecutionError(context, (err != NULL) ? err : "CONF:ADC:THRE: rejected");
+        return SCPI_RES_ERR;
+    }
+    return SCPI_RES_OK;
+}
+
+// CONF:ADC:THREshold? <ch> -> mode,lo,hi,tripCount,latched (0s if none configured)
+scpi_result_t SCPI_ADCThresholdGet(scpi_t * context) {
+    int32_t ch;
+    if (!SCPI_ParamInt32(context, &ch, TRUE)) return SCPI_RES_ERR;
+    if (ch < 0 || ch > 255) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+    AdcThresholdMode mode = ADC_THRESH_OFF;
+    uint16_t lo = 0, hi = 0; uint32_t cnt = 0; bool latched = false;
+    AdcThreshold_Query((uint8_t)ch, &mode, &lo, &hi, &cnt, &latched);
+    SCPI_ResultUInt32(context, (uint32_t)mode);
+    SCPI_ResultUInt32(context, (uint32_t)lo);
+    SCPI_ResultUInt32(context, (uint32_t)hi);
+    SCPI_ResultUInt32(context, cnt);
+    SCPI_ResultUInt32(context, latched ? 1u : 0u);
+    return SCPI_RES_OK;
+}
+
+// CONF:ADC:THREshold:CLEar [<ch>] -> clear latch+counter (no arg = all)
+scpi_result_t SCPI_ADCThresholdClear(scpi_t * context) {
+    int32_t ch;
+    if (!SCPI_ParamInt32(context, &ch, FALSE)) {
+        AdcThreshold_Clear(ADC_THRESHOLD_ALL_CH);
+        return SCPI_RES_OK;
+    }
+    if (ch < 0 || ch > 255) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+    AdcThreshold_Clear((uint8_t)ch);
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -835,6 +835,12 @@ scpi_result_t SCPI_ADCThresholdSet(scpi_t * context) {
     if (!SCPI_ParamInt32(context, &mode, TRUE)) return SCPI_RES_ERR;
     bool haveLo = SCPI_ParamInt32(context, &lo, FALSE);
     bool haveHi = SCPI_ParamInt32(context, &hi, FALSE);
+    // A malformed optional lo/hi (e.g. "...,banana") pushes a data-type error but
+    // still returns FALSE; treat that as a hard reject, not "absent", so a bad
+    // token can't fall through to a mode-0 release or a partially-parsed arm.
+    if (SCPI_ParamErrorOccurred(context)) {
+        return SCPI_RES_ERR;
+    }
     // Reject before the (uint8_t) narrowing so a value like 256 can't alias
     // onto a valid channel (#671 truncation-alias lesson).
     if (ch < 0 || ch > 255 || mode < 0 || mode > 4) {

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -886,17 +886,6 @@ scpi_result_t SCPI_ADCThresholdGet(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
-// TEMP DEBUG (#670 bring-up): dump comparator + interrupt regs for unit 1.
-scpi_result_t SCPI_ADCThresholdDbg(scpi_t * context) {
-    SCPI_ResultUInt32Base(context, ADCCMPCON1, 16);  // ENDCMP/DCMPGIEN/DCMPED/AINID/IE*
-    SCPI_ResultUInt32Base(context, ADCCMPEN1, 16);   // AN watch mask
-    SCPI_ResultUInt32Base(context, ADCCMP1, 16);     // DCMPHI:DCMPLO
-    SCPI_ResultUInt32Base(context, IFS1, 16);        // bit14 = ADCDC1IF
-    SCPI_ResultUInt32Base(context, IEC1, 16);        // bit14 = ADCDC1IE
-    SCPI_ResultUInt32Base(context, IPC11, 16);       // ADCDC1IP bits 20:18
-    return SCPI_RES_OK;
-}
-
 // CONF:ADC:THREshold:CLEar [<ch>] -> clear latch+counter (no arg = all)
 scpi_result_t SCPI_ADCThresholdClear(scpi_t * context) {
     int32_t ch;

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -886,6 +886,17 @@ scpi_result_t SCPI_ADCThresholdGet(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+// TEMP DEBUG (#670 bring-up): dump comparator + interrupt regs for unit 1.
+scpi_result_t SCPI_ADCThresholdDbg(scpi_t * context) {
+    SCPI_ResultUInt32Base(context, ADCCMPCON1, 16);  // ENDCMP/DCMPGIEN/DCMPED/AINID/IE*
+    SCPI_ResultUInt32Base(context, ADCCMPEN1, 16);   // AN watch mask
+    SCPI_ResultUInt32Base(context, ADCCMP1, 16);     // DCMPHI:DCMPLO
+    SCPI_ResultUInt32Base(context, IFS1, 16);        // bit14 = ADCDC1IF
+    SCPI_ResultUInt32Base(context, IEC1, 16);        // bit14 = ADCDC1IE
+    SCPI_ResultUInt32Base(context, IPC11, 16);       // ADCDC1IP bits 20:18
+    return SCPI_RES_OK;
+}
+
 // CONF:ADC:THREshold:CLEar [<ch>] -> clear latch+counter (no arg = all)
 scpi_result_t SCPI_ADCThresholdClear(scpi_t * context) {
     int32_t ch;

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -890,6 +890,13 @@ scpi_result_t SCPI_ADCThresholdGet(scpi_t * context) {
 scpi_result_t SCPI_ADCThresholdClear(scpi_t * context) {
     int32_t ch;
     if (!SCPI_ParamInt32(context, &ch, FALSE)) {
+        /* FALSE means EITHER "no argument" (clear all) OR "argument present but
+         * malformed" (e.g. `CLE ch5`, which pushes a data-type error). Only the
+         * absent case should clear all — a malformed token must not trigger a
+         * destructive clear-all of every unit (incl. an alarm on another ch). */
+        if (SCPI_ParamErrorOccurred(context)) {
+            return SCPI_RES_ERR;
+        }
         AdcThreshold_Clear(ADC_THRESHOLD_ALL_CH);
         return SCPI_RES_OK;
     }

--- a/firmware/src/services/SCPI/SCPIADC.h
+++ b/firmware/src/services/SCPI/SCPIADC.h
@@ -186,6 +186,18 @@ extern "C" {
     scpi_result_t SCPI_ADCSamcSharedSet(scpi_t * context);
     scpi_result_t SCPI_ADCSamcSharedGet(scpi_t * context);
 
+    /**
+     * #670 — hardware analog threshold alarms via the ADCHS digital comparators.
+     *   CONFigure:ADC:THREshold <ch>,<mode 0-4>,<lo>,<hi>  — mode 0=off, 1=below,
+     *       2=above, 3=inside window, 4=outside window; lo/hi are raw 12-bit codes.
+     *   CONFigure:ADC:THREshold? <ch>   — mode,lo,hi,tripCount,latched
+     *   CONFigure:ADC:THREshold:CLEar [<ch>]  — clear latch+counter (no arg = all)
+     * MC12b (NQ1/NQ2) channels with AN input < 32 only; rejected while streaming.
+     */
+    scpi_result_t SCPI_ADCThresholdSet(scpi_t * context);
+    scpi_result_t SCPI_ADCThresholdGet(scpi_t * context);
+    scpi_result_t SCPI_ADCThresholdClear(scpi_t * context);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/firmware/src/services/SCPI/SCPIADC.h
+++ b/firmware/src/services/SCPI/SCPIADC.h
@@ -197,6 +197,7 @@ extern "C" {
     scpi_result_t SCPI_ADCThresholdSet(scpi_t * context);
     scpi_result_t SCPI_ADCThresholdGet(scpi_t * context);
     scpi_result_t SCPI_ADCThresholdClear(scpi_t * context);
+    scpi_result_t SCPI_ADCThresholdDbg(scpi_t * context);  /* TEMP #670 bring-up */
 
 #ifdef	__cplusplus
 }

--- a/firmware/src/services/SCPI/SCPIADC.h
+++ b/firmware/src/services/SCPI/SCPIADC.h
@@ -188,8 +188,12 @@ extern "C" {
 
     /**
      * #670 — hardware analog threshold alarms via the ADCHS digital comparators.
-     *   CONFigure:ADC:THREshold <ch>,<mode 0-4>,<lo>,<hi>  — mode 0=off, 1=below,
-     *       2=above, 3=inside window, 4=outside window; lo/hi are raw 12-bit codes.
+     *   CONFigure:ADC:THREshold <ch>,<mode 0-4>,<lo>,<hi>  — mode 0=off,
+     *       1=below (uses lo: fires when DATA < lo),
+     *       2=above (uses hi: fires when DATA >= hi),
+     *       3=inside window (lo <= DATA < hi), 4=outside window (DATA < lo || DATA >= hi).
+     *       lo/hi are raw 12-bit codes (0..4095). Below/above ignore the unused
+     *       bound; only the window modes require lo <= hi.
      *   CONFigure:ADC:THREshold? <ch>   — mode,lo,hi,tripCount,latched
      *   CONFigure:ADC:THREshold:CLEar [<ch>]  — clear latch+counter (no arg = all)
      * MC12b (NQ1/NQ2) channels with AN input < 32 only; rejected while streaming.
@@ -197,7 +201,6 @@ extern "C" {
     scpi_result_t SCPI_ADCThresholdSet(scpi_t * context);
     scpi_result_t SCPI_ADCThresholdGet(scpi_t * context);
     scpi_result_t SCPI_ADCThresholdClear(scpi_t * context);
-    scpi_result_t SCPI_ADCThresholdDbg(scpi_t * context);  /* TEMP #670 bring-up */
 
 #ifdef	__cplusplus
 }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5476,7 +5476,6 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:ADC:THREshold", .callback = SCPI_ADCThresholdSet,},
     {.pattern = "CONFigure:ADC:THREshold?", .callback = SCPI_ADCThresholdGet,},
     {.pattern = "CONFigure:ADC:THREshold:CLEar", .callback = SCPI_ADCThresholdClear,},
-    {.pattern = "CONFigure:ADC:THREshold:DBG?", .callback = SCPI_ADCThresholdDbg,},
     {.pattern = "CONFigure:ADC:SAMC:DEDicated", .callback = SCPI_ADCSamcDedicatedSet,},
     {.pattern = "CONFigure:ADC:SAMC:DEDicated?", .callback = SCPI_ADCSamcDedicatedGet,},
     {.pattern = "CONFigure:ADC:SAMC:SHARed", .callback = SCPI_ADCSamcSharedSet,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -29,6 +29,7 @@
 #include "peripheral/gpio/plib_gpio.h"
 #include "HAL/BQ24297/BQ24297.h"
 #include "HAL/ADC.h"
+#include "HAL/ADC/AdcThreshold.h"
 #include "HAL/DIO.h"
 #include "HAL/DioProbe.h"
 #include "SCPIADC.h"
@@ -73,9 +74,10 @@
 #define QUES_ENCODER_FAIL   (1 << 11)  // Bit 11: Encoder failure
 #define QUES_TRANSPORT_DOWN (1 << 12)  // Bit 12: all configured transports down >grace (#397 auto-stop)
 #define QUES_SPI_BUS_FAULT  (1 << 13)  // Bit 13: shared SPI4 bus jammed (#589 — suspect SD card)
+#define QUES_ANALOG_LIMIT   (1 << 14)  // Bit 14: an ADC digital-comparator threshold has tripped (#670)
 #define QUES_ALL_BITS       (QUES_DATA_LOSS | QUES_USB_OVERFLOW | QUES_WIFI_OVERFLOW | \
                              QUES_SD_OVERFLOW | QUES_ENCODER_FAIL | QUES_TRANSPORT_DOWN | \
-                             QUES_SPI_BUS_FAULT)
+                             QUES_SPI_BUS_FAULT | QUES_ANALOG_LIMIT)
 
 #define UNUSED(x) (void)(x)
 //
@@ -345,6 +347,10 @@ static void SCPI_ClearOperBits(scpi_reg_val_t bits) {
  */
 static void SCPI_SyncQuesBits(void) {
     uint32_t bits = Streaming_GetQuesBits();
+    // The analog-limit bit (#670) is derived from the comparator latch state
+    // rather than stored in gQuesBits: the trip ISR only touches its own latch,
+    // and the condition persists until CONF:ADC:THREshold:CLEar (not stream stop).
+    if (AdcThreshold_AnyLatched()) { bits |= QUES_ANALOG_LIMIT; }
     UsbCdcData_t* usb = UsbCdc_GetSettings();
     wifi_tcp_server_context_t* wifi = wifi_manager_GetTcpServerContext();
     // Replace streaming-related QUES bits in a single write to avoid
@@ -5467,6 +5473,9 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:ADC:USECal?", .callback = SCPI_ADCUseCalGet,},
     {.pattern = "CONFigure:ADC:OBDiag", .callback = SCPI_ADCOnboardDiagSet,},
     {.pattern = "CONFigure:ADC:OBDiag?", .callback = SCPI_ADCOnboardDiagGet,},
+    {.pattern = "CONFigure:ADC:THREshold", .callback = SCPI_ADCThresholdSet,},
+    {.pattern = "CONFigure:ADC:THREshold?", .callback = SCPI_ADCThresholdGet,},
+    {.pattern = "CONFigure:ADC:THREshold:CLEar", .callback = SCPI_ADCThresholdClear,},
     {.pattern = "CONFigure:ADC:SAMC:DEDicated", .callback = SCPI_ADCSamcDedicatedSet,},
     {.pattern = "CONFigure:ADC:SAMC:DEDicated?", .callback = SCPI_ADCSamcDedicatedGet,},
     {.pattern = "CONFigure:ADC:SAMC:SHARed", .callback = SCPI_ADCSamcSharedSet,},

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5476,6 +5476,7 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "CONFigure:ADC:THREshold", .callback = SCPI_ADCThresholdSet,},
     {.pattern = "CONFigure:ADC:THREshold?", .callback = SCPI_ADCThresholdGet,},
     {.pattern = "CONFigure:ADC:THREshold:CLEar", .callback = SCPI_ADCThresholdClear,},
+    {.pattern = "CONFigure:ADC:THREshold:DBG?", .callback = SCPI_ADCThresholdDbg,},
     {.pattern = "CONFigure:ADC:SAMC:DEDicated", .callback = SCPI_ADCSamcDedicatedSet,},
     {.pattern = "CONFigure:ADC:SAMC:DEDicated?", .callback = SCPI_ADCSamcDedicatedGet,},
     {.pattern = "CONFigure:ADC:SAMC:SHARed", .callback = SCPI_ADCSamcSharedSet,},

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1357,8 +1357,9 @@ static void Streaming_Start(void) {
                         &css1, &css2);
                 MC12b_ApplyScanList(css1, css2);
                 gNeedSharedScan = (scanCount > 0);
-                // #670: a Type 2 threshold whose channel isn't in this session's
-                // scan can never fire — disable it (and log) now that ADCCSS is set.
+                // #670: inform (log only) about any Type 2 threshold whose channel
+                // isn't in this session's scan — it won't monitor stream samples,
+                // but stays armed for idle/MEAS and keeps its latch (persistence).
                 AdcThreshold_RevalidateForStream();
             }
             // #541 D-A: clear any Type 1 result parked since the last idle

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -37,6 +37,7 @@
 #include "UsbCdc/UsbCdc.h"
 #include "../HAL/TimerApi/TimerApi.h"
 #include "HAL/ADC/MC12bADC.h"
+#include "HAL/ADC/AdcThreshold.h"
 #include "sd_card_services/sd_card_manager.h"
 #include "wifi_services/wifi_tcp_server.h"
 #include "state/runtime/BoardRuntimeConfig.h"
@@ -140,6 +141,7 @@ static void Streaming_UpdateFlowWindow(bool dropped);
 #define QUES_BIT_ENCODER_FAIL (1 << 11)  // Bit 11: Encoder failure
 #define QUES_BIT_TRANSPORT_DOWN (1 << 12) // Bit 12: all configured transports down >grace (auto-stop fired)
 #define QUES_BIT_SPI_BUS_FAULT STREAMING_QUES_SPI_BUS_FAULT // Bit 13: shared SPI4 bus jammed (#589 — suspect SD card); set/cleared externally, survives session clears
+#define QUES_BIT_ANALOG_LIMIT (1 << 14) // Bit 14: ADC digital-comparator threshold tripped (#670); derived in SCPI_SyncQuesBits from the comparator latch (not set here)
 
 #define FLOW_WINDOW_MIN   20
 #define FLOW_WINDOW_MAX   10000
@@ -1355,6 +1357,9 @@ static void Streaming_Start(void) {
                         &css1, &css2);
                 MC12b_ApplyScanList(css1, css2);
                 gNeedSharedScan = (scanCount > 0);
+                // #670: a Type 2 threshold whose channel isn't in this session's
+                // scan can never fire — disable it (and log) now that ADCCSS is set.
+                AdcThreshold_RevalidateForStream();
             }
             // #541 D-A: clear any Type 1 result parked since the last idle
             // poll — ARDY would still be set and the direct-read path would


### PR DESCRIPTION
## What

Adds hardware analog threshold alarms (epic #664, issue #670) using the PIC32MZ ADCHS **digital comparators**. A comparator watches an ADC channel against raw-code limits and latches a trip **in hardware** — no host polling, no streaming samples consumed. Up to 6 alarms (one per comparator unit).

New SCPI (extends the `CONFigure:ADC:` namespace — no new top-level command):
- `CONFigure:ADC:THREshold <ch>,<mode>,<lo>,<hi>` — mode `0`=off, `1`=below (DATA<lo), `2`=above (DATA≥hi), `3`=inside window (lo≤DATA<hi), `4`=outside window. Below uses only `lo`, above only `hi`; only window modes require lo≤hi.
- `CONFigure:ADC:THREshold? <ch>` → `mode,lo,hi,tripCount,latched`
- `CONFigure:ADC:THREshold:CLEar [<ch>]` — clear latch+counter (no arg = all)
- QUES condition **bit 14** (Analog Limit, 16384) reflects any latched alarm; persists past stream stop, cleared by `:THREshold:CLEar`.

Supported on MC12b (NQ1/NQ2) channels whose ADC input is **AN < 32** (`ADCCMPENx` is one 32-bit register — FRM DS60001344E Reg 22-15 Note 1); AN≥32 channels are rejected with a clear message. Threshold changes are rejected while streaming (session scan is frozen at start, consistent with #116/#541).

## The "routing blocker" was a misdiagnosis

A prior WIP checkpoint concluded the comparator result "wasn't reaching the comparator" on shared-scan channels. **That was wrong.** `DCMPED` (the comparator "output-true" status bit) is *cleared by reading AINID* (FRM Reg 22-26) — and the trip ISR reads the CON register on every trip — so a polled register snapshot almost always reads `DCMPED=0` even while the comparator fires hundreds of times/sec. The real signal is the ISR software `tripCount`. There is **no shared-scan routing gap**: a MODULE7 (Class-2) scan result feeds the comparator fine, proven on hardware.

Two real bugs *were* found and fixed earlier via the FRM (validating the new "read the FRM" directive in CLAUDE.md): `DCMPGIEN` (interrupt-enable, bit 6) must be set separately from `ENDCMP`, and the in-window condition is `IEBTWN`, not `IEHILO`.

## Hardware validation (COM3, board 7E2898F46200E8A7)

- **8/8 directional battery** on shared-scan **AN24** (ch1): below/above/inside/outside, both directions, all deterministic (value-independent extreme thresholds — no signal rig needed).
- **Dedicated-module AN0** (ch8): above/below correct — Class-1 path also compared.
- QUES bit 14 set on latch, cleared on release; arm rejected mid-stream; AN≥32 rejected.
- cppcheck baseline unchanged; builds clean at -O3 -Werror.

## Test

Companion regression test: daqifi/daqifi-python-test-suite#TBD (`test_670_adc_comparators.py`) — passes on COM3, would fail on pre-#670 firmware (`-113`).

## Files

`HAL/ADC/AdcThreshold.{c,h}` (new), `SCPIADC.c` (set/get/clear), `interrupts.c` + `interrupts_a.S` (6 comparator ISR vectors 46–51), `streaming.c` (`RevalidateForStream`), `SCPIInterface.c` (QUES bit 14 + patterns), `Logger.h`, `configurations.xml`. Also bundles the CLAUDE.md FRM/Harmony-preference directives that came out of this work.

🤖 Generated with Claude Code