### PR TITLE
fix(#700): UART 300-baud floor + I2C recovery-comment follow-ups

### DIFF
--- a/firmware/src/HAL/UserI2c/UserI2c.c
+++ b/firmware/src/HAL/UserI2c/UserI2c.c
@@ -6,8 +6,10 @@
  * directly here. The register sequences mirror the hardware-proven I2C5 PLIB
  * (START/addr/ACKSTAT/TRN, RCEN/RCV/ACKEN, PEN); the state machine is folded
  * into bounded polled primitives that run from SCPI (task) context so a stuck
- * bus times out instead of hanging (a 9-clock + STOP recovery is wired into the
- * ENAble cycle). See UserI2c.h for the verified hardware topology.
+ * bus times out instead of hanging. A stuck-SDA recovery (9 SCL pulses + STOP)
+ * runs REACTIVELY on a transfer/scan timeout, so the next Scan/Transfer clears a
+ * slave holding SDA low; it is not run proactively at ENAble. See UserI2c.h for
+ * the verified hardware topology.
  */
 #include "device.h"
 #include "UserI2c.h"

--- a/firmware/src/HAL/UserI2c/UserI2c.h
+++ b/firmware/src/HAL/UserI2c/UserI2c.h
@@ -28,8 +28,10 @@
  *
  * Phase 1 transfers are polled/blocking-with-timeout, run from SCPI (task)
  * context, and are bounded so a stuck bus can't hang the task -- a stuck-SDA
- * recovery (9 SCL pulses + STOP) is wired into the ENAble off/on cycle. This
- * driver ships the mechanism; the client owns the sensor's register protocol.
+ * recovery (9 SCL pulses + STOP) runs reactively on a transfer/scan timeout, so
+ * the next Scan/Transfer self-heals a slave holding SDA low (it is not run
+ * proactively at ENAble). This driver ships the mechanism; the client owns the
+ * sensor's register protocol.
  *
  * Errata honored: #37 (SCL tLOW out of I2C spec at >=400 kHz, no workaround --
  * frequencies >=400 kHz are rejected); #6 (A1/A3 I2C misbehaves >100 kHz or

--- a/firmware/src/HAL/UserUart/UserUart.c
+++ b/firmware/src/HAL/UserUart/UserUart.c
@@ -206,22 +206,35 @@ static void uart_SetPmd(const UartDesc_t* u, bool enable) {
 // Section: helpers
 // *****************************************************************************
 
-/* BRG for a requested baud, BRGH=1, round-to-NEAREST (unlike SPI's round-down:
+/* BRG + BRGH-mode for a requested baud, round-to-NEAREST (unlike SPI's round-down:
  * UART baud is a match-tolerance constraint, both directions are fine within
- * ~2-3%, so nearest minimizes error). Also returns the achieved baud. Uses the
- * project's DAQIFI_UART_BRGH_DIV so the rounding matches the debug UART. */
-static uint32_t uart_ComputeBrg(uint32_t baudHz, uint32_t* actualOut) {
-    uint32_t brg = DAQIFI_UART_BRGH_DIV(baudHz);
-    if (brg > USER_UART_BRG_MAX) { brg = USER_UART_BRG_MAX; }
-    if (actualOut != NULL) {
-        *actualOut = USER_UART_PBCLK_HZ / (4u * (brg + 1u));
+ * ~2-3%, so nearest minimizes error). High rates use BRGH=1 (÷4, matching the
+ * debug UART's DAQIFI_UART_BRGH_DIV); a rate whose BRGH=1 divisor would saturate
+ * the 16-bit BRG falls back to BRGH=0 (÷16), quadrupling the reach so the
+ * advertised 300-baud floor is actually achievable (#700 — the code previously
+ * only ever used BRGH=1, whose floor is ~320 Hz, so 300..319 were rejected).
+ * Returns the achieved baud in *actualOut and the chosen mode in *brgh1Out. */
+static uint32_t uart_ComputeBrg(uint32_t baudHz, bool* brgh1Out, uint32_t* actualOut) {
+    uint32_t brg = DAQIFI_UART_BRGH_DIV(baudHz);         /* BRGH=1 candidate (÷4) */
+    bool brgh1 = (brg <= USER_UART_BRG_MAX);             /* use it iff it doesn't saturate */
+    if (!brgh1) {
+        /* BRGH=0: baud = PBCLK/(16*(BRG+1)); round-to-nearest (half-divisor = 8*baud). */
+        brg = ((USER_UART_PBCLK_HZ + (8u * baudHz)) / (16u * baudHz)) - 1u;
+        if (brg > USER_UART_BRG_MAX) { brg = USER_UART_BRG_MAX; }
     }
+    if (actualOut != NULL) {
+        uint32_t divk = brgh1 ? 4u : 16u;
+        *actualOut = USER_UART_PBCLK_HZ / (divk * (brg + 1u));
+    }
+    if (brgh1Out != NULL) { *brgh1Out = brgh1; }
     return brg;
 }
 
-/* Lowest achievable baud at this PBCLK (BRG saturates at 65535). */
+/* Lowest achievable baud at this PBCLK: BRGH=0 (÷16) with BRG saturated. This is
+ * the absolute floor (#700) — BRGH=1's floor is 4× higher; uart_ComputeBrg drops
+ * to BRGH=0 below it, so the advertised 300-baud minimum is reachable. */
 static uint32_t uart_BaudFloor(void) {
-    return USER_UART_PBCLK_HZ / (4u * (USER_UART_BRG_MAX + 1u));
+    return USER_UART_PBCLK_HZ / (16u * (USER_UART_BRG_MAX + 1u));
 }
 
 // *****************************************************************************
@@ -317,7 +330,12 @@ static bool uart_EnableLocked(const char** err) {
     /* UxMODE/UxSTA bit positions are identical across all UARTs, so the U1 mask
      * macros carry the generic values. PDSEL: parity 0/1/2 = 8N/8E/8O (the enum
      * matches the field). */
-    uint32_t mode = _U1MODE_BRGH_MASK;                                   /* BRGH=1 */
+    /* Compute BRG + BRGH mode up front: high rates use BRGH=1 (÷4), rates below
+     * its saturation floor fall back to BRGH=0 (÷16) so 300 baud is reachable (#700). */
+    bool brgh1 = true;
+    uint32_t brgVal = uart_ComputeBrg(gCfg.baudHz, &brgh1, &gActualBaud);
+
+    uint32_t mode = brgh1 ? _U1MODE_BRGH_MASK : 0u;                      /* BRGH per rate */
     mode |= ((uint32_t)gCfg.parity << _U1MODE_PDSEL_POSITION);           /* 8N/8E/8O */
     if (gCfg.stopBits == 2u) { mode |= _U1MODE_STSEL_MASK; }
     if (gCfg.rxInv)          { mode |= _U1MODE_RXINV_MASK; }
@@ -329,7 +347,7 @@ static bool uart_EnableLocked(const char** err) {
     if (gCfg.txInv)                       { sta |= _U1STA_UTXINV_MASK; }
     *(u->sta) = sta;
 
-    *(u->brg) = uart_ComputeBrg(gCfg.baudHz, &gActualBaud);
+    *(u->brg) = brgVal;
     *(u->modeSet) = _U1MODE_ON_MASK;
 
     /* Now route PPS (pin follows the already-idling UxTX) and switch the


### PR DESCRIPTION
Resolves **#700** — two LOW-severity defects the cross-vendor adversarial audit surfaced in *already-merged* epic-#664 code (confirmed by an independent opus skeptic; both clean/self-healing, no crash or data loss).

## 1. UART — advertised 300-baud minimum was rejected
`USER_UART_MIN_BAUD_HZ` advertises **300**, and the header comment justifies it with a BRGH=0 (÷16) floor of ~80 Hz — but the code only ever used **BRGH=1** (÷4), whose 16-bit-BRG floor is ~**320 Hz**, so `SYST:COMM:UART:CONFig … ,300` (and 301–319) was rejected with *"baud below the PBCLK BRG floor"*.

**Fix:** `uart_ComputeBrg` now returns the BRGH mode — it uses **BRGH=1** when its divisor fits the 16-bit BRG (finer resolution, still matching the debug UART's `DAQIFI_UART_BRGH_DIV`) and falls back to **BRGH=0** (÷16, round-to-nearest) below that. `UxMODE`'s BRGH bit is set per the chosen mode, and `uart_BaudFloor()` now returns the true BRGH=0 floor. 300 baud → BRGH=0 / BRG=17499 → **300 Hz exactly** on the 252 MHz build; the BRGH=1 high-rate path is byte-for-byte unchanged. (This makes the code match the pre-existing header comment.)

## 2. I2C — comment claimed proactive stuck-bus recovery that doesn't exist
`UserI2c.c/.h` said the 9-SCL-pulse + STOP stuck-SDA recovery is *"wired into the ENAble off/on cycle."* It isn't — `i2c_BusRecover()` runs **reactively** on a transfer/scan timeout (the next Scan/Transfer self-heals), never at Enable. **Fix:** corrected both comments to describe the actual reactive recovery. Kept the reactive design (it already self-heals; a proactive Enable-time pulse would be a behavior change for a separate PR).

## Build / test
- Builds clean at **-O3 -Werror**; cppcheck baseline unchanged.
- Regression test: **daqifi-python-test-suite #99** — 300-baud accepted + `ActualBaud ≈ 300`, sub-300 still rejected, 115200 unchanged (no external wiring; checks the achieved-baud report).

## Merge note
The I2C change is comment-only. The UART **BRGH=0 low-baud path is new behavior** — bench-validate a 300-baud round-trip before relying on it (the math is verified and the BRGH=1 path is untouched, so risk is contained to the new branch).

Closes #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)