### PR TITLE
docs(spi): #695 honest SPI:TRANsfer? single-command frame ceiling (~238 B)

### DIFF
--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -32,7 +32,16 @@
  * A timeout here means SCK is not toggling (hardware/config fault). */
 #define USER_SPI_XFER_TIMEOUT   2000000UL
 
-/* Max bytes per SYST:COMM:SPI:TRANsfer? frame (matches the SCPI hex cap). */
+/* HAL scratch capacity per UserSpi_Transfer() frame. NOTE (#695): a single
+ * SYST:COMM:SPI:TRANsfer? command cannot deliver a full 256 B frame -- the hex
+ * payload (2 chars/byte) plus the command framing must fit
+ * SCPI_INPUT_BUFFER_LENGTH (512). The longest query form
+ * `SYSTem:COMMunicate:SPI:TRANsfer? "<hex>"` adds 35 B (32 B pattern + space +
+ * two quotes), so the reachable single-command payload is (512-35)/2 = 238 B
+ * (a few more via the abbreviated form); larger requests are rejected by
+ * libscpi (INPUT_BUFFER_OVERRUN) before the callback runs. This 256 B is the
+ * HAL capability for any non-buffer-bound caller; SCPI clients split frames
+ * >238 B. See SCPI_SpiTransfer() and the wiki SPI:TRANsfer? row. */
 #define USER_SPI_MAX_FRAME      256u
 
 // *****************************************************************************

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -34,14 +34,15 @@
 
 /* HAL scratch capacity per UserSpi_Transfer() frame. NOTE (#695): a single
  * SYST:COMM:SPI:TRANsfer? command cannot deliver a full 256 B frame -- the hex
- * payload (2 chars/byte) plus the command framing must fit
- * SCPI_INPUT_BUFFER_LENGTH (512). The longest query form
- * `SYSTem:COMMunicate:SPI:TRANsfer? "<hex>"` adds 35 B (32 B pattern + space +
- * two quotes), so the reachable single-command payload is (512-35)/2 = 238 B
- * (a few more via the abbreviated form); larger requests are rejected by
- * libscpi (INPUT_BUFFER_OVERRUN) before the callback runs. This 256 B is the
- * HAL capability for any non-buffer-bound caller; SCPI clients split frames
- * >238 B. See SCPI_SpiTransfer() and the wiki SPI:TRANsfer? row. */
+ * payload (2 chars/byte) plus the command framing and CRLF terminator must fit
+ * SCPI_INPUT_BUFFER_LENGTH (512, one byte reserved). Bench-measured 2026-07-19
+ * (FW 3.7.2): the long query form `SYSTem:COMMunicate:SPI:TRANsfer? "<hex>"`
+ * tops out at 237 payload bytes (238 overruns); the abbreviated
+ * `SYST:COMM:SPI:TRAN?` form reaches 243. Larger requests are rejected by
+ * libscpi (INPUT_BUFFER_OVERRUN, -363) BEFORE this callback runs. Use 237 B as
+ * the safe single-command ceiling across command forms. This 256 B is the HAL
+ * capability for any non-buffer-bound caller; SCPI clients split larger frames.
+ * See SCPI_SpiTransfer() and the wiki SPI:TRANsfer? row. */
 #define USER_SPI_MAX_FRAME      256u
 
 // *****************************************************************************

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -917,11 +917,12 @@ static bool spi_ParseHex(const char* p, size_t len, uint8_t* out,
 }
 
 /* #695: the 256 B HAL scratch (USER_SPI_MAX_FRAME) is more than one SCPI
- * command can carry -- the hex payload plus the command framing must fit
- * SCPI_INPUT_BUFFER_LENGTH (512), so the reachable single-command frame is
- * ~238 B (see USER_SPI_MAX_FRAME's comment for the arithmetic). A larger
- * request is rejected as INPUT_BUFFER_OVERRUN by libscpi before this callback
- * runs; clients split frames >238 B. */
+ * command can carry -- the hex payload plus the command framing + CRLF must fit
+ * SCPI_INPUT_BUFFER_LENGTH (512). Bench-measured single-command ceiling is
+ * 237 B (long command form; the abbreviated form reaches 243) -- see
+ * USER_SPI_MAX_FRAME's comment. A larger request is rejected as
+ * INPUT_BUFFER_OVERRUN by libscpi before this callback runs; clients split
+ * frames >237 B. */
 scpi_result_t SCPI_SpiTransfer(scpi_t * context) {
     const char* p = NULL;
     size_t len = 0;
@@ -953,7 +954,7 @@ scpi_result_t SCPI_SpiTransfer(scpi_t * context) {
     uint16_t n = 0;
     if (!spi_ParseHex(p, len, tx, 256u, &n)) {
         SCPI_ResponseBuf_Give();
-        SCPI_ExecutionError(context, "SPI:TRAN: bad hex (even digits; <=238 bytes/command, split larger frames)");
+        SCPI_ExecutionError(context, "SPI:TRAN: bad hex (even digits; <=237 bytes/command, split larger frames)");
         return SCPI_RES_ERR;
     }
     if (!UserSpi_Transfer(tx, rx, n)) {

--- a/firmware/src/services/SCPI/SCPILAN.c
+++ b/firmware/src/services/SCPI/SCPILAN.c
@@ -916,6 +916,12 @@ static bool spi_ParseHex(const char* p, size_t len, uint8_t* out,
     return true;
 }
 
+/* #695: the 256 B HAL scratch (USER_SPI_MAX_FRAME) is more than one SCPI
+ * command can carry -- the hex payload plus the command framing must fit
+ * SCPI_INPUT_BUFFER_LENGTH (512), so the reachable single-command frame is
+ * ~238 B (see USER_SPI_MAX_FRAME's comment for the arithmetic). A larger
+ * request is rejected as INPUT_BUFFER_OVERRUN by libscpi before this callback
+ * runs; clients split frames >238 B. */
 scpi_result_t SCPI_SpiTransfer(scpi_t * context) {
     const char* p = NULL;
     size_t len = 0;
@@ -947,7 +953,7 @@ scpi_result_t SCPI_SpiTransfer(scpi_t * context) {
     uint16_t n = 0;
     if (!spi_ParseHex(p, len, tx, 256u, &n)) {
         SCPI_ResponseBuf_Give();
-        SCPI_ExecutionError(context, "SPI:TRAN: bad hex (even digits, <=256 bytes)");
+        SCPI_ExecutionError(context, "SPI:TRAN: bad hex (even digits; <=238 bytes/command, split larger frames)");
         return SCPI_RES_ERR;
     }
     if (!UserSpi_Transfer(tx, rx, n)) {


### PR DESCRIPTION
## Summary

Closes #695 — the advertised 256-byte `SYST:COMM:SPI:TRANsfer?` frame is unreachable through a single SCPI command. A 256-byte frame is 512 hex digits, and the full command (`SYSTem:COMMunicate:SPI:TRANsfer? "<512 hex>"`, ~535 B) exceeds `SCPI_INPUT_BUFFER_LENGTH` (512), so libscpi raises `INPUT_BUFFER_OVERRUN` **before the callback runs**. The reachable single-command payload is `(512 − 35)/2 = 238 B` (35 B of framing: 32 B pattern + space + two quotes; a few more via the abbreviated command form).

## What changed (docs only — no behavior change)

- `UserSpi.c` — `USER_SPI_MAX_FRAME` doc-comment now distinguishes the **256 B HAL scratch capability** from the **~238 B single-command ceiling**, with the buffer arithmetic.
- `SCPILAN.c` — a note by `SCPI_SpiTransfer` explains the ceiling; the parse-error text now points clients at splitting frames > 238 B instead of implying 256 is reachable.
- Wiki `01-SCPI-Interface.md` — `SPI:TRANsfer?` row documents the ~238 B/command limit + split guidance (pushed).

This is the issue's option (b): keep the 256 B HAL capability, make the docs honest. The overrun was already cleanly rejected (nothing clocked, no residual state) — this is purely an advertised-vs-reachable documentation fix, so **no regression test** (comment/string-only, no behavior change; hardware-test-exempt per CLAUDE.md).

Refs #664 #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)