### PR TITLE
feat(settings): #306 CRC32 settings integrity, sever wolfSSL from save path

### DIFF
--- a/firmware/src/services/daqifi_settings.c
+++ b/firmware/src/services/daqifi_settings.c
@@ -101,7 +101,18 @@ bool daqifi_settings_LoadFromNvm(DaqifiSettingsType type, DaqifiSettings* settin
     uint32_t crc = CRC32_Compute(&(tmpSettings.settings), dataSize);
     uint32_t storedCrc;
     memcpy(&storedCrc, tmpSettings.checksum, sizeof(storedCrc));
-    bool valid = (storedCrc == crc);
+    /* A valid CRC32 record is [crc(4) | zero(12)] (see the save path). Require
+     * the zero padding as well, so a legacy MD5 (or corrupt) 16-byte checksum
+     * can't alias a CRC32 match on just the first 4 bytes and wrongly skip the
+     * MD5 fallback — the full checksum field must match the CRC32 record shape. */
+    bool padZero = true;
+    for (size_t i = sizeof(storedCrc); i < DAQIFI_SETTINGS_CHECKSUM_SIZE; i++) {
+        if (tmpSettings.checksum[i] != 0u) {
+            padZero = false;
+            break;
+        }
+    }
+    bool valid = padZero && (storedCrc == crc);
 
     if (!valid) {
         uint8_t hash[CRYPT_MD5_DIGEST_SIZE];

--- a/firmware/src/services/daqifi_settings.c
+++ b/firmware/src/services/daqifi_settings.c
@@ -5,6 +5,7 @@
 #include "state/board/BoardConfig.h"
 #include "state/board/NQ3BoardConfig.h"
 #include "state/runtime/BoardRuntimeConfig.h"
+#include "Util/CRC32.h"   /* #306: settings integrity checksum (severs wolfSSL) */
 
 uint8_t gTempFflashBuffer[NVM_FLASH_ROWSIZE] __attribute__((coherent, aligned(16)));
 
@@ -90,13 +91,28 @@ bool daqifi_settings_LoadFromNvm(DaqifiSettingsType type, DaqifiSettings* settin
     }
     memcpy(&tmpSettings, (uint32_t *) PA_TO_KVA1(address), sizeof (DaqifiSettings));
 
-    uint8_t hash[CRYPT_MD5_DIGEST_SIZE];
-    CRYPT_MD5_CTX md5Sum;
-    CRYPT_MD5_Initialize(&md5Sum);
-    CRYPT_MD5_DataAdd(&md5Sum, (const uint8_t*) &(tmpSettings.settings), dataSize);
-    CRYPT_MD5_Finalize(&md5Sum, hash);
+    /* #306: validate integrity with CRC32 (Util/CRC32), severing the settings
+     * load path from wolfSSL. Dual-validate for the migration window: if the
+     * CRC32 doesn't match, fall back to the legacy 16-byte MD5 checksum so a
+     * device upgrading from pre-#306 firmware still reads its stored settings
+     * (the next save rewrites them with CRC32). The CRC32 lives in the first
+     * 4 bytes of the layout-stable checksum field; the checksum covers only the
+     * `settings` payload (dataSize bytes), exactly as the MD5 did. */
+    uint32_t crc = CRC32_Compute(&(tmpSettings.settings), dataSize);
+    uint32_t storedCrc;
+    memcpy(&storedCrc, tmpSettings.checksum, sizeof(storedCrc));
+    bool valid = (storedCrc == crc);
 
-    if (memcmp(hash, &tmpSettings.md5Sum, CRYPT_MD5_DIGEST_SIZE) != 0) {
+    if (!valid) {
+        uint8_t hash[CRYPT_MD5_DIGEST_SIZE];
+        CRYPT_MD5_CTX md5Ctx;
+        CRYPT_MD5_Initialize(&md5Ctx);
+        CRYPT_MD5_DataAdd(&md5Ctx, (const uint8_t*) &(tmpSettings.settings), dataSize);
+        CRYPT_MD5_Finalize(&md5Ctx, hash);
+        valid = (memcmp(hash, tmpSettings.checksum, CRYPT_MD5_DIGEST_SIZE) == 0);
+    }
+
+    if (!valid) {
         return false;
     }
 
@@ -234,12 +250,15 @@ bool daqifi_settings_SaveToNvm(DaqifiSettings* settings) {
         return false;
     }
 
-    CRYPT_MD5_CTX md5Sum;
-    CRYPT_MD5_Initialize(&md5Sum);
-    CRYPT_MD5_DataAdd(&md5Sum, (const uint8_t*) &(settings->settings), dataSize);
-    CRYPT_MD5_Finalize(&md5Sum, settings->md5Sum);
+    /* #306: CRC32 integrity (Util/CRC32) — no wolfSSL on the save path. Store
+     * the 4-byte CRC32 in the first bytes of the layout-stable checksum field
+     * and zero the rest, so the field is deterministic and can't be mistaken
+     * for a 16-byte MD5 by the load-path fallback. */
+    uint32_t crc = CRC32_Compute(&(settings->settings), dataSize);
+    memset(settings->checksum, 0, sizeof(settings->checksum));
+    memcpy(settings->checksum, &crc, sizeof(crc));
 
-    if (sizeof (DaqifiSettings)>sizeof (gTempFflashBuffer)) {        
+    if (sizeof (DaqifiSettings)>sizeof (gTempFflashBuffer)) {
         return false;
     }
     memcpy(gTempFflashBuffer, settings, sizeof (DaqifiSettings));

--- a/firmware/src/services/daqifi_settings.h
+++ b/firmware/src/services/daqifi_settings.h
@@ -143,13 +143,28 @@ extern "C" {
     } DaqifiSettingsType;
 
     /**
+     * Size of the NVM integrity checksum field. #306: this used to hold a
+     * 16-byte MD5 (wolfSSL); it now holds a 4-byte CRC32 (Util/CRC32) in the
+     * first 4 bytes, with the remaining bytes zero. The field is kept at the
+     * MD5 digest size so the on-NVM struct layout is byte-identical to pre-#306
+     * releases — a device upgrading from MD5 firmware still reads its stored
+     * settings via the CRC32-fails -> MD5-fallback path in daqifi_settings.c
+     * (see daqifi_settings_LoadFromNvm). Decoupling this from wolfSSL entirely
+     * (and dropping the MD5 fallback) is #306 phase 2, once all fielded devices
+     * have re-saved with CRC32.
+     */
+#define DAQIFI_SETTINGS_CHECKSUM_SIZE CRYPT_MD5_DIGEST_SIZE
+
+    /**
      * The wrapper for all Daqifi NVM settings
      */
     typedef struct sDaqifiSettings {
         /**
-         * The MD5 Checksum of this structure. This is how the system determines whether the values are valid.
+         * Integrity checksum of this structure's `settings` payload — how the
+         * system determines whether stored values are valid. CRC32 since #306
+         * (was MD5); see DAQIFI_SETTINGS_CHECKSUM_SIZE above.
          */
-        uint8_t md5Sum[CRYPT_MD5_DIGEST_SIZE];
+        uint8_t checksum[DAQIFI_SETTINGS_CHECKSUM_SIZE];
 
         /**
          * The type of settings stored in this object


### PR DESCRIPTION
## What

**#306 consumer 1 (phase 1).** The NVM settings load/save path checksummed each record with wolfSSL's `CRYPT_MD5`. wolfSSL is pinned at v5.4.0 and can't be upgraded safely (CLAUDE.md), so settings integrity shouldn't sit in that blast radius — and MD5 is overkill for non-security integrity. Switch to **CRC32** (`Util/CRC32`, the IEEE-802.3 utility landed in [#610](https://github.com/daqifi/daqifi-nyquist-firmware/pull/610)).

## How

- **Save**: CRC32 over the settings payload → first 4 bytes of the checksum field, rest zeroed. No wolfSSL on the save path.
- **Load**: validate with CRC32; on mismatch, fall back to the legacy 16-byte MD5 checksum so a device upgrading from pre-#306 firmware still reads its stored settings (the next save rewrites them with CRC32). **Dual-validate** for the migration window.
- The checksum field (`md5Sum` → `checksum`) is kept at the MD5 digest size so the **on-NVM struct layout is byte-identical** to pre-#306 releases — no offset shift, so the MD5 fallback reads the legacy checksum from the same bytes. Save/load are symmetric host-order `memcpy`, so the comparison is endianness-agnostic.

**Phase 2 (separate PR)** drops the MD5 fallback and decouples the field size from wolfSSL once all fielded devices have re-saved with CRC32 — that needs a boot migration pass first (factory cal never re-saves on its own).

## Test

Builds clean under `-O3 -Werror`. **Bench-validated** (board `7E2898F46200E8A7`):
- post-flash **blank-NVM boots to defaults with no crash** — CRC32 correctly rejects erased NVM (the load returns false → factory defaults);
- a saved voltage precision **persists across `SYST:REBoot`**, while an **unsaved change does not** — the CRC32 round-trip.

Companion regression: [`daqifi-python-test-suite#103`](https://github.com/daqifi/daqifi-python-test-suite/pull/103) — `test_306_settings_crc32.py` (positive round-trip + negative control, 8/8 PASS).

> Orthogonal note: post-wipe default precision reads 0 not the documented 4, but that's the **unchanged** `LoadFactoryDeafult`/runtime-seed path — this diff only changes checksum *validation*, which correctly rejects blank NVM in both old and new code. Pre-existing, not caused by #306.

Refs #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)