### PR TITLE
fix(streaming): lower over-high PB pure-T1 caps (SD #714 + USB at-cap silent loss)

### DIFF
--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -147,7 +147,15 @@ static inline uint32_t Streaming_AdcAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2us
         } else if (armed != 0u) {
             period_ns = 58000ULL + 2160ULL*nT1 + 10000ULL*nT2user;
         } else {
-            period_ns = 43200ULL + 2300ULL*nT1;
+            /* #714/#90 refit (2026-07-23): the #596 pure-T1 term (43200+2300*nT1)
+             * over-caps USB PB at 252 MHz — at-cap silently drops. Freeze-aware
+             * walk-down soaks (COM3 …E8A7, 100 s/step, atcap_20260723_013919.csv)
+             * measured the true zero-loss ceilings: 1xT1 16900, 3xT1 15350,
+             * 5xT1 14075 (vs the enforced 19340/17564/16087 — ~14% too high).
+             * Re-fit ~7% under the measured ceilings (never-over): 1xT1 15799,
+             * 3xT1 14263, 5xT1 12998. Binds USB PB pure-T1 only (SD is SdAdditive-
+             * bound lower, WiFi/USB+SD transport-bound lower). */
+            period_ns = 52700ULL + 3000ULL*nT1;
         }
         num = 880000000ULL;   /* 1e9 * 0.88 (PB safe envelope) */
     } else {
@@ -188,8 +196,21 @@ static inline uint32_t Streaming_SdAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2use
         return STREAMING_ISR_MAX_HZ;   /* CSV is byte-bound: the transport term binds it */
     }
     uint32_t armed = (nT2user > 0u || nMon > 0u) ? 1u : 0u;
-    uint64_t period_ns = 93539ULL + 63468ULL*armed
-                       + 7959ULL*(uint64_t)nT1 + 4615ULL*(uint64_t)nT2user;
+    uint64_t period_ns;
+    if (armed != 0u) {
+        /* Armed (scan running) cells UNCHANGED from the #574 fit — every armed
+         * SD-PB cell (1xT2, mixed, OBDiag) at-cap-validated clean 2026-07-23.
+         * 157007 = the old 93539 base + 63468 armed offset. */
+        period_ns = 157007ULL + 7959ULL*(uint64_t)nT1 + 4615ULL*(uint64_t)nT2user;
+    } else {
+        /* #714 refit (2026-07-23): the pure-T1 (no-scan) branch over-capped
+         * 1xT1 at 9852 — at-cap silently dropped 2.57M bytes/100 s. Freeze-aware
+         * walk-down (COM3 …E8A7, atcap_20260723_013919.csv) measured the true
+         * zero-loss ceiling at 8600. Re-fit ~8% under (never-over): 1xT1 7900.
+         * Slope keeps 3xT1 (SD-transport-bound at 5528) and 5xT1 (~7499)
+         * unchanged — only the additive-bound 1xT1 cell moves. */
+        period_ns = 124890ULL + 1692ULL*(uint64_t)nT1;
+    }
     uint32_t hz = (uint32_t)(1000000000ULL / period_ns);  /* period_ns >= base, no div-by-0 */
     if (hz > STREAMING_ISR_MAX_HZ) hz = STREAMING_ISR_MAX_HZ;
     return (hz == 0u) ? 1u : hz;

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -203,12 +203,19 @@ static inline uint32_t Streaming_SdAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2use
          * 157007 = the old 93539 base + 63468 armed offset. */
         period_ns = 157007ULL + 7959ULL*(uint64_t)nT1 + 4615ULL*(uint64_t)nT2user;
     } else {
-        /* #714 refit (2026-07-23): the pure-T1 (no-scan) branch over-capped
-         * 1xT1 at 9852 — at-cap silently dropped 2.57M bytes/100 s. Freeze-aware
-         * walk-down (COM3 …E8A7, atcap_20260723_013919.csv) measured the true
-         * zero-loss ceiling at 8600. Re-fit ~8% under (never-over): 1xT1 7900.
-         * Slope keeps 3xT1 (SD-transport-bound at 5528) and 5xT1 (~7499)
-         * unchanged — only the additive-bound 1xT1 cell moves. */
+        /* #714 refit (2026-07-23): the whole pure-T1 (no-scan, OBDiag=off) branch
+         * was over-high. The old 93539+7959*nT1 curve capped 1xT1 at 9852, which
+         * at-cap silently dropped 2.57M bytes/100 s (measured ceiling 8600); the
+         * higher-nT1 cells of that curve (2xT1 9137, 3xT1 8517, 4xT1 7979) sit in
+         * the SAME over-high regime — the SD-PB transport term (99000/(4+n):
+         * 2ch 16500 ... 5ch 11000) is well ABOVE them, so this additive binds and
+         * the old values were enforced with no measured backing. The pure-T1 SD
+         * Hz ceiling is roughly FLAT (SD-writer per-tick cost dominates, not bytes):
+         * re-fit ~5-8% under the flat ceiling — 1xT1 7900, 2xT1 7795, 3xT1 7694,
+         * 4xT1 7592, 5xT1 7499. BOTH endpoints at-cap-validated zero-loss (1xT1
+         * @7900, 5xT1 @7499, atcap_20260723_025553.csv); 2/3/4xT1 are bracketed on
+         * this monotonic curve. A precise per-channel multi-T1 SD ceiling sweep
+         * (to reclaim any headroom) is a #714 follow-up — never-over holds now. */
         period_ns = 124890ULL + 1692ULL*(uint64_t)nT1;
     }
     uint32_t hz = (uint32_t)(1000000000ULL / period_ns);  /* period_ns >= base, no div-by-0 */


### PR DESCRIPTION
## Lower over-high PB pure-T1 caps — SD #714 + USB #90 at-cap silent loss

The 252 MHz PB additive refit (#596 ADC-additive / #574 SD-additive) left the **pure-T1 (no-scan, `armed=0`) PB** caps **above** their true zero-loss ceilings, so streaming *at the enforced cap* silently drops data — the exact failure the hard cap (#524) exists to prevent.

### Evidence (E) — freeze-aware walk-down, COM3 …E8A7, 100 s/step
`benchmarks/atcap_20260723_013919.csv`

| cell | enforced cap | at-cap result | measured ceiling |
|---|---:|---|---:|
| USB PB 1×T1 | 19340 | FAIL (2% / 49.8k drops) | **16900** |
| USB PB 3×T1 | 17564 | FAIL (3868 drops) | **15350** |
| USB PB 5×T1 | 16087 | FAIL | **14075** |
| SD PB 1×T1 | 9852 | FAIL (2.57M B/100 s) | **8600** |

Every other PB cell (T2, OBDiag, mixed) was clean at cap — the over-cap is specific to the pure-T1 additive branches.

### Fix
Re-fit the two `armed=0` PB branches ~7–8% under the measured ceilings (never-over). **Both changes only lower caps**, so no cell can newly exceed its ceiling:
- `Streaming_AdcAdditiveCap_NQ1` armed=0 PB: `43200+2300·nT1 → 52700+3000·nT1` (binds USB PB pure-T1 only). New caps: 1×T1 15799, 3×T1 14263, 5×T1 12998.
- `Streaming_SdAdditiveCap_NQ1`: split `armed=0` into its own branch `124890+1692·nT1` (1×T1 → 7900). Armed cells unchanged (`157007` = old `93539+63468`); 3×T1 stays SD-transport-bound (5528), 5×T1 ~7499.

### Validation
🔄 At-cap soak (`--at-cap --walk-down --skip-csv --sd`, PB, USB+SD) running on the fixed build — will confirm every cell zero-loss at its corrected cap before marking ready. NQ1-only (the additive terms are NQ1); CSV is transport-bound (PB-only).

Companion regression: the nightly `at-cap` gate already flags these leaks; this fix makes them pass. Test-suite update to follow per the test-with-firmware policy.

Refs #714, #90-equivalent (USB-PB sibling), #562, #574, #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
