### PR TITLE
fix(streaming): deterministic per-tick timestamp (#717 duplicate msg_time_stamp)

### DIFF
--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -629,24 +629,24 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             }
             /* #717: deterministic per-tick timestamp, computed ONCE per tick
              * BEFORE the pool alloc so a pool-exhaust drop still advances the
-             * tick index (the next emitted sample stays phase-correct). Seeds
-             * baseTS (a clean slot read) + periodTicks on the session's first
-             * tick; thereafter ts = baseTS + N*periodTicks with no shared-slot
-             * read (kills the catch-up aliasing that produced t,t,t+2p). The
-             * uint32_t product wraps in lockstep with TMR6's own 32-bit wrap
-             * ((N mod 2^32)*p == N*p mod 2^32), so it stays the exact TMR6 value.
-             * #533 0->1 clamp kept. Single writer (this task) -> no critical
-             * section on the tick-index RMW. */
+             * tick index (next emitted sample stays phase-correct). Kills the
+             * catch-up aliasing (t,t,t+2p) from reading the shared 1-deep slot at
+             * variable task latency. Seed baseTS (clean slot read) + periodTicks
+             * on the session's first tick; thereafter ts = baseTS + N*periodTicks.
+             * periodTicks = TSTimer(TMR6) freq / rate, from the SAME
+             * TimerApi_FrequencyGet reported as msg timestamp_freq
+             * (NanoPB_Encoder.c:521) -- so stamps stay consistent with what
+             * clients divide by, it is EXACT for the (integer-dividing) streaming
+             * rates, and it composes with the #716 clock fix (which corrects
+             * tsFreq). NOT ClockPeriod (TMR4/5 runs a different prescale than
+             * TMR6) and NOT a first-inter-tick measurement (that captures a
+             * slightly-long startup-transient period, e.g. 8431 vs the real 8400
+             * @5kHz -- rejected 2026-07-24). The uint32_t product wraps in
+             * lockstep with TMR6's 32-bit wrap ((N mod 2^32)*p == N*p mod 2^32).
+             * #533 0->1 clamp kept. */
             if (!gStreamTSSeeded) {
                 uint32_t* pSeed = BoardData_Get(BOARDDATA_STREAMING_TIMESTAMP, 0);
                 gStreamBaseTS = (pSeed != NULL) ? *pSeed : 1u;
-                /* periodTicks = TMR6-advance per streaming tick = tsFreq / rate.
-                 * tsFreq is TimerApi_FrequencyGet(TSTimerIndex) -- the SAME value
-                 * reported as msg timestamp_freq (NanoPB_Encoder.c:521), so the
-                 * computed stamps stay self-consistent with what clients divide
-                 * by (and compose with the #716 clock fix, which corrects tsFreq).
-                 * NOT ClockPeriod (the streaming timer TMR4/5 runs a different
-                 * prescale than TMR6, so ClockPeriod is in the wrong units). */
                 uint32_t tsFreq = TimerApi_FrequencyGet(gpStreamingConfig->TSTimerIndex);
                 uint64_t rate = (gpRuntimeConfigStream != NULL)
                               ? gpRuntimeConfigStream->Frequency : 0u;
@@ -656,7 +656,14 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             }
             uint32_t trigStamp = gStreamBaseTS + gStreamTickIndex * gStreamPeriodTicks;
             if (trigStamp == 0u) trigStamp = 1u;
+            /* #722: gStreamTickIndex is also written (=0) by Streaming_Start on
+             * the SCPI task, so this RMW is not single-writer — guard it (matches
+             * gTestPatternSampleCount's protected reset/increment; Compliance
+             * 68846). Bounded 32-bit increment, so the section stays trivially
+             * short. */
+            taskENTER_CRITICAL();
             gStreamTickIndex++;
+            taskEXIT_CRITICAL();
             DioProbe_PulseStart(3);  /* probe 3: alloc + channel loop + queue push */
             // Use object pool instead of heap allocation (eliminates vPortFree overhead)
             // No heap check needed - pool uses pre-allocated static memory

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -48,6 +48,22 @@
 // 32-bit atomic read on PIC32MZ — no critical section needed for reads/writes.
 static volatile uint32_t gTestPattern = 0;       // 0=off, 1-4=pattern type
 static uint64_t gTestPatternSampleCount = 0;      // Monotonic counter, reset on start
+// #717: deterministic per-tick streaming timestamp. The old path read the
+// ISR-captured shared 1-deep slot (BOARDDATA_STREAMING_TIMESTAMP) once per
+// emitted sample; when the deferred task fell behind at high rate, K catch-up
+// iterations read the SAME (latest) slot value -> K duplicate msg_time_stamps
+// then a jump (t,t,t+2p; 0.07% @1kHz -> 15% @5kHz over USB). The streaming timer
+// (TMR4/5) and the timestamp timer (TMR6) both count PBCLK3 and the trigger is
+// hardware-periodic, so tick N's stamp is EXACTLY baseTS + N*periodTicks --
+// computed here, race-free, and still on TMR6's timebase so edge-event (#667)
+// correlation is preserved. periodTicks = TSTimer(TMR6) freq / stream rate,
+// sourced from the SAME TimerApi_FrequencyGet the msg timestamp_freq uses, so
+// the stamps stay consistent with what clients divide by.
+// Owner: the deferred streaming task (single writer); seeded per session.
+static uint32_t gStreamTickIndex = 0;      // ticks since session start (incl. drops)
+static uint32_t gStreamBaseTS = 0;         // TMR6 at the session's first tick
+static uint32_t gStreamPeriodTicks = 0;    // TMR6 ticks per streaming tick
+static bool     gStreamTSSeeded = false;   // baseTS/periodTicks captured this session?
 
 // Benchmark mode level (BENCHMARK_OFF/NOCAP/PIPELINE).
 // Uses uint32_t for guaranteed 32-bit atomic access on PIC32MZ.
@@ -611,6 +627,36 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             if (!pRunTimeStreamConf->IsEnabled) {
                 goto pool_done;
             }
+            /* #717: deterministic per-tick timestamp, computed ONCE per tick
+             * BEFORE the pool alloc so a pool-exhaust drop still advances the
+             * tick index (the next emitted sample stays phase-correct). Seeds
+             * baseTS (a clean slot read) + periodTicks on the session's first
+             * tick; thereafter ts = baseTS + N*periodTicks with no shared-slot
+             * read (kills the catch-up aliasing that produced t,t,t+2p). The
+             * uint32_t product wraps in lockstep with TMR6's own 32-bit wrap
+             * ((N mod 2^32)*p == N*p mod 2^32), so it stays the exact TMR6 value.
+             * #533 0->1 clamp kept. Single writer (this task) -> no critical
+             * section on the tick-index RMW. */
+            if (!gStreamTSSeeded) {
+                uint32_t* pSeed = BoardData_Get(BOARDDATA_STREAMING_TIMESTAMP, 0);
+                gStreamBaseTS = (pSeed != NULL) ? *pSeed : 1u;
+                /* periodTicks = TMR6-advance per streaming tick = tsFreq / rate.
+                 * tsFreq is TimerApi_FrequencyGet(TSTimerIndex) -- the SAME value
+                 * reported as msg timestamp_freq (NanoPB_Encoder.c:521), so the
+                 * computed stamps stay self-consistent with what clients divide
+                 * by (and compose with the #716 clock fix, which corrects tsFreq).
+                 * NOT ClockPeriod (the streaming timer TMR4/5 runs a different
+                 * prescale than TMR6, so ClockPeriod is in the wrong units). */
+                uint32_t tsFreq = TimerApi_FrequencyGet(gpStreamingConfig->TSTimerIndex);
+                uint64_t rate = (gpRuntimeConfigStream != NULL)
+                              ? gpRuntimeConfigStream->Frequency : 0u;
+                gStreamPeriodTicks = (rate > 0u) ? (uint32_t)(tsFreq / rate) : 1u;
+                if (gStreamPeriodTicks == 0u) gStreamPeriodTicks = 1u;
+                gStreamTSSeeded = true;
+            }
+            uint32_t trigStamp = gStreamBaseTS + gStreamTickIndex * gStreamPeriodTicks;
+            if (trigStamp == 0u) trigStamp = 1u;
+            gStreamTickIndex++;
             DioProbe_PulseStart(3);  /* probe 3: alloc + channel loop + queue push */
             // Use object pool instead of heap allocation (eliminates vPortFree overhead)
             // No heap check needed - pool uses pre-allocated static memory
@@ -662,19 +708,9 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             pPublicSampleList->validMask = 0;
             pPublicSampleList->Timestamp = 0;
 
-            // Streaming trigger timestamp for this tick, captured by
-            // Streaming_TimerHandler at the single point all sample stamps
-            // derive from (clamps 0 -> 1, so 0 can never alias the #533
-            // invalid sentinel).  Hoisted out of the channel loop: the #541
-            // T1 direct-read path stamps every T1 sample with it, and the
-            // post-loop fallback uses it too.
-            uint32_t trigStamp = 0;
-            {
-                uint32_t* pTrigStamp =
-                        BoardData_Get(BOARDDATA_STREAMING_TIMESTAMP, 0);
-                if (pTrigStamp != NULL) trigStamp = *pTrigStamp;
-            }
-
+            // #717: trigStamp for this tick is the deterministic value computed
+            // above (baseTS + tickIndex*periodTicks) — the #541 T1 direct-read
+            // path and the post-loop fallback both stamp with it.
             for (uint8_t j = 0; j < mapping->count; j++) {
                 uint8_t cfgIdx = mapping->configIndices[j];
 
@@ -1292,6 +1328,10 @@ static void Streaming_Start(void) {
             // Reset test pattern counter so each session starts at 0
             taskENTER_CRITICAL();
             gTestPatternSampleCount = 0;
+            // #717: re-seed the deterministic timestamp on this session's first
+            // tick (baseTS + periodTicks captured there from a clean slot read).
+            gStreamTSSeeded = false;
+            gStreamTickIndex = 0;
             taskEXIT_CRITICAL();
             // #450: anchor the startup-grace window at the start of each
             // enabled session.  Steady drop counters won't increment
@@ -1654,6 +1694,10 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
      * No critical section needed: this runs pre-scheduler with interrupts off. */
     gTestPattern = 0;
     gTestPatternSampleCount = 0;
+    gStreamTickIndex = 0;      // #717 deterministic-ts state (retained-RAM safety)
+    gStreamBaseTS = 0;
+    gStreamPeriodTicks = 0;
+    gStreamTSSeeded = false;
     gBenchmarkMode = BENCHMARK_OFF;
     gSdPbMetadataSent = false;
     gSdFileWasReady = false;

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -52,18 +52,22 @@ static uint64_t gTestPatternSampleCount = 0;      // Monotonic counter, reset on
 // ISR-captured shared 1-deep slot (BOARDDATA_STREAMING_TIMESTAMP) once per
 // emitted sample; when the deferred task fell behind at high rate, K catch-up
 // iterations read the SAME (latest) slot value -> K duplicate msg_time_stamps
-// then a jump (t,t,t+2p; 0.07% @1kHz -> 15% @5kHz over USB). The streaming timer
-// (TMR4/5) and the timestamp timer (TMR6) both count PBCLK3 and the trigger is
-// hardware-periodic, so tick N's stamp is EXACTLY baseTS + N*periodTicks --
-// computed here, race-free, and still on TMR6's timebase so edge-event (#667)
-// correlation is preserved. periodTicks = TSTimer(TMR6) freq / stream rate,
-// sourced from the SAME TimerApi_FrequencyGet the msg timestamp_freq uses, so
-// the stamps stay consistent with what clients divide by.
-// Owner: the deferred streaming task (single writer); seeded per session.
-static uint32_t gStreamTickIndex = 0;      // ticks since session start (incl. drops)
-static uint32_t gStreamBaseTS = 0;         // TMR6 at the session's first tick
-static uint32_t gStreamPeriodTicks = 0;    // TMR6 ticks per streaming tick
-static bool     gStreamTSSeeded = false;   // baseTS/periodTicks captured this session?
+// then a jump (t,t,t+2p; 0.07% @1kHz -> 15% @5kHz over USB). Tick N's stamp is
+// now EXACTLY baseTS + N*periodTicks, still on TMR6's timebase so edge-event
+// (#667) correlation is preserved. Ownership (audit #722, race-free):
+//   gStreamBaseTS   — TMR6 at the session's first enabled tick. Written ONCE by
+//                     the timer ISR (Streaming_TimerHandler); read by the task.
+//   gStreamPeriodTicks — exact TMR6 ticks/streaming-period, config-derived.
+//                     Written ONCE by Streaming_Start (SCPI task, timer stopped);
+//                     read by the task.
+//   gStreamTickIndex — dispatches since session start (incl. drops). Reset =0 by
+//                     Streaming_Start (timer stopped); incremented by the task.
+//   gStreamTSSeeded  — latches the ISR baseTS capture. Cleared by Streaming_Start
+//                     (timer stopped), set by the ISR. No concurrent writers.
+static uint32_t gStreamTickIndex = 0;      // dispatches since session start (incl. drops)
+static uint32_t gStreamBaseTS = 0;         // TMR6 at the session's first tick (ISR-seeded)
+static uint32_t gStreamPeriodTicks = 0;    // TMR6 ticks per streaming tick (Start-computed)
+static bool     gStreamTSSeeded = false;   // baseTS captured this session? (ISR latch)
 
 // Benchmark mode level (BENCHMARK_OFF/NOCAP/PIPELINE).
 // Uses uint32_t for guaranteed 32-bit atomic access on PIC32MZ.
@@ -604,11 +608,7 @@ void _Streaming_Deferred_Interrupt_Task(void) {
     uint64_t ChannelScanFreqDivCount = 0;
 
     while (1) {
-        /* pre-decrement pending-notification count = ticks that fired before
-         * this wake (1 in steady state; >1 only if a pri-9 peer starved us).
-         * Used once, at session-start seeding, to anchor baseTS to tick 0 when
-         * the first wake coalesced M ticks (#717 / Fable Q3). */
-        uint32_t notifyCount = ulTaskNotifyTake(pdFALSE, xBlockTime);
+        ulTaskNotifyTake(pdFALSE, xBlockTime);
         DioProbe_Toggle(2);  /* probe 2: deferred task wake rate */
 
         if (pRunTimeStreamConf->IsEnabled) {
@@ -631,70 +631,27 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             if (!pRunTimeStreamConf->IsEnabled) {
                 goto pool_done;
             }
-            /* #717: deterministic per-tick timestamp, computed ONCE per tick
-             * BEFORE the pool alloc so a pool-exhaust drop still advances the
-             * tick index (next emitted sample stays phase-correct). Kills the
-             * catch-up aliasing (t,t,t+2p) from reading the shared 1-deep slot at
-             * variable task latency. Seed baseTS (clean slot read) + periodTicks
-             * on the session's first tick; thereafter ts = baseTS + N*periodTicks.
-             * periodTicks = the EXACT TMR6-tick count of one streaming-timer
-             * period: (ClockPeriod+1) streaming-timer (TMR4/5) cycles scaled by
-             * the live TMR6:TMR4/5 frequency ratio (tsFreq/streamTimerFreq).
-             * The two timers run DIFFERENT prescales (TMR4/5 1:8, TMR6 1:2 = a
-             * 4x ratio) and the requested rate is quantized into ClockPeriod by
-             * CEILING division (SCPIInterface.c ~3419), so the actual tick rate
-             * != the requested rate -- the old `tsFreq/rate` drifted ~428 ppm at
-             * non-clean-dividing rates (9000 Hz: computed 4666 vs the real 4668
-             * TMR6 ticks), unbounded per session and desyncing from #667
-             * edge-event TMR6 correlation (audit #722, fix 1). Deriving from the
-             * ACTUAL configured ClockPeriod and the live TimerApi_FrequencyGet
-             * ratio is exact for every rate/prescaler and composes with the #716
-             * clock fix. tsFreq is the same TimerApi_FrequencyGet reported as the
-             * msg timestamp_freq (NanoPB_Encoder.c:521), so stamps stay
-             * consistent with what clients divide by. Rejected a first-inter-tick
-             * measurement (captures a slightly-long startup-transient period,
-             * e.g. 8431 vs the real 8400 @5kHz -- 2026-07-24). The uint32_t
-             * product wraps in lockstep with TMR6's 32-bit wrap
-             * ((N mod 2^32)*p == N*p mod 2^32). #533 0->1 clamp kept. */
-            if (!gStreamTSSeeded) {
-                // Exact TMR6 ticks per streaming period: (ClockPeriod+1) TMR4/5
-                // cycles * (tsFreq/streamTimerFreq). Multiply in uint64 first to
-                // avoid the intermediate wrap; result fits uint32 (<= tsFreq).
-                // Exactness holds while TIMER_CLOCK_FRQ divides both prescalers
-                // and the stream:ts prescale ratio is integral (currently
-                // 1:8/1:2 = 4); a TS prescale COARSER than the stream timer's
-                // would truncate here and reintroduce per-tick drift.
-                uint32_t tsFreq =
-                        TimerApi_FrequencyGet(gpStreamingConfig->TSTimerIndex);
-                uint32_t streamTimerFreq =
-                        TimerApi_FrequencyGet(gpStreamingConfig->TimerIndex);
-                uint32_t periodCycles = (gpRuntimeConfigStream != NULL)
-                              ? (gpRuntimeConfigStream->ClockPeriod + 1u) : 1u;
-                gStreamPeriodTicks = (streamTimerFreq > 0u)
-                        ? (uint32_t)(((uint64_t)tsFreq * periodCycles) / streamTimerFreq)
-                        : 1u;
-                if (gStreamPeriodTicks == 0u) gStreamPeriodTicks = 1u;
-                // Anchor baseTS at THIS session's tick 0. The 1-deep slot holds
-                // the LATEST fired tick's stamp; if M ticks coalesced before this
-                // first wake (notifyCount = the pre-decrement count captured at
-                // the top of the loop) the slot is tick (M-1) while this
-                // iteration is tick 0 — back it out so absolute stamps anchor
-                // correctly. A constant (M-1)*p offset otherwise: invisible to
-                // intra-stream dt, but it would desync the #667 edge-event TMR6
-                // correlation the exact periodTicks exists to preserve. Common
-                // case M==1 -> no correction. The uint32 subtraction wraps in
-                // lockstep with TMR6 (audit #722 / Fable Q3, 2026-07-26); the
-                // #533 0->1 sentinel is handled by the trigStamp clamp below.
-                uint32_t* pSeed = BoardData_Get(BOARDDATA_STREAMING_TIMESTAMP, 0);
-                if (pSeed != NULL) {
-                    uint32_t coalesced =
-                            (notifyCount > 0u) ? (notifyCount - 1u) : 0u;
-                    gStreamBaseTS = *pSeed - coalesced * gStreamPeriodTicks;
-                } else {
-                    gStreamBaseTS = 1u;
-                }
-                gStreamTSSeeded = true;
-            }
+            /* #717: deterministic per-tick timestamp. The old path read the
+             * ISR-captured shared 1-deep slot (BOARDDATA_STREAMING_TIMESTAMP)
+             * once per emitted sample; when the deferred task fell behind at high
+             * rate, K catch-up iterations read the SAME latest slot value -> K
+             * duplicate msg_time_stamps then a 2-period jump (t,t,t+2p; 0.07%
+             * @1kHz -> 15% @5kHz over USB). Now stamp N = gStreamBaseTS +
+             * N*gStreamPeriodTicks, race-free:
+             *   - gStreamBaseTS is captured in the timer ISR
+             *     (Streaming_TimerHandler) on this session's FIRST enabled tick,
+             *     atomically with the tick — so no task-wake latency or coalesced
+             *     first wake can offset it (audit #722 seed race; supersedes the
+             *     deferred-task notifyCount reconstruction).
+             *   - gStreamPeriodTicks (config-derived, no timing race) is computed
+             *     once in Streaming_Start as the EXACT TMR6-tick count of one
+             *     streaming period = (ClockPeriod+1) TMR4/5 cycles * (tsFreq /
+             *     streamTimerFreq), which corrects the ~428 ppm drift the naive
+             *     floor(tsFreq/rate) had at non-clean-dividing rates (9000 Hz:
+             *     4666 vs the real 4668) and composes with the #716 clock fix.
+             * gStreamBaseTS is written once per session by the ISR and only read
+             * here (uint32 atomic); the task's wake is the ISR's own notify, so
+             * the seed is always visible. #533 0->1 handled by the clamp below. */
             /* gStreamTickIndex is the session-relative twin of gTimerISRCalls
              * (#265): one increment per processed tick, so tick N deterministically
              * stamps baseTS + N*periodTicks. The iterations<->notifications<->ISR
@@ -1098,6 +1055,20 @@ static void Streaming_TimerHandler(uintptr_t context, uint32_t alarmCount) {
             if (eosSeq == gScanEosSeqSeen) gScanStaleDropped++;  // no new EOS since last tick -> stale
             gScanEosSeqSeen = eosSeq;
         }
+        // #717 (audit #722): seed the deterministic-timestamp base HERE, in ISR
+        // context, on the session's FIRST enabled tick — race-free. valueTMR is
+        // this trigger's clamped TMR6 stamp = tick 0's absolute time, so the
+        // deferred task (which processes this dispatch as tickIndex 0) stamps
+        // baseTS + 0. Capturing it here, atomically with the tick, eliminates the
+        // task-side TOCTOU (a coalesced first wake, or ticks firing between the
+        // task reading the notify count and the shared slot, could otherwise
+        // offset baseTS by K periods and desync #667 correlation). Single writer
+        // (same-source ISR can't preempt itself); Streaming_Start clears
+        // gStreamTSSeeded while the timer is stopped, so no concurrent write.
+        if (!gStreamTSSeeded) {
+            gStreamBaseTS = valueTMR;
+            gStreamTSSeeded = true;
+        }
         Streaming_Defer_Interrupt();
     }
 
@@ -1388,11 +1359,38 @@ static void Streaming_Start(void) {
             // Reset test pattern counter so each session starts at 0
             taskENTER_CRITICAL();
             gTestPatternSampleCount = 0;
-            // #717: re-seed the deterministic timestamp on this session's first
-            // tick (baseTS + periodTicks captured there from a clean slot read).
+            // #717: reset deterministic-timestamp state for this session. baseTS
+            // is seeded in the timer ISR on tick 0 (race-free, audit #722);
+            // tickIndex starts at 0 so the first processed dispatch stamps
+            // baseTS + 0. periodTicks is computed just below.
             gStreamTSSeeded = false;
             gStreamTickIndex = 0;
             taskEXIT_CRITICAL();
+            // #717: periodTicks is config-derived (not timing), so compute it
+            // here once — the EXACT TMR6-tick count of one streaming period:
+            // (ClockPeriod+1) TMR4/5 cycles * (tsFreq / streamTimerFreq). The two
+            // timers run different prescales (1:8 / 1:2 = 4) and the requested
+            // rate is quantized into ClockPeriod by ceiling division
+            // (SCPIInterface.c ~3419), so deriving from the ACTUAL configured
+            // period + live frequency ratio is exact for every rate (vs the
+            // drift-prone floor(tsFreq/rate); composes with #716). Multiply in
+            // uint64 first (fits: result <= tsFreq). The timer isn't started
+            // until below, so this store races no reader. ClockPeriod is set by
+            // SCPI_StartStreaming before this runs; the prescalers are fixed at
+            // boot. Exactness holds while the stream:ts prescale ratio is
+            // integral; a TS prescale coarser than the stream timer would
+            // truncate here and reintroduce per-tick drift.
+            {
+                uint32_t tsFreq =
+                        TimerApi_FrequencyGet(gpStreamingConfig->TSTimerIndex);
+                uint32_t streamTimerFreq =
+                        TimerApi_FrequencyGet(gpStreamingConfig->TimerIndex);
+                uint32_t periodCycles = gpRuntimeConfigStream->ClockPeriod + 1u;
+                gStreamPeriodTicks = (streamTimerFreq > 0u)
+                        ? (uint32_t)(((uint64_t)tsFreq * periodCycles) / streamTimerFreq)
+                        : 1u;
+                if (gStreamPeriodTicks == 0u) gStreamPeriodTicks = 1u;
+            }
             // #450: anchor the startup-grace window at the start of each
             // enabled session.  Steady drop counters won't increment
             // until xTaskGetTickCount() - gStreamStartTick >= grace.

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -604,7 +604,11 @@ void _Streaming_Deferred_Interrupt_Task(void) {
     uint64_t ChannelScanFreqDivCount = 0;
 
     while (1) {
-        ulTaskNotifyTake(pdFALSE, xBlockTime);
+        /* pre-decrement pending-notification count = ticks that fired before
+         * this wake (1 in steady state; >1 only if a pri-9 peer starved us).
+         * Used once, at session-start seeding, to anchor baseTS to tick 0 when
+         * the first wake coalesced M ticks (#717 / Fable Q3). */
+        uint32_t notifyCount = ulTaskNotifyTake(pdFALSE, xBlockTime);
         DioProbe_Toggle(2);  /* probe 2: deferred task wake rate */
 
         if (pRunTimeStreamConf->IsEnabled) {
@@ -633,34 +637,80 @@ void _Streaming_Deferred_Interrupt_Task(void) {
              * catch-up aliasing (t,t,t+2p) from reading the shared 1-deep slot at
              * variable task latency. Seed baseTS (clean slot read) + periodTicks
              * on the session's first tick; thereafter ts = baseTS + N*periodTicks.
-             * periodTicks = TSTimer(TMR6) freq / rate, from the SAME
-             * TimerApi_FrequencyGet reported as msg timestamp_freq
-             * (NanoPB_Encoder.c:521) -- so stamps stay consistent with what
-             * clients divide by, it is EXACT for the (integer-dividing) streaming
-             * rates, and it composes with the #716 clock fix (which corrects
-             * tsFreq). NOT ClockPeriod (TMR4/5 runs a different prescale than
-             * TMR6) and NOT a first-inter-tick measurement (that captures a
-             * slightly-long startup-transient period, e.g. 8431 vs the real 8400
-             * @5kHz -- rejected 2026-07-24). The uint32_t product wraps in
-             * lockstep with TMR6's 32-bit wrap ((N mod 2^32)*p == N*p mod 2^32).
-             * #533 0->1 clamp kept. */
+             * periodTicks = the EXACT TMR6-tick count of one streaming-timer
+             * period: (ClockPeriod+1) streaming-timer (TMR4/5) cycles scaled by
+             * the live TMR6:TMR4/5 frequency ratio (tsFreq/streamTimerFreq).
+             * The two timers run DIFFERENT prescales (TMR4/5 1:8, TMR6 1:2 = a
+             * 4x ratio) and the requested rate is quantized into ClockPeriod by
+             * CEILING division (SCPIInterface.c ~3419), so the actual tick rate
+             * != the requested rate -- the old `tsFreq/rate` drifted ~428 ppm at
+             * non-clean-dividing rates (9000 Hz: computed 4666 vs the real 4668
+             * TMR6 ticks), unbounded per session and desyncing from #667
+             * edge-event TMR6 correlation (audit #722, fix 1). Deriving from the
+             * ACTUAL configured ClockPeriod and the live TimerApi_FrequencyGet
+             * ratio is exact for every rate/prescaler and composes with the #716
+             * clock fix. tsFreq is the same TimerApi_FrequencyGet reported as the
+             * msg timestamp_freq (NanoPB_Encoder.c:521), so stamps stay
+             * consistent with what clients divide by. Rejected a first-inter-tick
+             * measurement (captures a slightly-long startup-transient period,
+             * e.g. 8431 vs the real 8400 @5kHz -- 2026-07-24). The uint32_t
+             * product wraps in lockstep with TMR6's 32-bit wrap
+             * ((N mod 2^32)*p == N*p mod 2^32). #533 0->1 clamp kept. */
             if (!gStreamTSSeeded) {
-                uint32_t* pSeed = BoardData_Get(BOARDDATA_STREAMING_TIMESTAMP, 0);
-                gStreamBaseTS = (pSeed != NULL) ? *pSeed : 1u;
-                uint32_t tsFreq = TimerApi_FrequencyGet(gpStreamingConfig->TSTimerIndex);
-                uint64_t rate = (gpRuntimeConfigStream != NULL)
-                              ? gpRuntimeConfigStream->Frequency : 0u;
-                gStreamPeriodTicks = (rate > 0u) ? (uint32_t)(tsFreq / rate) : 1u;
+                // Exact TMR6 ticks per streaming period: (ClockPeriod+1) TMR4/5
+                // cycles * (tsFreq/streamTimerFreq). Multiply in uint64 first to
+                // avoid the intermediate wrap; result fits uint32 (<= tsFreq).
+                // Exactness holds while TIMER_CLOCK_FRQ divides both prescalers
+                // and the stream:ts prescale ratio is integral (currently
+                // 1:8/1:2 = 4); a TS prescale COARSER than the stream timer's
+                // would truncate here and reintroduce per-tick drift.
+                uint32_t tsFreq =
+                        TimerApi_FrequencyGet(gpStreamingConfig->TSTimerIndex);
+                uint32_t streamTimerFreq =
+                        TimerApi_FrequencyGet(gpStreamingConfig->TimerIndex);
+                uint32_t periodCycles = (gpRuntimeConfigStream != NULL)
+                              ? (gpRuntimeConfigStream->ClockPeriod + 1u) : 1u;
+                gStreamPeriodTicks = (streamTimerFreq > 0u)
+                        ? (uint32_t)(((uint64_t)tsFreq * periodCycles) / streamTimerFreq)
+                        : 1u;
                 if (gStreamPeriodTicks == 0u) gStreamPeriodTicks = 1u;
+                // Anchor baseTS at THIS session's tick 0. The 1-deep slot holds
+                // the LATEST fired tick's stamp; if M ticks coalesced before this
+                // first wake (notifyCount = the pre-decrement count captured at
+                // the top of the loop) the slot is tick (M-1) while this
+                // iteration is tick 0 — back it out so absolute stamps anchor
+                // correctly. A constant (M-1)*p offset otherwise: invisible to
+                // intra-stream dt, but it would desync the #667 edge-event TMR6
+                // correlation the exact periodTicks exists to preserve. Common
+                // case M==1 -> no correction. The uint32 subtraction wraps in
+                // lockstep with TMR6 (audit #722 / Fable Q3, 2026-07-26); the
+                // #533 0->1 sentinel is handled by the trigStamp clamp below.
+                uint32_t* pSeed = BoardData_Get(BOARDDATA_STREAMING_TIMESTAMP, 0);
+                if (pSeed != NULL) {
+                    uint32_t coalesced =
+                            (notifyCount > 0u) ? (notifyCount - 1u) : 0u;
+                    gStreamBaseTS = *pSeed - coalesced * gStreamPeriodTicks;
+                } else {
+                    gStreamBaseTS = 1u;
+                }
                 gStreamTSSeeded = true;
             }
+            /* gStreamTickIndex is the session-relative twin of gTimerISRCalls
+             * (#265): one increment per processed tick, so tick N deterministically
+             * stamps baseTS + N*periodTicks. The iterations<->notifications<->ISR
+             * mapping is guaranteed by the portMAX_DELAY block + pdFALSE take +
+             * IsEnabled gate (same invariant as TimerISRCalls == Total+Dropped). */
             uint32_t trigStamp = gStreamBaseTS + gStreamTickIndex * gStreamPeriodTicks;
             if (trigStamp == 0u) trigStamp = 1u;
-            /* #722: gStreamTickIndex is also written (=0) by Streaming_Start on
-             * the SCPI task, so this RMW is not single-writer — guard it (matches
-             * gTestPatternSampleCount's protected reset/increment; Compliance
-             * 68846). Bounded 32-bit increment, so the section stays trivially
-             * short. */
+            /* gStreamTickIndex is also written (=0) by Streaming_Start on the
+             * SCPI task (pri<=7). The pri-9 deferred task can't be preempted
+             * mid-RMW by a lower-priority writer, and that store only runs while
+             * this task is blocked (IsEnabled false through the stop gap,
+             * notifications drained) — so no torn interleave is actually
+             * reachable. The critical section is kept for symmetry with
+             * gTestPatternSampleCount and future-proofing, not because a race is
+             * live (#722 / Fable Q4; Compliance 68846). Bounded 32-bit
+             * increment — the section stays trivially short. */
             taskENTER_CRITICAL();
             gStreamTickIndex++;
             taskEXIT_CRITICAL();
@@ -713,11 +763,18 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             const AInChannelMapping* mapping = &gChannelMapping;
             pPublicSampleList->channelCount = mapping->count;
             pPublicSampleList->validMask = 0;
-            pPublicSampleList->Timestamp = 0;
+            // #717 (audit #722 fix 2): stamp the packet with the deterministic
+            // per-tick trigStamp computed above, UNCONDITIONALLY and up front.
+            // The first cut only set trigStamp on the #541 T1-direct path and the
+            // all-invalid post-loop fallback; the normal ADC path and EVERY
+            // AD7609/NQ2-NQ3 session stamped from pAiSample->Timestamp (the
+            // shared 1-deep slot) -> the same catch-up aliasing (t,t,t+2p) for
+            // any T2-first config. Setting it here makes every path (incl.
+            // Pipeline/test-pattern/DIO-only) deterministic. trigStamp is >=1
+            // (clamped), so the PB encoder never omits msg_time_stamp (it drops
+            // the field on Timestamp==0), which retires the old post-loop net.
+            pPublicSampleList->Timestamp = trigStamp;
 
-            // #717: trigStamp for this tick is the deterministic value computed
-            // above (baseTS + tickIndex*periodTicks) — the #541 T1 direct-read
-            // path and the post-loop fallback both stamp with it.
             for (uint8_t j = 0; j < mapping->count; j++) {
                 uint8_t cfgIdx = mapping->configIndices[j];
 
@@ -757,11 +814,9 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                     pPublicSampleList->validMask |= (1U << j);
                 } else if (gTestPattern != 0) {
                     // Test pattern: always produce deterministic data regardless
-                    // of ADC state. Read ADC for timestamp only.
-                    pAiSample = BoardData_Get(BOARDDATA_AIN_LATEST, cfgIdx);
-                    if (pAiSample != NULL && pPublicSampleList->Timestamp == 0) {
-                        pPublicSampleList->Timestamp = pAiSample->Timestamp;
-                    }
+                    // of ADC state. Packet Timestamp is the deterministic
+                    // trigStamp set once before the loop (#717) — no ADC read
+                    // needed here for the timestamp.
                     pPublicSampleList->Values[j] =
                         Streaming_GenerateTestValue(gTestPattern,
                             mapping->channelIds[j],
@@ -787,9 +842,8 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                             &val)) {
                         pPublicSampleList->Values[j] = val;
                         pPublicSampleList->validMask |= (1U << j);
-                        if (pPublicSampleList->Timestamp == 0) {
-                            pPublicSampleList->Timestamp = trigStamp;
-                        }
+                        // Packet Timestamp is the deterministic trigStamp set
+                        // before the loop (#717) — nothing to set per-channel.
                         // Refresh the LATEST cache so non-streaming readers
                         // (MEAS:VOLT:DC?) stay live during a session.  Same
                         // per-tick work the EOS task used to do at the same
@@ -825,29 +879,28 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                         // A genuine counter reading of 0 can never alias the
                         // sentinel: Streaming_TimerHandler clamps 0 -> 1 at
                         // the single capture point all stamps derive from.
+                        // #533 slot-validity gate stays: ts==0 marks the LATEST
+                        // slot invalid, so the value + validMask bit are gated on
+                        // it. The PACKET Timestamp is the deterministic trigStamp
+                        // (#717) and is no longer derived from this per-channel
+                        // slot ts — that per-channel derivation was the T2-first
+                        // aliasing source the #722 audit flagged (fix 2).
                         if (ts != 0) {
                             pPublicSampleList->Values[j] = val;
                             pPublicSampleList->validMask |= (1U << j);
-                            if (pPublicSampleList->Timestamp == 0) {
-                                pPublicSampleList->Timestamp = ts;
-                            }
                         }
                     }
                     // else: bit stays 0 in validMask (invalid)
                 }
             }
 
-            // Guarantee a non-zero timestamp on every emitted packet. Pipeline
-            // mode never reads ADC samples; normal/test-pattern modes may also
-            // end up with Timestamp=0 in edge cases (DIO-only streaming, or
-            // all AIN channels happen to be invalid this cycle). Fall back to
-            // the streaming timer tick captured by Streaming_TimerHandler —
-            // same source the ADC ISR writes to AInSample.Timestamp, so the
-            // wire output remains consistent across modes. Required because
-            // the PB encoder omits the msg_time_stamp field when timestamp==0.
-            if (pPublicSampleList->Timestamp == 0) {
-                pPublicSampleList->Timestamp = trigStamp;
-            }
+            // #717: every emitted packet already carries the deterministic
+            // trigStamp (set before the channel loop, >=1) regardless of mode —
+            // Pipeline (no ADC read), DIO-only, and all-AIN-invalid cycles
+            // included. The old "fall back to trigStamp if Timestamp==0" net is
+            // now provably dead (Timestamp can never be 0 here), so it's retired.
+            // The PB encoder omits msg_time_stamp only on Timestamp==0, which no
+            // longer occurs.
             if(!AInSampleList_PushBack(pPublicSampleList)){//failed pushing to Q
                 // #499: split counter — this path = FreeRTOS queue full,
                 // i.e. streaming_Task can't drain fast enough. Distinct from

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -64,10 +64,17 @@ static uint64_t gTestPatternSampleCount = 0;      // Monotonic counter, reset on
 //                     Streaming_Start (timer stopped); incremented by the task.
 //   gStreamTSSeeded  — latches the ISR baseTS capture. Cleared by Streaming_Start
 //                     (timer stopped), set by the ISR. No concurrent writers.
-static uint32_t gStreamTickIndex = 0;      // dispatches since session start (incl. drops)
-static uint32_t gStreamBaseTS = 0;         // TMR6 at the session's first tick (ISR-seeded)
-static uint32_t gStreamPeriodTicks = 0;    // TMR6 ticks per streaming tick (Start-computed)
-static bool     gStreamTSSeeded = false;   // baseTS captured this session? (ISR latch)
+// All four are volatile: each is written in one context (timer ISR or the SCPI
+// task inside Streaming_Start) and read in another (the deferred task), which is
+// exactly the case where the compiler must not cache the value in a register at
+// -O3. uint32_t throughout for guaranteed 32-bit atomic load/store on PIC32MZ
+// (the seeded latch included — a plain bool would still be atomic, but the
+// native width keeps the whole set uniform). volatile does NOT make the
+// gStreamTickIndex RMW atomic — that keeps its critical section.
+static volatile uint32_t gStreamTickIndex = 0;   // dispatches since session start (incl. drops)
+static volatile uint32_t gStreamBaseTS = 0;      // TMR6 at the session's first tick (ISR-seeded)
+static volatile uint32_t gStreamPeriodTicks = 0; // TMR6 ticks per streaming tick (Start-computed)
+static volatile uint32_t gStreamTSSeeded = 0u;   // baseTS captured this session? (ISR latch)
 
 // Benchmark mode level (BENCHMARK_OFF/NOCAP/PIPELINE).
 // Uses uint32_t for guaranteed 32-bit atomic access on PIC32MZ.
@@ -1067,7 +1074,7 @@ static void Streaming_TimerHandler(uintptr_t context, uint32_t alarmCount) {
         // gStreamTSSeeded while the timer is stopped, so no concurrent write.
         if (!gStreamTSSeeded) {
             gStreamBaseTS = valueTMR;
-            gStreamTSSeeded = true;
+            gStreamTSSeeded = 1u;
         }
         Streaming_Defer_Interrupt();
     }
@@ -1363,7 +1370,7 @@ static void Streaming_Start(void) {
             // is seeded in the timer ISR on tick 0 (race-free, audit #722);
             // tickIndex starts at 0 so the first processed dispatch stamps
             // baseTS + 0. periodTicks is computed just below.
-            gStreamTSSeeded = false;
+            gStreamTSSeeded = 0u;
             gStreamTickIndex = 0;
             taskEXIT_CRITICAL();
             // #717: periodTicks is config-derived (not timing), so compute it
@@ -1755,7 +1762,7 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     gStreamTickIndex = 0;      // #717 deterministic-ts state (retained-RAM safety)
     gStreamBaseTS = 0;
     gStreamPeriodTicks = 0;
-    gStreamTSSeeded = false;
+    gStreamTSSeeded = 0u;
     gBenchmarkMode = BENCHMARK_OFF;
     gSdPbMetadataSent = false;
     gSdFileWasReady = false;


### PR DESCRIPTION
Fixes #717. At high rate the deferred task read the ISR-captured **shared 1-deep** timestamp slot once per emitted sample; when behind, K catch-up iterations read the same latest value → K identical `msg_time_stamp` then a 2-period jump (`t,t,t+2p`; 0.07%@1kHz → **15%@5kHz** USB).

**Fix:** tick N's stamp = `baseTS + N·periodTicks`, computed deterministically — no shared-slot read.

- **`baseTS`** is captured **in the timer ISR** (`Streaming_TimerHandler`) on the session's first enabled tick, atomically with the tick — no task-wake latency or coalesced first wake can offset it.
- **`periodTicks`** is the EXACT TMR6-tick count of one streaming period, `(ClockPeriod+1) × (tsFreq / streamTimerFreq)`. TMR4/5 (streaming) and TMR6 (timestamp) run at different prescales (1:8 vs 1:2 = ratio 4), so the ceiling belongs in the slow domain; the naive `floor(tsFreq/rate)` drifts ~428 ppm at rates like 9000 Hz (4666 vs the real 4668) and would desync the #667 edge-event TMR6 correlation. Computed once in `Streaming_Start` before the timer runs.
- Applied on **every** emit path — not just the #541 T1-direct read — so T2-first sessions and all AD7609/NQ2/NQ3 sessions get it too.
- Computed before the pool alloc so drops stay phase-correct; #533 sentinel kept; `gStreamTickIndex` RMW guarded; the four shared globals are `volatile uint32_t` (ISR↔task / SCPI-task↔deferred-task).

`periodTicks` derives from the same `TimerApi_FrequencyGet(TSTimerIndex)` the device reports as `timestamp_freq` / JSON `tick_hz`, so stamps stay consistent with what clients divide by, and it composes with #716. T2 (per-sample ADC-ISR timestamp) was already race-free and is unchanged.

## Validation

**Companion regression test:** [daqifi-python-test-suite PR #115](https://github.com/daqifi/daqifi-python-test-suite/pull/115) — `test_717_deterministic_timestamp.py`, gating duplicates, period drift, and per-path coverage.

**Bench A/B — board `7E2898F46200E8A7` (COM3), USB JSON, same session, adjacent windows:**

| firmware | result |
|---|---|
| `main` 673ba485 | **0/9 PASS** — dupes to 1.63%, ~all deltas off-grid, period 7243 vs 7637 @5500 Hz (−51591 ppm) |
| this branch e54f712a | **9/9 PASS** — period exact (+0 ppm), dupes 0.00%, off-grid 0, skips 0 |

Cases = {`t1_first` ch4+ch8, `t2_first` ch1+ch4, `t2_only` ch1} × {1000, 4500, 5500 Hz}. 4500/5500 are deliberately **not** clean-dividing (9336 = `ceil(10.5e6/4500)·4`, vs floor's 9333; 7640 vs 7636) — the drift gate. The original validation in this PR was T1-only at clean-dividing rates (1000/5000), where both formulas agree, which is why the audit found what the bench missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)