### PR TITLE
fix(sd): keep SD:GET working after a non-SD stream — SD circular collapses 32K→512 (#703)

### DIFF
--- a/firmware/src/Util/StreamingBufferPool.h
+++ b/firmware/src/Util/StreamingBufferPool.h
@@ -38,7 +38,13 @@ extern "C" {
 #define STREAMING_WIFI_MIN          1400   /* SOCKET_BUFFER_MAX_LENGTH (one TCP packet) */
 #define ENCODER_BUFFER_MIN          1024   /* Must fit at least one encoded sample set */
 #define ENCODER_BUFFER_DEFAULT      8192   /* Optimal for USB; SD benefits from 16384 */
-#define STREAMING_SD_CIRCULAR_MIN   512    /* Min valid circular buffer (unused when inactive) */
+/* #703: the SD *read* path (SD:GET) reads into this SAME circular buffer and
+ * bails (maxRead==0) if it is below one read-alignment unit (SD_READ_ALIGNMENT_SIZE
+ * = 4096). So this floor is NOT "unused when inactive" — a non-SD stream shrinks
+ * the SD circular to it, and SD:GET afterwards depends on it being >= 4096. At 512
+ * every SD:GET after any non-SD stream silently failed until reboot. Keep >= 4096;
+ * a _Static_assert in sd_card_manager.c cross-ties this to SD_READ_ALIGNMENT_SIZE. */
+#define STREAMING_SD_CIRCULAR_MIN   4096   /* Min SD circular; also the SD:GET read floor (#703) */
 
 /** Active-interface defaults used by Streaming_ComputeAutoBuffers */
 #define STREAMING_USB_DEFAULT       (64U * 1024U)  /* USB circular when active */

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3448,9 +3448,26 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
+    /* #703: SD:GET read / CRC / directory LIST are ASYNC — the SD task streams
+     * into the SD circular buffer (static BSS in the streaming pool) using a
+     * chunk size it computes ONCE up front. PrepareStreamingBuffers below
+     * re-partitions that pool and pointer-swaps the SD buffer out from under an
+     * in-flight op, so its stale chunk would overflow the shrunk region into
+     * adjacent (live-stream) partitions — memory corruption during acquisition.
+     * The prior SD-busy gate only ran for SD-*logging* streams (below); reject
+     * ANY stream start while such an op is in flight. Deliberately narrower than
+     * IsBusy() (see sd_card_manager_BufferOpInFlight) so it does NOT spuriously
+     * reject a start during a post-stop unmount transient or a quick GET_SPACE. */
+    if (sd_card_manager_BufferOpInFlight()) {
+        LOG_E("Cannot start streaming - SD read/list/CRC in flight (#703)");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+
     // If SD logging is requested, set mode to WRITE now (deferred from LOGging command)
     if (sdLoggingRequested) {
-        // Check if SD card is busy with another operation (DELETE, FORMAT, etc.)
+        // Check if SD card is busy with another operation (DELETE, FORMAT, etc.).
+        // SD is a single consumer — don't start a logging file while any SD op runs.
         if (sd_card_manager_IsBusy()) {
             LOG_E("Cannot start SD logging - SD card busy with another operation");
             SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
@@ -4302,6 +4319,22 @@ static scpi_result_t SCPI_GetMemFree(scpi_t * context) {
 static bool PrepareStreamingBuffers(uint32_t poolCount, size_t sampleElemSize) {
     uint32_t usbSize, wifiSize, sdCircSize;
     uint32_t sdDmaSize, usbDmaSize, wifiDmaSize, encSize;
+
+    /* #703: this function re-partitions the streaming pool and pointer-swaps the
+     * SD circular buffer. An in-flight async SD read/CRC/LIST op streams into
+     * that same buffer using a chunk size computed once, up front — swapping it
+     * out from under the op would make FileRead overflow the shrunk region into
+     * adjacent partitions (memory corruption during acquisition). Refuse to
+     * re-partition while such an op is in flight. This backstops the non-
+     * STR:START callers (SYST:MEM:AUTO, THRoughput, WiFi rate finder); STR:START
+     * itself rejects earlier with a clearer error. (WRITE is not flagged by
+     * BufferOpInFlight — it's the caller's own logging setup, the intended
+     * consumer of the new partition.) */
+    if (sd_card_manager_BufferOpInFlight()) {
+        LOG_E("PrepareStreamingBuffers: refused — SD read/list/CRC in flight; "
+              "cannot re-partition the SD read buffer (#703)");
+        return false;
+    }
 
     // Mirror SCPI_StartStreaming's auto-vs-explicit decision so the finder
     // measures with the SAME buffer layout the user's real stream will use:

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4324,8 +4324,13 @@ static bool PrepareStreamingBuffers(uint32_t poolCount, size_t sampleElemSize) {
      * SD circular buffer. An in-flight async SD read/CRC/LIST op streams into
      * that same buffer using a chunk size computed once, up front — swapping it
      * out from under the op would make FileRead overflow the shrunk region into
-     * adjacent partitions (memory corruption during acquisition). Refuse to
-     * re-partition while such an op is in flight. This backstops the non-
+     * adjacent partitions (memory corruption during acquisition).
+     *
+     * This entry check is a FAIL-FAST only: it rejects before the ~1 s of
+     * vTaskDelay waits below when SD is already busy. It is NOT the correctness
+     * guard — an op can still arm on the other SCPI task during those waits.
+     * The actual guard is sd_card_manager_TryLockBuffer() held across the swap
+     * (just before StreamingBufferPool_Partition below). Backstops the non-
      * STR:START callers (SYST:MEM:AUTO, THRoughput, WiFi rate finder); STR:START
      * itself rejects earlier with a clearer error. (WRITE is not flagged by
      * BufferOpInFlight — it's the caller's own logging setup, the intended
@@ -4384,6 +4389,20 @@ static bool PrepareStreamingBuffers(uint32_t poolCount, size_t sampleElemSize) {
         }
     }
 
+    /* #703 (Qodo TOCTOU): the BufferOpInFlight() check at function entry is only
+     * fail-fast — an SD READ/LIST/CRC can arm on the OTHER SCPI task (USB pri 7
+     * vs TCP pri 2) during the vTaskDelay waits above, then read the buffer with a
+     * chunk size computed against the OLD partition. Take the SAME mutex those ops
+     * hold before they touch the SD buffer and keep it across the re-partition +
+     * pointer swap below: if an op holds it now, abort (fail-fast, no multi-second
+     * block); an op that arms during the swap blocks at its own take until we
+     * release, then reads from the NEW buffer size (consistent). Released on every
+     * exit path after this point. */
+    if (!sd_card_manager_TryLockBuffer()) {
+        LOG_E("PrepareStreamingBuffers: refused — SD read/list/CRC holds the buffer lock (#703)");
+        return false;
+    }
+
     StreamingBufferPool_Partition(usbSize, wifiSize, encSize,
                                   sdCircSize, poolCount, sampleElemSize);
 
@@ -4396,6 +4415,7 @@ static bool PrepareStreamingBuffers(uint32_t poolCount, size_t sampleElemSize) {
     if (usbBuf == NULL || wifiBuf == NULL || encBuf == NULL || sdCircBuf == NULL) {
         LOG_E("PrepareStreamingBuffers: partition failed USB=%u WiFi=%u enc=%u sd=%u",
               (unsigned)usbLen, (unsigned)wifiLen, (unsigned)encLen, (unsigned)sdCircLen);
+        sd_card_manager_UnlockBuffer();   /* #703: release SD buffer lock on abort */
         return false;
     }
     // NOTE: buffer-pointer Set calls are deferred to the END (after the coherent
@@ -4420,6 +4440,7 @@ static bool PrepareStreamingBuffers(uint32_t poolCount, size_t sampleElemSize) {
         wifiDmaSize = WIFI_DMA_MIN;
     }
     if (!SCPI_QuiesceAndResetCoherentPool()) {
+        sd_card_manager_UnlockBuffer();   /* #703: release SD buffer lock on abort */
         return false;
     }
     // Allocate all three coherent DMA buffers; ABORT if any fails rather than
@@ -4431,6 +4452,7 @@ static bool PrepareStreamingBuffers(uint32_t poolCount, size_t sampleElemSize) {
     if (sdDmaBuf == NULL || usbDmaBuf == NULL || wifiDmaBuf == NULL) {
         LOG_E("PrepareStreamingBuffers: coherent alloc failed SD=%u USB=%u WIFI=%u",
               (unsigned)sdDmaSize, (unsigned)usbDmaSize, (unsigned)wifiDmaSize);
+        sd_card_manager_UnlockBuffer();   /* #703: release SD buffer lock on abort */
         return false;
     }
     // All allocations succeeded — now apply every buffer pointer together
@@ -4442,6 +4464,10 @@ static bool PrepareStreamingBuffers(uint32_t poolCount, size_t sampleElemSize) {
     sd_card_manager_SetWriteBuffer(sdDmaBuf, sdDmaSize);
     UsbCdc_SetDmaWriteBuffer(usbDmaBuf, usbDmaSize);
     WDRV_WINC_SPI_SetBuffer(wifiDmaBuf, wifiDmaSize);
+    /* #703: swap complete — release the SD buffer lock. Any SD op that armed
+     * during the swap was blocked at its read_operation take and now proceeds
+     * against the new buffer size. */
+    sd_card_manager_UnlockBuffer();
 
     void* sPoolMem; int16_t* sFreeMem; uint32_t sCount; size_t sElemSz;
     StreamingBufferPool_GetSamplePool(&sPoolMem, &sFreeMem, &sCount, &sElemSz);

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -318,6 +318,20 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
         goto __exit_point;
     }
 
+    /* #703: SD:GET reads into the streaming pool's SD circular buffer, which the
+     * auto-balancer shrinks after a non-SD stream. If it collapsed below the read
+     * minimum, fail loudly and synchronously here (SCPI -200 + LOG_E) rather than
+     * arming an async read that bails on the SD task. The floor fix keeps this
+     * from ever tripping in practice; it's the host-visible mirror of the SD-task
+     * terminal bail so a client gets an error instead of a bare EOF marker. */
+    if (!sd_card_manager_ReadBufferReady()) {
+        LOG_E("[SD] GET rejected: read buffer too small — start an SD-logging "
+              "session or reboot to restore the SD buffer");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        result = SCPI_RES_ERR;
+        goto __exit_point;
+    }
+
     SCPI_ParamCharacters(context, &pBuff, &fileLen, false);
 
     if (fileLen > 0) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -37,6 +37,14 @@
 #define SD_READ_ALIGNMENT_SIZE      4096U   // Chunk alignment (4KB) - matches USB transfer granularity
 #define SD_FLUSH_THRESHOLD          4096U   // Minimum bytes to trigger flush before unmount
 
+/* #703: SD:GET reads into the streaming pool's SD circular buffer; the read
+ * bails (maxRead==0) if that buffer is below one alignment unit. Pin the pool's
+ * inactive SD floor at/above the read minimum so a non-SD stream can never
+ * shrink SD:GET into a silent failure. If a future RAM-pressure trim drops
+ * STREAMING_SD_CIRCULAR_MIN below the alignment, this fails the build. */
+_Static_assert(STREAMING_SD_CIRCULAR_MIN >= SD_READ_ALIGNMENT_SIZE,
+               "SD circular floor must be >= SD read alignment (#703)");
+
 // =============================================================================
 // Debug Timeout Configuration
 // =============================================================================
@@ -1178,6 +1186,17 @@ void sd_card_manager_ProcessState() {
                      * Mirrors the CRC read-error terminal path. Fixes the
                      * SYST:STOR:SD:CRC "missing" wedge and the pre-existing
                      * latent SD:GET open-fail wedge. */
+                    /* #703: for a READ (SD:GET) the host is blocked waiting for
+                     * the file bytes + __END_OF_FILE__ terminator; without a
+                     * terminator it hangs on a missing/unopenable file. Emit the
+                     * marker so the GET terminates as an empty transfer. (CRC has
+                     * no streamed terminator — its result is queried via SD:CRC?
+                     * — so only send it for READ.) */
+                    if (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_READ) {
+                        sd_card_manager_DataReadyCB(SD_CARD_MANAGER_MODE_READ,
+                                (uint8_t*)"__END_OF_FILE__",
+                                sizeof("__END_OF_FILE__") - 1);
+                    }
                     gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                     LOG_E("[%s:%d]Failed to open SD Card file for reading: '%s'", __FILE__, __LINE__, gSDCardData.filePath);
@@ -1513,12 +1532,33 @@ void sd_card_manager_ProcessState() {
             TickType_t lastYieldTime = xTaskGetTickCount();
             const TickType_t yieldInterval = pdMS_TO_TICKS(1000);
 
+            // EOF marker as literal constant (safer than sprintf).
+            // Declared before the buffer-size check so the terminal bail
+            // below (#703) can also emit it.
+            static const char eofMarker[] = "__END_OF_FILE__";
+
             // Calculate safe read size based on buffer capacity
             size_t maxRead = gSdSharedBufferSize;
             if (maxRead > SD_READ_MAX_CHUNK_SIZE) maxRead = SD_READ_MAX_CHUNK_SIZE;
             maxRead = (maxRead / SD_READ_ALIGNMENT_SIZE) * SD_READ_ALIGNMENT_SIZE;
             if (maxRead == 0U) {
-                LOG_E("[SD] Buffer too small for read");
+                /* #703: terminal, host-safe bail. This path previously skipped
+                 * the mode=NONE reset (SD subsystem latched busy — every later
+                 * SD command rejected), leaked the open file handle, and sent
+                 * NO __END_OF_FILE__ (the host hung waiting for a terminator).
+                 * With the SD-circular floor pinned >= SD_READ_ALIGNMENT_SIZE
+                 * this is now practically unreachable, but keep it terminal as
+                 * defense in depth. Mirror the normal-exit ordering:
+                 * drain -> marker -> close -> priority -> mutex -> mode/state. */
+                LOG_E("[SD] Buffer too small for read (%u < %u) — aborting GET",
+                      (unsigned)gSdSharedBufferSize, (unsigned)SD_READ_ALIGNMENT_SIZE);
+                sd_wait_usb_drain();
+                sd_card_manager_DataReadyCB(SD_CARD_MANAGER_MODE_READ,
+                        (uint8_t*)eofMarker, sizeof(eofMarker) - 1);
+                if (gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID) {
+                    (void)SYS_FS_FileClose(gSDCardData.fileHandle);
+                    gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
+                }
                 vTaskPrioritySet(currentTask, originalPriority);
 
                 // Release mutex on error path
@@ -1526,12 +1566,10 @@ void sd_card_manager_ProcessState() {
                     xSemaphoreGive(gSDOpMutex);
                 }
 
+                gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
                 gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_IDLE;
                 break;
             }
-
-            // EOF marker as literal constant (safer than sprintf)
-            static const char eofMarker[] = "__END_OF_FILE__";
 
             // Clear abort flag at start of transfer
             gTransferAbortRequested = false;
@@ -2141,6 +2179,39 @@ bool sd_card_manager_IsWriteReady(void) {
         && gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE
         && gSDCardData.currentProcessState == SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE
         && gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID;
+}
+
+/* #703: is the SD read scratch large enough for SD:GET to make progress?
+ * The read chunk is floor-aligned to SD_READ_ALIGNMENT_SIZE, so anything below
+ * that yields maxRead==0 and the read bails. Reads the SAME variable the read
+ * loop uses (gSdSharedBufferSize, a 32-bit aligned scalar -> atomic read on
+ * PIC32MZ) so the SCPI-side pre-check faithfully mirrors what the SD task will
+ * see. The floor fix keeps this true; this is the host-visible fail-loud guard. */
+bool sd_card_manager_ReadBufferReady(void) {
+    return gSdSharedBufferSize >= SD_READ_ALIGNMENT_SIZE;
+}
+
+/* #703: is an async SD op actively streaming into the shared SD circular buffer
+ * with a chunk size it computed ONCE up front? Those ops (SD:GET read, CRC,
+ * directory LIST) would be corrupted if the streaming partitioner re-sized /
+ * pointer-swapped the buffer mid-transfer (stale chunk -> FileRead overflows the
+ * shrunk region into adjacent partitions). Deliberately NARROWER than IsBusy():
+ * excludes WRITE (logging is the partition's intended consumer), GET_SPACE,
+ * DELETE/FORMAT (don't stream into the buffer), and post-stop unmount transients
+ * (mode NONE) — so it won't spuriously reject a stream start right after an SD
+ * session stops. */
+bool sd_card_manager_BufferOpInFlight(void) {
+    if (gpSDCardSettings == NULL) {
+        return false;
+    }
+    switch (gpSDCardSettings->mode) {
+        case SD_CARD_MANAGER_MODE_READ:
+        case SD_CARD_MANAGER_MODE_COMPUTE_CRC:
+        case SD_CARD_MANAGER_MODE_LIST_DIRECTORY:
+            return true;
+        default:
+            return false;
+    }
 }
 
 void sd_card_manager_AbortTransfer(void) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2214,6 +2214,31 @@ bool sd_card_manager_BufferOpInFlight(void) {
     }
 }
 
+/* #703: non-blocking acquire of the SD op mutex (the SAME mutex the READ/LIST/CRC
+ * loops take before they touch the shared SD buffer — read_operation/list_operation).
+ * The streaming partitioner calls this right before it re-partitions and pointer-
+ * swaps the SD circular buffer, and holds it across the swap, to close the TOCTOU
+ * that BufferOpInFlight()-at-entry alone leaves open: an SD op can arm on the OTHER
+ * SCPI task (USB pri 7 vs TCP pri 2) between the entry check and the swap. With the
+ * lock held: a swap can't begin while an op holds it (try-lock fails -> caller
+ * aborts, fail-fast, no multi-second block), and an op that arms during the swap
+ * blocks at its read_operation take until the swap completes -> it then computes its
+ * read chunk from the NEW buffer size (consistent, no overflow). Returns true if the
+ * lock was acquired (caller MUST pair with Unlock) or if the mutex doesn't exist yet
+ * (early boot — no SD op machinery, nothing to guard). */
+bool sd_card_manager_TryLockBuffer(void) {
+    if (gSDOpMutex == NULL) {
+        return true;
+    }
+    return xSemaphoreTake(gSDOpMutex, 0) == pdTRUE;
+}
+
+void sd_card_manager_UnlockBuffer(void) {
+    if (gSDOpMutex != NULL) {
+        xSemaphoreGive(gSDOpMutex);
+    }
+}
+
 void sd_card_manager_AbortTransfer(void) {
     gTransferAbortRequested = true;
 }

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2191,13 +2191,24 @@ bool sd_card_manager_ReadBufferReady(void) {
     return gSdSharedBufferSize >= SD_READ_ALIGNMENT_SIZE;
 }
 
-/* #703: is an async SD op actively streaming into the shared SD circular buffer
- * with a chunk size it computed ONCE up front? Those ops (SD:GET read, CRC,
- * directory LIST) would be corrupted if the streaming partitioner re-sized /
- * pointer-swapped the buffer mid-transfer (stale chunk -> FileRead overflows the
- * shrunk region into adjacent partitions). Deliberately NARROWER than IsBusy():
+/* #703: is an async SD op in flight that touches a STREAMING-POOL buffer the
+ * partitioner (PrepareStreamingBuffers -> StreamingBufferPool_Partition) re-sizes
+ * and pointer-swaps? TWO distinct-but-real hazards, hence three modes:
+ *   - READ (SD:GET) and COMPUTE_CRC read the SD *circular* buffer (gSdSharedBuffer)
+ *     with a chunk size computed ONCE up front — a mid-transfer swap makes their
+ *     next FileRead overflow the shrunk region into adjacent partitions.
+ *   - LIST_DIRECTORY does NOT read gSdSharedBuffer (it formats into the fixed
+ *     512 B gSDCardData.messageBuffer). Its hazard is on the OUTPUT side: the
+ *     listing chunks are written into the streaming-pool USB/WiFi *output*
+ *     circular buffer (DataReadyCB -> sd_reply_write_usb/tcp ->
+ *     UsbCdc_WriteToBuffer / wifi_tcp_server), the SAME buffer PrepareStreamingBuffers
+ *     swaps via UsbCdc_SetWriteBuffer / wifi_tcp_server_SetWriteBuffer — a
+ *     mid-listing swap races that output. (Audit note #723: the earlier comment
+ *     wrongly attributed LIST's inclusion to the SD-circular read; the real reason
+ *     is the output-buffer swap, so LIST correctly stays in the set.)
+ * All three must block a re-partition. Deliberately NARROWER than IsBusy():
  * excludes WRITE (logging is the partition's intended consumer), GET_SPACE,
- * DELETE/FORMAT (don't stream into the buffer), and post-stop unmount transients
+ * DELETE/FORMAT (touch no re-partitioned buffer), and post-stop unmount transients
  * (mode NONE) — so it won't spuriously reject a stream start right after an SD
  * session stops. */
 bool sd_card_manager_BufferOpInFlight(void) {
@@ -2215,10 +2226,12 @@ bool sd_card_manager_BufferOpInFlight(void) {
 }
 
 /* #703: non-blocking acquire of the SD op mutex (the SAME mutex the READ/LIST/CRC
- * loops take before they touch the shared SD buffer — read_operation/list_operation).
- * The streaming partitioner calls this right before it re-partitions and pointer-
- * swaps the SD circular buffer, and holds it across the swap, to close the TOCTOU
- * that BufferOpInFlight()-at-entry alone leaves open: an SD op can arm on the OTHER
+ * ProcessState loops take — read_operation/list_operation — before they touch the
+ * buffers the partitioner swaps: READ/CRC the SD circular, LIST the USB/WiFi output
+ * circular; see sd_card_manager_BufferOpInFlight above). The streaming partitioner
+ * calls this right before it re-partitions and pointer-swaps those buffers, and
+ * holds it across the swap, to close the TOCTOU that BufferOpInFlight()-at-entry
+ * alone leaves open: an SD op can arm on the OTHER
  * SCPI task (USB pri 7 vs TCP pri 2) between the entry check and the swap. With the
  * lock held: a swap can't begin while an op holds it (try-lock fails -> caller
  * aborts, fail-fast, no multi-second block), and an op that arms during the swap

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -297,6 +297,24 @@ extern "C" {
     bool sd_card_manager_BufferOpInFlight(void);
 
     /**
+     * @brief #703: non-blocking acquire of the SD op mutex around a buffer swap.
+     *
+     * The streaming partitioner calls this immediately before it re-partitions
+     * and pointer-swaps the SD circular buffer, and holds it across the swap, to
+     * close the TOCTOU that a BufferOpInFlight() check at function entry leaves
+     * open (an SD op can arm on the other SCPI task in the interim). Non-blocking:
+     * returns false immediately if an SD READ/LIST/CRC currently holds the lock,
+     * so the caller can fail-fast instead of blocking for a multi-second transfer.
+     *
+     * @return true if the lock was taken (caller MUST call Unlock) or the mutex
+     *         does not exist yet (early boot); false if an SD op holds it.
+     */
+    bool sd_card_manager_TryLockBuffer(void);
+
+    /** @brief #703: release the lock taken by sd_card_manager_TryLockBuffer(). */
+    void sd_card_manager_UnlockBuffer(void);
+
+    /**
      * @brief Checks if the SD card file is open and ready to accept write data.
      *
      * Returns true only after the file has been opened and the write buffer

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -270,6 +270,33 @@ extern "C" {
     bool sd_card_manager_IsBusy(void);
 
     /**
+     * @brief #703: is the SD read scratch buffer large enough for SD:GET?
+     *
+     * SD:GET reads into the streaming pool's SD circular buffer, floor-aligned
+     * to the read chunk size; below one alignment unit the read bails. A non-SD
+     * stream can shrink that buffer, so a SCPI GET handler can call this to fail
+     * loudly (synchronous SCPI error) instead of arming an async read that
+     * bails silently.
+     *
+     * @return true if SD:GET can proceed, false if the buffer is too small
+     */
+    bool sd_card_manager_ReadBufferReady(void);
+
+    /**
+     * @brief #703: is an SD op actively streaming into the shared SD buffer?
+     *
+     * True while an SD:GET read / CRC / directory LIST is in flight — the ops
+     * that read into the SD circular buffer with a chunk size fixed up front.
+     * The streaming partitioner must not re-size / pointer-swap that buffer
+     * while one of these runs, or the stale chunk overflows adjacent partitions.
+     * Narrower than sd_card_manager_IsBusy(): excludes WRITE, GET_SPACE,
+     * DELETE/FORMAT and idle/unmount transients.
+     *
+     * @return true if a buffer-streaming SD op is in flight
+     */
+    bool sd_card_manager_BufferOpInFlight(void);
+
+    /**
      * @brief Checks if the SD card file is open and ready to accept write data.
      *
      * Returns true only after the file has been opened and the write buffer


### PR DESCRIPTION
## Summary

Fixes **#703** — `SYST:STORage:SD:GET` silently returns no data (host hangs) after **any** non-SD streaming session, on NQ1 firmware 3.7.2.

**Root cause (bench-confirmed):** `SD:GET` reads into the streaming pool's SD **circular** buffer (static BSS, not heap). `Streaming_ComputeAutoBuffers()` shrinks that buffer to `STREAMING_SD_CIRCULAR_MIN` whenever SD logging isn't armed at stream start, and nothing restores it on stop. At `MIN = 512` (below the read path's 4096-byte alignment) the read computes `maxRead == 0` and bails — returning 0 bytes with **no** `__END_OF_FILE__` marker (the multi-minute hang) — until a reboot or an SD-armed stream. The failed read also latched the SD subsystem "busy" and leaked the open file handle.

Root cause was fully traced by @tylerkron in [the issue thread](https://github.com/daqifi/daqifi-nyquist-firmware/issues/703#issuecomment-5081601857); a second-opinion review (fable) surfaced the additional re-partition-under-read corruption hazard (fix 5).

## Fixes

1. **Root cause:** raise `STREAMING_SD_CIRCULAR_MIN` 512 → **4096** (`== SD_READ_ALIGNMENT_SIZE`) so a non-SD stream can never shrink the SD:GET read scratch below the read minimum. Cross-tied by a `_Static_assert` in `sd_card_manager.c`; the misleading "unused when inactive" comment is corrected. Costs ~3.5 KB of the 194 KB static pool (sample-pool depth), which is far below its peak usage.
2. **Terminal, host-safe read bail:** the `maxRead == 0` path now drains → sends the EOF marker → closes the handle → resets `mode = NONE` (previously it did none of these — SD latched busy, handle leaked, host hung). Practically unreachable after (1); kept as defense in depth.
3. **Open-failure terminator:** a `SD:GET` of a missing/unopenable file now emits the EOF marker (empty transfer) instead of hanging the host.
4. **Fail loud + synchronous:** `sd_card_manager_ReadBufferReady()` + a pre-check in `SCPI_StorageSDGetData` reject with a SCPI error + `LOG_E` if the read buffer is too small, rather than arming an async read that bails silently.
5. **Re-partition-under-read corruption guard:** `SD:GET`/CRC/LIST are async and stream into the SD circular buffer with a chunk size fixed up front. A USB-only `SYST:STR:START` skipped the SD-busy gate (it only ran for SD-logging streams), so `PrepareStreamingBuffers` could re-partition + pointer-swap that buffer under an in-flight read → `FileRead` overflows the shrunk region into adjacent live-stream partitions. New `sd_card_manager_BufferOpInFlight()` (narrower than `IsBusy()` — only READ/CRC/LIST, so it won't spuriously reject a start during a post-stop unmount transient) now gates both `SYST:STR:START` and `PrepareStreamingBuffers`.

## Bench validation (E-class, board SN ...E8A7, same session)

Clean A/B on firmware 3.7.2 → 3.7.2+this fix, same board, same file:

| | baseline (3.7.2) | fixed |
|---|---|---|
| `MEM:SD:BUFfer?` after a USB-only stream | **512** | **4096** |
| `SD:GET` after that stream | **0 B, no marker (hang)** | **full file + `__END_OF_FILE__`** |
| `SYST:LOG?` | `[SD] Buffer too small for read` | *(clean)* |
| bad-filename `SD:GET` | (hangs on 3.7.2) | **terminates in 0.02 s (empty transfer)** |
| `STR:START` during an in-flight `SD:GET` | (admitted → corruption) | **rejected: `SD read/list/CRC in flight (#703)`** |

## Test

Companion regression test **`test_703_sd_circular_collapse.py`** in `daqifi-python-test-suite` (T1 buffer floor ≥ 4096, T2 GET-after-non-SD-stream, T3 open-fail terminates, T4 re-partition guard). Fails on 3.7.2 (buffer 512 / GET 0 B, captured in `repro703_baseline.txt`), passes on this fix. Companion PR: _linked below._

## Follow-ups (filed separately, out of scope here)

- **Filename clobber (data loss):** `SD:GET`/`DELETE`/CRC write the requested name into the shared `sd->file` logging field — a later SD-armed stream without re-setting `SD:FILE` truncates the downloaded file. Its own issue + fix (dedicated transient op-filename field).
- **Mid-transfer read-error host-hang:** a read error partway through still hangs the host; a distinguishable `__TRANSFER_ERROR__` terminator is a client-coordinated protocol change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
