### PR TITLE
fix(scpi): correct off-by-one bound in ADC channel index checks (#720)

### DIFF
--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -372,7 +372,7 @@ scpi_result_t SCPI_ADCChanEnableGet(scpi_t * context) {
         // Single channel
         size_t index = ADC_FindChannelIndex((uint8_t) param1);
         // TODO: This function should be able to read which version of the board we are using and assign the ADC channels associated that version
-        if (index > pBoardConfigAInChannels->Size) {
+        if (index >= pBoardConfigAInChannels->Size) {
             return SCPI_RES_ERR;
         }
 
@@ -413,7 +413,7 @@ scpi_result_t SCPI_ADCChanSingleEndSet(scpi_t * context) {
     if (SCPI_ParamInt32(context, &param2, FALSE)) {
         // Single channel
         size_t index = ADC_FindChannelIndex((uint8_t) param1);
-        if (index > pBoardConfigAInChannels->Size) {
+        if (index >= pBoardConfigAInChannels->Size) {
             return SCPI_RES_ERR;
         }
 
@@ -448,7 +448,7 @@ scpi_result_t SCPI_ADCChanSingleEndGet(scpi_t * context) {
     if (SCPI_ParamInt32(context, &param1, FALSE)) {
         // Single channel
         size_t index = ADC_FindChannelIndex((uint8_t) param1);
-        if (index > pBoardConfigAInChannels->Size) {
+        if (index >= pBoardConfigAInChannels->Size) {
             return SCPI_RES_ERR;
         }
 
@@ -578,7 +578,7 @@ scpi_result_t SCPI_ADCChanCalmSet(scpi_t * context) {
     }
 
     size_t index = ADC_FindChannelIndex((uint8_t) param1);
-    if (index > pBoardConfigAInChannels->Size) {
+    if (index >= pBoardConfigAInChannels->Size) {
         return SCPI_RES_ERR;
     }
 
@@ -604,7 +604,7 @@ scpi_result_t SCPI_ADCChanCalbSet(scpi_t * context) {
     }
 
     size_t index = ADC_FindChannelIndex((uint8_t) param1);
-    if (index > pBoardConfigAInChannels->Size) {
+    if (index >= pBoardConfigAInChannels->Size) {
         return SCPI_RES_ERR;
     }
 
@@ -624,7 +624,7 @@ scpi_result_t SCPI_ADCChanCalmGet(scpi_t * context) {
     }
 
     size_t index = ADC_FindChannelIndex((uint8_t) param1);
-    if (index > pBoardConfigAInChannels->Size) {
+    if (index >= pBoardConfigAInChannels->Size) {
         return SCPI_RES_ERR;
     }
 
@@ -644,7 +644,7 @@ scpi_result_t SCPI_ADCChanCalbGet(scpi_t * context) {
     }
 
     size_t index = ADC_FindChannelIndex((uint8_t) param1);
-    if (index > pBoardConfigAInChannels->Size) {
+    if (index >= pBoardConfigAInChannels->Size) {
         return SCPI_RES_ERR;
     }
 


### PR DESCRIPTION
## Summary

Fixes **#720** — corrects an off-by-one in seven ADC channel-index bounds checks in `SCPIADC.c`.

All seven used `index > pBoardConfigAInChannels->Size` (should be `>= Size`), which would admit `index == Size` — a one-past-the-end access of `pRuntimeAInChannels->Data` (valid indices are `0..Size-1`). Sites: enable-get, differential set/get, and CalM/CalB set + get (the two `Set` variants would write OOB; the `Get` variants read OOB).

Changed all seven to `>= Size`.

## Honesty note — this is a *latent*, currently-unreachable off-by-one

Per debugging discipline: `ADC_FindChannelIndex` (`HAL/ADC.c`) returns either a valid index (`0..Size-1`) or `(size_t)-1` (`SIZE_MAX`) on not-found — **never exactly `Size`**. So `> Size` already rejects every invalid channel via the `SIZE_MAX` path, and no SCPI input resolves to `index == Size`. The issue's stated impact ("writes past the end / corrupts adjacent runtime state") is therefore **not currently reachable**.

This PR is a **defensive correctness hardening** — the bound is simply wrong, and `>= Size` is the correct one — that guards against a future change to `ADC_FindChannelIndex`'s return contract or a copy of the idiom. It has **no observable behavior change**.

## Test

No behavioral regression test ships with this PR: because the fix has no reachable behavior change (invalid channels are already rejected via the `SIZE_MAX` path both before and after), no bench input distinguishes old from new firmware. This is a static-correctness fix, in the same exempt class as a pure no-behavior-change refactor. cppcheck CI covers it; the firmware builds clean at `-O3 -Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
