### PR TITLE
fix(sd): stop SD:GET/CRC/DELETE from clobbering the SD logging filename (#724)

### DIFF
--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -350,10 +350,10 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
         pSDCardRuntimeConfig->opFile[fileLen] = '\0';
     } else {
         /* #724: legacy no-argument GET operated on the current filename; preserve
-         * that by copying the logging target into opFile (without clobbering it). */
-        strncpy(pSDCardRuntimeConfig->opFile, pSDCardRuntimeConfig->file,
-                SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX);
-        pSDCardRuntimeConfig->opFile[SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX] = '\0';
+         * that by copying the logging target into opFile (without clobbering it).
+         * snprintf guarantees NUL-termination within the destination bound. */
+        snprintf(pSDCardRuntimeConfig->opFile, sizeof(pSDCardRuntimeConfig->opFile),
+                 "%s", pSDCardRuntimeConfig->file);
     }
     /* #598: route the async file data back to the interface that asked.
      * #599: capture the requesting TCP connection's generation so the SD

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -265,8 +265,9 @@ scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         return SCPI_RES_ERR;
     }
-    memcpy(pSDCardRuntimeConfig->file, pBuff, fileLen);
-    pSDCardRuntimeConfig->file[fileLen] = '\0';
+    /* #724: transient operand, not the logging target `file`. */
+    memcpy(pSDCardRuntimeConfig->opFile, pBuff, fileLen);
+    pSDCardRuntimeConfig->opFile[fileLen] = '\0';
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_COMPUTE_CRC;
     sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
     return SCPI_RES_OK;
@@ -344,8 +345,15 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
-        memcpy(pSDCardRuntimeConfig->file, pBuff, fileLen);
-        pSDCardRuntimeConfig->file[fileLen] = '\0';
+        /* #724: write the transient operand, NOT the logging target `file`. */
+        memcpy(pSDCardRuntimeConfig->opFile, pBuff, fileLen);
+        pSDCardRuntimeConfig->opFile[fileLen] = '\0';
+    } else {
+        /* #724: legacy no-argument GET operated on the current filename; preserve
+         * that by copying the logging target into opFile (without clobbering it). */
+        strncpy(pSDCardRuntimeConfig->opFile, pSDCardRuntimeConfig->file,
+                SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX);
+        pSDCardRuntimeConfig->opFile[SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX] = '\0';
     }
     /* #598: route the async file data back to the interface that asked.
      * #599: capture the requesting TCP connection's generation so the SD
@@ -767,9 +775,10 @@ scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         goto __exit_point;
     }
-    memcpy(pSDCardRuntimeConfig->file, pBuff, fileLen);
-    pSDCardRuntimeConfig->file[fileLen] = '\0';
-    LOG_D("SD:DELete - Deleting file '%s'\r\n", pSDCardRuntimeConfig->file);
+    /* #724: delete the transient operand, not the logging target `file`. */
+    memcpy(pSDCardRuntimeConfig->opFile, pBuff, fileLen);
+    pSDCardRuntimeConfig->opFile[fileLen] = '\0';
+    LOG_D("SD:DELete - Deleting file '%s'\r\n", pSDCardRuntimeConfig->opFile);
 
     // Set mode to DELETE and trigger the operation
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_DELETE_FILE;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -699,9 +699,12 @@ void sd_card_manager_ProcessState() {
                                 strlen(opName) <= SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX;
 
                 // LIST and FORMAT modes don't need a filename
-                // DELETE, READ, WRITE need a filename
+                // DELETE, READ, WRITE, CRC need a filename. #724 (Qodo): include
+                // COMPUTE_CRC so its opFile is validated upfront (consistent with
+                // isTransientOp above) rather than only failing at file open.
                 bool needsFile = (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_DELETE_FILE ||
                                  gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_READ ||
+                                 gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_COMPUTE_CRC ||
                                  gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE);
 
                 // GET_SPACE only needs to mount - no directory or file needed

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -683,11 +683,20 @@ void sd_card_manager_ProcessState() {
             // GET_SPACE is allowed even when disabled (transient read-only query)
             if ((gpSDCardSettings->enable || gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_GET_SPACE)
                 && gpSDCardSettings->mode != SD_CARD_MANAGER_MODE_NONE) {
-                // Validate directory and file settings
+                // Validate directory and file settings.
+                // #724: READ/CRC/DELETE operate on the transient `opFile`; WRITE
+                // (logging) uses the persistent `file`. Validate the field the
+                // active mode will actually open.
+                bool isTransientOp =
+                        (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_READ ||
+                         gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_COMPUTE_CRC ||
+                         gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_DELETE_FILE);
+                const char* opName = isTransientOp ? gpSDCardSettings->opFile
+                                                   : gpSDCardSettings->file;
                 bool dirValid = strlen(gpSDCardSettings->directory) > 0 &&
                                strlen(gpSDCardSettings->directory) <= SD_CARD_MANAGER_CONF_DIR_NAME_LEN_MAX;
-                bool fileValid = strlen(gpSDCardSettings->file) > 0 &&
-                                strlen(gpSDCardSettings->file) <= SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX;
+                bool fileValid = strlen(opName) > 0 &&
+                                strlen(opName) <= SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX;
 
                 // LIST and FORMAT modes don't need a filename
                 // DELETE, READ, WRITE need a filename
@@ -711,7 +720,7 @@ void sd_card_manager_ProcessState() {
                         LOG_E("[%s:%d]Invalid SD Card Directory or file name (dir='%s', file='%s')",
                               __FILE__, __LINE__,
                               gpSDCardSettings->directory,
-                              gpSDCardSettings->file);
+                              opName);
                         errorLogged = true;
                     }
                 }
@@ -1156,9 +1165,10 @@ void sd_card_manager_ProcessState() {
                 }
             } else if (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_READ ||
                        gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_COMPUTE_CRC) {
-                // READ/CRC: construct filename directly from settings (no splitting)
+                // READ/CRC: construct filename directly from settings (no splitting).
+                // #724: open the transient operand (opFile), not the logging target.
                 snprintf(gSDCardData.filePath, SD_CARD_MANAGER_FILE_PATH_LEN_MAX, "%s/%s",
-                        gpSDCardSettings->directory, gpSDCardSettings->file);
+                        gpSDCardSettings->directory, gpSDCardSettings->opFile);
                 LOG_D("[SD] Opening file for read: '%s'\r\n", gSDCardData.filePath);
 
                 gSDCardData.fileHandle = SYS_FS_FileOpen(gSDCardData.filePath,
@@ -1213,8 +1223,9 @@ void sd_card_manager_ProcessState() {
                 while (dirLen > 0 && gpSDCardSettings->directory[dirLen - 1] == '/') {
                     dirLen--;
                 }
+                // #724: delete the transient operand (opFile), not the logging target.
                 int pathLen = snprintf(gSDCardData.filePath, SD_CARD_MANAGER_FILE_PATH_LEN_MAX, "%.*s/%s",
-                        (int)dirLen, gpSDCardSettings->directory, gpSDCardSettings->file);
+                        (int)dirLen, gpSDCardSettings->directory, gpSDCardSettings->opFile);
 
                 // Validate path was not truncated
                 if (pathLen < 0 || pathLen >= (int)SD_CARD_MANAGER_FILE_PATH_LEN_MAX) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -69,6 +69,14 @@ extern "C" {
         uint32_t replyGeneration;
         char directory[SD_CARD_MANAGER_CONF_DIR_NAME_LEN_MAX + 1];
         char file[SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX + 1];
+        /* #724: transient operand filename for the READ (SD:GET) / COMPUTE_CRC /
+         * DELETE ops. Kept SEPARATE from `file` (the persistent logging target set
+         * by SD:FILE) so downloading/CRC'ing/deleting a file no longer clobbers the
+         * logging target — previously all four wrote `file`, so a GET/DELETE
+         * followed by an SD-armed stream (without re-setting SD:FILE) truncated the
+         * just-referenced file. The READ/CRC/DELETE path construction and the INIT
+         * filename validation use this field for those modes; WRITE uses `file`. */
+        char opFile[SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX + 1];
         uint64_t maxFileSizeBytes;  // Max file size before auto-split (0 = unlimited)
         // Pre-start free-space floor (#498).  When > 0, SYST:STR:START
         // for SD-output sessions runs a SYS_FS_DriveSectorGet() check


### PR DESCRIPTION
## Summary

Fixes **#724** — `SYST:STORage:SD:GET` / `:CRC` / `:DELete` silently clobbered the SD **logging** filename, causing data loss.

All three wrote the requested operand into the **shared** `sd_card_manager_settings_t.file` field — the same field the logging path opens with `SYS_FS_FILE_OPEN_WRITE_PLUS` (create/**truncate**). So:

> Download (or CRC, or delete) a file, then start any SD-armed stream **without** re-setting `SYST:STOR:SD:FILE`, and the stream logs into — and truncates to zero — the file you just referenced.

Found while fixing #703 (a second-opinion review flagged it as a class, not one instance).

## Fix

Add a dedicated transient operand field **`opFile`** to the settings struct. READ / CRC / DELETE now write and open `opFile`; `file` stays purely the logging target (only `SYST:STOR:SD:FILE` writes it). Made mode-aware:
- INIT-state filename validation validates `opFile` for READ/CRC/DELETE, `file` for WRITE.
- READ/CRC path construction (`sd_card_manager.c`) and DELETE path construction open `opFile`.
- A no-argument `GET` copies `file` → `opFile` to preserve the legacy "operate on the current filename" behavior without clobbering `file`.

## Bench validation (E-class, NQ1 …E8A7)

1. Create file B (`t724_get.csv`, 2 s ≈ 22 KB). 2. Set logging target A (`t724_log.csv`, 2 s ≈ 22 KB). 3. `SD:GET "t724_get.csv"`. 4. Stream to SD **without** re-setting `SD:FILE`, for a distinct 5 s.

| | result |
|---|---|
| `t724_log.csv` (logging target) after step 4 | **52,200 B** (rewritten by the 5 s stream) |
| `t724_get.csv` (GET'd file) after step 4 | **22,210 B** (untouched) |

→ the stream logged to the **logging target**, proving the GET did not clobber `file`. On the old firmware step 4 would have rewritten `t724_get.csv` (the memcpy wrote `file`).

## Follow-up (out of scope)

`SCPI_StorageSDBenchmark` also writes `benchmark_XXXX.dat` into `file` (via `mode=WRITE`) — same clobber class, but through the logging/WRITE path (different mechanism). Filed separately.

## Test

Companion regression test in `daqifi-python-test-suite` (fails on pre-#724 firmware, passes here) — linked below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
