### PR TITLE
feat(streaming): expose the streaming timebase in SYSInfoPB and CAP:JSON (#730)

### DIFF
--- a/firmware/src/services/DaqifiPB/DaqifiOutMessage.pb.h
+++ b/firmware/src/services/DaqifiPB/DaqifiOutMessage.pb.h
@@ -125,6 +125,12 @@ typedef struct _DaqifiOutMessage { /* Put repetitive information in first 15 fie
     char device_hw_rev[16]; /* Device hardware revision */
     char device_fw_rev[16]; /* Device firmware revision */
     uint64_t device_sn; /* Device serial number */
+    /* Streaming timebase (#730). timestamp_freq (12) is the timestamp counter;
+ these three complete the picture so a client never has to assume a clock
+ or a prescale ratio, and can see the rate the hardware ACTUALLY runs. */
+    uint32_t stream_timer_freq; /* Streaming trigger timer frequency, Hz */
+    uint32_t timestamp_ticks_per_sample; /* Exact timestamp ticks per streaming period (0 = unconfigured) */
+    uint32_t actual_rate_millihz; /* Quantized streaming rate actually applied, millihertz (0 = unconfigured) */
 } DaqifiOutMessage;
 
 
@@ -133,8 +139,8 @@ extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define DaqifiOutMessage_init_default            {0, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, {0}}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, 0, {0, 0}, 0, {0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, {0}}, {0, {0}}, 0, {0, {0}}, 0, 0, {0}, 0, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, "", 0, "", "", 0, 0, 0, 0, {"", "", "", "", "", "", "", ""}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, "", "", "", 0}
-#define DaqifiOutMessage_init_zero               {0, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, {0}}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, 0, {0, 0}, 0, {0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, {0}}, {0, {0}}, 0, {0, {0}}, 0, 0, {0}, 0, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, "", 0, "", "", 0, 0, 0, 0, {"", "", "", "", "", "", "", ""}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, "", "", "", 0}
+#define DaqifiOutMessage_init_default            {0, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, {0}}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, 0, {0, 0}, 0, {0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, {0}}, {0, {0}}, 0, {0, {0}}, 0, 0, {0}, 0, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, "", 0, "", "", 0, 0, 0, 0, {"", "", "", "", "", "", "", ""}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, "", "", "", 0, 0, 0, 0}
+#define DaqifiOutMessage_init_zero               {0, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, {0, {0}}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, 0, {0, 0}, 0, {0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, {0}}, {0, {0}}, 0, {0, {0}}, 0, 0, {0}, 0, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, {0, {0}}, "", 0, "", "", 0, 0, 0, 0, {"", "", "", "", "", "", "", ""}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0}, "", "", "", 0, 0, 0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define DaqifiOutMessage_msg_time_stamp_tag      1
@@ -202,6 +208,9 @@ extern "C" {
 #define DaqifiOutMessage_device_hw_rev_tag       67
 #define DaqifiOutMessage_device_fw_rev_tag       68
 #define DaqifiOutMessage_device_sn_tag           69
+#define DaqifiOutMessage_stream_timer_freq_tag   70
+#define DaqifiOutMessage_timestamp_ticks_per_sample_tag 71
+#define DaqifiOutMessage_actual_rate_millihz_tag 72
 
 /* Struct field encoding specification for nanopb */
 #define DaqifiOutMessage_FIELDLIST(X, a) \
@@ -269,7 +278,10 @@ X(a, STATIC,   REPEATED, UINT32,   av_wifi_inf_mode,  65) \
 X(a, STATIC,   SINGULAR, STRING,   device_pn,        66) \
 X(a, STATIC,   SINGULAR, STRING,   device_hw_rev,    67) \
 X(a, STATIC,   SINGULAR, STRING,   device_fw_rev,    68) \
-X(a, STATIC,   SINGULAR, UINT64,   device_sn,        69)
+X(a, STATIC,   SINGULAR, UINT64,   device_sn,        69) \
+X(a, STATIC,   SINGULAR, UINT32,   stream_timer_freq,  70) \
+X(a, STATIC,   SINGULAR, UINT32,   timestamp_ticks_per_sample,  71) \
+X(a, STATIC,   SINGULAR, UINT32,   actual_rate_millihz,  72)
 #define DaqifiOutMessage_CALLBACK NULL
 #define DaqifiOutMessage_DEFAULT NULL
 
@@ -280,7 +292,7 @@ extern const pb_msgdesc_t DaqifiOutMessage_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define DAQIFIOUTMESSAGE_PB_H_MAX_SIZE           DaqifiOutMessage_size
-#define DaqifiOutMessage_size                    2008
+#define DaqifiOutMessage_size                    2029
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/firmware/src/services/DaqifiPB/DaqifiOutMessage.proto
+++ b/firmware/src/services/DaqifiPB/DaqifiOutMessage.proto
@@ -93,4 +93,11 @@ message DaqifiOutMessage
 	string device_hw_rev = 67;						//  Device hardware revision
 	string device_fw_rev = 68;						//  Device firmware revision
     uint64 device_sn = 69;                         //  Device serial number
+
+	// Streaming timebase (#730). timestamp_freq (12) is the timestamp counter;
+	// these three complete the picture so a client never has to assume a clock
+	// or a prescale ratio, and can see the rate the hardware ACTUALLY runs.
+	uint32 stream_timer_freq = 70;                 //  Streaming trigger timer frequency, Hz
+	uint32 timestamp_ticks_per_sample = 71;        //  Exact timestamp ticks per streaming period (0 = unconfigured)
+	uint32 actual_rate_millihz = 72;               //  Quantized streaming rate actually applied, millihertz (0 = unconfigured)
 }

--- a/firmware/src/services/DaqifiPB/DaqifiOutMessage.proto
+++ b/firmware/src/services/DaqifiPB/DaqifiOutMessage.proto
@@ -94,7 +94,7 @@ message DaqifiOutMessage
 	string device_fw_rev = 68;						//  Device firmware revision
     uint64 device_sn = 69;                         //  Device serial number
 
-	// Streaming timebase (#730). timestamp_freq (12) is the timestamp counter;
+	// Streaming timebase (#730). timestamp_freq (16) is the timestamp counter;
 	// these three complete the picture so a client never has to assume a clock
 	// or a prescale ratio, and can see the rate the hardware ACTUALLY runs.
 	uint32 stream_timer_freq = 70;                 //  Streaming trigger timer frequency, Hz

--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -536,7 +536,8 @@ size_t Nanopb_Encode(tBoardData* state,
                         pBoardConfig->StreamingConfig.TSTimerIndex);
                 break;
 
-            /* #730 streaming timebase. timestamp_freq alone is not enough to
+            /* #730 streaming timebase (with timestamp_freq, field 16). That field
+             * alone is not enough to
              * predict the stamps: the trigger and the timestamp counter run
              * different prescales, and the requested rate is quantized into an
              * integer period register. These three close that gap so a client

--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -17,6 +17,7 @@
 #include "HAL/TimerApi/TimerApi.h"
 #include "state/board/BoardConfig.h"
 #include "HAL/DIO.h"
+#include "services/streaming.h"   /* #730: timebase helpers */
 #ifndef min
 #define min(x,y) ((x) <= (y) ? (x) : (y))
 #endif // min
@@ -116,6 +117,19 @@ static int Nanopb_EncodeLength(const NanopbFlagsArray* fields) {
 
             case DaqifiOutMessage_timestamp_freq_tag:
                 len += sizeof (out->timestamp_freq);
+                break;
+
+            /* #730 streaming timebase */
+            case DaqifiOutMessage_stream_timer_freq_tag:
+                len += sizeof (out->stream_timer_freq);
+                break;
+
+            case DaqifiOutMessage_timestamp_ticks_per_sample_tag:
+                len += sizeof (out->timestamp_ticks_per_sample);
+                break;
+
+            case DaqifiOutMessage_actual_rate_millihz_tag:
+                len += sizeof (out->actual_rate_millihz);
                 break;
 
             case DaqifiOutMessage_analog_in_port_num_tag:
@@ -521,6 +535,39 @@ size_t Nanopb_Encode(tBoardData* state,
                 message.timestamp_freq = TimerApi_FrequencyGet(
                         pBoardConfig->StreamingConfig.TSTimerIndex);
                 break;
+
+            /* #730 streaming timebase. timestamp_freq alone is not enough to
+             * predict the stamps: the trigger and the timestamp counter run
+             * different prescales, and the requested rate is quantized into an
+             * integer period register. These three close that gap so a client
+             * never assumes a clock or a ratio. */
+            case DaqifiOutMessage_stream_timer_freq_tag:
+                message.stream_timer_freq = TimerApi_FrequencyGet(
+                        pBoardConfig->StreamingConfig.TimerIndex);
+                break;
+
+            case DaqifiOutMessage_timestamp_ticks_per_sample_tag:
+            case DaqifiOutMessage_actual_rate_millihz_tag:
+            {
+                /* Both derive from the configured trigger period. Reported as
+                 * 0 when no rate has been configured yet, so a client can tell
+                 * "unconfigured" from a real value. Computed by the streaming
+                 * module so these can never disagree with the stamps the
+                 * deferred task actually emits (#717 gStreamPeriodTicks). */
+                const StreamingRuntimeConfig* cfg = BoardRunTimeConfig_Get(
+                        BOARDRUNTIME_STREAMING_CONFIGURATION);
+                uint32_t clockPeriod = (cfg != NULL) ? cfg->ClockPeriod : 0u;
+                bool configured = (cfg != NULL) && (cfg->Frequency > 0u);
+                if (fields->Data[i] ==
+                        DaqifiOutMessage_timestamp_ticks_per_sample_tag) {
+                    message.timestamp_ticks_per_sample = configured
+                            ? Streaming_TimestampTicksPerSample(clockPeriod) : 0u;
+                } else {
+                    message.actual_rate_millihz = configured
+                            ? Streaming_ActualRateMilliHz(clockPeriod) : 0u;
+                }
+                break;
+            }
             case DaqifiOutMessage_analog_in_port_num_tag:
             {
                 /**

--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -557,7 +557,7 @@ size_t Nanopb_Encode(tBoardData* state,
                 const StreamingRuntimeConfig* cfg = BoardRunTimeConfig_Get(
                         BOARDRUNTIME_STREAMING_CONFIGURATION);
                 uint32_t clockPeriod = (cfg != NULL) ? cfg->ClockPeriod : 0u;
-                bool configured = (cfg != NULL) && (cfg->Frequency > 0u);
+                bool configured = Streaming_IsRateConfigured();
                 if (fields->Data[i] ==
                         DaqifiOutMessage_timestamp_ticks_per_sample_tag) {
                     message.timestamp_ticks_per_sample = configured

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -345,6 +345,7 @@ scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
         uint32_t periodCycles = (clkFreq + freq - 1) / freq;
         if (periodCycles < 2) periodCycles = 2;
         pRunTimeStreamConfig->ClockPeriod = periodCycles - 1;
+        Streaming_NoteRateConfigured();   /* #730 */
     }
     pRunTimeStreamConfig->Frequency = freq;
     pRunTimeStreamConfig->TSClockPeriod = 0xFFFFFFFF;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2135,6 +2135,7 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
             Streaming_SetTestPattern(savedPattern);
             StreamFreq_Set(pStreamCfg, savedFrequency);     // no-op here (poke is later), kept for consistency
             pStreamCfg->ClockPeriod = savedClockPeriod;
+            Streaming_RestoreRateConfigured(savedRateConfigured);   /* #730 */
             RestoreSdMode(savedSdMode);
             SCPI_ExecutionError(context, "SYST:STR:THR: buffer prepare failed");
             return SCPI_RES_ERR;
@@ -2160,6 +2161,11 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
         Streaming_SetTestPattern(savedPattern);
         StreamFreq_Set(pStreamCfg, savedFrequency);
         pStreamCfg->ClockPeriod = savedClockPeriod;
+        /* #730/#733 Qodo: Streaming_Start may already have marked the rate
+         * configured before the start failed — restore on THIS path too, or a
+         * failed benchmark leaves the flag set over the period it just put
+         * back. Every exit from this function restores the same four things. */
+        Streaming_RestoreRateConfigured(savedRateConfigured);
         RestoreSdMode(savedSdMode);
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         return SCPI_RES_ERR;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3423,6 +3423,7 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
             uint32_t periodCycles = (clkFreq + freq - 1) / freq;
             if (periodCycles < 2) periodCycles = 2;  // PR must be >= 1
             pRunTimeStreamConfig->ClockPeriod = periodCycles - 1;
+            Streaming_NoteRateConfigured();   /* #730 */
             pRunTimeStreamConfig->Frequency = freq;
             pRunTimeStreamConfig->TSClockPeriod = 0xFFFFFFFF;
             // #107: scan the shared MODULE7 (Type-2) mux on EVERY tick so T2 yields
@@ -5065,7 +5066,7 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
         StreamingRuntimeConfig* tcfg =
             BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
         uint32_t tClockPeriod = (tcfg != NULL) ? tcfg->ClockPeriod : 0u;
-        bool tConfigured = (tcfg != NULL) && (StreamFreq_Get(tcfg) > 0u);
+        bool tConfigured = Streaming_IsRateConfigured();
         scpi_printf(context,
             "\"timing\":{\"timestamp_hz\":%u,\"stream_timer_hz\":%u,"
             "\"timestamp_ticks_per_sample\":%u,\"actual_rate_millihz\":%u},",

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2100,6 +2100,10 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
     uint32_t savedPattern = Streaming_GetTestPattern();
     uint64_t savedFrequency = StreamFreq_Get(pStreamCfg);   // Frequency is uint64_t — no truncation
     uint32_t savedClockPeriod = pStreamCfg->ClockPeriod;
+    /* #730/#733: this path restores ClockPeriod below, so the rate-configured
+     * flag must be restored with it — otherwise a benchmark on a fresh boot
+     * leaves it set over the meaningless boot default. */
+    bool savedRateConfigured = Streaming_IsRateConfigured();
 
     // Enable benchmark mode + test pattern
     Streaming_SetBenchmarkMode(BENCHMARK_NOCAP);
@@ -2173,6 +2177,7 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
     Streaming_SetTestPattern(savedPattern);
     StreamFreq_Set(pStreamCfg, savedFrequency);
     pStreamCfg->ClockPeriod = savedClockPeriod;
+    Streaming_RestoreRateConfigured(savedRateConfigured);   /* #730 */
     RestoreSdMode(savedSdMode);
 
     // Collect and report results
@@ -2437,6 +2442,7 @@ static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
     uint32_t savedPattern = Streaming_GetTestPattern();
     uint64_t savedFrequency = StreamFreq_Get(cfg);      // Frequency is uint64_t — no truncation
     uint32_t savedClockPeriod = cfg->ClockPeriod;
+    bool savedRateConfigured = Streaming_IsRateConfigured();   /* #730, see above */
     Streaming_SetBenchmarkMode(BENCHMARK_NOCAP);   // bypass cap to probe the link
     Streaming_SetTestPattern(3);                   // fullscale: worst-case PB size
 
@@ -2582,6 +2588,7 @@ static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
     Streaming_SetTestPattern(savedPattern);
     StreamFreq_Set(cfg, savedFrequency);
     cfg->ClockPeriod = savedClockPeriod;
+    Streaming_RestoreRateConfigured(savedRateConfigured);   /* #730 */
     RestoreSdMode(savedSdMode);
 
     // ---- Bench-fitted WiFi cap (#522) -------------------------------------

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -171,7 +171,7 @@ const NanopbFlagsArray fields_all = {
 };
 
 const NanopbFlagsArray fields_info = {
-    .Size = 59,
+    .Size = 62,
     .Data =
     {
         DaqifiOutMessage_msg_time_stamp_tag,
@@ -180,6 +180,10 @@ const NanopbFlagsArray fields_info = {
         DaqifiOutMessage_batt_status_tag,
         DaqifiOutMessage_temp_status_tag,
         DaqifiOutMessage_timestamp_freq_tag,
+        /* #730 streaming timebase */
+        DaqifiOutMessage_stream_timer_freq_tag,
+        DaqifiOutMessage_timestamp_ticks_per_sample_tag,
+        DaqifiOutMessage_actual_rate_millihz_tag,
         DaqifiOutMessage_analog_in_port_num_tag,
         DaqifiOutMessage_analog_in_port_num_priv_tag,
         DaqifiOutMessage_analog_in_port_type_tag,
@@ -5038,6 +5042,40 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
         (unsigned)st.isrMaxHz,
         (unsigned)cfg->CapabilitiesFlags.streamingConservativeEnvelopeHz,
         (unsigned)st.maxFreqHz);
+
+    /* #730 timing block — the streaming timebase, so a client never has to
+     * assume a clock or a prescale ratio, and can see the rate the hardware
+     * ACTUALLY runs.
+     *
+     * Emitted here as well as in SYSTem:SYSInfoPB? (fields 70-72) because this
+     * is the "render your UI from one query" surface; the PB route otherwise
+     * forces a second round-trip just for timing. Same values, same helpers.
+     *
+     * - timestamp_hz / stream_timer_hz: divide them for the prescale ratio
+     *   (4 today). Reported rather than derivable because the ratio is a
+     *   PRESCALER ratio — clock-invariant across the 200/252 MHz configs —
+     *   while the core-timer ratio would not be (see #731).
+     * - timestamp_ticks_per_sample: exactly what the deferred task stamps with
+     *   (#717 gStreamPeriodTicks), from the shared helper so it cannot drift.
+     * - actual_rate_millihz: the QUANTIZED rate. `Frequency` is what was asked
+     *   for; the period register is an integer, so asking for 4500 Hz yields
+     *   4498.714 Hz at 252 MHz (~286 ppm). Millihertz keeps it integral.
+     * Both per-config values are 0 until a rate is configured. */
+    {
+        StreamingRuntimeConfig* tcfg =
+            BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
+        uint32_t tClockPeriod = (tcfg != NULL) ? tcfg->ClockPeriod : 0u;
+        bool tConfigured = (tcfg != NULL) && (StreamFreq_Get(tcfg) > 0u);
+        scpi_printf(context,
+            "\"timing\":{\"timestamp_hz\":%u,\"stream_timer_hz\":%u,"
+            "\"timestamp_ticks_per_sample\":%u,\"actual_rate_millihz\":%u},",
+            (unsigned)TimerApi_FrequencyGet(cfg->StreamingConfig.TSTimerIndex),
+            (unsigned)TimerApi_FrequencyGet(cfg->StreamingConfig.TimerIndex),
+            (unsigned)(tConfigured
+                ? Streaming_TimestampTicksPerSample(tClockPeriod) : 0u),
+            (unsigned)(tConfigured
+                ? Streaming_ActualRateMilliHz(tClockPeriod) : 0u));
+    }
 
     scpi_printf(context,
         "\"rate_model\":{\"formula\":"

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1387,17 +1387,8 @@ static void Streaming_Start(void) {
             // boot. Exactness holds while the stream:ts prescale ratio is
             // integral; a TS prescale coarser than the stream timer would
             // truncate here and reintroduce per-tick drift.
-            {
-                uint32_t tsFreq =
-                        TimerApi_FrequencyGet(gpStreamingConfig->TSTimerIndex);
-                uint32_t streamTimerFreq =
-                        TimerApi_FrequencyGet(gpStreamingConfig->TimerIndex);
-                uint32_t periodCycles = gpRuntimeConfigStream->ClockPeriod + 1u;
-                gStreamPeriodTicks = (streamTimerFreq > 0u)
-                        ? (uint32_t)(((uint64_t)tsFreq * periodCycles) / streamTimerFreq)
-                        : 1u;
-                if (gStreamPeriodTicks == 0u) gStreamPeriodTicks = 1u;
-            }
+            gStreamPeriodTicks = Streaming_TimestampTicksPerSample(
+                    gpRuntimeConfigStream->ClockPeriod);
             // #450: anchor the startup-grace window at the start of each
             // enabled session.  Steady drop counters won't increment
             // until xTaskGetTickCount() - gStreamStartTick >= grace.
@@ -2653,6 +2644,64 @@ void TimestampTimer_Init(void) {
     TimerApi_InterruptEnable(gpStreamingConfig->TSTimerIndex);
     TimerApi_Start(gpStreamingConfig->TSTimerIndex);
 
+}
+
+/* #730: the timestamp-domain length of one streaming period, for a given
+ * stream-timer period register value.
+ *
+ * Single source of truth for the #717 period math — Streaming_Start stores the
+ * result in gStreamPeriodTicks (what the deferred task actually stamps with),
+ * and the capability/SYSInfoPB emitters report it to clients. Splitting the
+ * formula across those call sites is how a reported value silently stops
+ * matching the emitted stamps.
+ *
+ * The two timers run different prescales (1:8 stream / 1:2 TS = ratio 4) and
+ * the requested rate is quantized into ClockPeriod by ceiling division in the
+ * STREAM domain (SCPIInterface.c ~3419), so deriving from the ACTUAL configured
+ * period + the live frequency ratio is exact at every rate — unlike the
+ * drift-prone floor(tsFreq/rate). Multiply in uint64 first (result <= tsFreq).
+ *
+ * Exactness holds while the stream:ts prescale ratio is integral. That ratio is
+ * 4 at BOTH clock configurations (#487: 1:2 vs 1:8 is a prescaler ratio, so it
+ * is immune to SYSCLK and the PBCLK divider alike), which is why this survived
+ * the 200->252 MHz move untouched. A TS prescale COARSER than the stream
+ * timer's would truncate here and reintroduce per-tick drift.
+ *
+ * Returns >= 1 always; never 0 (a zero period would make every stamp identical).
+ */
+uint32_t Streaming_TimestampTicksPerSample(uint32_t clockPeriod) {
+    if (gpStreamingConfig == NULL) return 1u;
+    uint32_t tsFreq = TimerApi_FrequencyGet(gpStreamingConfig->TSTimerIndex);
+    uint32_t streamTimerFreq =
+            TimerApi_FrequencyGet(gpStreamingConfig->TimerIndex);
+    if (streamTimerFreq == 0u) return 1u;
+    uint32_t periodCycles = clockPeriod + 1u;
+    uint32_t ticks =
+            (uint32_t)(((uint64_t)tsFreq * periodCycles) / streamTimerFreq);
+    return (ticks == 0u) ? 1u : ticks;
+}
+
+/* #730: the rate the hardware ACTUALLY runs, in millihertz.
+ *
+ * `StreamingRuntimeConfig.Frequency` stores what the client ASKED for; the
+ * trigger period is an integer register, so the achievable rates are quantized
+ * to streamTimerFreq / N. Request 4500 Hz at 252 MHz and the device runs
+ * 10.5e6/2334 = 4498.714 Hz while reporting 4500 — ~286 ppm, and there was no
+ * way to observe it before this. Millihertz keeps the value integral (no FPU
+ * in an SCPI callback, and the deferred task is pure-integer by design).
+ *
+ * Returns 0 when no period is configured, so a client can distinguish
+ * "unconfigured" from a real rate.
+ */
+uint32_t Streaming_ActualRateMilliHz(uint32_t clockPeriod) {
+    if (gpStreamingConfig == NULL) return 0u;
+    uint32_t streamTimerFreq =
+            TimerApi_FrequencyGet(gpStreamingConfig->TimerIndex);
+    uint32_t periodCycles = clockPeriod + 1u;
+    if (streamTimerFreq == 0u || periodCycles == 0u) return 0u;
+    /* uint64 intermediate: 10.5e6 * 1000 overflows uint32. Max result at the
+     * 22 kHz cap is 22e6 millihertz, well inside uint32. */
+    return (uint32_t)(((uint64_t)streamTimerFreq * 1000u) / periodCycles);
 }
 
 void Streaming_SetTestPattern(uint32_t pattern) {

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -71,6 +71,21 @@ static uint64_t gTestPatternSampleCount = 0;      // Monotonic counter, reset on
 // (the seeded latch included — a plain bool would still be atomic, but the
 // native width keeps the whole set uniform). volatile does NOT make the
 // gStreamTickIndex RMW atomic — that keeps its critical section.
+/* #730: has a streaming rate been configured this boot?
+ *
+ * Deliberately a flag rather than a test of the config fields. The boot
+ * defaults (CommonRuntimeDefaults.h) are placeholders that do not describe any
+ * real rate: ClockPeriod=130 works out to 80,153 Hz at 252 MHz while
+ * Frequency=30000 claims 30 kHz — they disagree with each other, and both sit
+ * above the 22 kHz ISR ceiling. Testing either would report a confident,
+ * meaningless number at exactly the moment a client reads the timebase
+ * (connect time, before any START). Tracked separately as a defaults cleanup.
+ *
+ * Set by Streaming_NoteRateConfigured() from the SCPI paths that write
+ * ClockPeriod; never cleared — a configured rate stays configured until reboot.
+ */
+static volatile uint32_t gStreamRateConfigured = 0;
+
 static volatile uint32_t gStreamTickIndex = 0;   // dispatches since session start (incl. drops)
 static volatile uint32_t gStreamBaseTS = 0;      // TMR6 at the session's first tick (ISR-seeded)
 static volatile uint32_t gStreamPeriodTicks = 0; // TMR6 ticks per streaming tick (Start-computed)
@@ -1389,6 +1404,10 @@ static void Streaming_Start(void) {
             // truncate here and reintroduce per-tick drift.
             gStreamPeriodTicks = Streaming_TimestampTicksPerSample(
                     gpRuntimeConfigStream->ClockPeriod);
+            /* #730: whatever set ClockPeriod, by the time a session starts the
+             * period is real. Covers the benchmark/finder paths, which poke
+             * ClockPeriod directly instead of going through the SCPI setters. */
+            Streaming_NoteRateConfigured();
             // #450: anchor the startup-grace window at the start of each
             // enabled session.  Steady drop counters won't increment
             // until xTaskGetTickCount() - gStreamStartTick >= grace.
@@ -2679,6 +2698,26 @@ uint32_t Streaming_TimestampTicksPerSample(uint32_t clockPeriod) {
     uint32_t ticks =
             (uint32_t)(((uint64_t)tsFreq * periodCycles) / streamTimerFreq);
     return (ticks == 0u) ? 1u : ticks;
+}
+
+/* #730: has a streaming rate been configured this boot?
+ *
+ * Gates the two per-config timebase values below, so a client can tell
+ * "unconfigured" (0) from a real value. StreamingRuntimeConfig.Frequency is
+ * uint64_t and therefore NOT atomic on PIC32MZ, so the read takes a critical
+ * section per the project atomicity rule — the same reason SCPIInterface.c
+ * wraps it in StreamFreq_Get. Callers are SCPI-task one-shots, never the hot
+ * path, so the latency cost is nil.
+ */
+bool Streaming_IsRateConfigured(void) {
+    return (gStreamRateConfigured != 0u);
+}
+
+/* Called from the SCPI paths that write ClockPeriod (stream START and the
+ * per-channel enable). See gStreamRateConfigured for why a flag is needed
+ * rather than testing the config fields. */
+void Streaming_NoteRateConfigured(void) {
+    gStreamRateConfigured = 1u;   // 32-bit store is atomic on PIC32MZ
 }
 
 /* #730: the rate the hardware ACTUALLY runs, in millihertz.

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2707,11 +2707,14 @@ uint32_t Streaming_TimestampTicksPerSample(uint32_t clockPeriod) {
 /* #730: has a streaming rate been configured this boot?
  *
  * Gates the two per-config timebase values below, so a client can tell
- * "unconfigured" (0) from a real value. StreamingRuntimeConfig.Frequency is
- * uint64_t and therefore NOT atomic on PIC32MZ, so the read takes a critical
- * section per the project atomicity rule — the same reason SCPIInterface.c
- * wraps it in StreamFreq_Get. Callers are SCPI-task one-shots, never the hot
- * path, so the latency cost is nil.
+ * "unconfigured" (0) from a real value.
+ *
+ * Reads a 32-bit flag, so no critical section: aligned 32-bit loads are atomic
+ * on PIC32MZ. (An earlier revision tested StreamingRuntimeConfig.Frequency
+ * instead, which IS uint64_t and would have needed one — but that test could
+ * not tell a configured rate from the boot default, which is why the flag
+ * exists. The stale "takes a critical section" comment outlived the change;
+ * Qodo #733 caught it.)
  */
 bool Streaming_IsRateConfigured(void) {
     return (gStreamRateConfigured != 0u);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1777,6 +1777,12 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     gStreamBaseTS = 0;
     gStreamPeriodTicks = 0;
     gStreamTSSeeded = 0u;
+    /* #730: same retained-RAM safety. The runtime config is NOT retained
+     * (InitBoardRuntimeConfig memcpy's the const defaults every boot), so a
+     * flag that survived while ClockPeriod reverted to the 130 placeholder
+     * would report the meaningless 524 ticks / 80,153 Hz as "configured" —
+     * the very thing the flag exists to suppress (#733 audit). */
+    gStreamRateConfigured = 0u;
     gBenchmarkMode = BENCHMARK_OFF;
     gSdPbMetadataSent = false;
     gSdFileWasReady = false;

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1404,9 +1404,13 @@ static void Streaming_Start(void) {
             // truncate here and reintroduce per-tick drift.
             gStreamPeriodTicks = Streaming_TimestampTicksPerSample(
                     gpRuntimeConfigStream->ClockPeriod);
-            /* #730: whatever set ClockPeriod, by the time a session starts the
-             * period is real. Covers the benchmark/finder paths, which poke
-             * ClockPeriod directly instead of going through the SCPI setters. */
+            /* #730: by the time a session starts, ClockPeriod describes a real
+             * rate whoever set it — including the benchmark/finder paths, which
+             * poke it directly instead of going through the SCPI setters. Those
+             * two then RESTORE the previous period on exit, and restore this
+             * flag with it (Streaming_RestoreRateConfigured), so a temporary
+             * benchmark stream doesn't leave the flag set over a period nobody
+             * configured. */
             Streaming_NoteRateConfigured();
             // #450: anchor the startup-grace window at the start of each
             // enabled session.  Steady drop counters won't increment
@@ -2718,6 +2722,20 @@ bool Streaming_IsRateConfigured(void) {
  * rather than testing the config fields. */
 void Streaming_NoteRateConfigured(void) {
     gStreamRateConfigured = 1u;   // 32-bit store is atomic on PIC32MZ
+}
+
+/* Restore a previously captured flag value.
+ *
+ * For the benchmark and WiFi-finder paths, which poke ClockPeriod, stream at
+ * it, then RESTORE the previous period. Without this they would leave the flag
+ * set over a period they did not configure — on a fresh boot that means
+ * reporting the meaningless default (524 ticks / 80,153 Hz) right after a
+ * benchmark, which is the exact failure the flag exists to prevent. They
+ * already save/restore Frequency and ClockPeriod; the flag belongs in that
+ * same block (pre-merge audit on PR #733).
+ */
+void Streaming_RestoreRateConfigured(bool configured) {
+    gStreamRateConfigured = configured ? 1u : 0u;
 }
 
 /* #730: the rate the hardware ACTUALLY runs, in millihertz.

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -706,6 +706,10 @@ bool Streaming_IsRateConfigured(void);
 // placeholders that describe no real rate, so the flag is what makes the
 // "0 = unconfigured" contract on the timebase values true.
 void Streaming_NoteRateConfigured(void);
+// Restore a previously captured flag value. For the benchmark / WiFi-finder
+// paths, which stream at a temporary period and then restore the previous one:
+// the flag belongs in the same save/restore block as Frequency and ClockPeriod.
+void Streaming_RestoreRateConfigured(bool configured);
 uint32_t Streaming_TimestampTicksPerSample(uint32_t clockPeriod);
 uint32_t Streaming_ActualRateMilliHz(uint32_t clockPeriod);
 

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -698,8 +698,8 @@ void Streaming_SetFlowWindowOverride(uint32_t size);
 // Both take ClockPeriod (the PR value, i.e. periodCycles-1) so a caller can ask
 // about a hypothetical rate without mutating the runtime config.
 // True once a streaming rate has been configured this boot. Gates the two
-// per-config values above (both report 0 when unconfigured). Takes a
-// critical section: Frequency is uint64_t, non-atomic on PIC32MZ.
+// per-config values above (both report 0 when unconfigured). Reads a 32-bit
+// flag — atomic on PIC32MZ, no critical section needed.
 bool Streaming_IsRateConfigured(void);
 // Called by the SCPI paths that set ClockPeriod (stream START, per-channel
 // enable) to mark the rate as genuinely configured. The boot defaults are

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -697,6 +697,15 @@ void Streaming_SetFlowWindowOverride(uint32_t size);
 //
 // Both take ClockPeriod (the PR value, i.e. periodCycles-1) so a caller can ask
 // about a hypothetical rate without mutating the runtime config.
+// True once a streaming rate has been configured this boot. Gates the two
+// per-config values above (both report 0 when unconfigured). Takes a
+// critical section: Frequency is uint64_t, non-atomic on PIC32MZ.
+bool Streaming_IsRateConfigured(void);
+// Called by the SCPI paths that set ClockPeriod (stream START, per-channel
+// enable) to mark the rate as genuinely configured. The boot defaults are
+// placeholders that describe no real rate, so the flag is what makes the
+// "0 = unconfigured" contract on the timebase values true.
+void Streaming_NoteRateConfigured(void);
 uint32_t Streaming_TimestampTicksPerSample(uint32_t clockPeriod);
 uint32_t Streaming_ActualRateMilliHz(uint32_t clockPeriod);
 

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -684,6 +684,22 @@ void Streaming_SetLossThreshold(uint32_t pct);
 uint32_t Streaming_GetFlowWindowOverride(void);
 void Streaming_SetFlowWindowOverride(uint32_t size);
 
+// #730 streaming timebase, for clients that need exact timing.
+//
+// Streaming_TimestampTicksPerSample: the timestamp-domain length of one
+//   streaming period for a given stream-timer period register value. This is
+//   the SAME value Streaming_Start stamps with (#717 gStreamPeriodTicks) —
+//   shared so a reported value can't drift from the emitted stamps. Always >= 1.
+// Streaming_ActualRateMilliHz: the rate the hardware actually runs, in
+//   millihertz. StreamingRuntimeConfig.Frequency stores the REQUESTED rate;
+//   the period register quantizes it (4500 Hz -> 4498.714 Hz at 252 MHz).
+//   Returns 0 when no period is configured.
+//
+// Both take ClockPeriod (the PR value, i.e. periodCycles-1) so a caller can ask
+// about a hypothetical rate without mutating the runtime config.
+uint32_t Streaming_TimestampTicksPerSample(uint32_t clockPeriod);
+uint32_t Streaming_ActualRateMilliHz(uint32_t clockPeriod);
+
 // Test pattern streaming mode.
 // 0=off (real ADC data), 1=counter, 2=midscale, 3=fullscale, 4=walking,
 // 5=triangle, 6=sine. Runtime-only (not persisted to NVM).


### PR DESCRIPTION
Fixes #730. The device quantized the requested streaming rate and never reported what it actually ran, and the stream-timer clock was not exposed anywhere at all.

Ask for 4500 Hz at 252 MHz and the hardware runs `10.5e6/2334` = **4498.714 Hz** while `StreamingRuntimeConfig.Frequency` reports 4500 — ~286 ppm, ~1 s/hour for any client computing time from the requested rate. The #487 clock bump made this ~3.6× worse: PBCLK3 moved ÷2 → ÷3, so the stream timer *slowed* 12.5 → 10.5 MHz and the rate grid got coarser.

## What's added

Three PB fields (70-72), emitted by `SYSTem:SYSInfoPB?` and mirrored into `CONFigure:CAPabilities:JSON?` as a `timing` block:

| field | meaning |
|---|---|
| `stream_timer_freq` | trigger timer Hz — divide `timestamp_freq` by it for the prescale ratio (4) |
| `timestamp_ticks_per_sample` | exact timestamp ticks per streaming period |
| `actual_rate_millihz` | the **quantized** rate, in millihertz |

Both per-config values report `0` until a rate is configured, so a client can tell "unconfigured" from a real value.

Emitting to both surfaces is deliberate: SYSInfoPB is the versioned machine-readable route (owner's call, #730), while the capabilities JSON is the documented "render your UI from one query" surface and shouldn't force a PB round-trip just for timing. Same values, same helpers.

**Live-stream emission was declined** — adding `timestamp_freq` to the per-sample PB field set would change the wire shape for every existing client, and the same data is one query away. CSV and JSON already emit the tick rate once in their header/meta.

## Single source of truth

The period math moved into `Streaming_TimestampTicksPerSample()` / `Streaming_ActualRateMilliHz()`, shared with `Streaming_Start`. A reported value therefore cannot drift from the stamps the deferred task actually emits (#722 `gStreamPeriodTicks`). Behavior is unchanged; `Streaming_Start` calls the helper instead of inlining the formula.

## Two bugs caught in pre-PR review (second commit)

1. **Unguarded 64-bit read.** The PB encoder tested `cfg->Frequency > 0` bare. `Frequency` is `uint64_t` and not atomic on PIC32MZ — the project rule requires a critical section (hence the existing `StreamFreq_Get`). Both emitters now call one guarded `Streaming_IsRateConfigured()`.
2. **The "0 = unconfigured" contract was false.** At connect time it reported `ticks=524, actual_rate=80152671` — a confident, meaningless 80 kHz. Root cause is a **pre-existing** defaults bug: `ClockPeriod=130` implies 80,153 Hz while `Frequency=30000` claims 30 kHz; they disagree and both exceed the 22 kHz ISR cap, so no test of either field can distinguish "configured" from "default". Fixed here with an explicit flag set by the paths that set a real period. **The stale defaults are deliberately left alone** — changing device defaults doesn't belong in a reporting change. Filed as #732.

## Proto regeneration

nanopb-0.4.9.1, the same version that produced the committed bindings. Verified by regenerating the **unmodified** proto first: it reproduces the committed files byte-for-byte apart from the tree's local include-path edit (`"libraries/nanopb/pb.h"` vs `<pb.h>`), which is re-applied. Additive fields stay wire-compatible — existing decoders skip unknown tags — so no client breaks until it chooses to regenerate.

## Validation

Bench, board `7E2898F46200E8A7` (COM3), both emitters agreeing exactly:

| requested | ticks/sample | actual rate | vs requested |
|---|---|---|---|
| unconfigured | 0 | 0 | — |
| 1000 Hz | 42000 | 1000.000 Hz | +0 ppm |
| 4500 Hz | **9336** | 4498.714 Hz | −286 ppm |
| 5500 Hz | **7640** | 5497.382 Hz | −476 ppm |

9336 and 7640 are exactly the periods the #717 regression test measures on the wire — that cross-check is the one that matters, since it proves the reported value tracks reality rather than just being self-consistent.

**Companion test:** [daqifi-python-test-suite PR #116](https://github.com/daqifi/daqifi-python-test-suite/pull/116) — gates both surfaces agreeing, the report matching the wire, and the quantization model. **Wiki:** updated ([Capabilities JSON Schema § timing](https://github.com/daqifi/daqifi-nyquist-firmware/wiki/03-Capabilities-JSON-Schema#timing), SCPI interface page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)