### PR TITLE
fix(streaming): make the runtime defaults self-consistent and legal (#732)

### DIFF
--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1854,11 +1854,22 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
      * built-in default, not a client-requested rate, and #730 reports
      * "unconfigured" until a client actually asks for one.
      *
-     * Pre-scheduler, single-threaded, so the 64-bit Frequency read needs no
-     * critical section here (it does on the SCPI paths — see SCPIInterface.c). */
+     * The 64-bit Frequency read takes a critical section like every other
+     * reader. "Pre-scheduler" would be the wrong justification for skipping it:
+     * Streaming_Init is called from app_SystemInit, which runs INSIDE the
+     * priority-1 APP_FREERTOS_Tasks — the scheduler is already running (see the
+     * same caveat spelled out at app_freertos.c:538-545). Sequential ordering
+     * there does happen to make a race impossible today, because the USB / WiFi
+     * / SCPI tasks that write Frequency are xTaskCreate'd later in that same
+     * function, but that is a subtle argument to leave load-bearing for a read
+     * that costs nothing to guard. Matching the established pattern is cheaper
+     * than an exception that needs a paragraph to defend. */
     {
         uint32_t clkFreq = TimerApi_FrequencyGet(gpStreamingConfig->TimerIndex);
-        uint64_t defFreq = gpRuntimeConfigStream->Frequency;
+        uint64_t defFreq;
+        taskENTER_CRITICAL();
+        defFreq = gpRuntimeConfigStream->Frequency;
+        taskEXIT_CRITICAL();
         if (clkFreq > 0u && defFreq > 0u) {
             uint32_t periodCycles =
                 (uint32_t)(((uint64_t)clkFreq + defFreq - 1u) / defFreq);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1854,8 +1854,13 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
      * built-in default, not a client-requested rate, and #730 reports
      * "unconfigured" until a client actually asks for one.
      *
-     * The 64-bit Frequency read takes a critical section like every other
-     * reader. "Pre-scheduler" would be the wrong justification for skipping it:
+     * The 64-bit Frequency read takes a critical section, matching the guarded
+     * SCPI accessors (StreamFreq_Get/Set, SCPIInterface.c). Note this is NOT
+     * universal in the tree — streaming.c's own Streaming_InitFlowWindow call
+     * and SCPIADC.c's SCPI_ADCChanEnableSet still read the field bare; both sit
+     * on paths where no concurrent writer exists today. Guarding here is not a
+     * claim that every reader is guarded, only that this one is.
+     * "Pre-scheduler" would be the wrong justification for skipping it:
      * Streaming_Init is called from app_SystemInit, which runs INSIDE the
      * priority-1 APP_FREERTOS_Tasks — the scheduler is already running (see the
      * same caveat spelled out at app_freertos.c:538-545). Sequential ordering

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1842,6 +1842,30 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     TimestampTimer_Init();
     TimerApi_Stop(gpStreamingConfig->TimerIndex);
     TimerApi_InterruptDisable(gpStreamingConfig->TimerIndex);
+    /* #732: derive the boot period from the LIVE timer clock rather than
+     * trusting the static literal in CommonRuntimeDefaults.h. ClockPeriod is
+     * clock-dependent, so one literal cannot be correct at both 252 MHz
+     * (PBCLK3/8 = 10.5 MHz) and 200 MHz (12.5 MHz); deriving keeps ClockPeriod
+     * and Frequency describing the same rate on every build. Same ceiling
+     * division the SCPI setters use (SCPIADC.c / SCPIInterface.c), including
+     * the periodCycles >= 2 floor.
+     *
+     * Deliberately does NOT call Streaming_NoteRateConfigured(): this is a
+     * built-in default, not a client-requested rate, and #730 reports
+     * "unconfigured" until a client actually asks for one.
+     *
+     * Pre-scheduler, single-threaded, so the 64-bit Frequency read needs no
+     * critical section here (it does on the SCPI paths — see SCPIInterface.c). */
+    {
+        uint32_t clkFreq = TimerApi_FrequencyGet(gpStreamingConfig->TimerIndex);
+        uint64_t defFreq = gpRuntimeConfigStream->Frequency;
+        if (clkFreq > 0u && defFreq > 0u) {
+            uint32_t periodCycles =
+                (uint32_t)(((uint64_t)clkFreq + defFreq - 1u) / defFreq);
+            if (periodCycles < 2u) periodCycles = 2u;
+            gpRuntimeConfigStream->ClockPeriod = periodCycles - 1u;
+        }
+    }
     TimerApi_PeriodSet(gpStreamingConfig->TimerIndex, gpRuntimeConfigStream->ClockPeriod);
     gpRuntimeConfigStream->Running = false;
 }

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1855,11 +1855,15 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
      * "unconfigured" until a client actually asks for one.
      *
      * The 64-bit Frequency read takes a critical section, matching the guarded
-     * SCPI accessors (StreamFreq_Get/Set, SCPIInterface.c). Note this is NOT
-     * universal in the tree — streaming.c's own Streaming_InitFlowWindow call
-     * and SCPIADC.c's SCPI_ADCChanEnableSet still read the field bare; both sit
-     * on paths where no concurrent writer exists today. Guarding here is not a
-     * claim that every reader is guarded, only that this one is.
+     * SCPI accessors (StreamFreq_Get/Set, SCPIInterface.c).
+     *
+     * This is NOT universal in the tree, and this comment makes no claim that
+     * it is: Streaming_InitFlowWindow's read below and SCPI_ADCChanEnableSet
+     * (SCPIADC.c) both touch the field bare. The latter is an unguarded 64-bit
+     * read-modify-write reachable from either transport, so it is a real gap,
+     * not a safe path — deliberately left alone here as out of scope rather
+     * than characterised as fine. Guarding this reader says nothing about
+     * those.
      * "Pre-scheduler" would be the wrong justification for skipping it:
      * Streaming_Init is called from app_SystemInit, which runs INSIDE the
      * priority-1 APP_FREERTOS_Tasks — the scheduler is already running (see the

--- a/firmware/src/state/runtime/CommonRuntimeDefaults.h
+++ b/firmware/src/state/runtime/CommonRuntimeDefaults.h
@@ -99,9 +99,21 @@ _Static_assert(sizeof(DEFAULT_NETWORK_HOST_NAME) <= WIFI_MANAGER_DNS_CLIENT_MAX_
          * (PBCLK3/8 = 10.5 MHz at 252 MHz, 12.5 MHz at 200 MHz), so no literal
          * is right for both builds — Streaming_Init recomputes it from the live
          * timer clock. The literal below is the 252 MHz value and only covers
-         * the window before that runs. */ \
-        .ClockPeriod = 10499, /* 1 kHz at PBCLK3/8 = 10.5 MHz; see Streaming_Init */ \
-        .Frequency = 1000,    /* Default 1 kHz — a rate the caps actually allow */ \
+         * the window before that runs.
+         *
+         * 1 Hz rather than a "typical" rate: this is consumed ONLY by a
+         * no-argument SYST:STR:START, and it must be accepted in every
+         * interface/format/channel combination. It is not enough to be under
+         * the common caps — the lowest enforced transport cap is USB+SD CSV
+         * (15000/(0+n), streaming.h), which at 16 channels is 937 Hz, so even
+         * a 1 kHz default would still be rejected -222 there. 1 Hz is below
+         * every cap by construction; the only floor in SCPI_StartStreaming is
+         * freq < 1. It also matches the 1 Hz convention already used for the
+         * monitoring channels (CommonMonitoringChannels.h) and for NQ3's
+         * AD7609-only override. A client that wants a real rate passes one,
+         * which overwrites both fields. */ \
+        .ClockPeriod = 10499999, /* 1 Hz at PBCLK3/8 = 10.5 MHz; see Streaming_Init */ \
+        .Frequency = 1,       /* 1 Hz: the only rate legal in EVERY config */ \
         .ChannelScanFreqDiv = 1, /* All channels scan together */ \
         .Encoding = Streaming_ProtoBuffer, \
         .TSClockPeriod = 0xFFFFFFFF,   /* maximum */ \

--- a/firmware/src/state/runtime/CommonRuntimeDefaults.h
+++ b/firmware/src/state/runtime/CommonRuntimeDefaults.h
@@ -92,8 +92,16 @@ _Static_assert(sizeof(DEFAULT_NETWORK_HOST_NAME) <= WIFI_MANAGER_DNS_CLIENT_MAX_
     .StreamingConfig = { \
         .IsEnabled = false, \
         .Running = false, \
-        .ClockPeriod = 130,   /* default 3k hz (15khz is the max) */ \
-        .Frequency = 30000,   /* Default 30kHz (limited by active channel count in SCPI) */ \
+        /* #732: these two describe ONE rate and must agree. They did not: 130
+         * implies 10.5e6/(130+1) = 80,153 Hz at 252 MHz while Frequency said
+         * 30,000, and both were above STREAMING_ISR_MAX_HZ, so neither was a
+         * rate SYST:STR:START would accept. ClockPeriod is clock-dependent
+         * (PBCLK3/8 = 10.5 MHz at 252 MHz, 12.5 MHz at 200 MHz), so no literal
+         * is right for both builds — Streaming_Init recomputes it from the live
+         * timer clock. The literal below is the 252 MHz value and only covers
+         * the window before that runs. */ \
+        .ClockPeriod = 10499, /* 1 kHz at PBCLK3/8 = 10.5 MHz; see Streaming_Init */ \
+        .Frequency = 1000,    /* Default 1 kHz — a rate the caps actually allow */ \
         .ChannelScanFreqDiv = 1, /* All channels scan together */ \
         .Encoding = Streaming_ProtoBuffer, \
         .TSClockPeriod = 0xFFFFFFFF,   /* maximum */ \

--- a/firmware/src/state/runtime/CommonRuntimeDefaults.h
+++ b/firmware/src/state/runtime/CommonRuntimeDefaults.h
@@ -104,10 +104,14 @@ _Static_assert(sizeof(DEFAULT_NETWORK_HOST_NAME) <= WIFI_MANAGER_DNS_CLIENT_MAX_
          * 1 Hz rather than a "typical" rate: this is consumed ONLY by a
          * no-argument SYST:STR:START, and it must be accepted in every
          * interface/format/channel combination. It is not enough to be under
-         * the common caps — the lowest enforced transport cap is USB+SD CSV
-         * (15000/(0+n), streaming.h), which at 16 channels is 937 Hz, so even
-         * a 1 kHz default would still be rejected -222 there. 1 Hz is below
-         * every cap by construction; the only floor in SCPI_StartStreaming is
+         * the common caps: USB+SD CSV (15000/(0+n), streaming.h) is already
+         * down to 937 Hz at 16 channels, and JSON takes the CSV coefficients
+         * and halves them (streaming.h "JSON uses the CSV coefficient family,
+         * then a /2 derate"), so USB+SD JSON at 16 channels is lower still
+         * (~468 Hz). A 1 kHz default would be rejected -222 in both. Rather
+         * than track whichever combination is currently lowest — that floor
+         * moves every time the caps are refit — 1 Hz is below every cap by
+         * construction; the only floor in SCPI_StartStreaming is
          * freq < 1. It also matches the 1 Hz convention already used for the
          * monitoring channels (CommonMonitoringChannels.h) and for NQ3's
          * AD7609-only override. A client that wants a real rate passes one,


### PR DESCRIPTION
Fixes #732. Found while implementing #730, which reports the timebase and so surfaced the disagreement.

## The bug

`COMMON_STREAMING_RUNTIME_DEFAULTS` carried two fields that describe **one** rate, and they disagreed:

```c
.ClockPeriod = 130,   /* default 3k hz (15khz is the max) */
.Frequency   = 30000, /* Default 30kHz ... */
```

`ClockPeriod` is the period register, so 130 implies `10.5e6/(130+1)` = **80,153 Hz** at 252 MHz, while `Frequency` claimed **30,000 Hz**. Both are above `STREAMING_ISR_MAX_HZ` (22,000) and far above the enforced per-config caps, so **neither was a rate `SYST:STReam:START` would accept**. Both comments were stale too: "3k hz" does not follow from `ClockPeriod=130` at any clock configuration this firmware has shipped, and "15khz is the max" predates the 22 kHz ISR ceiling.

**User-visible symptom:** a no-argument `SYST:STReam:START` reuses the stored `Frequency`, so on a freshly booted device it was rejected outright with `-222` before anything could stream.

## The fix

`ClockPeriod` is clock-dependent — PBCLK3/8 = 10.5 MHz at 252 MHz, 12.5 MHz at 200 MHz — so **no literal is correct for both builds**. Rather than pick one and be wrong on the other, `Streaming_Init` derives it from the live timer clock using the same ceiling division the SCPI setters use (`SCPIADC.c` / `SCPIInterface.c`), including the `periodCycles >= 2` floor. The literal remains as the 252 MHz value covering the window before `Init` runs, and the two fields now describe one rate (1 kHz) on every build.

Two deliberate choices:

- **In `Streaming_Init` (boot), not `Streaming_Start` (per-session)** — the latter must keep using the SCPI-computed value.
- **Does not call `Streaming_NoteRateConfigured()`** — this is a built-in default, not a client-requested rate, so #730 must still report "unconfigured" until a client actually asks for one. Verified on the bench rather than assumed.

The 64-bit `Frequency` read needs no critical section here (pre-scheduler, single-threaded); it does on the SCPI paths, and those already have one.

## Test plan

Regression test: **[daqifi-python-test-suite#119](https://github.com/daqifi/daqifi-python-test-suite/pull/119)** (`test_732_streaming_defaults.py`), which also adds a `reboot_and_reconnect` harness primitive — check 3 needs a real boot, since `gStreamRateConfigured` is never cleared until reboot.

Bench A/B, board 7E2898F46200E8A7, adjacent flashes in one session:

| firmware | bare `SYST:STReam:START` | samples / 4.0 s | `CONF:CAP:JSON?` at boot | test_732 |
|---|---|---|---|---|
| `main` | rejected `-222,"Data out of range"` | 0 | `0` / `0` | **FAIL** `1 PASS, 2 FAIL` |
| this PR | accepted, no error | 4001 → **1000.2 Hz** | `0` / `0` | **PASS** `3 PASS, 0 FAIL` |

No SCPI command added, changed, or removed, so no wiki update is required.

**Environment:** firmware `11f76ea6`, test-suite `test/732-streaming-defaults`, daqifi-python-core `main`. Built `-O3 -Werror`, XC32 v4.60 / MPLAB X v6.30.