### PR TITLE
fix(clock): derive the peripheral clock at run time instead of assuming it (#716)

### DIFF
--- a/firmware/src/HAL/DIO.c
+++ b/firmware/src/HAL/DIO.c
@@ -434,7 +434,12 @@ bool DIO_PWMFrequencySet(uint8_t dataIndex) {
     }
 
     const uint16_t tim3PreScalers[8] = {1, 2, 4, 8, 16, 32, 64, 256};
-    uint32_t timerClock = TIMER_CLOCK_FRQ;//TimerApi_FrequencyGet(3);
+    /* #716: the real PBCLK3, not the built-for constant — otherwise a PWM
+     * frequency request is off by the same 1.26x as everything else on a
+     * config-word/application clock mismatch. (The commented-out
+     * TimerApi_FrequencyGet(3) alternative would additionally divide by TMR3's
+     * prescaler, which this calculation applies itself just below.) */
+    uint32_t timerClock = TimerApi_PeripheralClockHz();
     uint32_t pwmFrequency = gpRuntimeBoardConfig->DIOChannels.Data[ dataIndex ].PwmFrequency;
     // #671 defense-in-depth: never divide the shared PWM timebase by zero — a
     // MIPS integer div-by-zero traps to a general exception (device reset). The

--- a/firmware/src/HAL/TimerApi/TimerApi.c
+++ b/firmware/src/HAL/TimerApi/TimerApi.c
@@ -205,36 +205,56 @@ uint16_t TimerApi_PreScalerGet(uint8_t index) {
  * which makes a lazily-filled cache-valid flag a hazard for no gain here — the
  * callers are SCPI/config paths, never the per-sample path.
  */
-uint32_t TimerApi_PeripheralClockHz(void) {
-    uint32_t sysclkHz;
+static uint32_t TimerApi_DerivePbclkHz(bool* pDerived) {
+    bool derived = false;
+    uint32_t sysclkHz = (uint32_t)DAQIFI_SYSCLK_HZ;   /* fallback, see below */
 
     if (OSCCONbits.COSC == 0x1u) {          /* running from the System PLL */
-        const uint32_t inHz = (SPLLCONbits.PLLICLK != 0u)
-                              ? (uint32_t)DAQIFI_FRC_HZ
-                              : (uint32_t)DAQIFI_POSC_HZ;
-        const uint32_t idiv = (uint32_t)SPLLCONbits.PLLIDIV + 1u;
-        const uint32_t mult = (uint32_t)SPLLCONbits.PLLMULT + 1u;
         const uint32_t odivField = (uint32_t)SPLLCONbits.PLLODIV;
-        /* 000 is Reserved; treat it as the /2 POR default rather than shifting
-         * by 0 and reporting double the real clock. */
-        const uint32_t odiv = (odivField == 0u) ? 2u : (1u << odivField);
+        /* Only 001..101 (/2 .. /32) are defined; 000 and 11x are Reserved.
+         * Shifting by a reserved field would invent a /1, /64 or /128 divisor
+         * and silently skew every timer-derived rate — the exact failure class
+         * this whole function exists to remove — so treat it as underivable
+         * instead of guessing. */
+        if ((odivField >= 1u) && (odivField <= 5u)) {
+            const uint32_t inHz = (SPLLCONbits.PLLICLK != 0u)
+                                  ? (uint32_t)DAQIFI_FRC_HZ
+                                  : (uint32_t)DAQIFI_POSC_HZ;
+            const uint32_t idiv = (uint32_t)SPLLCONbits.PLLIDIV + 1u;
+            const uint32_t mult = (uint32_t)SPLLCONbits.PLLMULT + 1u;
+            const uint32_t odiv = 1u << odivField;
 
-        /* 64-bit intermediate: 24 MHz x 128 overflows uint32. Multiply before
-         * dividing so a non-integral input divide cannot truncate. */
-        sysclkHz = (uint32_t)(((uint64_t)inHz * mult) / idiv / odiv);
-    } else {
-        /* Not on the PLL (FRC/POSC/SOSC directly). Nothing in this firmware
-         * switches away from SPLL, so this is unreachable in practice; fall
-         * back to the built-for value rather than reporting nonsense. */
-        sysclkHz = (uint32_t)DAQIFI_SYSCLK_HZ;
+            /* 64-bit intermediate: 24 MHz x 128 overflows uint32. Multiply
+             * before dividing so a non-integral input divide cannot truncate. */
+            sysclkHz = (uint32_t)(((uint64_t)inHz * mult) / idiv / odiv);
+            derived = true;
+        }
     }
 
-    /* Timers live on PBCLK3. */
+    if (pDerived != NULL) {
+        *pDerived = derived;
+    }
+    /* PB3DIV is a plain runtime register this firmware wrote itself, so it is
+     * trustworthy even when the PLL side is not. Timers live on PBCLK3. */
     return sysclkHz / ((uint32_t)PB3DIVbits.PBDIV + 1u);
 }
 
+uint32_t TimerApi_PeripheralClockHz(void) {
+    return TimerApi_DerivePbclkHz(NULL);
+}
+
 bool TimerApi_ClockMatchesBuild(void) {
-    return (TimerApi_PeripheralClockHz() == (uint32_t)TIMER_CLOCK_FRQ_BUILT);
+    bool derived = false;
+    const uint32_t pbclkHz = TimerApi_DerivePbclkHz(&derived);
+
+    /* An underivable clock is NOT a match. Returning the built-for value from
+     * the fallback and then comparing it against itself would report "clock
+     * OK" by construction while the part ran on, say, the 8 MHz FRC — turning
+     * the detector into a rubber stamp on exactly the case it should catch. */
+    if (!derived) {
+        return false;
+    }
+    return (pbclkHz == (uint32_t)TIMER_CLOCK_FRQ_BUILT);
 }
 
 uint32_t TimerApi_FrequencyGet(uint8_t index) {

--- a/firmware/src/HAL/TimerApi/TimerApi.c
+++ b/firmware/src/HAL/TimerApi/TimerApi.c
@@ -181,20 +181,82 @@ uint16_t TimerApi_PreScalerGet(uint8_t index) {
     return preScaler;
 }
 
+/* #716: derive the real clock rather than trusting the compile-time constant.
+ *
+ * Bit encodings are from the PIC32MZ EF datasheet DS60001320G Register 8-3
+ * (SPLLCON) and Register 8-9 (PBxDIV) — quoted here because getting any of
+ * them wrong silently scales every streamed rate:
+ *
+ *   SPLLCON PLLIDIV<2:0>  bits 10:8   000 = /1 ... 111 = /8      -> value + 1
+ *   SPLLCON PLLMULT<6:0>  bits 22:16  0000000 = x1 ... x128      -> value + 1
+ *   SPLLCON PLLODIV<2:0>  bits 26:24  001 = /2, 010 = /4, 011 = /8,
+ *                                     100 = /16, 101 = /32       -> 1 << value
+ *                                     (000 and 11x are Reserved)
+ *   SPLLCON PLLICLK       bit 7       0 = POSC, 1 = FRC
+ *   OSCCON  COSC<2:0>     bits 14:12  001 = SPLL
+ *   PBxDIV  PBDIV<6:0>    bits 6:0    0000001 = /2, 0000010 = /3 -> value + 1
+ *
+ * Uses the SFR bitfield accessors rather than raw register maths (CLAUDE.md
+ * peripheral-access preference); there is no Harmony PLIB that reports a
+ * derived clock frequency on this part.
+ *
+ * Not cached: file statics on this part can land in .bss sections outside
+ * [_bss_begin,_bss_end] and so are NOT reliably zero-initialised across MCLR,
+ * which makes a lazily-filled cache-valid flag a hazard for no gain here — the
+ * callers are SCPI/config paths, never the per-sample path.
+ */
+uint32_t TimerApi_PeripheralClockHz(void) {
+    uint32_t sysclkHz;
+
+    if (OSCCONbits.COSC == 0x1u) {          /* running from the System PLL */
+        const uint32_t inHz = (SPLLCONbits.PLLICLK != 0u)
+                              ? (uint32_t)DAQIFI_FRC_HZ
+                              : (uint32_t)DAQIFI_POSC_HZ;
+        const uint32_t idiv = (uint32_t)SPLLCONbits.PLLIDIV + 1u;
+        const uint32_t mult = (uint32_t)SPLLCONbits.PLLMULT + 1u;
+        const uint32_t odivField = (uint32_t)SPLLCONbits.PLLODIV;
+        /* 000 is Reserved; treat it as the /2 POR default rather than shifting
+         * by 0 and reporting double the real clock. */
+        const uint32_t odiv = (odivField == 0u) ? 2u : (1u << odivField);
+
+        /* 64-bit intermediate: 24 MHz x 128 overflows uint32. Multiply before
+         * dividing so a non-integral input divide cannot truncate. */
+        sysclkHz = (uint32_t)(((uint64_t)inHz * mult) / idiv / odiv);
+    } else {
+        /* Not on the PLL (FRC/POSC/SOSC directly). Nothing in this firmware
+         * switches away from SPLL, so this is unreachable in practice; fall
+         * back to the built-for value rather than reporting nonsense. */
+        sysclkHz = (uint32_t)DAQIFI_SYSCLK_HZ;
+    }
+
+    /* Timers live on PBCLK3. */
+    return sysclkHz / ((uint32_t)PB3DIVbits.PBDIV + 1u);
+}
+
+bool TimerApi_ClockMatchesBuild(void) {
+    return (TimerApi_PeripheralClockHz() == (uint32_t)TIMER_CLOCK_FRQ_BUILT);
+}
+
 uint32_t TimerApi_FrequencyGet(uint8_t index) {
     uint32_t ret = 0;
+    /* #716: the ACTUAL peripheral clock, not the compile-time constant. Every
+     * streaming-rate computation funnels through this function (stream START,
+     * channel enable, Streaming_Init's boot derivation, CONF:CAP:JSON?), so
+     * making it honest here fixes the rate, the reported timebase and the caps
+     * together. The prescaler was already read from the register. */
+    const uint32_t clkHz = TimerApi_PeripheralClockHz();
     switch (index) {
         case 2:
-            ret=TIMER_CLOCK_FRQ/TimerApi_PreScalerGet(2);            
+            ret=clkHz/TimerApi_PreScalerGet(2);
             break;
         case 3:
-            ret=TIMER_CLOCK_FRQ/TimerApi_PreScalerGet(3); 
+            ret=clkHz/TimerApi_PreScalerGet(3);
             break;
         case 4:
-            ret=TIMER_CLOCK_FRQ/TimerApi_PreScalerGet(4); 
+            ret=clkHz/TimerApi_PreScalerGet(4);
             break;
         case 6:
-             ret=TIMER_CLOCK_FRQ/TimerApi_PreScalerGet(6); 
+             ret=clkHz/TimerApi_PreScalerGet(6);
             break;
         default:
             break;

--- a/firmware/src/HAL/TimerApi/TimerApi.h
+++ b/firmware/src/HAL/TimerApi/TimerApi.h
@@ -27,7 +27,44 @@
 extern "C" {
 #endif
 #include "clock_config.h"
-#define TIMER_CLOCK_FRQ DAQIFI_PBCLK_HZ  /* #487: PBCLK3 (84 MHz @252 / 100 @200 via clock_config.h). Governs streaming-timer period + CSV/JSON/PB timestamps. */
+
+/* The peripheral-bus clock this image was BUILT for. NOT necessarily the clock
+ * the silicon is running — use TimerApi_PeripheralClockHz() for that (#716).
+ * Kept as the reference value the boot-time mismatch check compares against. */
+#define TIMER_CLOCK_FRQ_BUILT DAQIFI_PBCLK_HZ
+
+/**
+ * @brief Actual PBCLK3 in Hz, derived from the live clock hardware.
+ *
+ * #716: the PLL multiplier lives in DEVCFG2, a device Configuration Word, and
+ * our USB bootloader deliberately refuses to program config words
+ * (bootloader/.../nvm.c:244 "Make sure we are not writing boot area and device
+ * configuration bits"), which erratum 45 in DS80000663 Rev R says could not be
+ * done at run time anyway ("RTSP of Configuration Words is not functional.
+ * Work around: None."). So a field device that takes a firmware update keeps
+ * whatever PLL it was manufactured with, while PBxDIV — an ordinary runtime
+ * register write in SystemInit — DOES get updated.
+ *
+ * A unit built at 200 MHz and updated to the 252 MHz image therefore runs
+ * 200/3/2 = 33.33 MHz while a compile-time constant claims 42 MHz, and every
+ * streamed rate comes out at 33.333/42 = 79.4% of what was asked for. That was
+ * measured in the field and reproduced on the bench.
+ *
+ * Reading the clock tree instead makes one image correct on both silicon
+ * configurations. Derived per DS60001320G Register 8-3 (SPLLCON) and
+ * Register 8-9 (PBxDIV); see the implementation for the bit encodings.
+ *
+ * @return PBCLK3 frequency in Hz.
+ */
+uint32_t TimerApi_PeripheralClockHz(void);
+
+/**
+ * @brief True when the running clock matches what this image was built for.
+ *
+ * False means a config-word/application mismatch (#716) — the device works but
+ * every clock-derived rate is scaled. Reported at boot and via CONF:CAP:JSON?.
+ */
+bool TimerApi_ClockMatchesBuild(void);
 
 typedef enum {
     TMR_INDEX_2 = 2,

--- a/firmware/src/HAL/UserIC/UserIC.h
+++ b/firmware/src/HAL/UserIC/UserIC.h
@@ -38,10 +38,16 @@ extern "C" {
 
 #define USER_IC_UNITS          9u        /*!< IC1..IC9 */
 /* TMR2 (the IC timebase) is clocked from PBCLK3; derive the rate from the same
- * central constant the streaming timer + timestamps use, so freq/period/pulse-
- * width stay correct across clock profiles — 84 MHz @252-MHz build, 100 MHz on
- * the 200-MHz build (#702). Was hardcoded 84000000, wrong on the 200-MHz build. */
-#define USER_IC_TIMER_HZ       TIMER_CLOCK_FRQ
+ * source the streaming timer + timestamps use, so freq/period/pulse-width stay
+ * correct across clock profiles (#702 — was hardcoded 84000000).
+ *
+ * #716: now the RUN-TIME clock, not a compile-time constant. A field device
+ * whose DEVCFG still holds the 200 MHz PLL runs PBCLK3 at 66.67 MHz while the
+ * built-for constant says 84 MHz, which would scale every measured frequency,
+ * period and pulse width by 1.26x. Evaluates to a function call — fine in the
+ * three double-precision expressions in UserIC.c that use it, none of which is
+ * a constant initialiser or a per-sample path. */
+#define USER_IC_TIMER_HZ       TimerApi_PeripheralClockHz()
 
 /** Boot-time init: parks all 9 IC units (disabled, capture IRQ off, priority set)
  *  and clears the epoch. Safe to call before Timer2 is running. */

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -646,6 +646,32 @@ void app_SystemInit() {
     DioProbe_Init();
     // #667: park edge-event (INT1-4) + pulse-totalizer (Timer8/9) hardware.
     UserEdge_Initialize();
+    /* #716: does the silicon's clock match what this image was built for?
+     *
+     * FPLLMULT lives in DEVCFG2, a device Configuration Word. Our USB
+     * bootloader deliberately refuses to program config words, and erratum 45
+     * (DS80000663 Rev R) says run-time self-programming of them is not
+     * functional with no workaround — so a field firmware update CANNOT move a
+     * device's PLL. PBxDIV, by contrast, is an ordinary register write in
+     * SystemInit and does get updated. A unit manufactured at 200 MHz that
+     * takes the 252 MHz image therefore runs PBCLK3 at 66.67 MHz while this
+     * build expects 84 MHz.
+     *
+     * The clock-derived paths now read the real rate, so the device streams
+     * accurately either way. This check exists because the condition is
+     * otherwise invisible: nothing else tells the operator that a unit is
+     * running below its intended clock and will never reach the documented
+     * ceilings until it is physically reprogrammed. */
+    if (!TimerApi_ClockMatchesBuild()) {
+        LOG_E("Clock mismatch (#716): PBCLK3 is %u Hz, image built for %u Hz. "
+              "Device configuration words hold an older PLL and cannot be "
+              "updated by a firmware update — reprogram with a PICkit/IPE to "
+              "reach the intended clock. Rates are derived from the ACTUAL "
+              "clock, so streaming is accurate but ceilings are lower.",
+              (unsigned)TimerApi_PeripheralClockHz(),
+              (unsigned)TIMER_CLOCK_FRQ_BUILT);
+    }
+
     Streaming_Init(&gpBoardConfig->StreamingConfig,
             &gpBoardRuntimeConfig->StreamingConfig);
     Streaming_UpdateState();

--- a/firmware/src/config/default/clock_config.h
+++ b/firmware/src/config/default/clock_config.h
@@ -29,6 +29,16 @@
 /* 1 = 252 MHz (chip-rated max, #487) · 0 = 200 MHz (legacy revert path) */
 #define DAQIFI_SYSCLK_252   1
 
+/* PLL input sources, needed to DERIVE the actual SYSCLK from SPLLCON at run
+ * time (#716). The values below describe the hardware, not a build choice:
+ *   POSC — 24 MHz external clock on this board (FPLLICLK = PLL_POSC,
+ *          POSCMOD = EC in initialization.c)
+ *   FRC  — 8 MHz internal oscillator, the alternative PLL input (PLLICLK = 1)
+ * Every constant in this header is what the image was BUILT for; what the
+ * silicon is actually running may differ — see TimerApi_PeripheralClockHz(). */
+#define DAQIFI_POSC_HZ      24000000UL
+#define DAQIFI_FRC_HZ        8000000UL
+
 #if DAQIFI_SYSCLK_252
   #define DAQIFI_SYSCLK_HZ   252000000UL   /* SPLL: 24 MHz POSC /3 x63 /2 */
   #define DAQIFI_PBCLK_HZ     84000000UL   /* peripheral buses at PBxDIV /3 */

--- a/firmware/src/services/SCPI/SCPIDIO.c
+++ b/firmware/src/services/SCPI/SCPIDIO.c
@@ -327,7 +327,7 @@ scpi_result_t SCPI_PWMChannelEnableGet(scpi_t * context){
 scpi_result_t SCPI_PWMChannelFrequencySet(scpi_t * context){
     uint32_t param1,param2;
     int i;
-    uint32_t timerClock=TIMER_CLOCK_FRQ;
+    uint32_t timerClock=TimerApi_PeripheralClockHz();   /* #716: real clock, not built-for */
     if (!SCPI_ParamUInt32(context, &param1, FALSE))
     {
         return SCPI_RES_ERR;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5091,16 +5091,26 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
             BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
         uint32_t tClockPeriod = (tcfg != NULL) ? tcfg->ClockPeriod : 0u;
         bool tConfigured = Streaming_IsRateConfigured();
+        /* Split across two writes on purpose. scpi_printf has a 192-byte
+         * buffer and truncates SILENTLY (SCPIInterface.h) — and truncation
+         * here would drop the trailing comma before the next chunk, making
+         * the whole capability response unparseable JSON rather than merely
+         * short. As one call this expansion reaches 189 bytes on the shipped
+         * 252 MHz build and 192 on the legacy 200 MHz build, i.e. from three
+         * bytes of margin down to none (#740 audit). Two calls put both
+         * halves under 110 bytes, so no plausible clock/rate combination can
+         * reach the limit. */
         scpi_printf(context,
             "\"timing\":{\"timestamp_hz\":%u,\"stream_timer_hz\":%u,"
-            "\"timestamp_ticks_per_sample\":%u,\"actual_rate_millihz\":%u,"
-            "\"pbclk_hz\":%u,\"pbclk_built_hz\":%u,\"clock_ok\":%s},",
+            "\"timestamp_ticks_per_sample\":%u,\"actual_rate_millihz\":%u,",
             (unsigned)TimerApi_FrequencyGet(cfg->StreamingConfig.TSTimerIndex),
             (unsigned)TimerApi_FrequencyGet(cfg->StreamingConfig.TimerIndex),
             (unsigned)(tConfigured
                 ? Streaming_TimestampTicksPerSample(tClockPeriod) : 0u),
             (unsigned)(tConfigured
-                ? Streaming_ActualRateMilliHz(tClockPeriod) : 0u),
+                ? Streaming_ActualRateMilliHz(tClockPeriod) : 0u));
+        scpi_printf(context,
+            "\"pbclk_hz\":%u,\"pbclk_built_hz\":%u,\"clock_ok\":%s},",
             (unsigned)TimerApi_PeripheralClockHz(),
             (unsigned)TIMER_CLOCK_FRQ_BUILT,
             TimerApi_ClockMatchesBuild() ? "true" : "false");

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5074,7 +5074,18 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
      * - actual_rate_millihz: the QUANTIZED rate. `Frequency` is what was asked
      *   for; the period register is an integer, so asking for 4500 Hz yields
      *   4498.714 Hz at 252 MHz (~286 ppm). Millihertz keeps it integral.
-     * Both per-config values are 0 until a rate is configured. */
+     * Both per-config values are 0 until a rate is configured.
+     *
+     * - pbclk_hz / pbclk_built_hz + clock_ok: #716. The PLL multiplier lives in
+     *   a device Configuration Word, which our bootloader will not program (and
+     *   which erratum 45 says cannot be self-programmed at all), so a device
+     *   that took a firmware update keeps the PLL it was manufactured with
+     *   while the application's PBxDIV write DOES apply. The two can therefore
+     *   disagree, and the symptom is silent: every rate comes out scaled by
+     *   pbclk_hz/pbclk_built_hz (0.794 for a 200 MHz unit running the 252 MHz
+     *   image). Reported so a client or support engineer can SEE it instead of
+     *   inferring it from a rate that looks 21% low. clock_ok=false means the
+     *   unit needs a physical reprogram to reach its intended clock. */
     {
         StreamingRuntimeConfig* tcfg =
             BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
@@ -5082,13 +5093,17 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
         bool tConfigured = Streaming_IsRateConfigured();
         scpi_printf(context,
             "\"timing\":{\"timestamp_hz\":%u,\"stream_timer_hz\":%u,"
-            "\"timestamp_ticks_per_sample\":%u,\"actual_rate_millihz\":%u},",
+            "\"timestamp_ticks_per_sample\":%u,\"actual_rate_millihz\":%u,"
+            "\"pbclk_hz\":%u,\"pbclk_built_hz\":%u,\"clock_ok\":%s},",
             (unsigned)TimerApi_FrequencyGet(cfg->StreamingConfig.TSTimerIndex),
             (unsigned)TimerApi_FrequencyGet(cfg->StreamingConfig.TimerIndex),
             (unsigned)(tConfigured
                 ? Streaming_TimestampTicksPerSample(tClockPeriod) : 0u),
             (unsigned)(tConfigured
-                ? Streaming_ActualRateMilliHz(tClockPeriod) : 0u));
+                ? Streaming_ActualRateMilliHz(tClockPeriod) : 0u),
+            (unsigned)TimerApi_PeripheralClockHz(),
+            (unsigned)TIMER_CLOCK_FRQ_BUILT,
+            TimerApi_ClockMatchesBuild() ? "true" : "false");
     }
 
     scpi_printf(context,


### PR DESCRIPTION
Fixes #716.

A field device that takes a firmware update streams at **79.4% of every requested rate** — silently, while reporting a timebase it is not running.

## Root cause

`FPLLMULT` lives in DEVCFG2, a device Configuration Word.

- Our USB bootloader deliberately refuses to program config words — `bootloader/.../nvm.c:244-245`, comment: *"Make sure we are not writing boot area and device configuration bits."* Verified empirically: our production hex carries 1,036 bytes at `0x1FC00000` (decoding to `FPLLMULT = MUL_63 → 252 MHz`) and every one of them is dropped.
- It could not be self-programmed anyway: DS80000663 **Rev R** (04/2023, current) erratum 45 — *"Run-Time Self Programming of Configuration Words is not functional. Work around: None."* — affecting A1/A3/B2/B3, i.e. all revisions.

`PBxDIV`, by contrast, is an ordinary runtime register write in `SystemInit`, so an update **does** apply it. A unit manufactured at 200 MHz that takes the 252 MHz image therefore runs:

| | field device after update | bench unit (PICkit-flashed) |
|---|---|---|
| PLL (DEVCFG — not updatable) | MUL_50 → 200 MHz | MUL_63 → 252 MHz |
| PBxDIV (runtime — updated) | ÷3 | ÷3 |
| PBCLK3 | **66.67 MHz** | 84 MHz |
| stream timer (÷2) | **33.33 MHz** | 42 MHz |

33.333 / 42 = **0.79365**. That is why every bench unit is immune — PICkit writes config words, so the mismatch cannot arise here by accident.

## The fix

`TimerApi_FrequencyGet` already read the prescaler from its register; only the base clock was a literal. It is now derived from `SPLLCON` + `PBxDIV`, so **one image is correct on both silicon configurations**.

Every streaming-rate path funnels through that one function — stream START, channel enable, `Streaming_Init`, `CONF:CAP:JSON?` — so the delivered rate, the reported timebase and the caps are fixed together.

Bit encodings are from **DS60001320G Register 8-3 (SPLLCON)** and **Register 8-9 (PBxDIV)**, quoted at the implementation because getting any of them wrong silently rescales everything: `PLLIDIV`/`PLLMULT` are value+1, `PLLODIV` is `1 << value` (000 Reserved), `COSC` 001 = SPLL, `PBDIV` is value+1.

### The rename earned its keep

Renaming `TIMER_CLOCK_FRQ` → `TIMER_CLOCK_FRQ_BUILT` surfaced **three more consumers** of the same assumption that a grep of the streaming path had missed — `UserIC.h` (input-capture timebase), `DIO.c` and `SCPIDIO.c` (PWM). All are on PBCLK3 and all were off by the same 1.26× on a mismatched device, so input-capture frequency/period/pulse-width measurements and PWM output frequency were wrong too. All three now use the derived clock. `DIO.c` already carried a commented-out `TimerApi_FrequencyGet(3)`, so this had been noticed once before and not followed through.

### Making it observable

The condition is otherwise completely silent — the device just runs 21% slow forever:

- boot `LOG_E` naming both clocks and stating that a PICkit/IPE reprogram is required
- `CONF:CAP:JSON?` `timing` gains `pbclk_hz`, `pbclk_built_hz`, `clock_ok`

Deliberately **not cached**: file statics on this part can land in `.bss` sections outside `[_bss_begin,_bss_end]` and are not reliably zeroed across MCLR, so a lazily-filled cache-valid flag would be a hazard for no gain — the callers are SCPI/config paths, never per-sample.

## Test plan

Board 7E2898F46200E8A7. The A/B forces `FPLLMULT = MUL_50` in DEVCFG while leaving every other constant at its 252 MHz value — i.e. **exactly** a bootloader-updated field unit. Same silicon in all three rows; only the config word differs.

| build | 100 Hz | 1000 Hz | 5000 Hz | ratio | reports | `clock_ok` |
|---|--:|--:|--:|--:|---|---|
| 200 MHz DEVCFG + 252 image, **before** | 793 | 7,936 | 39,685 | **0.7937** | 42 MHz | — |
| 200 MHz DEVCFG + 252 image, **after** | 1,000 | 9,999 | 49,994 | **0.9999** | 33,333,333 Hz | false + boot LOG_E |
| 252 MHz DEVCFG (normal bench), after | 1,000 | 9,999 | 50,005 | **1.0000** | 42 MHz | true, no log line |

(samples over a 10 s window; the 793 at 100 Hz is the field report's exact number)

No regression on this build: `test_717` **9/9**, `test_730` **3/3**.

Regression test: **[daqifi-python-test-suite#121](https://github.com/daqifi/daqifi-python-test-suite/pull/121)**.

No SCPI command added, changed or removed — `CONF:CAP:JSON?` gains three fields inside the existing `timing` block, so no wiki table row changes.

**Environment:** firmware `e228e28e` (branched off `main`, independent of #737), test-suite `test/716-clock-derivation`, XC32 v4.60 / MPLAB X v6.30, built `-O3 -Werror`.

## Follow-up

This makes a mismatched device *accurate and honest*, but it does not make it *fast* — a 200 MHz unit stays at 200 MHz and its caps stay proportionally lower. Raising it needs a runtime PLL switch, filed separately.
