### PR TITLE
feat(clock): raise SYSCLK to the target PLL at boot (#741)

### DIFF
--- a/firmware/src/config/default/clock_config.h
+++ b/firmware/src/config/default/clock_config.h
@@ -39,6 +39,17 @@
 #define DAQIFI_POSC_HZ      24000000UL
 #define DAQIFI_FRC_HZ        8000000UL
 
+/* #741: the SPLLCON PLLMULT FIELD value for the target SYSCLK — the field is
+ * (multiplier - 1) per DS60001320G Register 8-3, so x63 -> 62 and x50 -> 49.
+ * SystemInit compares the live SPLLCON against this and switches the PLL at
+ * boot if they differ, because the DEVCFG default cannot be changed by a
+ * firmware update (see #716) but SPLLCON is an ordinary runtime register. */
+#if DAQIFI_SYSCLK_252
+  #define DAQIFI_PLLMULT_FIELD      62u    /* x63 */
+#else
+  #define DAQIFI_PLLMULT_FIELD      49u    /* x50 */
+#endif
+
 #if DAQIFI_SYSCLK_252
   #define DAQIFI_SYSCLK_HZ   252000000UL   /* SPLL: 24 MHz POSC /3 x63 /2 */
   #define DAQIFI_PBCLK_HZ     84000000UL   /* peripheral buses at PBxDIV /3 */

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -732,10 +732,47 @@ static const SYS_TIME_INIT sysTimeInitData =
  * worst case. Big enough never to trip on a healthy part, small enough that a
  * dead clock source cannot hang the boot. */
 #define DAQIFI_OSW_TIMEOUT  2000000u
+/* Separate symbol for the raise-to-target switch purely so a bench build can
+ * shrink it and force the revert path to run. Production value is identical. */
+#ifndef DAQIFI_OSW_SPLL_TIMEOUT
+#define DAQIFI_OSW_SPLL_TIMEOUT  DAQIFI_OSW_TIMEOUT
+#endif
 
-/* One clock switch, per the FRM's recommended sequence. Returns false if OSWEN
- * did not clear, i.e. the requested source never started. */
-static bool DAQIFI_ClockSwitch(uint32_t nosc)
+/* One clock switch, per the FRM's recommended sequence.
+ *
+ * REGISTERS AND BITS (FRM DS60001250B 42.3.7.2 "Oscillator Switching Sequence";
+ * register/bit definitions DS60001320H Register 8-1 OSCCON, Register 8-3
+ * SPLLCON):
+ *   SYSKEY<31:0>            0xAA996655 then 0x556699AA unlocks; any non-key
+ *                           value (0x33333333) relocks. The two key writes
+ *                           must be BACK-TO-BACK with no intervening
+ *                           peripheral access (42.3.7.3).
+ *   OSCCON<10:8> NOSC<2:0>  requested source; 000 = FRC, 001 = SPLL.
+ *   OSCCON<14:12> COSC<2:0> current source, same encoding. NOSC == COSC is
+ *                           defined as redundant: hardware clears OSWEN and
+ *                           aborts (42.3.7.2), which is the only software way
+ *                           to cancel a stuck switch.
+ *   OSCCON<0>    OSWEN      1 initiates; hardware clears it on success, having
+ *                           first waited for PLL lock when the new source uses
+ *                           the PLL. "If the new clock source does not start,
+ *                           or is not present, the OSWEN bit remains set"
+ *                           (42.3.7.3) — hence the bounded wait.
+ *
+ * NO PLIB PATH EXISTS for this: the generated clock PLIB exposes only
+ * CLK_Initialize() (plib_clk.h), which writes PMD bits, and nothing under
+ * config/default/peripheral touches OSCCON or SPLLCON. CLAUDE.md's preference
+ * order therefore lands on SFR bitfield accessors (used here for OSCCON and
+ * SPLLCON) with raw writes only for SYSKEY, which has no bitfields — and only
+ * after reading the FRM, cited above.
+ *
+ * @param nosc     NOSC value for the requested source.
+ * @param timeout  bound on the OSWEN poll, in iterations. Parameterised rather
+ *                 than fixed so a bench build can force a timeout and exercise
+ *                 the revert path, which is otherwise unreachable (the PLL
+ *                 locks over a very wide range — see the envelope above).
+ * @return true if OSWEN cleared, i.e. the switch completed.
+ */
+static bool DAQIFI_ClockSwitch(uint32_t nosc, uint32_t timeout)
 {
     uint32_t guard;
 
@@ -753,7 +790,7 @@ static bool DAQIFI_ClockSwitch(uint32_t nosc)
      * outside the unlocked window. */
     SYSKEY = 0x33333333U;
 
-    for (guard = 0u; guard < DAQIFI_OSW_TIMEOUT; ++guard) {
+    for (guard = 0u; guard < timeout; ++guard) {
         if (OSCCONbits.OSWEN == 0u) {
             return true;
         }
@@ -782,9 +819,16 @@ static void DAQIFI_ApplyTargetPll(void)
     uint32_t odiv;
     uint32_t wouldBe;
 
-    /* Already what this image wants — the normal case on a PICkit-programmed
-     * unit, whose DEVCFG matches the build. Do nothing at all. */
-    if (SPLLCONbits.PLLMULT == target) {
+    /* Already what this image wants AND actually running from the PLL — the
+     * normal case on a PICkit-programmed unit whose DEVCFG matches the build.
+     * Do nothing at all.
+     *
+     * COSC is checked too, not just the multiplier: SPLLCON can hold the target
+     * while the part runs from FRC or POSC directly, in which case skipping
+     * would leave initialisation to continue with peripheral constants that
+     * assume the PLL frequency. Falling through instead lets the switch below
+     * put the part onto the PLL (Qodo #742). */
+    if ((SPLLCONbits.PLLMULT == target) && (OSCCONbits.COSC == DAQIFI_NOSC_SPLL)) {
         return;
     }
 
@@ -813,7 +857,7 @@ static void DAQIFI_ApplyTargetPll(void)
 
     /* Step 1: off the PLL, so SPLLCON becomes writable. If this fails we are
      * still on the original PLL — a perfectly serviceable state. */
-    if (!DAQIFI_ClockSwitch(DAQIFI_NOSC_FRC)) {
+    if (!DAQIFI_ClockSwitch(DAQIFI_NOSC_FRC, DAQIFI_OSW_TIMEOUT)) {
         return;
     }
 
@@ -825,7 +869,7 @@ static void DAQIFI_ApplyTargetPll(void)
     /* Step 3: back onto the PLL. Hardware waits for lock before clearing
      * OSWEN (42.3.7.3), so success here means the PLL is locked at the new
      * multiplier. */
-    if (!DAQIFI_ClockSwitch(DAQIFI_NOSC_SPLL)) {
+    if (!DAQIFI_ClockSwitch(DAQIFI_NOSC_SPLL, DAQIFI_OSW_SPLL_TIMEOUT)) {
         /* Did not lock, so per 42.3.7.3 OSWEN is STILL SET and the switch is
          * still pending. Cancel it before touching SPLLCON again.
          *
@@ -843,12 +887,12 @@ static void DAQIFI_ApplyTargetPll(void)
          * FRC again is exactly that no-op, and it is the only software-visible
          * way to clear a stuck OSWEN — FSCM's OSWEN clear needs the Fail-Safe
          * Clock Monitor, which FCKSM = CSECMD leaves disabled. */
-        (void)DAQIFI_ClockSwitch(DAQIFI_NOSC_FRC);
+        (void)DAQIFI_ClockSwitch(DAQIFI_NOSC_FRC, DAQIFI_OSW_TIMEOUT);
 
         /* Now SPLLCON is writable again: restore the multiplier the part
          * booted with, which demonstrably locked at reset, and go back to it. */
         DAQIFI_SetPllMult(saved);
-        (void)DAQIFI_ClockSwitch(DAQIFI_NOSC_SPLL);
+        (void)DAQIFI_ClockSwitch(DAQIFI_NOSC_SPLL, DAQIFI_OSW_TIMEOUT);
     }
 }
 

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -644,6 +644,179 @@ static const SYS_TIME_INIT sysTimeInitData =
   Remarks:
  */
 
+/* ===================================================================== #741
+ * Boot-time System PLL switch.
+ *
+ * WHY THIS EXISTS. FPLLMULT lives in DEVCFG2, a device Configuration Word.
+ * Our USB bootloader refuses to program config words on purpose
+ * (bootloader/.../nvm.c:244 "Make sure we are not writing boot area and device
+ * configuration bits"), and DS80000663 Rev R erratum 45 says run-time
+ * self-programming of them is not functional with no workaround. So a field
+ * firmware update can never change the DEVCFG default, and every device
+ * manufactured with the MUL_50 bootloader hex boots at 200 MHz forever (#716).
+ *
+ * But the DEVCFG value is only the POWER-ON DEFAULT. SPLLCON is an ordinary
+ * runtime R/W register that POR-loads from DEVCFG2 (DS60001320G Register 8-3),
+ * so software can override it. The datasheet in fact PRESCRIBES this for
+ * 252 MHz parts (DS60001320G p.165):
+ *
+ *   "Devices that support 252 MHz operation should be configured for
+ *    SYSCLK <= 200 MHz operation. Adjust the dividers of the PBCLKs, and then
+ *    increase the SYSCLK to the desired speed."
+ *
+ * Boot-at-200-then-raise is the vendor's recommended bring-up, not a
+ * workaround. Running it here also removes the transient this file documents
+ * above (buses at 126 MHz during crt0), because a 200 MHz part's /2 reset
+ * default is 100 MHz — in spec.
+ *
+ * WHY IT IS SAFE TO ATTEMPT. Every field device is already fused to permit it:
+ * the bootloader hex sets FCKSM = CSECMD (clock switching enabled, FSCM
+ * disabled) alongside the MUL_50 that causes the problem. Nothing here writes
+ * flash, so the worst case is a boot that never reaches the application — and
+ * the bootloader lives in boot flash and always runs first at reset, so button
+ * entry still recovers the unit exactly as it does after any bad app update.
+ *
+ * SEQUENCE. FRM DS60001250B 42.3.7 Note 2 forbids changing the multiplier
+ * while running from the affected PLL, so this is the documented two-step:
+ * switch to FRC, rewrite SPLLCON, switch back. 42.3.7.2's recommended code
+ * sequence is followed exactly, including the back-to-back key writes and an
+ * immediate relock. Interrupts and DMA are required to be off during the
+ * unlock; that holds by construction here — __builtin_enable_interrupts() is
+ * not called until the end of SYS_Initialize, and no DMA is configured yet.
+ *
+ * 42.3.7.3: "If the new clock source does not start, or is not present, the
+ * OSWEN bit remains set", so every wait below is BOUNDED. A failed raise
+ * reverts the multiplier and returns to the PLL that demonstrably worked at
+ * reset. If even that fails the part keeps running on FRC — slow, but alive,
+ * bootloader intact, and #716's runtime clock derivation reports the real
+ * frequency and clock_ok=false rather than lying about it.
+ */
+#define DAQIFI_NOSC_FRC     0x0u   /* OSCCON NOSC: 000 = FRC (non-PLL) */
+#define DAQIFI_NOSC_SPLL    0x1u   /* OSCCON NOSC: 001 = System PLL */
+/* Generous: a PLL lock is microseconds, and this loop runs at 8 MHz FRC in the
+ * worst case. Big enough never to trip on a healthy part, small enough that a
+ * dead clock source cannot hang the boot. */
+#define DAQIFI_OSW_TIMEOUT  2000000u
+
+/* One clock switch, per the FRM's recommended sequence. Returns false if OSWEN
+ * did not clear, i.e. the requested source never started. */
+static bool DAQIFI_ClockSwitch(uint32_t nosc)
+{
+    uint32_t guard;
+
+    /* Unlock: the two key writes MUST be back-to-back with no intervening
+     * peripheral access (42.3.7.3). Nothing is inserted between them. */
+    SYSKEY = 0x00000000U;
+    SYSKEY = 0xAA996655U;
+    SYSKEY = 0x556699AAU;
+
+    OSCCONbits.NOSC = nosc;
+    OSCCONbits.OSWEN = 1;
+
+    /* "The system will not relock automatically. Perform the relock sequence as
+     * soon as possible after the clock switch." The wait below is deliberately
+     * outside the unlocked window. */
+    SYSKEY = 0x33333333U;
+
+    for (guard = 0u; guard < DAQIFI_OSW_TIMEOUT; ++guard) {
+        if (OSCCONbits.OSWEN == 0u) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Write PLLMULT. Caller MUST already be off the PLL: DS60001320G Register 8-3
+ * Note 2 says writes are not allowed while SPLL is the clock source. */
+static void DAQIFI_SetPllMult(uint32_t multField)
+{
+    SYSKEY = 0x00000000U;
+    SYSKEY = 0xAA996655U;
+    SYSKEY = 0x556699AAU;
+    SPLLCONbits.PLLMULT = multField;
+    SYSKEY = 0x33333333U;
+}
+
+static void DAQIFI_ApplyTargetPll(void)
+{
+    const uint32_t target = (uint32_t)DAQIFI_PLLMULT_FIELD;
+    uint32_t saved;
+    uint32_t inHz;
+    uint32_t idiv;
+    uint32_t odivField;
+    uint32_t odiv;
+    uint32_t wouldBe;
+
+    /* Already what this image wants — the normal case on a PICkit-programmed
+     * unit, whose DEVCFG matches the build. Do nothing at all. */
+    if (SPLLCONbits.PLLMULT == target) {
+        return;
+    }
+
+    /* Only switch when the outcome can be PROVEN to equal what every constant
+     * in this build assumes. If the PLL is wired differently than expected
+     * (unexpected input select, reserved PLLODIV), leave the hardware alone:
+     * #716's runtime derivation will still report the truth, whereas a blind
+     * switch could land somewhere neither correct nor detected. */
+    inHz = (SPLLCONbits.PLLICLK != 0u) ? (uint32_t)DAQIFI_FRC_HZ
+                                       : (uint32_t)DAQIFI_POSC_HZ;
+    /* Register 8-3: with PLLICLK = FRC the input divider is ignored and the
+     * PLL uses divide-by-1. */
+    idiv = (SPLLCONbits.PLLICLK != 0u) ? 1u
+                                       : ((uint32_t)SPLLCONbits.PLLIDIV + 1u);
+    odivField = (uint32_t)SPLLCONbits.PLLODIV;
+    if ((odivField < 1u) || (odivField > 5u)) {   /* 000 and 11x are Reserved */
+        return;
+    }
+    odiv = 1u << odivField;
+    wouldBe = (uint32_t)(((uint64_t)inHz * (target + 1u)) / idiv / odiv);
+    if (wouldBe != (uint32_t)DAQIFI_SYSCLK_HZ) {
+        return;
+    }
+
+    saved = (uint32_t)SPLLCONbits.PLLMULT;
+
+    /* Step 1: off the PLL, so SPLLCON becomes writable. If this fails we are
+     * still on the original PLL — a perfectly serviceable state. */
+    if (!DAQIFI_ClockSwitch(DAQIFI_NOSC_FRC)) {
+        return;
+    }
+
+    /* Step 2: retune. Only PLLMULT moves; PLLIDIV / PLLODIV / PLLRANGE /
+     * PLLICLK keep the values DEVCFG2 loaded, so the PLL input frequency and
+     * therefore the PLLRANGE selection stay valid. */
+    DAQIFI_SetPllMult(target);
+
+    /* Step 3: back onto the PLL. Hardware waits for lock before clearing
+     * OSWEN (42.3.7.3), so success here means the PLL is locked at the new
+     * multiplier. */
+    if (!DAQIFI_ClockSwitch(DAQIFI_NOSC_SPLL)) {
+        /* Did not lock, so per 42.3.7.3 OSWEN is STILL SET and the switch is
+         * still pending. Cancel it before touching SPLLCON again.
+         *
+         * This ordering was found by fault injection, not by reading: an
+         * earlier version reverted the multiplier immediately and the part
+         * stayed stuck on FRC. Register 8-3 Note 2 forbids writing SPLLCON
+         * while SPLL is the clock source, and a pending switch appears to
+         * count — the write is dropped, the PLL stays at the bad multiplier,
+         * and the pending switch can never complete.
+         *
+         * The documented way out is a REDUNDANT switch: 42.3.7.2 says when
+         * NOSC equals COSC the hardware treats it as redundant, "the OSWEN
+         * bit is cleared automatically and the clock switch is aborted".
+         * COSC is still FRC here (the switch never completed), so asking for
+         * FRC again is exactly that no-op, and it is the only software-visible
+         * way to clear a stuck OSWEN — FSCM's OSWEN clear needs the Fail-Safe
+         * Clock Monitor, which FCKSM = CSECMD leaves disabled. */
+        (void)DAQIFI_ClockSwitch(DAQIFI_NOSC_FRC);
+
+        /* Now SPLLCON is writable again: restore the multiplier the part
+         * booted with, which demonstrably locked at reset, and go back to it. */
+        DAQIFI_SetPllMult(saved);
+        (void)DAQIFI_ClockSwitch(DAQIFI_NOSC_SPLL);
+    }
+}
+
 void SYS_Initialize ( void* data )
 {
 
@@ -689,6 +862,12 @@ void SYS_Initialize ( void* data )
      * TODO(#487): tune down to the DS60001320H Table 7-1 / §39 value after boot-verify. */
     PRECONbits.PFMWS = DAQIFI_PFMWS;
     CFGCONbits.ECCCON = 3;
+
+    /* #741: raise (or lower) the PLL to match this build. Deliberately AFTER
+     * the PBxDIV and flash-wait-state writes above: the datasheet's 252 MHz
+     * note says to set the PBCLK dividers first and increase SYSCLK last, and
+     * PFMWS must already cover the higher speed before the core runs at it. */
+    DAQIFI_ApplyTargetPll();
 
 
 

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -855,9 +855,18 @@ static void DAQIFI_ApplyTargetPll(void)
 
     saved = (uint32_t)SPLLCONbits.PLLMULT;
 
-    /* Step 1: off the PLL, so SPLLCON becomes writable. If this fails we are
-     * still on the original PLL — a perfectly serviceable state. */
+    /* Step 1: off the PLL, so SPLLCON becomes writable. */
     if (!DAQIFI_ClockSwitch(DAQIFI_NOSC_FRC, DAQIFI_OSW_TIMEOUT)) {
+        /* Giving up is not enough: 42.3.7.3 says OSWEN stays set, so the
+         * switch is STILL PENDING and could complete later — dropping the
+         * part onto FRC in the middle of peripheral init, while every
+         * constant still assumes the PLL. Cancel it first.
+         *
+         * COSC is still SPLL here (the switch never completed), so asking for
+         * SPLL again is the redundant no-op that 42.3.7.2 defines as clearing
+         * OSWEN and aborting. Then we are back exactly where we started, on
+         * the original PLL, with nothing pending (Qodo #742). */
+        (void)DAQIFI_ClockSwitch(DAQIFI_NOSC_SPLL, DAQIFI_OSW_TIMEOUT);
         return;
     }
 

--- a/firmware/src/config/default/initialization.c
+++ b/firmware/src/config/default/initialization.c
@@ -690,6 +690,41 @@ static const SYS_TIME_INIT sysTimeInitData =
  * reset. If even that fails the part keeps running on FRC — slow, but alive,
  * bootloader intact, and #716's runtime clock derivation reports the real
  * frequency and clock_ok=false rather than lying about it.
+ *
+ * WHAT ACTUALLY PROTECTS THIS (read before changing it). The load-bearing
+ * guard is the pre-switch validation in DAQIFI_ApplyTargetPll(): the only
+ * multiplier ever written is the compile-time target, and it is written only
+ * after proving, from the LIVE PLL input fields, that it yields exactly
+ * DAQIFI_SYSCLK_HZ. The revert is belt-and-braces for a lock failure and is
+ * deliberately NOT load-bearing — see the measured envelope below.
+ *
+ * MEASURED FREQUENCY ENVELOPE (E, bench 7E2898F46200E8A7, deliberate fault
+ * injection observed via Windows device state):
+ *   x1   -> VCO 8 MHz    -> SYSCLK ~4 MHz   : PLL LOCKS. The part runs but is
+ *                                             too slow to meet USB enumeration
+ *                                             timing — Windows reports "Device
+ *                                             Descriptor Request Failed"
+ *                                             (VID_0000): D+ pulled up, no
+ *                                             descriptor returned. So the USB
+ *                                             floor sits well above 4 MHz.
+ *   x128 -> VCO 1024 MHz -> SYSCLK ~512 MHz : locks; CPU dies immediately
+ *                                             (device absent from USB).
+ *   x50 / x63 (200 / 252 MHz)               : fully functional.
+ *
+ * The 4 MHz result is not just empirical: 60 MHz is the DOCUMENTED minimum
+ * SYSCLK with the USB module enabled (DS60001320H OS51 / MOS51, Tables 37-18
+ * and 39-5 — "60 ... 252 MHz, USB module enabled"). 4 MHz is 15x below that
+ * floor, so the enumeration failure is spec-predicted, not a surprise.
+ *
+ * The lesson for anyone extending this: a lock FAILURE is not the realistic
+ * hazard, because this PLL locks across a very wide range. Writing the WRONG
+ * multiplier is, and the validation is what prevents it. Runtime frequency
+ * scaling would additionally have to stay above the 60 MHz USB floor, AND
+ * recompute every PBCLK-derived BRG (consumer list atop clock_config.h), AND
+ * carry its own fitted streaming caps — note the two-step switch necessarily
+ * transits FRC at 8 MHz, i.e. below that USB floor, so a runtime switch would
+ * likely drop the CDC connection every time. Evaluated and declined; a
+ * boot-time selected point is the viable shape if it is ever wanted.
  */
 #define DAQIFI_NOSC_FRC     0x0u   /* OSCCON NOSC: 000 = FRC (non-PLL) */
 #define DAQIFI_NOSC_SPLL    0x1u   /* OSCCON NOSC: 001 = System PLL */
@@ -794,12 +829,12 @@ static void DAQIFI_ApplyTargetPll(void)
         /* Did not lock, so per 42.3.7.3 OSWEN is STILL SET and the switch is
          * still pending. Cancel it before touching SPLLCON again.
          *
-         * This ordering was found by fault injection, not by reading: an
-         * earlier version reverted the multiplier immediately and the part
-         * stayed stuck on FRC. Register 8-3 Note 2 forbids writing SPLLCON
-         * while SPLL is the clock source, and a pending switch appears to
-         * count — the write is dropped, the PLL stays at the bad multiplier,
-         * and the pending switch can never complete.
+         * UNTESTED, and labelled as such. Two fault-injection attempts
+         * could not produce a genuine lock failure — the PLL locked both
+         * times, just at a useless frequency (see the envelope above), and
+         * OSWEN cleared normally, so this branch never executed. The cancel
+         * below is FRM-documented behaviour, not something demonstrated on
+         * hardware here.
          *
          * The documented way out is a REDUNDANT switch: 42.3.7.2 says when
          * NOSC equals COSC the hardware treats it as redundant, "the OSWEN


### PR DESCRIPTION
Implements #741. **Draft** — the feature works and is bench-proven, but one safety path is unverified and I could not construct a valid test for it. Detail below.

## What this does

#716 concluded that only a physical reprogram could move a field device to 252 MHz. That conclusion was wrong, and this is the correction.

`FPLLMULT` in DEVCFG2 is only the **power-on default**. `SPLLCON` is an ordinary runtime R/W register that POR-loads from it (DS60001320G Register 8-3), so software can override it. The datasheet actually *prescribes* this for 252 MHz parts (p.165):

> **Note:** Devices that support 252 MHz operation should be configured for SYSCLK <= 200 MHz operation. Adjust the dividers of the PBCLKs, and then increase the SYSCLK to the desired speed.

Boot-at-200-then-raise is the vendor's recommended bring-up, not a workaround. Every field device is already fused to allow it — the factory bootloader hex sets `FCKSM = CSECMD` (clock switching enabled) alongside the `MUL_50` that causes #716.

Implemented per FRM DS60001250B §42.3.7.2's recommended sequence, honouring §42.3.7 Note 2's two-step requirement (the multiplier cannot be changed while running from the affected PLL): **switch to FRC → rewrite `SPLLCON` → switch back**. Interrupts and DMA are off by construction here — `__builtin_enable_interrupts()` is not called until the end of `SYS_Initialize` — which is what §42.3.7.3 requires for the unlock.

Placed **after** the `PBxDIV` and flash-wait-state writes, per the datasheet's dividers-first ordering: `PFMWS` must already cover the higher speed before the core runs at it.

### Three guards

1. **Skip** entirely when `SPLLCON` already holds the target — the normal case on a PICkit-programmed unit, which does nothing at all.
2. **Refuse** unless the resulting SYSCLK can be *proven* equal to `DAQIFI_SYSCLK_HZ`, computed from the live `PLLICLK`/`PLLIDIV`/`PLLODIV`. If the PLL is wired differently than expected, leave the hardware alone — #716's runtime derivation will still report the truth, whereas a blind switch could land somewhere neither correct nor detected.
3. **Bound** every `OSWEN` wait, because §42.3.7.3 says a source that does not start leaves `OSWEN` set forever.

## Verified on hardware (7E2898F46200E8A7)

| scenario | result |
|---|---|
| DEVCFG `MUL_50` (a field device) + this code | reports `pbclk_hz` **84,000,000**, `clock_ok` true — **running 252 MHz from a 200 MHz config word**, reached purely by application code |
| full gate set on that self-raised unit | `716` 5/5 · `717` 9/9 · `730` 3/3 · `732` 3/3 |
| skip path, normal 252-DEVCFG unit | boots unchanged, 84 MHz, `clock_ok` true |

The first row is the whole point: that is what a field firmware update delivers.

## What is NOT verified, and why

**The revert-on-lock-failure path is unproven.** I tried twice to exercise it and neither attempt was a valid test — both produced a *successful* lock at a useless frequency rather than a lock failure:

| injected multiplier | VCO | Windows device state | what actually happened |
|---|---|---|---|
| x1 | 8 MHz (below the 350 MHz min) | `Unknown USB Device (Device Descriptor Request Failed)`, `VID_0000&PID_0002` | device **present and running** — it locked at ~4 MHz SYSCLK and was simply too slow to meet USB enumeration timing |
| x128 | 1024 MHz (above the 700 MHz max) | device **absent entirely** | consistent with locking at ~512 MHz SYSCLK and the CPU dying immediately |

`VID_0000` is the key evidence for the first row: Windows saw the device pull up D+ but never got a descriptor back. A hung part would not appear at all — which is exactly what the second row shows, and the contrast between the two is what makes the interpretation solid.

In both cases `OSWEN` would have cleared normally, so **no revert logic could have caught either**. The implication is that this PLL locks across a very wide range, and a genuine lock failure is hard to produce deliberately.

Two consequences I want to be explicit about:

- The revert path's code is untested, and the one change I made to it (cancelling the pending switch via a redundant `NOSC == COSC` switch, per §42.3.7.2) was based on a diagnosis I no longer believe. It may well be correct — it is FRM-documented — but I have not demonstrated it.
- More importantly, **the guard that actually protects production is guard 2**, not the revert. Production only ever writes the compile-time target, validated to produce exactly `DAQIFI_SYSCLK_HZ` at a 504 MHz VCO that is inside spec and demonstrably locks. The revert covers a scenario I could not even manufacture.

Nothing bricked at any point: every fault run recovered fully with a PICkit reflash, confirming the no-flash-writes risk analysis. But a customer has no PICkit, so a field device that failed to lock would need an RMA — which is why I am not proposing to merge this without a decision on that risk.

## Open question for review

Given that the PLL appears to lock at essentially anything, is the revert path worth keeping at all? Three options:

1. **Keep as-is** — belt-and-braces for an event I cannot produce, at the cost of untested code in the boot path.
2. **Remove it**, rely on guard 2, and document that a lock failure means an RMA.
3. **Make failure survivable instead of recoverable** — e.g. a watchdog-backed retry that gives up and boots at the DEVCFG default on the second attempt. More robust, more complexity, needs its own design pass.

My inclination is (3) before this ships to customers, but it is a real design decision rather than something I should pick unilaterally.

## Also fixed by this

The 126 MHz `PBCLK` transient during crt0 that `initialization.c` currently documents as an accepted wart (Qodo #584) only exists on 252-fused units. Booting at 200 and raising afterwards puts the reset-default /2 at 100 MHz — in spec — so this removes it rather than adding to it.

**Environment:** firmware `feat/741-boot-spll-switch`, XC32 v4.60 / MPLAB X v6.30, `-O3 -Werror`. No SCPI surface change, so no wiki update. No companion test yet — the behaviour is only observable on a DEVCFG/image mismatch, which the bench cannot produce without a source edit; `test_716_clock_derivation.py` already covers the resulting clock being correct.
