### PR TITLE
feat(power): halt the core in the FreeRTOS idle hook (#513)

### DIFF
--- a/firmware/src/config/default/FreeRTOSConfig.h
+++ b/firmware/src/config/default/FreeRTOSConfig.h
@@ -326,6 +326,12 @@
 /* #513: the idle task drops the CPU into Idle mode (see vApplicationIdleHook
  * in freertos_hooks.c). Idle halts the core while leaving every peripheral
  * clock, USB, the tick and the ADC trigger running. */
+/* HAND-EDITED. This file sits under config/default/, i.e. MCC/Harmony
+ * territory: a regeneration would restore the stock 0 and silently remove the
+ * power saving with NO build error. Team direction (2026-06-10) is that
+ * MCC/Harmony regeneration will not be used on this codebase again, so this is
+ * a documentation hazard rather than a live one — but if a regen ever does
+ * happen, this line AND vApplicationIdleHook's body must both be restored. */
 #define configUSE_IDLE_HOOK                     1
 #define configUSE_TICK_HOOK                     0
 #define configUSE_MALLOC_FAILED_HOOK            1

--- a/firmware/src/config/default/FreeRTOSConfig.h
+++ b/firmware/src/config/default/FreeRTOSConfig.h
@@ -323,7 +323,10 @@
  * functionality in the build.  Set to 0 to exclude the hook functionality from the
  * build.  The application writer is responsible for providing the hook function
  * for any set to 1.  See https://www.freertos.org/a00016.html. */
-#define configUSE_IDLE_HOOK                     0
+/* #513: the idle task drops the CPU into Idle mode (see vApplicationIdleHook
+ * in freertos_hooks.c). Idle halts the core while leaving every peripheral
+ * clock, USB, the tick and the ADC trigger running. */
+#define configUSE_IDLE_HOOK                     1
 #define configUSE_TICK_HOOK                     0
 #define configUSE_MALLOC_FAILED_HOOK            1
 #define configUSE_DAEMON_TASK_STARTUP_HOOK      0

--- a/firmware/src/config/default/freertos_hooks.c
+++ b/firmware/src/config/default/freertos_hooks.c
@@ -38,6 +38,7 @@
 // DOM-IGNORE-END
 #include "FreeRTOS.h"
 #include "task.h"
+#include "peripheral/power/plib_power.h"   /* #513: POWER_LowPowerModeEnter */
 
 
 void vApplicationIdleHook( void );
@@ -187,7 +188,30 @@ void vApplicationIdleHook( void )
     important that vApplicationIdleHook() is permitted to return to its calling
     function, because it is the responsibility of the idle task to clean up
     memory allocated by the kernel to any task that has since been deleted. */
-    
+
+    /* #513: halt the core until the next interrupt.
+     *
+     * IDLE, not Sleep. Idle mode (SLPEN = 0) stops the CPU pipeline but leaves
+     * SYSCLK and every peripheral clock running — USB stays enumerated, the
+     * FreeRTOS tick keeps arriving, the streaming timer keeps triggering the
+     * ADC, and wake-up on any interrupt has "very low" latency
+     * (DS60001320H 33.2.2). Sleep would gate the peripheral clocks and drop
+     * USB, so it is not usable here.
+     *
+     * The saving is the whole reason this is worth doing: DS60001320H puts the
+     * running core at 156 mA and the idle core at 41 mA, both typ at 252 MHz
+     * (MDC27a / MDC35, Tables 39-2 and 39-3).
+     *
+     * Via the PLIB rather than a hand-rolled `wait`: POWER_LowPowerModeEnter()
+     * already performs the SYSKEY unlock, clears SLPEN and issues the
+     * instruction, and CLAUDE.md's peripheral-access rule prefers the PLIB
+     * where one exists. The per-call SYSKEY pair costs a handful of
+     * instructions against a wake that is at minimum a whole tick away.
+     *
+     * Safe to call unconditionally from here: this hook only runs when NO task
+     * is ready, and any interrupt — tick, streaming timer, USB, SPI — resumes
+     * the core, so nothing that was runnable can be delayed by it. */
+    POWER_LowPowerModeEnter(LOW_POWER_IDLE_MODE);
 }
 
 /*-----------------------------------------------------------*/

--- a/firmware/src/config/default/freertos_hooks.c
+++ b/firmware/src/config/default/freertos_hooks.c
@@ -191,12 +191,20 @@ void vApplicationIdleHook( void )
 
     /* #513: halt the core until the next interrupt.
      *
-     * IDLE, not Sleep. Idle mode (SLPEN = 0) stops the CPU pipeline but leaves
-     * SYSCLK and every peripheral clock running — USB stays enumerated, the
-     * FreeRTOS tick keeps arriving, the streaming timer keeps triggering the
-     * ADC, and wake-up on any interrupt has "very low" latency
-     * (DS60001320H 33.2.2). Sleep would gate the peripheral clocks and drop
-     * USB, so it is not usable here.
+      * IDLE, not Sleep. Which mode a WAIT enters is selected by OSCCON<4>
+     * SLPEN, whose bit definition is exactly this choice (DS60001320H
+     * Register 8-1: "1 = Device will enter Sleep mode when a WAIT instruction
+     * is executed / 0 = Device will enter Idle mode when a WAIT instruction is
+     * executed"); the modes themselves are DS60001320H Section 33
+     * "Power-Saving Features", 33.2.2 for Idle, and the oscillator side is FRM
+     * DS60001250B. POWER_LowPowerModeEnter's LOW_POWER_IDLE_MODE clears SLPEN
+     * before issuing WAIT, which is why Idle is what we get.
+     *
+     * Idle stops the CPU pipeline while leaving SYSCLK and every peripheral
+     * clock running, so USB stays enumerated, the FreeRTOS tick keeps
+     * arriving, the streaming timer keeps triggering the ADC, and wake on any
+     * interrupt has "very low" latency (33.2.2). Sleep would gate the
+     * peripheral clocks and drop USB, so it is not usable here.
      *
      * The saving is the whole reason this is worth doing: DS60001320H puts the
      * running core at 156 mA and the idle core at 41 mA, both typ at 252 MHz

--- a/firmware/src/config/default/freertos_hooks.c
+++ b/firmware/src/config/default/freertos_hooks.c
@@ -40,6 +40,22 @@
 #include "task.h"
 #include "peripheral/power/plib_power.h"   /* #513: POWER_LowPowerModeEnter */
 
+/* #513: fail the BUILD rather than lose the power saving quietly.
+ *
+ * FreeRTOSConfig.h lives under config/default/, i.e. MCC/Harmony territory. If
+ * it were ever regenerated, configUSE_IDLE_HOOK would revert to the stock 0,
+ * FreeRTOS would simply stop calling vApplicationIdleHook, and the core would
+ * go back to spinning — with no build error, no runtime symptom and no test
+ * failure, because the device behaves identically apart from drawing ~115 mA
+ * more. Silent is the problem; this makes it loud.
+ *
+ * If you are here because the build broke: either restore
+ * configUSE_IDLE_HOOK = 1 in FreeRTOSConfig.h, or delete this guard together
+ * with the hook body below if disabling the saving is genuinely intended. */
+#if !defined(configUSE_IDLE_HOOK) || (configUSE_IDLE_HOOK != 1)
+#error "#513: configUSE_IDLE_HOOK must be 1 or the CPU never idles. See vApplicationIdleHook in this file."
+#endif
+
 
 void vApplicationIdleHook( void );
 void vApplicationTickHook( void );


### PR DESCRIPTION
Implements #513, **de-scoped** — idle hook only, no tickless. Reasoning below.

## What it does

The idle task now halts the CPU instead of spinning. Per DS60001320H at 252 MHz that is **156 mA running vs 41 mA idle** (MDC27a / MDC35, Tables 39-2 and 39-3) — the largest single power lever on this part, for a handful of lines.

**Idle, not Sleep.** Idle (`SLPEN = 0`) stops the CPU pipeline while leaving SYSCLK and every peripheral clock running: USB stays enumerated, the FreeRTOS tick keeps arriving, the streaming timer keeps triggering the ADC, and wake on any interrupt has "very low" latency (DS60001320H §33.2.2). Sleep would gate the peripheral clocks and drop USB, so it is not usable here.

Uses `POWER_LowPowerModeEnter(LOW_POWER_IDLE_MODE)` rather than the inline `__asm__("wait")` the ticket proposed. The PLIB already performs the SYSKEY unlock, clears `SLPEN` and issues the instruction, and CLAUDE.md's peripheral-access rule prefers a PLIB where one exists — which also sidesteps the "bypasses the PLIB" class of review finding that came up on #742.

## De-scope: no `configUSE_TICKLESS_IDLE`, and why

#513 states the MPLAB PIC32MZ port ships a stock `vPortSuppressTicksAndSleep` and asks to confirm it is compiled in. **It does not ship one:**

```
$ grep -c "vPortSuppressTicksAndSleep\|configUSE_TICKLESS_IDLE" \
    firmware/src/third_party/rtos/FreeRTOS/Source/portable/MPLAB/PIC32MZ/port.c
0
```

So full tickless is custom port work, not a config flag. And the payoff is small: suppressing a 1 kHz tick whose wake costs microseconds adds single-digit mA against a **41 mA floor**. The hook captures nearly all of the saving at a fraction of the cost and risk, so it goes first and tickless can be revisited once there is a measurement to judge it against.

## Test plan

The concern with halting the core is wake latency on the streaming path. Note that `test_717` alone cannot settle this — its timestamps are counter-derived, so they stay exact even if ISR entry were delayed. The **at-cap A/B is the real evidence**: stream at the enforced cap and look for actual loss.

Board 7E2898F46200E8A7, 1×T2 USB PB, at cap (7746 Hz) for 20 s, adjacent flashes:

| | with idle hook | `main` baseline |
|---|---|---|
| `TimerISRCalls` | 154,869 | 154,869 |
| `TotalSamplesStreamed` | 154,869 | 154,869 |
| PC bytes received | 1,548,580 | 1,548,580 |
| `QueueDroppedSamples` | 0 | 0 |
| `UsbDroppedBytes` | 0 | 0 |
| `ScanStaleDropped` | 0 | 0 |

**Identical.** Halting the core costs no throughput headroom and loses no ISR entries; the documented `TimerISRCalls == TotalSamplesStreamed` invariant holds on both.

Everything else, with the hook active:

| check | result |
|---|---|
| `test_742_boot_clock_switch` | 2/2 |
| `test_716_clock_derivation` | 5/5 |
| `test_717_deterministic_timestamp` | 9/9 — 0 off-grid, 0 dupes, exact period |
| `test_730_timebase_report` | 3/3 |
| `test_732_streaming_defaults` | 3/3 |
| `test_728` (SD write + benchmark) | PASS |
| SCPI control plane | 5/5 queries answered |

## What is NOT measured

**The actual current saving.** There is no current meter on this bench, and the BQ24297 exposes only an input current *limit* (`IINLIM`), not draw — I checked. The 156 → 41 mA figure is datasheet-typical under spec-table conditions (PBCLK/128, peripherals off), so **the real-world delta will be smaller than that**.

So this PR is "provably free" rather than "proven to save X mA". A current-meter A/B — idle / 1 kHz / 5 kHz / at-cap — remains the outstanding validation, and it is the ticket's own test plan. I would not close #513 on this PR alone.

## Note for review

One thing worth a second opinion: the hook calls the PLIB unconditionally on every idle iteration, which performs a SYSKEY unlock/relock pair each time (~1000×/s minimum at the 1 kHz tick). That is a handful of instructions against a wake that is at minimum a whole tick away, so the overhead is negligible — but if the churn is considered undesirable, the alternative is clearing `SLPEN` once at init and issuing a bare `wait` here, at the cost of leaving the PLIB path.

**Environment:** firmware `feat/513-idle-hook-wait`, XC32 v4.60 / MPLAB X v6.30, `-O3 -Werror`. No SCPI surface change, so no wiki update. No new regression test: the contract is "no behavioural change, less power", and the existing gate set plus the at-cap A/B is what demonstrates the first half — the second half needs instrumentation this bench does not have.
