### PR TITLE
fix(streaming): suppress the priming tick instead of emitting a partial frame or a phantom drop (#707, #745)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3102,7 +3102,6 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
     // still streamed, just with frozen data; same exclusion as EosOverruns).
     // ~0 with the scan cap in place; non-zero flags over-rate / NOCAP scan-busy.
     scpi_printf(context, "ScanStaleDropped=%u\r\n", (unsigned)s.scanStaleDropped);
-    scpi_printf(context, "DryTicks=%u\r\n", (unsigned)s.dryTicks);   /* #707/#745 */
     // #541 D-A diag: ticks where a T1 result was not ready (ARDY clear) at
     // the deferred task's direct read.  Expected 0; non-zero ticks emitted
     // that channel with its validMask bit clear.

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3102,6 +3102,7 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
     // still streamed, just with frozen data; same exclusion as EosOverruns).
     // ~0 with the scan cap in place; non-zero flags over-rate / NOCAP scan-busy.
     scpi_printf(context, "ScanStaleDropped=%u\r\n", (unsigned)s.scanStaleDropped);
+    scpi_printf(context, "DryTicks=%u\r\n", (unsigned)s.dryTicks);   /* #707/#745 */
     // #541 D-A diag: ticks where a T1 result was not ready (ARDY clear) at
     // the deferred task's direct read.  Expected 0; non-zero ticks emitted
     // that channel with its validMask bit clear.

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -162,6 +162,19 @@ static volatile uint64_t gTimerISRCalls = 0;
 static volatile uint32_t gScanEosSeq      = 1u;  // bumped per completed scan (EOS ISR); primed 1 ahead of "seen"
 static volatile uint32_t gScanEosSeqSeen  = 0u;  // last seq the timer ISR observed
 static volatile uint32_t gScanStaleDropped = 0;  // ticks scan armed but no new EOS
+/* #707/#745: ticks that fired before the session's first shared scan had
+ * completed, so no sample could be built. A DRY TICK, not a sample and not a
+ * drop — see the emit-path comment for why it is neither. Separate volatile,
+ * single writer (the deferred task), same pattern as gScanStaleDropped. */
+static volatile uint32_t gDryTicks = 0;
+/* #707/#745: true when at least one ENABLED USER channel takes its value from
+ * the shared-scan LATEST cache, i.e. the frame cannot be complete until the
+ * session's first scan finishes. Deliberately NOT gNeedSharedScan: that is true
+ * whenever the scan list is non-empty, which includes a monitoring-only scan
+ * (OBDiag=1) in a T1-only session — where the user's channels are read directly
+ * via ARDY and ARE ready on tick 0, so suppressing that tick would discard a
+ * perfectly good sample. */
+static volatile bool gUserT2Enabled = false;
 
 // Log-once flags: each error condition logs once per session via
 // LOG_E_SESSION / LOG_I_SESSION macros (gSessionOneShot bitmask in Logger).
@@ -880,6 +893,55 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             // now provably dead (Timestamp can never be 0 here), so it's retired.
             // The PB encoder omits msg_time_stamp only on Timestamp==0, which no
             // longer occurs.
+            /* #707/#745: a tick that fires before the session's FIRST shared
+             * scan has completed cannot produce a ready sample, so it must not
+             * produce one at all.
+             *
+             * gScanEosSeq is primed to 1 at start and is incremented only by
+             * Streaming_NoteEosFired() from the EOS ISR, so == 1 means "no scan
+             * has completed yet this session". Until then the T2 slots are
+             * still invalid (the #533 ts != 0 gate), and whether ANY channel
+             * appears in the frame depends purely on which channel the scan
+             * happened to convert first — the two observed outcomes being:
+             *   exactly one channel published  -> partial frame  (#707)
+             *   none published                 -> validMask 0, the encoder
+             *                                     emits nothing, and it was
+             *                                     booked as a lost sample and
+             *                                     an encoder failure (#745)
+             * The second is why every clean session reported one phantom drop.
+             *
+             * Neither is a sample and neither is a loss: the ISR fired, but
+             * there was nothing ready to emit. Counted as a dry tick, which is
+             * why the session invariant is
+             *   TimerISRCalls == TotalSamplesStreamed + QueueDroppedSamples
+             *                    + DryTicks
+             * The tick is still counted as having happened (TimerISRCalls is a
+             * hardware truth used to detect timer rate-limiting, #265) — it is
+             * only excluded from samples and from loss.
+             *
+             * Gated on gUserT2Enabled, not gNeedSharedScan: a T1-only session
+             * with OBDiag=1 has a non-empty scan list (monitoring rides it) but
+             * its USER channels are read directly via ARDY and ARE ready on
+             * tick 0, so suppressing there would throw away a good sample. Only
+             * sessions with an enabled user channel on the cache path pay.
+             *
+             * Mixed T1+T2 configs do give up one tick of otherwise-valid T1
+             * data. That is deliberate: a frame missing its T2 channels is not
+             * ready, and frame consistency at session start is worth more than
+             * one sample. Self-limiting to the genuine priming window — after
+             * the first EOS this is never true again, and a scan that later
+             * falls behind is a different condition already counted by
+             * ScanStaleDropped. */
+            if (gUserT2Enabled && (gScanEosSeq == 1u)) {
+                taskENTER_CRITICAL();
+                gDryTicks++;
+                taskEXIT_CRITICAL();
+                AInSampleList_FreeToPool(pPublicSampleList);
+                /* Deliberately NOT Streaming_UpdateFlowWindow(): the flow
+                 * window measures loss, and nothing was lost. */
+                goto pool_done;
+            }
+
             if(!AInSampleList_PushBack(pPublicSampleList)){//failed pushing to Q
                 // #499: split counter — this path = FreeRTOS queue full,
                 // i.e. streaming_Task can't drain fast enough. Distinct from
@@ -1486,6 +1548,10 @@ static void Streaming_Start(void) {
                         &css1, &css2);
                 MC12b_ApplyScanList(css1, css2);
                 gNeedSharedScan = (scanCount > 0);
+                /* #707/#745: enabled USER T2 channels only — monitoring
+                 * excluded, no registers written (pure count). */
+                gUserT2Enabled =
+                        (MC12b_ComputeScanList(true, false, NULL, NULL) > 0u);
                 // #670: inform (log only) about any Type 2 threshold whose channel
                 // isn't in this session's scan — it won't monitor stream samples,
                 // but stays armed for idle/MEAS and keeps its latch (persistence).
@@ -1799,6 +1865,8 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
+    gDryTicks = 0;
+    gUserT2Enabled = false;
     gScanEosSeq = 1u;       // #557/#563: prime seq one ahead of "seen" so the
     gScanEosSeqSeen = 0u;   // first post-start tick (no scan completed yet) reads fresh
     memset(gFlowWindow, 0, sizeof(gFlowWindow));
@@ -1904,6 +1972,7 @@ void Streaming_GetStats(StreamingStats* out) {
     // timer ISR (priority 1) so we get a coherent reading.
     out->timerISRCalls = gTimerISRCalls;
     out->scanStaleDropped = gScanStaleDropped;  // #557 (separate volatile, like timerISRCalls)
+    out->dryTicks = gDryTicks;                  // #707/#745 (same pattern)
     taskEXIT_CRITICAL();
 }
 
@@ -1952,6 +2021,8 @@ void Streaming_ClearStats(void) {
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
+    gDryTicks = 0;
+    gUserT2Enabled = false;
     gScanEosSeq = 1u;       // #557/#563: prime seq one ahead of "seen" so the
     gScanEosSeqSeen = 0u;   // first post-start tick (no scan completed yet) reads fresh
 #if PB_PROFILE_COUNTERS

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -163,9 +163,20 @@ static volatile uint32_t gScanEosSeq      = 1u;  // bumped per completed scan (E
 static volatile uint32_t gScanEosSeqSeen  = 0u;  // last seq the timer ISR observed
 static volatile uint32_t gScanStaleDropped = 0;  // ticks scan armed but no new EOS
 /* #707/#745: ticks that fired before the session's first shared scan had
- * completed, so no sample could be built. A DRY TICK, not a sample and not a
- * drop — see the emit-path comment for why it is neither. Separate volatile,
- * single writer (the deferred task), same pattern as gScanStaleDropped. */
+ * completed, so no sample could be built. A DRY TICK — not a sample and not a
+ * drop; see the emit-path comment.
+ *
+ * INTERNAL ONLY, deliberately not a reported statistic. It exists solely so
+ * TimerISRCalls can be reported as "ticks that produced a sample attempt",
+ * which keeps the documented invariant unchanged:
+ *   TimerISRCalls == TotalSamplesStreamed + QueueDroppedSamples
+ * A dry call is not a generated sample, so it is not counted as one.
+ *
+ * Subtracted at snapshot time rather than by adjusting gTimerISRCalls itself:
+ * that counter is incremented in true ISR context and relies on having exactly
+ * one writer (same-source cannot preempt itself, so it needs no critical
+ * section). Adding a task-context writer would break that. Single writer here
+ * too — the deferred task. */
 static volatile uint32_t gDryTicks = 0;
 /* #707/#745: true when at least one ENABLED USER channel takes its value from
  * the shared-scan LATEST cache, i.e. the frame cannot be complete until the
@@ -911,13 +922,12 @@ void _Streaming_Deferred_Interrupt_Task(void) {
              * The second is why every clean session reported one phantom drop.
              *
              * Neither is a sample and neither is a loss: the ISR fired, but
-             * there was nothing ready to emit. Counted as a dry tick, which is
-             * why the session invariant is
+             * there was nothing ready to emit. A dry call is not a generated
+             * sample, so it is not counted as one — gDryTicks is subtracted
+             * from the reported TimerISRCalls, leaving the documented invariant
+             * exactly as it always was:
              *   TimerISRCalls == TotalSamplesStreamed + QueueDroppedSamples
-             *                    + DryTicks
-             * The tick is still counted as having happened (TimerISRCalls is a
-             * hardware truth used to detect timer rate-limiting, #265) — it is
-             * only excluded from samples and from loss.
+             * No new statistic is exposed.
              *
              * Gated on gUserT2Enabled, not gNeedSharedScan: a T1-only session
              * with OBDiag=1 has a non-empty scan list (monitoring rides it) but
@@ -1970,9 +1980,19 @@ void Streaming_GetStats(StreamingStats* out) {
     // Snapshot the volatile ISR counter into the struct copy. The volatile
     // read forces a fresh load from memory; the critical section blocks the
     // timer ISR (priority 1) so we get a coherent reading.
-    out->timerISRCalls = gTimerISRCalls;
+    /* #707/#745: net of dry ticks. A tick that fired before the session's
+     * first shared scan completed had no sample to emit — it is not a
+     * generated sample, so it is not counted as one. This keeps the documented
+     * invariant exactly as it was:
+     *   TimerISRCalls == TotalSamplesStreamed + QueueDroppedSamples
+     * gDryTicks is internal and never reported on its own. */
+    {
+        uint64_t isrRaw = gTimerISRCalls;
+        uint32_t dry = gDryTicks;
+        out->timerISRCalls = (isrRaw > (uint64_t)dry) ? (isrRaw - (uint64_t)dry)
+                                                     : 0u;
+    }
     out->scanStaleDropped = gScanStaleDropped;  // #557 (separate volatile, like timerISRCalls)
-    out->dryTicks = gDryTicks;                  // #707/#745 (same pattern)
     taskEXIT_CRITICAL();
 }
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -175,17 +175,31 @@ static volatile uint32_t gScanStaleDropped = 0;  // ticks scan armed but no new 
  * Subtracted at snapshot time rather than by adjusting gTimerISRCalls itself:
  * that counter is incremented in true ISR context and relies on having exactly
  * one writer (same-source cannot preempt itself, so it needs no critical
- * section). Adding a task-context writer would break that. Single writer here
- * too — the deferred task. */
+ * section). Adding a task-context writer would break that.
+ *
+ * Writers: the deferred task increments it (under a critical section, since it
+ * is an RMW), and Streaming_Init / Streaming_ClearStats zero it. All task
+ * context — no ISR writer. */
 static volatile uint32_t gDryTicks = 0;
-/* #707/#745: true when at least one ENABLED USER channel takes its value from
- * the shared-scan LATEST cache, i.e. the frame cannot be complete until the
- * session's first scan finishes. Deliberately NOT gNeedSharedScan: that is true
- * whenever the scan list is non-empty, which includes a monitoring-only scan
- * (OBDiag=1) in a T1-only session — where the user's channels are read directly
- * via ARDY and ARE ready on tick 0, so suppressing that tick would discard a
- * perfectly good sample. */
-static volatile bool gUserT2Enabled = false;
+/* #707/#745: latched TRUE at Streaming_Start when at least one ENABLED USER
+ * channel takes its value from the shared-scan LATEST cache, i.e. the frame
+ * cannot be complete until the session's first scan finishes. The deferred task
+ * clears it on the first completed scan, and nothing re-arms it in a session.
+ *
+ * Deliberately NOT derived from gNeedSharedScan: that is true whenever the scan
+ * list is non-empty, which includes a monitoring-only scan (OBDiag=1) in a
+ * T1-only session — where the user's channels are read directly via ARDY and
+ * ARE ready on tick 0, so suppressing there would discard a good sample.
+ *
+ * Deliberately NOT reset by Streaming_ClearStats. Mid-session clearing is an
+ * intentionally supported operation (see that function), and it also rewinds
+ * gScanEosSeq to its primed value — so a condition derived from that seq alone
+ * would re-arm the suppression MID-STREAM and start dropping good ticks. A
+ * latch that only ever clears keeps the suppression strictly a session-start
+ * affair regardless of what a client clears and when, and a client that clears
+ * stats immediately after START still gets the protection, which resetting the
+ * flag would have silently removed (Qodo #746). */
+static volatile bool gPrimingPending = false;
 
 // Log-once flags: each error condition logs once per session via
 // LOG_E_SESSION / LOG_I_SESSION macros (gSessionOneShot bitmask in Logger).
@@ -929,7 +943,7 @@ void _Streaming_Deferred_Interrupt_Task(void) {
              *   TimerISRCalls == TotalSamplesStreamed + QueueDroppedSamples
              * No new statistic is exposed.
              *
-             * Gated on gUserT2Enabled, not gNeedSharedScan: a T1-only session
+             * Gated on the enabled-user-T2 latch, not gNeedSharedScan: a T1-only session
              * with OBDiag=1 has a non-empty scan list (monitoring rides it) but
              * its USER channels are read directly via ARDY and ARE ready on
              * tick 0, so suppressing there would throw away a good sample. Only
@@ -942,14 +956,23 @@ void _Streaming_Deferred_Interrupt_Task(void) {
              * the first EOS this is never true again, and a scan that later
              * falls behind is a different condition already counted by
              * ScanStaleDropped. */
-            if (gUserT2Enabled && (gScanEosSeq == 1u)) {
-                taskENTER_CRITICAL();
-                gDryTicks++;
-                taskEXIT_CRITICAL();
-                AInSampleList_FreeToPool(pPublicSampleList);
-                /* Deliberately NOT Streaming_UpdateFlowWindow(): the flow
-                 * window measures loss, and nothing was lost. */
-                goto pool_done;
+            if (gPrimingPending) {
+                if (gScanEosSeq == 1u) {          /* no scan completed yet */
+                    taskENTER_CRITICAL();
+                    gDryTicks++;
+                    taskEXIT_CRITICAL();
+                    AInSampleList_FreeToPool(pPublicSampleList);
+                    /* Deliberately NOT Streaming_UpdateFlowWindow(): the flow
+                     * window measures loss, and nothing was lost. */
+                    /* Close the probe pulse opened for this iteration — the
+                     * early exit would otherwise leave probe 3 asserted and
+                     * corrupt every later timing measurement (Qodo #746). */
+                    DioProbe_PulseEnd(3);
+                    goto pool_done;
+                }
+                /* First completed scan seen: the cache is live from here on, so
+                 * never suppress again this session. */
+                gPrimingPending = false;
             }
 
             if(!AInSampleList_PushBack(pPublicSampleList)){//failed pushing to Q
@@ -1560,7 +1583,7 @@ static void Streaming_Start(void) {
                 gNeedSharedScan = (scanCount > 0);
                 /* #707/#745: enabled USER T2 channels only — monitoring
                  * excluded, no registers written (pure count). */
-                gUserT2Enabled =
+                gPrimingPending =
                         (MC12b_ComputeScanList(true, false, NULL, NULL) > 0u);
                 // #670: inform (log only) about any Type 2 threshold whose channel
                 // isn't in this session's scan — it won't monitor stream samples,
@@ -1876,7 +1899,7 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
     gDryTicks = 0;
-    gUserT2Enabled = false;
+    gPrimingPending = false;
     gScanEosSeq = 1u;       // #557/#563: prime seq one ahead of "seen" so the
     gScanEosSeqSeen = 0u;   // first post-start tick (no scan completed yet) reads fresh
     memset(gFlowWindow, 0, sizeof(gFlowWindow));
@@ -2042,7 +2065,6 @@ void Streaming_ClearStats(void) {
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
     gDryTicks = 0;
-    gUserT2Enabled = false;
     gScanEosSeq = 1u;       // #557/#563: prime seq one ahead of "seen" so the
     gScanEosSeqSeen = 0u;   // first post-start tick (no scan completed yet) reads fresh
 #if PB_PROFILE_COUNTERS

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -535,11 +535,6 @@ typedef struct {
     uint32_t queueDroppedSamplesSteady;  // post-grace subset of queueDroppedSamples
     uint32_t eosOverruns;      // EOS notifications coalesced (>1 per wake) (#295)
     uint32_t scanStaleDropped; // #557: scan armed but EOS not fired by next trigger
-    uint32_t dryTicks;         // #707/#745: ticks before the session's first
-                               // completed scan — no sample was ready, so
-                               // neither a sample nor a loss. Session invariant:
-                               // TimerISRCalls == TotalSamplesStreamed
-                               //                  + QueueDroppedSamples + dryTicks
                                // (scan-busy/stale) — counted as a dropped sample
     // #541 D-A diagnostic: ticks where a T1 (dedicated-module) channel's
     // ARDY flag was not set when the deferred task went to read its result

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -535,6 +535,11 @@ typedef struct {
     uint32_t queueDroppedSamplesSteady;  // post-grace subset of queueDroppedSamples
     uint32_t eosOverruns;      // EOS notifications coalesced (>1 per wake) (#295)
     uint32_t scanStaleDropped; // #557: scan armed but EOS not fired by next trigger
+    uint32_t dryTicks;         // #707/#745: ticks before the session's first
+                               // completed scan — no sample was ready, so
+                               // neither a sample nor a loss. Session invariant:
+                               // TimerISRCalls == TotalSamplesStreamed
+                               //                  + QueueDroppedSamples + dryTicks
                                // (scan-busy/stale) — counted as a dropped sample
     // #541 D-A diagnostic: ticks where a T1 (dedicated-module) channel's
     // ARDY flag was not set when the deferred task went to read its result

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -551,6 +551,17 @@ typedef struct {
     // should always hold during a session — every timer event becomes either
     // a successfully queued sample or a pool-exhaustion drop.
     //
+    // #707/#745: the value REPORTED here is therefore ticks that produced a
+    // sample attempt, not raw ISR entries. At session start a tick can fire
+    // before the shared MODULE7 scan has published anything, so no sample is
+    // ready to emit; that is a dry call — not a generated sample and not a
+    // loss — and it is excluded here so the invariant above stays exact
+    // without inventing a third term. The exclusion is bounded to the
+    // session's scan-priming window (at most a handful of ticks, and 0 for
+    // configs with no enabled Type 2 user channel), so this remains a valid
+    // basis for the #265 use below: a timerISRCalls far short of
+    // `freq × duration` still means the timer itself is rate-limited.
+    //
     // 64-bit so it never wraps in practice — at the ~90 kHz hardware ceiling
     // it would take ~6 million years to overflow. Matches the other 64-bit
     // session counters (totalSamplesStreamed, totalBytesStreamed).
@@ -560,7 +571,8 @@ typedef struct {
     // global is the actual ISR-modified storage; the StreamingStats field is
     // a snapshot copy taken inside taskENTER_CRITICAL (which makes the
     // non-atomic 64-bit read coherent by blocking the timer ISR).
-    uint64_t timerISRCalls;          // Actual timer ISR entry count this session
+    uint64_t timerISRCalls;          // Sample-producing timer ticks this session
+                                     // (ISR entries less scan-priming dry calls)
     // #367 diagnostics — populated at Streaming_Stop() to reconcile the
     // accounting gap (TotalBytesStreamed vs WifiTcpBytesSent at saturation).
     uint32_t circularBufferEndBytes; // Bytes still in WiFi circular buffer at Stop


### PR DESCRIPTION
Fixes #707. Fixes #745.

## They are one bug

On the session's first tick the shared MODULE7 scan has not completed, so the Type 2 `LATEST` slots are still invalid (the #533 `ts != 0` gate). Which channels appear in the frame depends purely on which channel the scan happened to convert first:

| channels published before the tick-0 deferred read | result |
|---|---|
| exactly one | **#707** — a frame with 1 analog value instead of the full enabled set |
| none | **#745** — `validMask == 0`, the PB encoder emits nothing, and it was booked as a lost sample **and** an encoder failure |

The second fired on **every** session, so every clean run reported one phantom drop, set `QUES_BIT_ENCODER_FAIL`, and logged an encoder failure that never happened. It also explains a run-to-run sample-count wobble I had noticed and not chased — 299 vs 300 at 100 Hz / 3 s is simply which outcome the race produced.

## A correction: the existing comment blamed the wrong thing

`streaming.c` attributed #745's `encoded == 0` to the #484 **shutdown** race, stating it was *"verified empirically to fire at Stop, not mid-stream."*

That is wrong, and it cost me an attempt. `Streaming_Stop` clears `Running` before it drains the sample queues, so a stop race should have been distinguishable — guarding on `Running` changed nothing. Instrumenting the site directly:

```
diag745: enc0 IsEnabled=1 Running=1 ain=1 dio=0 batchIdx=0
```

`Running = 1`. And `EncoderFailuresSteady` stayed **0** even for an 8 s session whose stop lands ~5 s past the 3 s startup grace — so the event fires inside the first three seconds. **It is a startup event.** Comment corrected in this PR, because it would send the next person straight to the wrong place.

## The fix

Per the owner's direction — a guaranteed per-session drop is a bug, not a species of loss — a tick with no sample ready is a **dry call**: it emits nothing, and it is not counted as a generated sample. **No new statistic is exposed**, and the documented invariant is unchanged:

```
TimerISRCalls == TotalSamplesStreamed + QueueDroppedSamples
```

The dry call is excluded from the *reported* `TimerISRCalls` rather than offset by a new term. That does change what the field means — it is now sample-producing ticks, not raw ISR entries — so `streaming.h` documents that explicitly, along with the bound that keeps it useful for its #265 purpose: the exclusion only ever covers the session's scan-priming window (0 for configs with no enabled Type 2 user channel), so a count far short of `freq × duration` still means a rate-limited timer.

### Gated on a latch, not on anything `STATS:CLEar` can reset

Two distinctions matter here, and my first two attempts got one each wrong.

**Not `gNeedSharedScan`.** That is true whenever the scan list is non-empty, which includes a **monitoring-only** scan (OBDiag=1) in a T1-only session — where the user's channels are read directly via ARDY and *are* ready on tick 0. Suppressing there would discard a perfectly good sample. The gate uses `MC12b_ComputeScanList(true, false, NULL, NULL) > 0` — enabled user T2 count, monitoring excluded, no registers written.

**Not a live condition.** Qodo caught that `Streaming_ClearStats()` reset the flag, so a client clearing stats immediately after START lost the protection. Chasing it surfaced a second direction: `ClearStats` **also rewinds `gScanEosSeq`**, so merely not clearing the flag would have re-armed suppression **mid-stream** and started discarding good ticks. Both come from keying off state that clearing resets, so the condition is now a **latch** — set once at `Streaming_Start`, cleared by the deferred task on the first completed scan, never touched by `ClearStats`. Suppression is strictly a session-start affair regardless of what a client clears and when.

Mixed T1+T2 does give up one tick of otherwise-valid T1 data. Deliberate: a frame missing its T2 channels is not ready, and frame consistency at session start is worth more than one sample.

## Test plan

Board 7E2898F46200E8A7, adjacent flashes.

**#707 — ch0+1+2, JSON, 100 Hz:**

| firmware | frame 0 | frames 1+ |
|---|---|---|
| `main` | **1** analog value | 3 |
| this fix | **3** | 3 |

**#745 — phantom drop, across rates and durations:**

| rate | duration | `EncoderDroppedSamples` | `EncoderFailures` |
|---:|---:|---:|---:|
| 100 Hz | 3 s | 0 (was 1) | 0 (was 1) |
| 1000 Hz | 3 s | 0 (was 1) | 0 (was 1) |
| 1000 Hz | 10 s | 0 (was 1) | 0 (was 1) |
| 5000 Hz | 3 s | 0 (was 1) | 0 (was 1) |

**Suppression is correctly scoped** — measured dry calls are 1 for T2-bearing configs and **0** for T1-only, and the invariant balances in every case:

| config | ISR | samples | qDrop | balances |
|---|--:|--:|--:|:--|
| 1×T2 @ 1 kHz | 3999 | 3999 | 0 | yes |
| 1×T1 @ 1 kHz | 4000 | 4000 | 0 | yes |
| T1+T2 @ 1 kHz | 3998 | 3998 | 0 | yes |
| 1×T2 @ 5 kHz | 19999 | 19999 | 0 | yes |

**`STATS:CLEar` cannot perturb it** (the Qodo scenario, both directions):

| scenario | frames | partial frames | encoder loss | invariant |
|---|--:|--:|--:|:--|
| clear immediately after START | 298 | **0** | 0 | balances |
| clear mid-stream (1.5 s in) | 448 | **0** | 0 | balances |

**No regressions:** `513` 5/5 · `716` 5/5 · `717` 9/9 · `730` 3/3 · `732` 3/3 · `742` 2/2.

Regression test: **[daqifi-python-test-suite#124](https://github.com/daqifi/daqifi-python-test-suite/pull/124)** — fails on `main` with `frame 0=1`, passes here (12/12, including the clear-after-START case). It also let `test_513`'s encoder allowance drop from 1 to **0**, which was only ever a workaround for #745.

## No client-visible contract change

An earlier revision of this PR added a `DryTicks` field to `SYST:STR:STATS?`. The owner's direction was that a phantom drop is a bug to remove, not a new category to report, so that field was reverted — **the statistics surface and the documented invariant are both unchanged**, and no wiki update is needed.

**Environment:** firmware `fix/707-745-dry-tick` @ `b30da4fd`, XC32 v4.60 / MPLAB X v6.30, `-O3 -Werror`.
