### PR TITLE
fix(sd): bound circular-buffer drains by the runtime write-buffer size

### DIFF
--- a/firmware/src/Util/Logger.h
+++ b/firmware/src/Util/Logger.h
@@ -183,6 +183,7 @@ extern "C" {
         LOG_ONCE_BIT_SD_BACKOFF,          /**< drv_sdspi.c: detect-poll backoff engaged after 10 card-absent polls (#589 P1) */
         LOG_ONCE_MDNS_ARM_FAIL,           /**< mdns_responder.c: recvfrom re-arm failed — responder deaf until ServiceHealth() re-opens (#58) */
         LOG_ONCE_ADC_THRESHOLD_TRIP,      /**< AdcThreshold.c: an ADC digital-comparator threshold tripped (#670); one-shot so a signal parked past the limit can't flood */
+        LOG_ONCE_SD_WBUF_SUBSECTOR,       /**< sd_card_manager.c: SD DMA write buffer below one sector, so the sector-aligned drain can extract nothing (#738); unreachable with the current 512-byte floor, one-shot so a broken floor can't flood the drain loop */
         /* Add new entries above this line */
         LOG_ONCE_COUNT                     /**< Must be <= 32 */
     } LogOnceBit_t;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -834,8 +834,12 @@ void sd_card_manager_ProcessState() {
                         SD_TakeMutexDebug(gSDCardData.wMutex, "unmount_drain_loop");
                         if (gSDCardData.sdCardWritePending != 1) {
                             gSDCardData.sdCardWritePending = 1;
+                            /* #738: runtime size, not the compile-time
+                             * ceiling — see the WRITE_TO_FILE extract. This is
+                             * the close-time drain, so an over-large extract
+                             * loses the tail of the file outright. */
                             CircularBuf_ProcessBytes(&gSDCardData.wCirbuf, NULL,
-                                SD_CARD_MANAGER_CONF_WBUFFER_SIZE, &writeLen);
+                                gSDCardData.writeBufferSize, &writeLen);
                             gSDCardData.totalBytesFlushPending += gSDCardData.writeBufferLength;
                             xSemaphoreGive(gSDCardData.wMutex);
 
@@ -1280,8 +1284,19 @@ void sd_card_manager_ProcessState() {
                 uint32_t availBytes = CircularBuf_NumBytesAvailable(&gSDCardData.wCirbuf);
                 if (availBytes >= SD_SECTOR_SIZE_BYTES
                         && gSDCardData.sdCardWritePending != 1) {
-                    uint32_t maxExtract = (availBytes < SD_CARD_MANAGER_CONF_WBUFFER_SIZE)
-                                        ? availBytes : SD_CARD_MANAGER_CONF_WBUFFER_SIZE;
+                    /* #738: bound by the buffer we ACTUALLY have, not the
+                     * compile-time maximum. writeBufferSize is the runtime
+                     * size auto-balance assigned (SD_CARD_MANAGER_CONF_WBUFFER_SIZE
+                     * is only the 64 KB ceiling), and it collapses to the
+                     * inactive-interface minimum whenever SD is not the active
+                     * streaming interface. Extracting the ceiling into a
+                     * smaller buffer is refused by CircularBufferToSDWrite, so
+                     * the write fails and the data is dropped. Read under
+                     * wMutex, which is the mutex sd_card_manager_SetWriteBuffer
+                     * takes to change it. */
+                    uint32_t wbufCap = gSDCardData.writeBufferSize;
+                    uint32_t maxExtract = (availBytes < wbufCap) ? availBytes
+                                                                 : wbufCap;
                     maxExtract = (maxExtract / SD_SECTOR_SIZE_BYTES) * SD_SECTOR_SIZE_BYTES;
                     gSDCardData.sdCardWritePending = 1;
                     CircularBuf_ProcessBytes(&gSDCardData.wCirbuf, NULL, maxExtract, &writeLen);
@@ -1393,7 +1408,10 @@ void sd_card_manager_ProcessState() {
                         SD_TakeMutexDebug(gSDCardData.wMutex, "drain_loop");
                         if (gSDCardData.sdCardWritePending != 1) {
                             gSDCardData.sdCardWritePending = 1;
-                            CircularBuf_ProcessBytes(&gSDCardData.wCirbuf, NULL, SD_CARD_MANAGER_CONF_WBUFFER_SIZE, &writeLen);
+                            /* #738: runtime size, not the compile-time
+                             * ceiling — see the WRITE_TO_FILE extract. */
+                            CircularBuf_ProcessBytes(&gSDCardData.wCirbuf, NULL,
+                                gSDCardData.writeBufferSize, &writeLen);
                             gSDCardData.totalBytesFlushPending += gSDCardData.writeBufferLength;
                             xSemaphoreGive(gSDCardData.wMutex);
 

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1298,6 +1298,21 @@ void sd_card_manager_ProcessState() {
                     uint32_t maxExtract = (availBytes < wbufCap) ? availBytes
                                                                  : wbufCap;
                     maxExtract = (maxExtract / SD_SECTOR_SIZE_BYTES) * SD_SECTOR_SIZE_BYTES;
+                    /* Unreachable today: the branch above requires availBytes
+                     * >= one sector, and writeBufferSize is floored at 512 (by
+                     * PrepareStreamingBuffers, twice, and by the 64 KB init).
+                     * Guarded anyway because this loop now DEPENDS on that
+                     * floor, and the public setter only rejects size == 0 — a
+                     * future caller passing a sub-sector size would truncate to
+                     * 0 here, and extracting 0 after setting sdCardWritePending
+                     * would leave the state machine waiting on a write that
+                     * never had data (Qodo #748). */
+                    if (maxExtract == 0) {
+                        xSemaphoreGive(gSDCardData.wMutex);
+                        LOG_E_ONCE(LOG_ONCE_SD_WBUF_SUBSECTOR,
+                                   "[SD] write buffer below one sector - drain stalled");
+                        break;
+                    }
                     gSDCardData.sdCardWritePending = 1;
                     CircularBuf_ProcessBytes(&gSDCardData.wCirbuf, NULL, maxExtract, &writeLen);
                     gSDCardData.totalBytesFlushPending += gSDCardData.writeBufferLength;


### PR DESCRIPTION
Fixes #738.

## The bug

Three sites drain the SD circular buffer into the DMA write buffer. All three clamped their extraction to `SD_CARD_MANAGER_CONF_WBUFFER_SIZE` — the **64 KB compile-time ceiling** — instead of `gSDCardData.writeBufferSize`, the size auto-balance actually assigned. Those are not the same number.

`Streaming_ComputeAutoBuffers` counts SD as active only when the interface allows it **and** `sd->enable` **and** a filename is set. When SD is dormant at the moment the pool is partitioned, its coherent DMA write buffer collapses to `SD_CARD_MANAGER_MIN_WBUFFER_SIZE` (512). An extraction sized against the ceiling is then refused by `CircularBufferToSDWrite`, which returns `-1`, so the write fails and that data is dropped.

**Two of the three sites are the close-time and rotation drains** — the paths whose entire purpose is to flush everything before a file is closed. A refused extraction there loses the tail of a logged file outright. The reported benchmark `-200` is the visible symptom; this is the part that matters.

## A correction to the issue's diagnosis

The issue attributes it to the **SD circular** buffer being auto-balanced small. It is actually the **coherent DMA write buffer** — the overflow log reports `gSDCardData.writeBufferSize`, and #723 already floored the circular at 4096. The reported line reads `len=4096, max=512`: 4096 is the circular's floored size feeding the extract, 512 is the write buffer that refuses it.

The issue's stated precondition ("the pool was last auto-balanced for a non-SD interface") is also **not sufficient**, which is why my first two reproduction attempts passed. With SD enabled and the default non-empty filename, `hasSd` stays true through a USB-only stream and SD keeps full-size buffers. The reachable precondition is SD **disabled** at partition time.

## Reproduction and fix (E, 2026-07-30, board 7E2898F46200E8A7, adjacent builds)

```
SYST:STOR:SD:ENAble 0
SYST:STR:INT 0 ; START 1000 ; STOP        # partitions with hasSd = false
SYST:MEM:SD:BUFfer?          -> 4096      # active partition, not config (#494)
SYST:STOR:SD:ENAble 1
SYST:STOR:SD:BENCHmark 64,0
```

| firmware | 64 KB | 256 KB | log |
|---|---|---|---|
| `main` @ `4cadc778` | `-200` | `-200` | `overflow: len=4096, max=512` |
| this fix | complete | complete | clean |

All three sites now bound by the runtime size, read under `wMutex` — the same mutex `sd_card_manager_SetWriteBuffer` takes to change it.

## Notes for review

- **Loop iteration counts go up, and stay well inside their caps.** Smaller extracts mean more passes through the drain loops. In the reachable dormant configuration that is circular 4096 / write 512 = 8 iterations against the unmount loop's cap of 100; when SD is active both sizes scale together, so it stays at 1–2. Previously the over-large extract was refused outright, so this is strictly better in every configuration.
- **The benchmark now reports a slower number in this state** (262 KB/s at a 512 B write buffer vs 978 KB/s when SD-shaped) because it now actually runs instead of failing. That is honest — it is what the device achieves in that configuration — but it means the reported figure depends on prior streaming history. Making the benchmark re-partition for SD on entry (option 1 in the issue) would give a representative number; I left that out of scope here because this PR is the correctness fix, and noted it on the issue.

Regression test: **[daqifi-python-test-suite#125](https://github.com/daqifi/daqifi-python-test-suite/pull/125)** — 0 PASS / 6 FAIL on `main`, 6 PASS / 0 FAIL here.

**Environment:** firmware `fix/738-write-buffer-bound`, XC32 v4.60 / MPLAB X v6.30, `-O3 -Werror`.