### PR TITLE
fix(sd): accept the directory-qualified path SD:LISt? prints

### DIFF
--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -136,6 +136,44 @@ static bool SD_ValidatePathParam(const char *p, size_t len)
     return true;
 }
 
+/* #747: SYST:STOR:SD:LISt? prints every entry as "<directory>/<name>", but the
+ * operand sites below prepend the configured directory themselves — so handing
+ * back the exact string the device just printed builds "DAQiFi/DAQiFi/<name>",
+ * the open fails, and for SD:GET the host receives a bare __END_OF_FILE__ with
+ * SYST:ERR? still reading "No error". That is indistinguishable from an empty
+ * file, which is what made #747 read as a device fault rather than a rejected
+ * path.
+ *
+ * Accept the round-trip form by dropping ONE leading "<directory>/". Traversal
+ * stays impossible: the prefix must match the device's own configured
+ * directory exactly, and SD_ValidatePathParam still rejects absolute paths and
+ * "." / ".." segments in what remains.
+ *
+ * Case-sensitive on purpose — this normalizes the exact form the device emits,
+ * not arbitrary user spellings. Returns the (possibly advanced) pointer and
+ * updates *pLen. */
+static const char* SD_StripConfiguredDir(const char *p, size_t *pLen,
+                                         const char *directory)
+{
+    if (p == NULL || pLen == NULL || directory == NULL) {
+        return p;
+    }
+    size_t dirLen = strlen(directory);
+    while (dirLen > 0u && directory[dirLen - 1u] == '/') {
+        dirLen--;                    /* configured dir may carry a trailing '/' */
+    }
+    /* Need at least one character after "<dir>/" — a bare "DAQiFi/" is not a
+     * filename and must fall through to the existing validation. */
+    if (dirLen == 0u || *pLen <= dirLen + 1u) {
+        return p;
+    }
+    if (strncmp(p, directory, dirLen) != 0 || p[dirLen] != '/') {
+        return p;
+    }
+    *pLen -= (dirLen + 1u);
+    return p + dirLen + 1u;
+}
+
 scpi_result_t SCPI_StorageSDEnableSet(scpi_t * context){
     int param1;
     scpi_result_t result = SCPI_RES_ERR;
@@ -248,6 +286,9 @@ scpi_result_t SCPI_StorageSDLoggingSet(scpi_t * context) {
     }
 
     SCPI_ParamCharacters(context, &pBuff, &fileLen, false);
+    /* #747: accept the "<directory>/<name>" form SD:LISt? prints. Before the
+     * length check, so a max-length name is not rejected for the prefix. */
+    pBuff = SD_StripConfiguredDir(pBuff, &fileLen, pSDCardRuntimeConfig->directory);
 
     if (fileLen > 0) {
         if (fileLen > SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX) {
@@ -336,8 +377,13 @@ scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
     if (!SCPI_CheckSDCardPresent(context)) {
         return SCPI_RES_ERR;
     }
-    if (!SCPI_ParamCharacters(context, &pBuff, &fileLen, TRUE) ||
-        fileLen == 0 || fileLen > SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX) {
+    if (!SCPI_ParamCharacters(context, &pBuff, &fileLen, TRUE)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+    /* #747: accept the "<directory>/<name>" form SD:LISt? prints. */
+    pBuff = SD_StripConfiguredDir(pBuff, &fileLen, pSDCardRuntimeConfig->directory);
+    if (fileLen == 0 || fileLen > SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX) {
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         return SCPI_RES_ERR;
     }
@@ -414,6 +460,10 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
     }
 
     SCPI_ParamCharacters(context, &pBuff, &fileLen, false);
+    /* #747: accept the "<directory>/<name>" form SD:LISt? prints. Before the
+     * length check, so a max-length name is not rejected for carrying the
+     * prefix the device itself emitted. */
+    pBuff = SD_StripConfiguredDir(pBuff, &fileLen, pSDCardRuntimeConfig->directory);
 
     if (fileLen > 0) {
         if (fileLen > SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX) {
@@ -994,6 +1044,8 @@ scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
     }
 
     // Set the filename
+    /* #747: accept the "<directory>/<name>" form SD:LISt? prints. */
+    pBuff = SD_StripConfiguredDir(pBuff, &fileLen, pSDCardRuntimeConfig->directory);
     if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         goto __exit_point;

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -171,7 +171,20 @@ static const char* SD_StripConfiguredDir(const char *p, size_t *pLen,
         return p;
     }
     *pLen -= (dirLen + 1u);
-    return p + dirLen + 1u;
+    p += dirLen + 1u;
+    /* A configured directory carrying its own trailing slash makes the listing
+     * print "<dir>//<name>" (it concatenates dirPath verbatim with "%s/%s"),
+     * so one more separator can be left over here. Without this the remainder
+     * starts with '/' and SD_ValidatePathParam rejects it as an absolute path
+     * — the device's own output still would not round-trip (audit #749).
+     * Traversal is unaffected: the validator below still runs, and it rejects
+     * "." and ".." as whole segments regardless of how many slashes precede
+     * them. */
+    while (*pLen > 1u && *p == '/') {
+        p++;
+        (*pLen)--;
+    }
+    return p;
 }
 
 scpi_result_t SCPI_StorageSDEnableSet(scpi_t * context){
@@ -1035,6 +1048,12 @@ scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
 
     // Get filename parameter (required)
     SCPI_ParamCharacters(context, &pBuff, &fileLen, false);
+    /* #747: accept the "<directory>/<name>" form SD:LISt? prints. BEFORE the
+     * length check, like the other three operand sites: the prefix costs 7
+     * bytes against a 40-byte limit, so checking first rejects listed paths
+     * whose filename is 34-40 characters — a length SD:FILE accepts and which
+     * GET/CRC round-trip, leaving DELETE the odd one out (audit #749). */
+    pBuff = SD_StripConfiguredDir(pBuff, &fileLen, pSDCardRuntimeConfig->directory);
 
     if (fileLen == 0 || fileLen > SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX) {
         LOG_E("SD:DELete - Invalid filename length: %d\r\n", fileLen);
@@ -1044,8 +1063,6 @@ scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
     }
 
     // Set the filename
-    /* #747: accept the "<directory>/<name>" form SD:LISt? prints. */
-    pBuff = SD_StripConfiguredDir(pBuff, &fileLen, pSDCardRuntimeConfig->directory);
     if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         goto __exit_point;

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -251,7 +251,13 @@ typedef struct {
 static volatile SDBenchmarkResults_t gSDBenchmarkResults = {0};
 
 scpi_result_t SCPI_StorageSDLoggingSet(scpi_t * context) {
-    const char* pBuff;
+    /* #747: NULL, not indeterminate. SCPI_ParamCharacters(..., mandatory=false)
+     * leaves pBuff untouched when the argument is omitted, and the operand
+     * normalizer is called unconditionally. fileLen is 0 in that case so the
+     * normalizer returns before dereferencing anything, but merely READING an
+     * indeterminate pointer is undefined — and this file is built at -O3.
+     * Initializing costs nothing and makes the NULL guard meaningful. */
+    const char* pBuff = NULL;
     size_t fileLen = 0;
  
     scpi_result_t result = SCPI_RES_ERR;
@@ -373,7 +379,13 @@ __exit_point:
  * SYST:STOR:SD:CRC? - mirrors the GET_SPACE request/query split so the SCPI
  * task never blocks on a multi-second file scan. */
 scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
-    const char* pBuff;
+    /* #747: NULL, not indeterminate. SCPI_ParamCharacters(..., mandatory=false)
+     * leaves pBuff untouched when the argument is omitted, and the operand
+     * normalizer is called unconditionally. fileLen is 0 in that case so the
+     * normalizer returns before dereferencing anything, but merely READING an
+     * indeterminate pointer is undefined — and this file is built at -O3.
+     * Initializing costs nothing and makes the NULL guard meaningful. */
+    const char* pBuff = NULL;
     size_t fileLen = 0;
     sd_card_manager_settings_t* pSDCardRuntimeConfig =
             (sd_card_manager_settings_t*) BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
@@ -433,7 +445,13 @@ scpi_result_t SCPI_StorageSDCrcGet(scpi_t * context) {
 }
 
 scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
-    const char* pBuff;
+    /* #747: NULL, not indeterminate. SCPI_ParamCharacters(..., mandatory=false)
+     * leaves pBuff untouched when the argument is omitted, and the operand
+     * normalizer is called unconditionally. fileLen is 0 in that case so the
+     * normalizer returns before dereferencing anything, but merely READING an
+     * indeterminate pointer is undefined — and this file is built at -O3.
+     * Initializing costs nothing and makes the NULL guard meaningful. */
+    const char* pBuff = NULL;
     size_t fileLen = 0;
     scpi_result_t result = SCPI_RES_ERR;
     sd_card_manager_settings_t* pSDCardRuntimeConfig = (sd_card_manager_settings_t*) BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
@@ -514,7 +532,13 @@ __exit_point:
 }
 
 scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
-    const char* pBuff;
+    /* #747: NULL, not indeterminate. SCPI_ParamCharacters(..., mandatory=false)
+     * leaves pBuff untouched when the argument is omitted, and the operand
+     * normalizer is called unconditionally. fileLen is 0 in that case so the
+     * normalizer returns before dereferencing anything, but merely READING an
+     * indeterminate pointer is undefined — and this file is built at -O3.
+     * Initializing costs nothing and makes the NULL guard meaningful. */
+    const char* pBuff = NULL;
     size_t fileLen = 0;
     scpi_result_t result = SCPI_RES_ERR;
     sd_card_manager_settings_t* pSDCardRuntimeConfig = (sd_card_manager_settings_t*) BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
@@ -1020,7 +1044,13 @@ scpi_result_t SCPI_StorageSDBenchmarkQuery(scpi_t * context) {
  * Example: SYST:STOR:SD:DEL "test.csv"
  */
 scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
-    const char* pBuff;
+    /* #747: NULL, not indeterminate. SCPI_ParamCharacters(..., mandatory=false)
+     * leaves pBuff untouched when the argument is omitted, and the operand
+     * normalizer is called unconditionally. fileLen is 0 in that case so the
+     * normalizer returns before dereferencing anything, but merely READING an
+     * indeterminate pointer is undefined — and this file is built at -O3.
+     * Initializing costs nothing and makes the NULL guard meaningful. */
+    const char* pBuff = NULL;
     size_t fileLen = 0;
     scpi_result_t result = SCPI_RES_ERR;
     sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);


### PR DESCRIPTION
Fixes #747.

## Root cause — not a device fault

`SYST:STOR:SD:LISt?` prints every entry as `<directory>/<name>`. `SD:GET`, `SD:CRC`, `SD:DELete` and `SD:FILE` prepend the configured directory **themselves**. So handing back the exact string the device just printed built `DAQiFi/DAQiFi/<name>`, the open failed, and for `SD:GET` the host received a bare `__END_OF_FILE__` (15 bytes) while `SYST:ERR?` still read `No error`.

From the host that is indistinguishable from an empty file: command accepted, success reported, no data. That is what made #747 present as a device fault, and why the reporter's power-cycle workaround did not help — **nothing was wrong with the device**.

Confirmed by the firmware's own log at the moment of failure (`SYST:LOG:LEV SD,3`):

```
[SD] Opening file for read: 'DAQiFi/DAQiFi/default.bin'
[../src/services/sd_card_services/sd_card_manager.c:1219]Failed to open SD Card file for reading
```

The 15 bytes are exactly `sizeof("__END_OF_FILE__") - 1`, emitted by the open-failure path added in #703 so a missing file terminates instead of hanging. That path logs `LOG_E` but pushes **no SCPI error**, which is the whole "silence plus No error" signature.

## The fix

`SD_StripConfiguredDir` drops **one** leading `<directory>/` so the listing's own output round-trips. Traversal stays impossible: the prefix must match the device's configured directory exactly, and `SD_ValidatePathParam` (#612) still rejects absolute paths and `.` / `..` segments in what remains. Case-sensitive on purpose — this normalizes the exact form the device emits, not arbitrary user spellings.

Applied to all four operand sites. `SD:FILE` is included deliberately: it prepends the same directory, so it carries the same trap for anyone setting a logging target from a listing.

## Verification (E, 2026-07-30, board 7E2898F46200E8A7, adjacent builds)

Same file, same session:

| form passed to `SD:GET` | `main` @ `bf004337` | with this fix |
|---|---:|---:|
| `"DAQiFi/default.bin"` (as `LIST?` prints it) | **15 bytes** | **19,395 bytes** |
| `"default.bin"` (bare) | 19,395 bytes | 19,395 bytes |

19,395 = the 19,380-byte file + the 15-byte terminator, i.e. the complete file.

## Not addressed here

The open failure still reports `No error`, so a genuinely missing file remains indistinguishable from an empty one. That is the reporting half, and it belongs with **#725** (`SD:GET` needs a distinguishable `__TRANSFER_ERROR__` terminator) rather than being half-solved here. This PR removes the path that made an ordinary, correct-looking command hit that gap.

Regression test: **[daqifi-python-test-suite#126](https://github.com/daqifi/daqifi-python-test-suite/pull/126)** — 1 PASS / 2 FAIL on `main`, 3 PASS / 0 FAIL here.

**Environment:** firmware `fix/747-sd-get-path-roundtrip`, XC32 v4.60 / MPLAB X v6.30, `-O3 -Werror`.