### PR TITLE
fix(scpi): make scpi_printf truncation loud and detectable

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -119,11 +119,9 @@ extern "C" {
     /**
      * Printf-style helper for writing formatted text to a SCPI response.
      * Uses an internal 192-byte buffer; each call is one write.
+     *
      * @param context SCPI context
      * @param fmt printf format string
-     */
-    /**
-     * Formatted SCPI write with a 192-byte stack buffer.
      *
      * #744: overflow used to be SILENT — it wrote sizeof(buf)-1 bytes, i.e.
      * dropped the last character, with no log, no SCPI error, and a void

--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -122,16 +122,51 @@ extern "C" {
      * @param context SCPI context
      * @param fmt printf format string
      */
-    static inline void scpi_printf(scpi_t *context, const char *fmt, ...) {
+    /**
+     * Formatted SCPI write with a 192-byte stack buffer.
+     *
+     * #744: overflow used to be SILENT — it wrote sizeof(buf)-1 bytes, i.e.
+     * dropped the last character, with no log, no SCPI error, and a void
+     * return the caller could not check. That is the worst possible shape for
+     * this particular buffer, because the dropped character is usually the
+     * separating comma of a CONF:CAP:JSON? chunk: losing it does not shorten
+     * one field, it makes the ENTIRE ~8 KB response unparseable, since the
+     * next chunk's members run together with no separator.
+     *
+     * It already bit once. The `timing` chunk reached 189 of 192 bytes on the
+     * shipped build and exactly 192 on the legacy 200 MHz build — it truncated
+     * in one supported configuration, and was caught by an audit doing the
+     * arithmetic across every rate, not by a test or a build warning.
+     *
+     * Truncation is now loud (LOG_E naming the format string and the length
+     * needed) and detectable: the return value is vsnprintf's, so a caller
+     * that cares can compare it against the buffer size. The output behaviour
+     * is unchanged, so no existing caller has to react.
+     *
+     * @return bytes the format needed (>= sizeof(buf) means the response was
+     *         truncated and is corrupt), or vsnprintf's negative error.
+     */
+    static inline int scpi_printf(scpi_t *context, const char *fmt, ...) {
         char buf[192];
         va_list args;
         va_start(args, fmt);
         int n = vsnprintf(buf, sizeof(buf), fmt, args);
         va_end(args);
-        if (n > 0) {
-            size_t len = ((size_t)n < sizeof(buf)) ? (size_t)n : sizeof(buf) - 1;
-            context->interface->write(context, buf, len);
+        if (n < 0) {
+            LOG_E("scpi_printf: encoding error (fmt starts '%.32s')", fmt);
+            return n;
         }
+        if ((size_t)n >= sizeof(buf)) {
+            LOG_E("scpi_printf TRUNCATED: needed %d of %u bytes - response is "
+                  "corrupt, not merely short (fmt starts '%.48s')",
+                  n, (unsigned)sizeof(buf), fmt);
+            context->interface->write(context, buf, sizeof(buf) - 1);
+            return n;
+        }
+        if (n > 0) {
+            context->interface->write(context, buf, (size_t)n);
+        }
+        return n;
     }
 
     /**


### PR DESCRIPTION
Fixes #744.

## The failure shape, not the failure

`scpi_printf` formats into a 192-byte stack buffer. On overflow it wrote `sizeof(buf) - 1` bytes — **dropping the last character** — with no log, no SCPI error, and a `void` return the caller could not check.

For `CONF:CAP:JSON?` that last character is almost always the **separating comma** between chunks. Losing it does not shorten one field: it makes the entire ~8 KB response **unparseable**, because the next chunk's members run together with no separator:

```
...,"clock_ok":false}"rate_model":{...
```

Clients render their UI from that query.

It already bit once. The `timing` chunk reached **189 of 192** bytes on the shipped build and **exactly 192** on the legacy 200 MHz build — it truncated in one supported configuration, and was caught by an adversarial audit doing the arithmetic across every rate, not by a test or a build warning ([PR #740](https://github.com/daqifi/daqifi-nyquist-firmware/pull/740) `c062ffee`).

## What this changes

Truncation now emits `LOG_E` naming the **format string** and the **length needed**, and the function returns vsnprintf's count so a caller that cares can check it. Output behaviour is unchanged, so no existing caller has to react.

## What it deliberately does NOT do

It does **not** make truncation impossible. Chunking through a larger buffer would, and that remains the option if the JSON surface keeps growing — I did not do it here because it changes every call site's cost, and this PR is the diagnosability fix.

Nor is this a live defect being repaired: **no shipped chunk overflows today**. Every capability chunk is fixed-length, with no device-controlled string that could be inflated to force one. This converts a *latent silent corruption* into a *diagnosable* one — the difference between a field report of "the app shows nothing" and a log line naming the chunk.

## Verification (E, board 7E2898F46200E8A7)

`CONF:CAP:JSON?` after the change: parses, **10 top-level keys**, **11 streaming keys**, zero truncation reports, error queue clean.

## Note on the companion test

**[daqifi-python-test-suite#128](https://github.com/daqifi/daqifi-python-test-suite/pull/128) does not fail on pre-#744 firmware, and I am not claiming it does.** With no reachable overflow there is no device behaviour that distinguishes fixed from unfixed. What it buys is detection from now on: the day a chunk crosses 192 bytes, post-#744 firmware fails the test naming the format string, where pre-#744 firmware would have returned corrupt JSON silently.

**Environment:** firmware `fix/744-scpi-printf-truncation`, XC32 v4.60 / MPLAB X v6.30, `-O3 -Werror`.