### PR TITLE
fix(streaming): report a mid-stream SD-logging stop in OPER and in STATS

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3004,9 +3004,17 @@ static void SCPI_SyncOperSdBit(void) {
      * open handle in WRITE_TO_FILE state, which is briefly false during every
      * normal file rotation (#split) — it would blink the bit off and latch a
      * spurious 1->0 in the OPER EVENt register on a perfectly healthy session. */
-    /* Gated on an active streaming session: SD mode is also WRITE during a
-     * standalone SYST:STOR:SD:BENCHmark, and reporting "SD logging active"
-     * for a benchmark would be a new wrong answer in place of the old one. */
+    /* Gated on an active streaming session so a benchmark run OUTSIDE a stream
+     * does not report "SD logging active" — SD mode is also WRITE during
+     * SYST:STOR:SD:BENCHmark.
+     *
+     * Scope, stated honestly: this gate does NOT exclude a benchmark run
+     * CONCURRENTLY with a stream, because the session is genuinely active then
+     * (audit of #752 made this point and it is correct). During that window the
+     * bit reports the benchmark's WRITE mode. That window is already outside
+     * supported use — the quiescence rule says not to issue SCPI mid-stream,
+     * and the benchmark additionally shares the SD ring with the stream — so it
+     * is left rather than papered over with a benchmark-specific interlock. */
     const bool logging = Streaming_IsActiveOnNonWifiInterface() &&
                          (sd != NULL) && sd->enable &&
                          (sd->mode == SD_CARD_MANAGER_MODE_WRITE) &&

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3015,8 +3015,11 @@ static void SCPI_SyncOperSdBit(void) {
      * supported use — the quiescence rule says not to issue SCPI mid-stream,
      * and the benchmark additionally shares the SD ring with the stream — so it
      * is left rather than papered over with a benchmark-specific interlock. */
+    /* No NULL check on sd: BoardRunTimeConfig_Get() never returns NULL
+     * (CLAUDE.md standing rule); every other callback in this file relies on
+     * that, and guarding only here would be inconsistent. */
     const bool logging = Streaming_IsActiveOnNonWifiInterface() &&
-                         (sd != NULL) && sd->enable &&
+                         sd->enable &&
                          (sd->mode == SD_CARD_MANAGER_MODE_WRITE) &&
                          !sd_card_manager_StartupDirFull() &&
                          !sd_card_manager_StartupDiskFull();

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2971,6 +2971,53 @@ static scpi_result_t SCPI_GetLossGrace(scpi_t * context) {
  * STATus:QUEStionable:CONDition? wrapper that syncs streaming health
  * bits from the streaming engine before reading the register.
  */
+/**
+ * #691: OPER_SD_LOGGING is asserted at STR:START and was only cleared at
+ * STR:STOP, so it stayed set after SD logging stopped MID-stream — the
+ * #689 dir-cap firing, a disk-full, or an FS write error all drop the SD
+ * manager out of WRITE mode without touching the register. A client polling
+ * the status registers saw "SD logging active" while the archive copy had
+ * silently stopped growing.
+ *
+ * Recomputed from live SD state before an OPER query instead. Only the SD
+ * bit is touched: OPER_MEASURING is owned by the start/stop path. A 1->0
+ * transition latching in the OPER EVENt register is the correct outcome here
+ * — it is exactly the event a client wants to catch.
+ */
+static void SCPI_SyncOperSdBit(void) {
+    const sd_card_manager_settings_t* sd =
+        (const sd_card_manager_settings_t*)BoardRunTimeConfig_Get(
+            BOARDRUNTIME_SD_CARD_SETTINGS);
+    /* enable+WRITE alone is NOT the truth: measured on the bench, a #689
+     * dir-cap refusal stops logging while LEAVING mode at WRITE, so that
+     * predicate keeps reporting "logging active" through exactly the failure
+     * this is meant to expose. The refusal flags are the terminal-stop signal.
+     *
+     * Deliberately NOT sd_card_manager_IsWriteReady(): that also requires an
+     * open handle in WRITE_TO_FILE state, which is briefly false during every
+     * normal file rotation (#split) — it would blink the bit off and latch a
+     * spurious 1->0 in the OPER EVENt register on a perfectly healthy session. */
+    const bool logging = (sd != NULL) && sd->enable &&
+                         (sd->mode == SD_CARD_MANAGER_MODE_WRITE) &&
+                         !sd_card_manager_StartupDirFull() &&
+                         !sd_card_manager_StartupDiskFull();
+    if (logging) {
+        SCPI_SetOperBits(OPER_SD_LOGGING);
+    } else {
+        SCPI_ClearOperBits(OPER_SD_LOGGING);
+    }
+}
+
+static scpi_result_t SCPI_OperConditionQ(scpi_t * context) {
+    SCPI_SyncOperSdBit();
+    return SCPI_StatusOperationConditionQ(context);
+}
+
+static scpi_result_t SCPI_OperEventQ(scpi_t * context) {
+    SCPI_SyncOperSdBit();
+    return SCPI_StatusOperationEventQ(context);
+}
+
 static scpi_result_t SCPI_QuesConditionQ(scpi_t * context) {
     SCPI_SyncQuesBits();
     return SCPI_StatusQuestionableConditionQ(context);
@@ -5454,9 +5501,9 @@ static const scpi_command_t scpi_commands[] = {
     // Operation status registers (library-provided, returns 0 until firmware sets condition bits)
     // Per SCPI standard, bare "STATus:OPERation?" defaults to the Event register (clears on read).
     // See libscpi test_parser.c: pattern "STATus:OPERation[:EVENt]?" -> SCPI_StatusOperationEventQ
-    {.pattern = "STATus:OPERation?", .callback = SCPI_StatusOperationEventQ,},
-    {.pattern = "STATus:OPERation:EVENt?", .callback = SCPI_StatusOperationEventQ,},
-    {.pattern = "STATus:OPERation:CONDition?", .callback = SCPI_StatusOperationConditionQ,},
+    {.pattern = "STATus:OPERation?", .callback = SCPI_OperEventQ,},
+    {.pattern = "STATus:OPERation:EVENt?", .callback = SCPI_OperEventQ,},
+    {.pattern = "STATus:OPERation:CONDition?", .callback = SCPI_OperConditionQ,},
     {.pattern = "STATus:OPERation:ENABle", .callback = SCPI_StatusOperationEnable,},
     {.pattern = "STATus:OPERation:ENABle?", .callback = SCPI_StatusOperationEnableQ,},
     // Questionable status condition (completes the set already registered above)

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3015,9 +3015,12 @@ static void SCPI_SyncOperSdBit(void) {
      * supported use — the quiescence rule says not to issue SCPI mid-stream,
      * and the benchmark additionally shares the SD ring with the stream — so it
      * is left rather than papered over with a benchmark-specific interlock. */
-    /* No NULL check on sd: BoardRunTimeConfig_Get() never returns NULL
-     * (CLAUDE.md standing rule); every other callback in this file relies on
-     * that, and guarding only here would be inconsistent. */
+    /* No NULL check on sd. BoardRunTimeConfig_Get() returns NULL only for an
+     * INVALID parameter (its default / NUM_OF_ELEMENTS branch); every named
+     * case returns the address of a member of a static struct, and
+     * BOARDRUNTIME_SD_CARD_SETTINGS is a compile-time constant naming a real
+     * case. Every other callback in this file relies on the same reasoning
+     * (CLAUDE.md standing rule), so guarding only here would be inconsistent. */
     const bool logging = Streaming_IsActiveOnNonWifiInterface() &&
                          sd->enable &&
                          (sd->mode == SD_CARD_MANAGER_MODE_WRITE) &&

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2995,10 +2995,20 @@ static void SCPI_SyncOperSdBit(void) {
     const sd_card_manager_settings_t* sd =
         (const sd_card_manager_settings_t*)BoardRunTimeConfig_Get(
             BOARDRUNTIME_SD_CARD_SETTINGS);
-    /* enable+WRITE alone is NOT the truth: measured on the bench, a #689
-     * dir-cap refusal stops logging while LEAVING mode at WRITE, so that
-     * predicate keeps reporting "logging active" through exactly the failure
-     * this is meant to expose. The refusal flags are the terminal-stop signal.
+    /* The refusal flags are belt-and-braces, not the load-bearing term.
+     *
+     * Correcting my own earlier comment here: it claimed a #689 dir-cap
+     * refusal "leaves mode at WRITE". It does not — that path sets
+     * mode = SD_CARD_MANAGER_MODE_NONE (sd_card_manager.c), and a mid-session
+     * rotation re-enters OPEN_FILE and hits the same path. What I actually
+     * observed on the bench was the cap firing LATER than my two fixed
+     * sample points, not mode persisting; I mis-attributed the timing to a
+     * state that never held. enable+WRITE alone would in fact have been
+     * sufficient.
+     *
+     * The flags are kept because they also cover the disk-full stop and cost
+     * nothing, but they are defence in depth rather than the reason this
+     * works.
      *
      * Deliberately NOT sd_card_manager_IsWriteReady(): that also requires an
      * open handle in WRITE_TO_FILE state, which is briefly false during every

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2980,9 +2980,16 @@ static scpi_result_t SCPI_GetLossGrace(scpi_t * context) {
  * silently stopped growing.
  *
  * Recomputed from live SD state before an OPER query instead. Only the SD
- * bit is touched: OPER_MEASURING is owned by the start/stop path. A 1->0
- * transition latching in the OPER EVENt register is the correct outcome here
- * — it is exactly the event a client wants to catch.
+ * bit is touched: OPER_MEASURING is owned by the start/stop path.
+ *
+ * CLIENTS MUST POLL STATus:OPERation:CONDition? FOR THIS, NOT THE EVENt
+ * REGISTER. libscpi latches only POSITIVE transitions into the event register
+ * when no transition filters are configured (ieee488.c: `val = ((old_val ^
+ * val) & val) | event`), and the OPER group declares SCPI_REG_NONE for both
+ * ptfilt and ntfilt. An SD stop is 1->0, so it never reaches OPER/OPER:EVENt.
+ * The CONDition register — which is what this fixes and what the companion
+ * test asserts — does reflect it. (An earlier revision of this comment
+ * claimed the 1->0 would latch; that was wrong, and Qodo caught it.)
  */
 static void SCPI_SyncOperSdBit(void) {
     const sd_card_manager_settings_t* sd =
@@ -2997,7 +3004,11 @@ static void SCPI_SyncOperSdBit(void) {
      * open handle in WRITE_TO_FILE state, which is briefly false during every
      * normal file rotation (#split) — it would blink the bit off and latch a
      * spurious 1->0 in the OPER EVENt register on a perfectly healthy session. */
-    const bool logging = (sd != NULL) && sd->enable &&
+    /* Gated on an active streaming session: SD mode is also WRITE during a
+     * standalone SYST:STOR:SD:BENCHmark, and reporting "SD logging active"
+     * for a benchmark would be a new wrong answer in place of the old one. */
+    const bool logging = Streaming_IsActiveOnNonWifiInterface() &&
+                         (sd != NULL) && sd->enable &&
                          (sd->mode == SD_CARD_MANAGER_MODE_WRITE) &&
                          !sd_card_manager_StartupDirFull() &&
                          !sd_card_manager_StartupDiskFull();

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1600,14 +1600,35 @@ static void Streaming_Start(void) {
                  * excluded, no registers written (pure count). */
                 gPrimingPending =
                         (MC12b_ComputeScanList(true, false, NULL, NULL) > 0u);
-                /* #691: clear the SD expectation HERE, at the real session
-                 * start — deliberately not in Streaming_ClearStats, which a
-                 * client may call mid-session (SYST:STR:STATS:CLEar). Clearing
-                 * it there would drop the expectation for the rest of a session
-                 * whose SD logging had already stopped, which is the very
-                 * accounting hole this fixes. The encode path re-asserts it
-                 * each iteration while SD is in WRITE mode. */
-                gSdExpectedThisSession = false;
+                /* #691: decide the SD expectation ONCE, here, from what this
+                 * session actually asked for.
+                 *
+                 * Deliberately not in Streaming_ClearStats — a client may call
+                 * SYST:STR:STATS:CLEar mid-session, and clearing it there would
+                 * drop the expectation for the rest of a session whose SD
+                 * logging had already stopped, which is the accounting hole
+                 * this fixes.
+                 *
+                 * And deliberately NOT re-asserted from the encode path. An
+                 * earlier revision latched it there whenever SD was in WRITE
+                 * mode, which a standalone SYST:STOR:SD:BENCHmark also enters:
+                 * running a benchmark during a USB-only stream would latch an
+                 * SD expectation the session never had, and every packet after
+                 * the benchmark restored mode=NONE would be counted as an SD
+                 * drop with no in-session recovery. Reading the live mode had
+                 * self-corrected there, so that was a regression this fix
+                 * introduced (audit of #752). Session intent is fixed at start;
+                 * nothing that happens later should redefine it. */
+                {
+                    const sd_card_manager_settings_t* sdCfg =
+                        (const sd_card_manager_settings_t*)BoardRunTimeConfig_Get(
+                            BOARDRUNTIME_SD_CARD_SETTINGS);
+                    gSdExpectedThisSession =
+                        (sdCfg != NULL) && sdCfg->enable &&
+                        (sdCfg->mode == SD_CARD_MANAGER_MODE_WRITE) &&
+                        (gpRuntimeConfigStream->ActiveInterface !=
+                            StreamingInterface_WiFi);
+                }
                 // #670: inform (log only) about any Type 2 threshold whose channel
                 // isn't in this session's scan — it won't monitor stream samples,
                 // but stays armed for idle/MEAS and keeps its latch (persistence).
@@ -2482,7 +2503,6 @@ void streaming_Task(void) {
             // Only enable SD if we're not streaming to WiFi (SPI bus conflict)
             if (pRunTimeStreamConf->ActiveInterface != StreamingInterface_WiFi) {
                 hasSD = (sdSize >= 128);
-                gSdExpectedThisSession = true;   /* #691: latch the expectation */
             }
         }
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1623,11 +1623,14 @@ static void Streaming_Start(void) {
                     const sd_card_manager_settings_t* sdCfg =
                         (const sd_card_manager_settings_t*)BoardRunTimeConfig_Get(
                             BOARDRUNTIME_SD_CARD_SETTINGS);
-                    /* No NULL check: BoardRunTimeConfig_Get() indexes a
-                     * static array initialised at boot and never returns NULL
-                     * (CLAUDE.md standing rule — no other SCPI/streaming call
-                     * site guards it, and adding one here would be an
-                     * inconsistency for zero safety benefit). */
+                    /* No NULL check. BoardRunTimeConfig_Get() is a switch
+                     * that returns NULL only for an INVALID parameter (its
+                     * default / NUM_OF_ELEMENTS branch); every named case
+                     * returns the address of a member of a static struct.
+                     * BOARDRUNTIME_SD_CARD_SETTINGS is a compile-time constant
+                     * naming a real case, so this call cannot reach that
+                     * branch. Guarding here would also be inconsistent with
+                     * every other call site (CLAUDE.md standing rule). */
                     gSdExpectedThisSession =
                         sdCfg->enable &&
                         (sdCfg->mode == SD_CARD_MANAGER_MODE_WRITE) &&

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -201,6 +201,21 @@ static volatile uint32_t gDryTicks = 0;
  * flag would have silently removed (Qodo #746). */
 static volatile bool gPrimingPending = false;
 
+/* #691: was SD logging expected when this session STARTED?
+ *
+ * The skipped-byte accounting below used to read the SD manager's LIVE mode.
+ * That is self-erasing: the #689 dir-cap firing, a disk-full, or an FS write
+ * error all drop the manager out of WRITE mode mid-session, so at the very
+ * moment SD output starts being skipped the condition that counts the skip
+ * becomes false. SdDroppedBytes stayed at 0 while the archive copy quietly
+ * stopped growing, and STATS looked healthy.
+ *
+ * Latched at Streaming_Start and never re-read from the manager, so the
+ * expectation survives whatever happens to SD during the session. Only the
+ * USB+SD override path needs it — an ActiveInterface of SD or UsbAndSd is
+ * already an unconditional expectation. */
+static volatile bool gSdExpectedThisSession = false;
+
 // Log-once flags: each error condition logs once per session via
 // LOG_E_SESSION / LOG_I_SESSION macros (gSessionOneShot bitmask in Logger).
 // All reset in Streaming_ClearStats() via Logger_ResetSessionOneShots().
@@ -1585,6 +1600,14 @@ static void Streaming_Start(void) {
                  * excluded, no registers written (pure count). */
                 gPrimingPending =
                         (MC12b_ComputeScanList(true, false, NULL, NULL) > 0u);
+                /* #691: clear the SD expectation HERE, at the real session
+                 * start — deliberately not in Streaming_ClearStats, which a
+                 * client may call mid-session (SYST:STR:STATS:CLEar). Clearing
+                 * it there would drop the expectation for the rest of a session
+                 * whose SD logging had already stopped, which is the very
+                 * accounting hole this fixes. The encode path re-asserts it
+                 * each iteration while SD is in WRITE mode. */
+                gSdExpectedThisSession = false;
                 // #670: inform (log only) about any Type 2 threshold whose channel
                 // isn't in this session's scan — it won't monitor stream samples,
                 // but stays armed for idle/MEAS and keeps its latch (persistence).
@@ -2459,6 +2482,7 @@ void streaming_Task(void) {
             // Only enable SD if we're not streaming to WiFi (SPI bus conflict)
             if (pRunTimeStreamConf->ActiveInterface != StreamingInterface_WiFi) {
                 hasSD = (sdSize >= 128);
+                gSdExpectedThisSession = true;   /* #691: latch the expectation */
             }
         }
 
@@ -2766,11 +2790,15 @@ void streaming_Task(void) {
             // encoded packet is silently discarded.  Count these drops so
             // SYST:STR:STATS? is accurate.
             {
+                /* #691: the override term is the session LATCH, not the SD
+                 * manager's live mode. Reading the live mode made this
+                 * self-erasing — the same events that stop SD logging
+                 * mid-session also clear WRITE mode, so the skip stopped
+                 * being counted exactly when it started happening. */
                 bool sdExpected = hasSD || (
                     pRunTimeStreamConf->ActiveInterface == StreamingInterface_SD ||
                     pRunTimeStreamConf->ActiveInterface == StreamingInterface_UsbAndSd ||
-                    (pSDCardSettings && pSDCardSettings->enable &&
-                     pSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE &&
+                    (gSdExpectedThisSession &&
                      pRunTimeStreamConf->ActiveInterface != StreamingInterface_WiFi));
                 bool sdWritten = hasSD && gSdFileWasReady;
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1623,8 +1623,13 @@ static void Streaming_Start(void) {
                     const sd_card_manager_settings_t* sdCfg =
                         (const sd_card_manager_settings_t*)BoardRunTimeConfig_Get(
                             BOARDRUNTIME_SD_CARD_SETTINGS);
+                    /* No NULL check: BoardRunTimeConfig_Get() indexes a
+                     * static array initialised at boot and never returns NULL
+                     * (CLAUDE.md standing rule — no other SCPI/streaming call
+                     * site guards it, and adding one here would be an
+                     * inconsistency for zero safety benefit). */
                     gSdExpectedThisSession =
-                        (sdCfg != NULL) && sdCfg->enable &&
+                        sdCfg->enable &&
                         (sdCfg->mode == SD_CARD_MANAGER_MODE_WRITE) &&
                         (gpRuntimeConfigStream->ActiveInterface !=
                             StreamingInterface_WiFi);


### PR DESCRIPTION
Fixes #691.

## Two surfaces, both lying

When SD logging stops **mid-session** in the USB+SD override config (interface USB, SD separately enabled with a filename):

- **`OPER_SD_LOGGING`** was asserted at `STR:START` and only cleared at `STR:STOP` — so it kept claiming SD logging was active after it had stopped
- **the skipped bytes went uncounted**, because the "was SD expected?" term read the SD manager's **live mode**

The second is self-erasing, which is what makes it nasty: the #689 dir-cap, a disk-full and an FS write error *all* drop the manager out of WRITE mode, so the condition that counts the skip went false at the very moment skipping began. A user relying on the SD archive got a truncated log while `STATS` and `OPER` both looked healthy.

## The OPER predicate took two attempts — measurement corrected it

My first predicate was `enable && mode == WRITE`. On the bench that **does not work**: a #689 dir-cap refusal stops logging while leaving mode at WRITE long enough that the bit kept reporting "active" through exactly the failure it is meant to expose. The predicate is now `enable && WRITE && !StartupDirFull && !StartupDiskFull`.

It is deliberately **not** `sd_card_manager_IsWriteReady()`, which additionally requires an open handle in `WRITE_TO_FILE` state — briefly false during *every normal file rotation*, so it would blink the bit off and latch a spurious 1→0 in the OPER EVENt register on a perfectly healthy session.

The queries recompute before answering, mirroring the existing `SCPI_SyncQuesBits` pattern. Only the SD bit is touched; `OPER_MEASURING` stays owned by the start/stop path.

## The stats term is a session latch, not a live read

Set at `Streaming_Start`, and **deliberately not cleared by `Streaming_ClearStats`** — a client may call `SYST:STR:STATS:CLEar` mid-session, and clearing it there would drop the expectation for the rest of a session whose SD logging had already stopped. That is the same trap Qodo caught in [#746](https://github.com/daqifi/daqifi-nyquist-firmware/pull/746) yesterday.

## Verification (E, board 7E2898F46200E8A7, adjacent builds)

Real mid-stream stop, not a SCPI poke — `SYST:STOR:SD:ENAble 0` is correctly **rejected** while streaming (`-200`), so the trigger is the #689 dir-cap firing on a rotation. Dir-cap refusal confirmed in the log on both runs:

| firmware | OPER_SD_LOGGING | SdDroppedBytes |
|---|---|---|
| `main` | **never cleared** in 120 s | 20,847 |
| this fix | **cleared 29 s in** | **383,163** |

The byte totals are not directly comparable run-to-run (they depend on when the cap fires), which is why the companion test waits for the stop and then streams a **fixed** window past it. An earlier probe of mine sampled at two fixed times, missed the event, and briefly reported the fix as not working.

Regression test: **[daqifi-python-test-suite#129](https://github.com/daqifi/daqifi-python-test-suite/pull/129)** — 0 PASS / 2 FAIL on `main`, 2 PASS / 0 FAIL here.

**Environment:** firmware `fix/691-sd-logging-observability`, XC32 v4.60 / MPLAB X v6.30, `-O3 -Werror`.