### PR TITLE
fix(sd): clamp the SD:GET USB reply chunk so it fits a re-partitioned buffer

### DIFF
--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -180,6 +180,24 @@ void wifi_manager_FormUdpAnnouncePacketCB(const wifi_manager_settings_t *pWifiSe
  * by WifiTask (pri 2) concurrently, so retry-with-delay makes progress. */
 static size_t sd_reply_write_usb(const char* data, size_t len)
 {
+    /* #750: same hazard the TCP path below was fixed for (Qodo #599), and the
+     * USB path simply never got it.
+     *
+     * UsbCdc_WriteToBuffer is all-or-nothing, and the USB circular buffer
+     * collapses to STREAMING_USB_MIN (2048 B) after a NON-USB streaming
+     * session re-partitions the pool. The reply loop offers up to
+     * USB_TRANSFER_CHUNK_SIZE (~4000 B), which can never fit in 2048 — so
+     * every write returned 0, the retry loop burned its full 10 s budget per
+     * chunk, and SD:GET returned an empty file with SYST:ERR? reading
+     * "No error".
+     *
+     * Measured on the bench: after a 10 s SD-logging session, SD:GET went
+     * from 245,464 B (3.7 s) to 0 B, logging
+     *     [SD reply] USB timeout: sent 0/16384 bytes after 10000 retries
+     * Clamp below the floor; the caller's loop already handles short writes. */
+    if (len > 1024u) {
+        len = 1024u;
+    }
     return UsbCdc_WriteToBuffer(NULL, data, len);
 }
 
@@ -249,6 +267,24 @@ void sd_card_manager_DataReadyCB(sd_card_manager_mode_t mode, uint8_t *pDataBuff
                 LOG_E("[SD reply] %s timeout: sent %u/%u bytes after %u retries",
                       toTcp ? "TCP" : "USB",
                       (unsigned)transferredLength, (unsigned)dataLen, (unsigned)retryCount);
+                /* #750: give up on the whole transfer, not just this chunk.
+                 *
+                 * Dropping only the chunk left the read loop to continue and
+                 * spend a fresh USB_TRANSFER_MAX_RETRIES (10 s) on every
+                 * remaining one — a 47 KB file is ~12 chunks, so the SD
+                 * subsystem stayed busy for ~2 minutes and rejected every
+                 * SD:GET in the meantime with "SD card busy". It also punched
+                 * a fixed-size hole in a file the host was still told had
+                 * completed.
+                 *
+                 * The host is not reading; the next chunk will not fare
+                 * better. Requesting the abort makes the read loop terminate
+                 * on its next iteration, which closes the file and resets
+                 * mode/state to IDLE through the existing path — the same
+                 * mechanism the TCP-client-gone case above already uses. */
+                if (!toTcp) {
+                    sd_card_manager_AbortTransfer();
+                }
                 break;
             }
             vTaskDelay(1);

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -277,14 +277,23 @@ void sd_card_manager_DataReadyCB(sd_card_manager_mode_t mode, uint8_t *pDataBuff
                  * a fixed-size hole in a file the host was still told had
                  * completed.
                  *
-                 * The host is not reading; the next chunk will not fare
+                 * The peer is not reading; the next chunk will not fare
                  * better. Requesting the abort makes the read loop terminate
                  * on its next iteration, which closes the file and resets
                  * mode/state to IDLE through the existing path — the same
-                 * mechanism the TCP-client-gone case above already uses. */
-                if (!toTcp) {
-                    sd_card_manager_AbortTransfer();
-                }
+                 * mechanism the TCP-client-gone case above already uses.
+                 *
+                 * Applies to BOTH transports. An earlier revision gated this
+                 * on !toTcp, reasoning that the TCP branch already had its own
+                 * abort — it does not cover this case. That guard fires only
+                 * when wifi_tcp_server_ConnIsCurrent() goes false, i.e. the
+                 * client is GONE. A client that is still connected but has
+                 * stopped draining keeps clientSocket >= 0 and the same
+                 * generation, so the entry guard never fires and the TCP path
+                 * kept the exact stall this fix removes for USB (audit of
+                 * #753). The two failure modes are client-gone and
+                 * client-stalled; each transport needs both. */
+                sd_card_manager_AbortTransfer();
                 break;
             }
             vTaskDelay(1);

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1628,25 +1628,41 @@ void sd_card_manager_ProcessState() {
                     gTransferAbortRequested = false;
                     LOG_E("[SD] Transfer ABORTED at %u bytes", totalBytesRead);
                     sd_wait_usb_drain();
-                    /* Terminate the stream so the host stops waiting. Without
-                     * this the abort closed the file silently and a peer that
-                     * was still reading blocked until its own timeout — the
-                     * same hang #703 removed from the open-failure and
-                     * buffer-too-small paths, which emit the marker for
-                     * exactly this reason.
+                    /* Emit the terminator ONLY if no file content went out.
                      *
-                     * Cheap even when the abort came from a reply stall: the
-                     * marker is 15 bytes, so it fits where the refused
-                     * >=1024-byte chunk did not.
+                     * That is #723's actual precedent: it made the PRE-transfer
+                     * failures terminal (buffer-too-small, open-failure) — both
+                     * of which have sent nothing — and #725 records why the
+                     * mid-transfer case was deliberately left out:
                      *
-                     * It is deliberately the SAME marker as a clean finish.
-                     * The host cannot yet distinguish "complete" from
-                     * "aborted" — that needs a distinguishable terminator and
-                     * client coordination, which is #725. Sending nothing is
-                     * strictly worse: the peer hangs instead of ending on a
-                     * short file it can at least compare against SD:LISt?. */
-                    sd_card_manager_DataReadyCB(SD_CARD_MANAGER_MODE_READ,
-                            (uint8_t*)eofMarker, sizeof(eofMarker) - 1);
+                     *   "sending a plain EOF marker after partial data would
+                     *    convert a detectable hang into a silently truncated
+                     *    file that looks complete — the wrong trade for a
+                     *    data-acquisition product"
+                     *
+                     * An earlier revision of this fix emitted it
+                     * unconditionally, which contradicts that decision: a host
+                     * would have accepted a truncated capture as a whole one.
+                     * A hang is recoverable and visible; a short file that
+                     * looks complete is neither.
+                     *
+                     * So: nothing sent -> terminate cleanly (the host learns
+                     * the transfer produced no data). Partial data sent -> stay
+                     * silent until #725 gives us a DISTINGUISHABLE terminator,
+                     * which is the only thing that makes this case honest.
+                     *
+                     * Skipping the emit on the partial path also avoids a
+                     * second stall: DataReadyCB retries for 10 s, and the abort
+                     * is reached precisely when the peer is not draining. */
+                    if (totalBytesRead == 0u) {
+                        sd_card_manager_DataReadyCB(SD_CARD_MANAGER_MODE_READ,
+                                (uint8_t*)eofMarker, sizeof(eofMarker) - 1);
+                    } else {
+                        LOG_E("[SD] aborted after %u bytes — no terminator sent "
+                              "(a plain EOF would look like a complete file; "
+                              "#725 tracks a distinguishable one)",
+                              (unsigned)totalBytesRead);
+                    }
                     if (gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID) {
                         SYS_FS_FileClose(gSDCardData.fileHandle);
                         gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1626,8 +1626,27 @@ void sd_card_manager_ProcessState() {
                 // Check for user-requested abort
                 if (gTransferAbortRequested) {
                     gTransferAbortRequested = false;
-                    LOG_E("[SD] Transfer ABORTED by user at %u bytes", totalBytesRead);
+                    LOG_E("[SD] Transfer ABORTED at %u bytes", totalBytesRead);
                     sd_wait_usb_drain();
+                    /* Terminate the stream so the host stops waiting. Without
+                     * this the abort closed the file silently and a peer that
+                     * was still reading blocked until its own timeout — the
+                     * same hang #703 removed from the open-failure and
+                     * buffer-too-small paths, which emit the marker for
+                     * exactly this reason.
+                     *
+                     * Cheap even when the abort came from a reply stall: the
+                     * marker is 15 bytes, so it fits where the refused
+                     * >=1024-byte chunk did not.
+                     *
+                     * It is deliberately the SAME marker as a clean finish.
+                     * The host cannot yet distinguish "complete" from
+                     * "aborted" — that needs a distinguishable terminator and
+                     * client coordination, which is #725. Sending nothing is
+                     * strictly worse: the peer hangs instead of ending on a
+                     * short file it can at least compare against SD:LISt?. */
+                    sd_card_manager_DataReadyCB(SD_CARD_MANAGER_MODE_READ,
+                            (uint8_t*)eofMarker, sizeof(eofMarker) - 1);
                     if (gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID) {
                         SYS_FS_FileClose(gSDCardData.fileHandle);
                         gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;


### PR DESCRIPTION
Fixes #750. Also resolves the `T2_get_after_nonsd` short read tracked in #703.

## Root cause

`SYST:STOR:SD:GET` returned an empty file — a bare `__END_OF_FILE__` with `SYST:ERR?` reading **`No error`** — after any SD-logging streaming session.

`UsbCdc_WriteToBuffer` is **all-or-nothing**, and the USB circular buffer collapses to `STREAMING_USB_MIN` (2048 B) once a **non-USB** streaming session re-partitions the pool. The SD reply loop offers up to `USB_TRANSFER_CHUNK_SIZE` (~4000 B), which can never fit in 2048 — so every write returned 0, the retry loop burned its full 10 s budget per chunk, and the host got a terminator with no content.

The firmware's own log named it the moment SD debug was enabled:

```
[SD] Opening file for read: 'DAQiFi/w750.csv'
[SD reply] USB timeout: sent 0/16384 bytes after 10000 retries
```

**The TCP reply path was fixed for exactly this in Qodo #599** — same all-or-nothing write, same shrunk-buffer mechanism, with a comment naming it. The USB path simply never received the same treatment. This applies it.

## Second change: the reply-timeout path is now terminal

Dropping only the failed chunk left the read loop to spend a fresh 10 s on **every remaining chunk** — ~2 minutes of the SD subsystem rejecting other commands with `SD card busy` — and punched a fixed-size hole in a file the host was told had completed. It now requests the existing abort, which closes the file and resets mode/state to IDLE through the path the TCP-client-gone case already uses.

That is very likely the whole of #703's `T2` short read: a chunk given up on mid-transfer is exactly a fixed-size hole in an otherwise complete file. **`test_703` now passes for the first time** — `content=136200B expected~136200B full=True`, where it had been short by a constant 2049 B.

## Verification (E, board 7E2898F46200E8A7, adjacent builds)

One-step reproduction — reboot, GET, run a 10 s SD session, GET again:

| firmware | fresh boot | after SD session |
|---|---|---|
| `main` | 245,464 B in 3.7 s | **0 B in 33.4 s** |
| this fix | 247,000 B in 3.8 s | **247,000 B in 4.1 s** |

Against the directory-reported size, the milder form shows as clean multiples of the chunk size — deltas of exactly **2048 B** and **3584 B** on `main`, **0** with the fix.

## Correcting my own earlier speculation

On [#749](https://github.com/daqifi/daqifi-nyquist-firmware/pull/749) I suggested this might be the same condition as the path bug fixed there. It is not — this reproduces with the bare filename, and the failure is a stalled reply rather than a rejected path. I also wrote on #750 that the wedge was "permanent"; that was an inference from a 3-minute observation, and I have corrected it on the issue.

Regression test: **[daqifi-python-test-suite#130](https://github.com/daqifi/daqifi-python-test-suite/pull/130)** — 1 PASS / 2 FAIL on `main`, 3 PASS / 0 FAIL here.

**Environment:** firmware `fix/750-sd-reply-timeout-terminal`, XC32 v4.60 / MPLAB X v6.30, `-O3 -Werror`.