### PR TITLE
fix(#761): never set IOLOCK/PMDLOCK — restores the DIO-terminal family on fielded devices

### DIFF
--- a/firmware/src/HAL/UserClock/UserClock.c
+++ b/firmware/src/HAL/UserClock/UserClock.c
@@ -135,7 +135,12 @@ static void clock_SetPps(uint8_t dio, uint8_t ppsval) {
     uint32_t st = __builtin_disable_interrupts();
     clock_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_IOLOCK_MASK);
     *rpr = (uint32_t)ppsval;
-    clock_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_IOLOCK_MASK);
+        /* #761: DO NOT re-lock. On a bootloader-configured part
+         * IOL1WAY/PMDL1WAY are ON, and FRM DS60001120F 12.3.1.6.2 says a
+         * set BLOCKS the bit from ever being cleared again (until reset).
+         * Setting it here would make this the LAST reconfiguration the
+         * device ever accepts. The unlock above stays - it is idempotent
+         * and still correct on L1WAY=OFF bench parts. */
     __builtin_mtc0(12, 0, st);
 }
 

--- a/firmware/src/HAL/UserEdge/UserEdge.c
+++ b/firmware/src/HAL/UserEdge/UserEdge.c
@@ -197,7 +197,12 @@ static void edge_SetPps(volatile uint32_t* rpr, uint8_t code) {
     uint32_t st = __builtin_disable_interrupts();
     edge_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_IOLOCK_MASK);
     *rpr = (uint32_t)code;
-    edge_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_IOLOCK_MASK);
+        /* #761: DO NOT re-lock. On a bootloader-configured part
+         * IOL1WAY/PMDL1WAY are ON, and FRM DS60001120F 12.3.1.6.2 says a
+         * set BLOCKS the bit from ever being cleared again (until reset).
+         * Setting it here would make this the LAST reconfiguration the
+         * device ever accepts. The unlock above stays - it is idempotent
+         * and still correct on L1WAY=OFF bench parts. */
     __builtin_mtc0(12, 0, st);
 }
 
@@ -207,7 +212,12 @@ static void edge_CtrSetPmd(uint8_t u, bool enable) {
     uint32_t st = __builtin_disable_interrupts();
     edge_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_PMDLOCK_MASK);
     if (enable) { PMD4CLR = gCtr[u].pmdMask; } else { PMD4SET = gCtr[u].pmdMask; }
-    edge_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_PMDLOCK_MASK);
+        /* #761: DO NOT re-lock. On a bootloader-configured part
+         * IOL1WAY/PMDL1WAY are ON, and FRM DS60001120F 12.3.1.6.2 says a
+         * set BLOCKS the bit from ever being cleared again (until reset).
+         * Setting it here would make this the LAST reconfiguration the
+         * device ever accepts. The unlock above stays - it is idempotent
+         * and still correct on L1WAY=OFF bench parts. */
     __builtin_mtc0(12, 0, st);
     for (volatile int d = 0; enable && d < 8; d++) { /* let the module clock settle */ }
 }

--- a/firmware/src/HAL/UserI2c/UserI2c.c
+++ b/firmware/src/HAL/UserI2c/UserI2c.c
@@ -250,7 +250,12 @@ static void i2c_SetPmd(void) {
     uint32_t st = __builtin_disable_interrupts();
     i2c_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_PMDLOCK_MASK);
     PMD5CLR = _PMD5_I2C2MD_MASK;
-    i2c_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_PMDLOCK_MASK);
+        /* #761: DO NOT re-lock. On a bootloader-configured part
+         * IOL1WAY/PMDL1WAY are ON, and FRM DS60001120F 12.3.1.6.2 says a
+         * set BLOCKS the bit from ever being cleared again (until reset).
+         * Setting it here would make this the LAST reconfiguration the
+         * device ever accepts. The unlock above stays - it is idempotent
+         * and still correct on L1WAY=OFF bench parts. */
     __builtin_mtc0(12, 0, st);
 }
 

--- a/firmware/src/HAL/UserIC/UserIC.c
+++ b/firmware/src/HAL/UserIC/UserIC.c
@@ -157,7 +157,12 @@ static void ic_SetPps(uint8_t u, uint8_t code) {
     uint32_t st = __builtin_disable_interrupts();
     ic_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_IOLOCK_MASK);
     *(gIc[u].rpr) = (uint32_t)code;
-    ic_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_IOLOCK_MASK);
+        /* #761: DO NOT re-lock. On a bootloader-configured part
+         * IOL1WAY/PMDL1WAY are ON, and FRM DS60001120F 12.3.1.6.2 says a
+         * set BLOCKS the bit from ever being cleared again (until reset).
+         * Setting it here would make this the LAST reconfiguration the
+         * device ever accepts. The unlock above stays - it is idempotent
+         * and still correct on L1WAY=OFF bench parts. */
     __builtin_mtc0(12, 0, st);
 }
 
@@ -170,7 +175,12 @@ static void ic_SetPmd(uint8_t u, bool enable) {
     uint32_t st = __builtin_disable_interrupts();
     ic_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_PMDLOCK_MASK);
     if (enable) { PMD3CLR = (1u << u); } else { PMD3SET = (1u << u); }
-    ic_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_PMDLOCK_MASK);
+        /* #761: DO NOT re-lock. On a bootloader-configured part
+         * IOL1WAY/PMDL1WAY are ON, and FRM DS60001120F 12.3.1.6.2 says a
+         * set BLOCKS the bit from ever being cleared again (until reset).
+         * Setting it here would make this the LAST reconfiguration the
+         * device ever accepts. The unlock above stays - it is idempotent
+         * and still correct on L1WAY=OFF bench parts. */
     __builtin_mtc0(12, 0, st);
     /* PMD ungate needs a few clocks to settle before the module SFRs are live. */
     for (volatile int d = 0; enable && d < 8; d++) { /* brief settle */ }

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -175,7 +175,12 @@ static void spi_ApplyPps(bool enable) {
     }
     SDI1R = (enable && gCfg.misoDio != USER_SPI_PIN_NONE)
                 ? spi_MisoSdi1rValue(gCfg.misoDio) : 0U;
-    spi_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_IOLOCK_MASK);
+        /* #761: DO NOT re-lock. On a bootloader-configured part
+         * IOL1WAY/PMDL1WAY are ON, and FRM DS60001120F 12.3.1.6.2 says a
+         * set BLOCKS the bit from ever being cleared again (until reset).
+         * Setting it here would make this the LAST reconfiguration the
+         * device ever accepts. The unlock above stays - it is idempotent
+         * and still correct on L1WAY=OFF bench parts. */
 
     __builtin_mtc0(12, 0, st);
 }
@@ -213,7 +218,12 @@ static void spi_SetPmd(bool enable) {
     } else {
         PMD5SET = _PMD5_SPI1MD_MASK;
     }
-    spi_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_PMDLOCK_MASK);
+        /* #761: DO NOT re-lock. On a bootloader-configured part
+         * IOL1WAY/PMDL1WAY are ON, and FRM DS60001120F 12.3.1.6.2 says a
+         * set BLOCKS the bit from ever being cleared again (until reset).
+         * Setting it here would make this the LAST reconfiguration the
+         * device ever accepts. The unlock above stays - it is idempotent
+         * and still correct on L1WAY=OFF bench parts. */
     __builtin_mtc0(12, 0, st);
 }
 

--- a/firmware/src/HAL/UserUart/UserUart.c
+++ b/firmware/src/HAL/UserUart/UserUart.c
@@ -189,7 +189,12 @@ static void uart_ApplyPps(const UartDesc_t* u, bool enable) {
     if (gCfg.rxDio != USER_UART_PIN_NONE) {
         *(u->rxr) = enable ? (uint32_t)uart_RxPpsval(gCfg.rxDio) : 0u;
     }
-    uart_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_IOLOCK_MASK);
+        /* #761: DO NOT re-lock. On a bootloader-configured part
+         * IOL1WAY/PMDL1WAY are ON, and FRM DS60001120F 12.3.1.6.2 says a
+         * set BLOCKS the bit from ever being cleared again (until reset).
+         * Setting it here would make this the LAST reconfiguration the
+         * device ever accepts. The unlock above stays - it is idempotent
+         * and still correct on L1WAY=OFF bench parts. */
     __builtin_mtc0(12, 0, st);
 }
 
@@ -198,7 +203,12 @@ static void uart_SetPmd(const UartDesc_t* u, bool enable) {
     uint32_t st = __builtin_disable_interrupts();
     uart_CfgconUnlockedWrite(CFGCON & ~(uint32_t)_CFGCON_PMDLOCK_MASK);
     if (enable) { PMD5CLR = u->pmdMask; } else { PMD5SET = u->pmdMask; }
-    uart_CfgconUnlockedWrite(CFGCON | (uint32_t)_CFGCON_PMDLOCK_MASK);
+        /* #761: DO NOT re-lock. On a bootloader-configured part
+         * IOL1WAY/PMDL1WAY are ON, and FRM DS60001120F 12.3.1.6.2 says a
+         * set BLOCKS the bit from ever being cleared again (until reset).
+         * Setting it here would make this the LAST reconfiguration the
+         * device ever accepts. The unlock above stays - it is idempotent
+         * and still correct on L1WAY=OFF bench parts. */
     __builtin_mtc0(12, 0, st);
 }
 

--- a/firmware/src/Util/Logger.c
+++ b/firmware/src/Util/Logger.c
@@ -219,8 +219,10 @@ static void InitICSPLogging(void)
     PMD5bits.U4MD = 0;      // Enable UART4 module
 
     /* Lock back the system after PPS configuration */
-    CFGCONbits.IOLOCK = 1U;
-    CFGCONbits.PMDLOCK = 1U;
+    /* #761: deliberately NOT re-locked. Dev-only path, but the store is
+     * irreversible on an IOL1WAY/PMDL1WAY=ON part (FRM DS60001120F
+     * 12.3.1.6.2), so enabling the ICSP log would silently kill every
+     * later PPS/PMD reconfiguration on that unit. */
     SYSKEY = 0x33333333U;
     
     /* Restore interrupt state */

--- a/firmware/src/config/default/peripheral/clk/plib_clk.c
+++ b/firmware/src/config/default/peripheral/clk/plib_clk.c
@@ -101,7 +101,25 @@ void CLK_Initialize( void )
     PMD6 = 0xfffff0ffU;
     PMD7 = 0xffffffefU;
 
-    CFGCONbits.PMDLOCK = 1;
+    /* ===================== DO NOT RESTORE (#761) =====================
+     * The re-lock that MCC generates here is DELETED ON PURPOSE.
+     *
+     * Devices configured by the BOOTLOADER carry IOL1WAY/PMDL1WAY = ON.
+     * FRM DS60001120F 12.3.1.6.2: setting this bit "blocks [it] from being
+     * cleared after it has been set once ... the only way to clear the bit
+     * ... is to perform a device Reset."
+     *
+     * So this one store would permanently disable runtime PPS/PMD and kill
+     * the whole DIO-terminal family (#665 SPI, #666 IC, #667 edge, #668
+     * clocks, user I2C/UART) on every fielded unit. Config words cannot be
+     * fixed in the field: erratum #45 (RTSP of config words, "no
+     * workaround") and the bootloader refuses to program them.
+     *
+     * The bit resets to 0, and the bootloader hands off by JUMP not reset,
+     * so leaving it alone is all that is required.
+     *
+     * If an MCC regeneration puts this line back, DELETE IT AGAIN.
+     * ================================================================= */
 
 
       

--- a/firmware/src/config/default/peripheral/gpio/plib_gpio.c
+++ b/firmware/src/config/default/peripheral/gpio/plib_gpio.c
@@ -145,7 +145,25 @@ void GPIO_Initialize ( void )
     RPG8R = 6;
 
         /* Lock back the system after PPS configuration */
-    CFGCONbits.IOLOCK = 1U;
+    /* ===================== DO NOT RESTORE (#761) =====================
+     * The re-lock that MCC generates here is DELETED ON PURPOSE.
+     *
+     * Devices configured by the BOOTLOADER carry IOL1WAY/PMDL1WAY = ON.
+     * FRM DS60001120F 12.3.1.6.2: setting this bit "blocks [it] from being
+     * cleared after it has been set once ... the only way to clear the bit
+     * ... is to perform a device Reset."
+     *
+     * So this one store would permanently disable runtime PPS/PMD and kill
+     * the whole DIO-terminal family (#665 SPI, #666 IC, #667 edge, #668
+     * clocks, user I2C/UART) on every fielded unit. Config words cannot be
+     * fixed in the field: erratum #45 (RTSP of config words, "no
+     * workaround") and the bootloader refuses to program them.
+     *
+     * The bit resets to 0, and the bootloader hands off by JUMP not reset,
+     * so leaving it alone is all that is required.
+     *
+     * If an MCC regeneration puts this line back, DELETE IT AGAIN.
+     * ================================================================= */
 
     SYSKEY = 0x00000000U;
 


### PR DESCRIPTION
Fixes #761.

## The defect

Every device configured by the **bootloader** carries `IOL1WAY/PMDL1WAY = ON`. Our own firmware then set `IOLOCK`/`PMDLOCK` — and per FRM DS60001120F §12.3.1.6.2 that set **"blocks [the bit] from being cleared after it has been set once ... the only way to clear the bit ... is to perform a device Reset."**

Runtime PPS/PMD reconfiguration was therefore permanently dead on every fielded unit, disabling the whole epic-#664 family: #665 SPI, #666 input capture, #667 edge/totalizers, #668 clock outputs, user I2C and UART.

It passed every bench test because bench units are PICkit-flashed **standalone** and carry the app's own `L1WAY=OFF` config words. Bench and field were never running the same configuration.

## Why the obvious fix is unavailable

Config words are unreachable in the field — erratum #45 (RTSP of Configuration Words, **"no workaround"**), and the bootloader refuses to program them. A bootloader-linked app discards them at link (`old_hv2_bootld.ld:1236`).

But `CFGCON.IOLOCK/PMDLOCK` **reset to 0**, and the bootloader hands off by **jump, not reset** (`bootloader.c:186`) — so the app inherits them unlocked and merely has to never spend the one allowed transition. Same shape as #741/#742, where `FPLLMULT` was unreachable but `SPLLCON` was runtime-writable.

## The change

**14 lock-SET stores removed, 0 added.** Every SYSKEY unlock/relock and every `IOLOCK=0`/`PMDLOCK=0` clear is untouched and still correct on `L1WAY=OFF` parts.

Two boot sites — plus **twelve runtime sites** that a grep for `IOLOCK = 1` does not find, because the `User*` modules use `CFGCON | _CFGCON_IOLOCK_MASK`:

`plib_gpio.c` · `plib_clk.c` · `UserIC` x2 · `UserSpi` x2 · `UserUart` x2 · `UserEdge` x2 · `UserClock` · `UserI2c` · `Logger.c` x2 (dev-only)

**Removing only the two boot sites would have been worse than the defect** — the first reconfiguration succeeds, its trailing re-lock blocks every later one, giving "works exactly once per power-up", which passes a single-pass bench test. That was my initial proposal and it was wrong.

The MCC-generated plib sites carry a **DO NOT RESTORE** banner; a regen would silently reintroduce them.

## Validation on the fielded configuration

Built the customer state deliberately: PICkit-flashed the **bootloader** (config words `L1WAY=ON`), then a **bootloader-linked** app (verified 0 boot-flash records, so no config words of its own).

| test | before this PR | after |
|---|---|---|
| `DIO:MEASure:*` (#666) | all four `IC: no (or too-slow) signal` | **all working** |
| #665 user SPI | dead | **30 PASS** |
| #667 edge + totalizers | dead | **11 PASS, 0 FAIL** |
| #668 clock outputs | dead | **22 PASS** |

Covers `UserIC`, `UserSpi`, `UserClock`, and `UserEdge` on **both** its IOLOCK and PMDLOCK paths (the TMR8/9 totalizer route).

**Multi-cycle property** — the thing a missed re-lock site would break: every `DIO:MEASure` is a full route -> ungate -> measure -> unroute -> re-gate cycle, so 60 consecutive reads is 60 reconfigurations with the last still working. A single missed site would have failed on the second.

Negative control: on a standalone (`L1WAY=OFF`) unit this change is a **no-op** — measurements behave exactly as on `main`.

## Notes

- Stacks with #760 (phantom arm capture); independent, different regions of `UserIC.c`.
- The project note `project_runtime_pps_pmd_oneway_lock.md` describes the locks as changeable "exactly once after reset". The FRM's actual rule is *clear-after-set is blocked* — a set is legal at any time and always irreversible. That difference is exactly what makes the runtime re-locks fatal.
- Companion regression test still to come: it must run the family **twice with no reboot** and assert on the final cycle.