### PR TITLE
fix(#667): close the edge-event disarm race and the pre-scheduler critical section

### DIFF
--- a/firmware/src/HAL/UserEdge/UserEdge.c
+++ b/firmware/src/HAL/UserEdge/UserEdge.c
@@ -235,28 +235,55 @@ static bool edge_Streaming(void) {
  * 0, COUNter's 64-bit rollover extension dead). The same store from a live SCPI
  * task sticks, so call these at ARM time, right before the matching IECxSET.
  * Mirrors UserIC ic_SetPriority (the proven #702 fix). */
+/* Guard an IPCn read-modify-write.
+ *
+ * Each IPCn bitfield write is an RMW of a 32-bit register shared with other
+ * interrupts' priority fields — notably INT3 (IPC4<20:18>) shares IPC4 with IC3
+ * (IPC4<4:2>), so a concurrent DIO:MEASure arm on the other SCPI interface (USB
+ * pri 7 can preempt WiFi pri 2 mid-RMW) could clobber the write. The RMW must
+ * be atomic against both tasks and the pri-3 ISRs that touch these registers.
+ *
+ * The setters below run in BOTH contexts, so the guard picks per call:
+ *
+ *  - scheduler RUNNING (the #702 re-assert on the SCPI arm path, lines ~420 and
+ *    ~566) -> taskENTER_CRITICAL. It raises IPL to
+ *    configMAX_SYSCALL_INTERRUPT_PRIORITY (4), which covers every context that
+ *    can reach these registers while leaving the priority 5+ sources FreeRTOS
+ *    deliberately never disables alone. This is the FreeRTOS-idiomatic path and
+ *    the one taken at runtime (Qodo #705, second pass).
+ *
+ *  - scheduler NOT STARTED (UserEdge_Initialize, reached from app_SystemInit
+ *    inside SYS_Initialize: main.c -> initialization.c APP_FREERTOS_Initialize
+ *    -> app_SystemInit, i.e. BEFORE vTaskStartScheduler(), which lives in
+ *    SYS_Tasks()) -> raw mask. FreeRTOS_tasks.c wraps the whole body of
+ *    vTaskExitCritical(), portENABLE_INTERRUPTS() included, in
+ *    `if (xSchedulerRunning != pdFALSE)`, so pre-scheduler the exit is a no-op
+ *    and a critical section would leave interrupts masked for the rest of boot.
+ *
+ * (An earlier revision claimed app_SystemInit runs inside the pri-1
+ * APP_FREERTOS_Tasks task. It does not — APP_FREERTOS_Initialize and
+ * APP_FREERTOS_Tasks are different functions, and that confusion is what put a
+ * plain critical section on a pre-scheduler path in the first place.) */
+typedef struct { bool crit; uint32_t st; } EdgeIpcGuard_t;
+
+static EdgeIpcGuard_t edge_IpcGuardEnter(void) {
+    EdgeIpcGuard_t g = { false, 0u };
+    if (xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
+        g.crit = true;
+        taskENTER_CRITICAL();
+    } else {
+        g.st = (uint32_t)__builtin_disable_interrupts();
+    }
+    return g;
+}
+
+static void edge_IpcGuardExit(EdgeIpcGuard_t g) {
+    if (g.crit) { taskEXIT_CRITICAL(); }
+    else        { __builtin_mtc0(12, 0, g.st); }
+}
+
 static void edge_SetIntPriority(uint8_t u) {
-    /* Each IPCn bitfield write is a read-modify-write of a 32-bit register shared
-     * with other interrupts' priority fields — notably INT3 (IPC4<20:18>) shares
-     * IPC4 with IC3 (IPC4<4:2>), so a concurrent DIO:MEASure arm on the other SCPI
-     * interface (USB pri 7 can preempt WiFi pri 2 mid-RMW) could clobber this
-     * write, so the RMW must be atomic.
-     *
-     * RAW mask, not taskENTER_CRITICAL: this runs BOTH pre- and post-scheduler.
-     * UserEdge_Initialize reaches it from app_SystemInit, which runs inside
-     * SYS_Initialize (main.c -> initialization.c APP_FREERTOS_Initialize ->
-     * app_SystemInit) — i.e. BEFORE vTaskStartScheduler(), which lives in
-     * SYS_Tasks(). On this port vTaskExitCritical() wraps its whole body,
-     * portENABLE_INTERRUPTS() included, in `if (xSchedulerRunning != pdFALSE)`,
-     * so pre-scheduler the exit is a no-op and a critical section here would
-     * leave interrupts masked for the rest of boot. A raw mask restores the
-     * saved IPL either way.
-     *
-     * (An earlier revision of this comment claimed app_SystemInit runs inside
-     * the pri-1 APP_FREERTOS_Tasks task. It does not — APP_FREERTOS_Initialize
-     * and APP_FREERTOS_Tasks are different functions, and that confusion is
-     * what put a critical section here in the first place.) */
-    uint32_t st = __builtin_disable_interrupts();
+    EdgeIpcGuard_t g = edge_IpcGuardEnter();
     switch (u) {
         case 0: IPC2bits.INT1IP = 3; IPC2bits.INT1IS = 0; break;
         case 1: IPC3bits.INT2IP = 3; IPC3bits.INT2IS = 0; break;
@@ -264,26 +291,18 @@ static void edge_SetIntPriority(uint8_t u) {
         case 3: IPC5bits.INT4IP = 3; IPC5bits.INT4IS = 0; break;
         default: break;
     }
-    __builtin_mtc0(12, 0, st);
+    edge_IpcGuardExit(g);
 }
 
 static void edge_SetCtrPriority(uint8_t u) {
-    /* RMW on IPC9/IPC10 shared with IC8/IC9 priority fields — guard as in
-     * edge_SetIntPriority (task-context critical section; Qodo #705). */
-    /* RAW mask, not taskENTER_CRITICAL: UserEdge_Initialize calls this at
-     * boot, and on the PIC32MZ FreeRTOS port vTaskExitCritical() does NOT
-     * re-enable interrupts when the scheduler is not yet running — a
-     * critical section here would leave interrupts masked for the rest of
-     * boot. The RMW still needs to be atomic (IPC4 is shared between INT3
-     * and IC3), so only the mechanism changes (Qodo #705).
-     */
-    uint32_t st = __builtin_disable_interrupts();
+    /* IPC9/IPC10 are shared with the IC8/IC9 priority fields — same guard. */
+    EdgeIpcGuard_t g = edge_IpcGuardEnter();
     switch (u) {
         case 0: IPC9bits.T8IP  = 3; IPC9bits.T8IS  = 0; break;
         case 1: IPC10bits.T9IP = 3; IPC10bits.T9IS = 0; break;
         default: break;
     }
-    __builtin_mtc0(12, 0, st);
+    edge_IpcGuardExit(g);
 }
 
 /* ------------------------------------------------------------------ */

--- a/firmware/src/HAL/UserEdge/UserEdge.c
+++ b/firmware/src/HAL/UserEdge/UserEdge.c
@@ -240,16 +240,22 @@ static void edge_SetIntPriority(uint8_t u) {
      * with other interrupts' priority fields — notably INT3 (IPC4<20:18>) shares
      * IPC4 with IC3 (IPC4<4:2>), so a concurrent DIO:MEASure arm on the other SCPI
      * interface (USB pri 7 can preempt WiFi pri 2 mid-RMW) could clobber this
-     * write. All call sites (boot + arm) run in task context (app_SystemInit runs
-     * inside the pri-1 APP_FREERTOS_Tasks task), so a critical section is the
-     * correct guard (project atomicity rule; Qodo #705). */
-    /* RAW mask, not taskENTER_CRITICAL: UserEdge_Initialize calls this at
-     * boot, and on the PIC32MZ FreeRTOS port vTaskExitCritical() does NOT
-     * re-enable interrupts when the scheduler is not yet running — a
-     * critical section here would leave interrupts masked for the rest of
-     * boot. The RMW still needs to be atomic (IPC4 is shared between INT3
-     * and IC3), so only the mechanism changes (Qodo #705).
-     */
+     * write, so the RMW must be atomic.
+     *
+     * RAW mask, not taskENTER_CRITICAL: this runs BOTH pre- and post-scheduler.
+     * UserEdge_Initialize reaches it from app_SystemInit, which runs inside
+     * SYS_Initialize (main.c -> initialization.c APP_FREERTOS_Initialize ->
+     * app_SystemInit) — i.e. BEFORE vTaskStartScheduler(), which lives in
+     * SYS_Tasks(). On this port vTaskExitCritical() wraps its whole body,
+     * portENABLE_INTERRUPTS() included, in `if (xSchedulerRunning != pdFALSE)`,
+     * so pre-scheduler the exit is a no-op and a critical section here would
+     * leave interrupts masked for the rest of boot. A raw mask restores the
+     * saved IPL either way.
+     *
+     * (An earlier revision of this comment claimed app_SystemInit runs inside
+     * the pri-1 APP_FREERTOS_Tasks task. It does not — APP_FREERTOS_Initialize
+     * and APP_FREERTOS_Tasks are different functions, and that confusion is
+     * what put a critical section here in the first place.) */
     uint32_t st = __builtin_disable_interrupts();
     switch (u) {
         case 0: IPC2bits.INT1IP = 3; IPC2bits.INT1IS = 0; break;
@@ -421,35 +427,42 @@ bool UserEdge_EventEnable(uint8_t dio, uint8_t mode, const char** err) {
                 if (err) { *err = "DIO:EVENt: DIO is not the active event pin for its INT unit"; }
                 ok = false;
             } else {
-                /* Disarm under an interrupt mask (Qodo #705).
+                /* Tear the unit down as one unit (Qodo #705).
                  *
-                 * IEC0CLR does not stop an ISR that is ALREADY executing, and
-                 * this unit's ISR runs above the kernel-managed threshold, so
-                 * without masking there are two races:
+                 * The store to IEC0CLR is posted — it is not guaranteed to have
+                 * retired on the interrupt controller by the time the following
+                 * stores execute. This same file already accounts for that in
+                 * UserEdge_IsrEdge, which reads INTCON back to retire a write
+                 * before acting on it. So without a guard an edge can still
+                 * vector between the IEC0CLR and the state stores, and then:
                  *
-                 *  1. an in-flight ISR reaches edge_FifoPush AFTER the task
-                 *     zeroes gIntState[u].dio, enqueueing an event whose pin
-                 *     reads 0 — a bogus DIO number to whoever pops it;
-                 *  2. in USER_EDGE_BOTH the in-flight ISR ends with IEC0SET to
-                 *     retarget the opposite edge. Landing after the task's
-                 *     IEC0CLR, that leaves the interrupt ENABLED on a pin the
-                 *     caller was told is disarmed, and the next edge runs an
-                 *     ISR against enabled=false, dio=0.
+                 *  1. the ISR reaches edge_FifoPush after the task zeroed
+                 *     gIntState[u].dio, enqueueing an event whose pin reads 0;
+                 *  2. in USER_EDGE_BOTH the ISR ends with IEC0SET to retarget
+                 *     the opposite edge, leaving the interrupt ENABLED on a pin
+                 *     the caller was told is disarmed.
                  *
-                 * Masking the whole teardown closes both: the ISR either
-                 * finished before the mask (its IEC0SET then undone by our
-                 * IEC0CLR) or cannot start until the state is torn down. */
-                uint32_t st = __builtin_disable_interrupts();
+                 * taskENTER_CRITICAL raises IPL to configMAX_SYSCALL_INTERRUPT_
+                 * PRIORITY (4), and these ISRs run at priority 3 (see
+                 * edge_SetIntPriority / edge_SetCtrPriority above), so the
+                 * vector cannot be taken regardless of whether IEC0CLR has
+                 * retired. A raw __builtin_disable_interrupts() would also work
+                 * but is over-broad: it masks the priority 5+ sources FreeRTOS
+                 * deliberately never disables. This path is SCPI-only
+                 * (SCPIDIO.c UserEdge_EventEnable), so the scheduler is always
+                 * running here and taskEXIT_CRITICAL restores IPL correctly —
+                 * unlike the pre-scheduler priority setters above. */
+                taskENTER_CRITICAL();
                 IEC0CLR = r->ieMask;
                 IFS0CLR = r->ifMask;
                 gIntState[u].enabled = false;
                 gIntState[u].stormed = false;
                 gIntState[u].dio = 0u;   /* drop stale pin ref, symmetric w/ counter (Qodo #705) */
-                __builtin_mtc0(12, 0, st);
+                taskEXIT_CRITICAL();
 
-                /* PPS unroute AFTER the mask: a SYSKEY/CFGCON sequence should
-                 * not run with interrupts globally disabled, and by here no
-                 * ISR can reach this unit. */
+                /* PPS unroute AFTER the critical section: a SYSKEY/CFGCON
+                 * sequence should not run inside one, and by here no ISR can
+                 * reach this unit. */
                 edge_SetPps(r->rpr, 0u);
                 DIO_ReleaseChannel(dio, DIO_OWNER_EDGE);
                 DIO_RestoreChannel(dio);

--- a/firmware/src/HAL/UserEdge/UserEdge.c
+++ b/firmware/src/HAL/UserEdge/UserEdge.c
@@ -243,7 +243,14 @@ static void edge_SetIntPriority(uint8_t u) {
      * write. All call sites (boot + arm) run in task context (app_SystemInit runs
      * inside the pri-1 APP_FREERTOS_Tasks task), so a critical section is the
      * correct guard (project atomicity rule; Qodo #705). */
-    taskENTER_CRITICAL();
+    /* RAW mask, not taskENTER_CRITICAL: UserEdge_Initialize calls this at
+     * boot, and on the PIC32MZ FreeRTOS port vTaskExitCritical() does NOT
+     * re-enable interrupts when the scheduler is not yet running — a
+     * critical section here would leave interrupts masked for the rest of
+     * boot. The RMW still needs to be atomic (IPC4 is shared between INT3
+     * and IC3), so only the mechanism changes (Qodo #705).
+     */
+    uint32_t st = __builtin_disable_interrupts();
     switch (u) {
         case 0: IPC2bits.INT1IP = 3; IPC2bits.INT1IS = 0; break;
         case 1: IPC3bits.INT2IP = 3; IPC3bits.INT2IS = 0; break;
@@ -251,19 +258,26 @@ static void edge_SetIntPriority(uint8_t u) {
         case 3: IPC5bits.INT4IP = 3; IPC5bits.INT4IS = 0; break;
         default: break;
     }
-    taskEXIT_CRITICAL();
+    __builtin_mtc0(12, 0, st);
 }
 
 static void edge_SetCtrPriority(uint8_t u) {
     /* RMW on IPC9/IPC10 shared with IC8/IC9 priority fields — guard as in
      * edge_SetIntPriority (task-context critical section; Qodo #705). */
-    taskENTER_CRITICAL();
+    /* RAW mask, not taskENTER_CRITICAL: UserEdge_Initialize calls this at
+     * boot, and on the PIC32MZ FreeRTOS port vTaskExitCritical() does NOT
+     * re-enable interrupts when the scheduler is not yet running — a
+     * critical section here would leave interrupts masked for the rest of
+     * boot. The RMW still needs to be atomic (IPC4 is shared between INT3
+     * and IC3), so only the mechanism changes (Qodo #705).
+     */
+    uint32_t st = __builtin_disable_interrupts();
     switch (u) {
         case 0: IPC9bits.T8IP  = 3; IPC9bits.T8IS  = 0; break;
         case 1: IPC10bits.T9IP = 3; IPC10bits.T9IS = 0; break;
         default: break;
     }
-    taskEXIT_CRITICAL();
+    __builtin_mtc0(12, 0, st);
 }
 
 /* ------------------------------------------------------------------ */
@@ -407,12 +421,36 @@ bool UserEdge_EventEnable(uint8_t dio, uint8_t mode, const char** err) {
                 if (err) { *err = "DIO:EVENt: DIO is not the active event pin for its INT unit"; }
                 ok = false;
             } else {
+                /* Disarm under an interrupt mask (Qodo #705).
+                 *
+                 * IEC0CLR does not stop an ISR that is ALREADY executing, and
+                 * this unit's ISR runs above the kernel-managed threshold, so
+                 * without masking there are two races:
+                 *
+                 *  1. an in-flight ISR reaches edge_FifoPush AFTER the task
+                 *     zeroes gIntState[u].dio, enqueueing an event whose pin
+                 *     reads 0 — a bogus DIO number to whoever pops it;
+                 *  2. in USER_EDGE_BOTH the in-flight ISR ends with IEC0SET to
+                 *     retarget the opposite edge. Landing after the task's
+                 *     IEC0CLR, that leaves the interrupt ENABLED on a pin the
+                 *     caller was told is disarmed, and the next edge runs an
+                 *     ISR against enabled=false, dio=0.
+                 *
+                 * Masking the whole teardown closes both: the ISR either
+                 * finished before the mask (its IEC0SET then undone by our
+                 * IEC0CLR) or cannot start until the state is torn down. */
+                uint32_t st = __builtin_disable_interrupts();
                 IEC0CLR = r->ieMask;
                 IFS0CLR = r->ifMask;
-                edge_SetPps(r->rpr, 0u);
                 gIntState[u].enabled = false;
                 gIntState[u].stormed = false;
                 gIntState[u].dio = 0u;   /* drop stale pin ref, symmetric w/ counter (Qodo #705) */
+                __builtin_mtc0(12, 0, st);
+
+                /* PPS unroute AFTER the mask: a SYSKEY/CFGCON sequence should
+                 * not run with interrupts globally disabled, and by here no
+                 * ISR can reach this unit. */
+                edge_SetPps(r->rpr, 0u);
                 DIO_ReleaseChannel(dio, DIO_OWNER_EDGE);
                 DIO_RestoreChannel(dio);
             }


### PR DESCRIPTION
Carries the two remaining Qodo findings from #705. **Supersedes #705**, whose content already merged as `170b42ba` — see the note at the bottom.

## 1. Disarm re-enabled the interrupt

`IEC0CLR` does not stop an ISR that is **already executing**, and this unit's ISR runs above the kernel-managed threshold. Two races followed:

1. An in-flight ISR could reach `edge_FifoPush` **after** the task zeroed `gIntState[u].dio` — enqueueing an event whose pin reads `0`, a bogus DIO number to whoever pops it.
2. In `USER_EDGE_BOTH` the ISR ends with `IEC0SET` to retarget the opposite edge. Landing after the task's `IEC0CLR`, that leaves the interrupt **enabled on a pin the caller was told is disarmed** — and the next edge runs an ISR against `enabled=false, dio=0`.

Teardown now runs under a raw interrupt mask, so the ISR either finished before the mask (its `IEC0SET` then undone by our `IEC0CLR`) or cannot start until the state is torn down.

The PPS unroute is deliberately moved **after** the mask: it is a SYSKEY/CFGCON sequence that should not run with interrupts globally disabled, and by that point no ISR can reach the unit.

## 2. Pre-scheduler critical section

`edge_SetIntPriority` / `edge_SetCtrPriority` used `taskENTER_CRITICAL`, but `UserEdge_Initialize` calls them **at boot**. On the PIC32MZ FreeRTOS port `vTaskExitCritical()` does not re-enable interrupts when the scheduler is not yet running — so a critical section there would have left interrupts **masked for the remainder of boot**.

Both now use `__builtin_disable_interrupts`/`mtc0`, which restores the prior state correctly in either context. The RMW still needs to be atomic (IPC4 is shared between INT3 and IC3), so only the mechanism changed.

## Verification

Bench, COM3 with the DIO0→DIO3 jumper:

```
PASS: #667 edge events (no-hardware + hardware subsets)
===== 667_edge_events: 11 PASS, 0 FAIL =====
```

## Why a new branch instead of pushing to #705

`feat/667-edge-events` no longer reconciles with `main`. #705's content merged as `170b42ba`, and #762 then modified the same file, so a merge came back **add/add with 7 conflict hunks** in `UserEdge.c`.

Worth recording for anyone who hits this: my first read of `git merge` was *"refusing to merge unrelated histories"*, which looked alarming. That was a **local shallow-clone artifact** — the checkout had only 2 commits and its own root. After `git fetch --unshallow` a real merge base appeared (`59213206`). The unrelated-history message was about my clone, not the repository.

Rebuilding the two fixes on a fresh branch off `main` was cleaner than untangling that, and produces a diff that is exactly the two changes.

#705 can be closed once this lands.