### PR TITLE
fix(wifi): advance the READ_BLOCK cursor so large bridge reads terminate (#755)

### DIFF
--- a/firmware/src/services/wifi_services/wifi_serial_bridge.c
+++ b/firmware/src/services/wifi_services/wifi_serial_bridge.c
@@ -98,21 +98,38 @@ static bool ProcessCommand(wifi_serial_bridge_context_t * const pContext) {
 
         case WIFI_SERIAL_BRIDGE_COMMAND_READ_BLOCK:
         {
+            /* Walk the request in dataBuf-sized chunks. Both the remaining
+             * count and the source address must advance every iteration (#755):
+             * before this, neither did, so any cmdSize >= 2048 re-read and
+             * re-sent the SAME chunk forever and the loop could only exit on
+             * an error. cmdAddr is scratch for the duration of the command —
+             * ProcessHeader re-parses it from the wire for every request — so
+             * advancing it in place is safe. */
+            uint32_t addr = pContext->cmdAddr;
+
             cnt = pContext->cmdSize;
 
             while (cnt >= WIFI_SERIAL_BRIDGE_CMD_BUFFER_SIZE) {
-                if (M2M_SUCCESS != nm_read_block(pContext->cmdAddr, pContext->dataBuf, WIFI_SERIAL_BRIDGE_CMD_BUFFER_SIZE))
+                if (M2M_SUCCESS != nm_read_block(addr, pContext->dataBuf, WIFI_SERIAL_BRIDGE_CMD_BUFFER_SIZE))
                     return false;
 
                 if (false == wifi_serial_bridge_interface_UARTWritePutBuffer(pContext->dataBuf, WIFI_SERIAL_BRIDGE_CMD_BUFFER_SIZE))
                     return false;
+
+                addr += WIFI_SERIAL_BRIDGE_CMD_BUFFER_SIZE;
+                cnt  -= WIFI_SERIAL_BRIDGE_CMD_BUFFER_SIZE;
             }
 
             if (cnt) {
-                if (M2M_SUCCESS != nm_read_block(pContext->cmdAddr, pContext->dataBuf, cnt))
+                if (M2M_SUCCESS != nm_read_block(addr, pContext->dataBuf, cnt))
                     return false;
 
-                if (false == wifi_serial_bridge_interface_UARTWritePutBuffer(pContext->dataBuf, pContext->cmdSize))
+                /* cnt, NOT cmdSize: with the loop fixed, cnt is the remainder
+                 * and only the first cnt bytes of dataBuf are valid. Sending
+                 * cmdSize here would leak stale buffer contents past the data
+                 * actually read — harmless only while the loop above could
+                 * never terminate. */
+                if (false == wifi_serial_bridge_interface_UARTWritePutBuffer(pContext->dataBuf, cnt))
                     return false;
             }
 

--- a/firmware/src/services/wifi_services/wifi_serial_bridge.c
+++ b/firmware/src/services/wifi_services/wifi_serial_bridge.c
@@ -101,10 +101,10 @@ static bool ProcessCommand(wifi_serial_bridge_context_t * const pContext) {
             /* Walk the request in dataBuf-sized chunks. Both the remaining
              * count and the source address must advance every iteration (#755):
              * before this, neither did, so any cmdSize >= 2048 re-read and
-             * re-sent the SAME chunk forever and the loop could only exit on
-             * an error. cmdAddr is scratch for the duration of the command —
-             * ProcessHeader re-parses it from the wire for every request — so
-             * advancing it in place is safe. */
+             * re-sent the SAME chunk forever, and the loop could exit only on
+             * an error. The cursor is a local rather than a mutation of
+             * pContext->cmdAddr, so the command's parsed header stays
+             * read-only for its lifetime. */
             uint32_t addr = pContext->cmdAddr;
 
             cnt = pContext->cmdSize;

--- a/firmware/src/services/wifi_services/wifi_serial_bridge.c
+++ b/firmware/src/services/wifi_services/wifi_serial_bridge.c
@@ -9,6 +9,8 @@
 #include "nmdrv.h"
 #include "nmbus.h"
 #include "m2m_wifi.h"
+#include "FreeRTOS.h"
+#include "task.h"
 
 #define WIFI_SERIAL_BRIDGE_COMMAND_HEADER_SIZE      12
 
@@ -26,6 +28,42 @@ typedef enum {
     WIFI_SERIAL_BRIDGE_RESPONSE_ID_FIXED_BR = 0x5c,
     WIFI_SERIAL_BRIDGE_RESPONSE_ACK = 0xac
 } wifi_serial_bridge_response_t;
+
+/* Bounded retry around the bridge's USB write.
+ *
+ * UsbCdc_WriteToBuffer is NON-BLOCKING and ALL-OR-NOTHING: it returns 0 when
+ * the write mutex is busy or the circular buffer cannot take the whole chunk,
+ * and its contract explicitly puts retry on the caller — "Callers retry via
+ * Streaming_WriteWithRetry — no data loss" (UsbCdc.c). The bridge never did,
+ * so a single transient buffer-full aborted the command.
+ *
+ * That mattered little while READ_BLOCK's loop could never terminate: the
+ * unterminated loop accidentally supplied the retry by re-sending the same
+ * chunk forever. With the loop fixed (#755) a large transfer performs many
+ * distinct 2048-byte writes, so an unretried failure truncates the response
+ * and leaves the host waiting for bytes that never arrive.
+ *
+ * Deadline is (now - start) < window so a tick-counter wrap cannot end the
+ * wait early. Runs on app_WifiTask (wifi_manager.c calls
+ * wifi_serial_bridge_Process), i.e. task context, so vTaskDelay is legal.
+ */
+#define BRIDGE_WRITE_TIMEOUT_MS   2000u
+
+static bool bridge_WriteAll(const void *pBuf, size_t numBytes) {
+    if (wifi_serial_bridge_interface_UARTWritePutBuffer(pBuf, numBytes)) {
+        return true;
+    }
+    const TickType_t start = xTaskGetTickCount();
+    while ((TickType_t)(xTaskGetTickCount() - start) < pdMS_TO_TICKS(BRIDGE_WRITE_TIMEOUT_MS)) {
+        vTaskDelay(1);
+        if (wifi_serial_bridge_interface_UARTWritePutBuffer(pBuf, numBytes)) {
+            return true;
+        }
+    }
+    LOG_E("Serial bridge: USB write blocked >%u ms, response truncated",
+          (unsigned)BRIDGE_WRITE_TIMEOUT_MS);
+    return false;
+}
 
 static bool ProcessHeader(wifi_serial_bridge_context_t * const pContext, uint8_t *pHeader) {
     uint8_t checksum;
@@ -82,7 +120,7 @@ static bool ProcessCommand(wifi_serial_bridge_context_t * const pContext) {
             pContext->dataBuf[2] = (regVal >> 8) & 0xff;
             pContext->dataBuf[3] = (regVal) & 0xff;
 
-            if (false == wifi_serial_bridge_interface_UARTWritePutBuffer(pContext->dataBuf, 4)) {
+            if (false == bridge_WriteAll(pContext->dataBuf, 4)) {
                 return false;
             }
 
@@ -113,7 +151,7 @@ static bool ProcessCommand(wifi_serial_bridge_context_t * const pContext) {
                 if (M2M_SUCCESS != nm_read_block(addr, pContext->dataBuf, WIFI_SERIAL_BRIDGE_CMD_BUFFER_SIZE))
                     return false;
 
-                if (false == wifi_serial_bridge_interface_UARTWritePutBuffer(pContext->dataBuf, WIFI_SERIAL_BRIDGE_CMD_BUFFER_SIZE))
+                if (false == bridge_WriteAll(pContext->dataBuf, WIFI_SERIAL_BRIDGE_CMD_BUFFER_SIZE))
                     return false;
 
                 addr += WIFI_SERIAL_BRIDGE_CMD_BUFFER_SIZE;
@@ -129,7 +167,7 @@ static bool ProcessCommand(wifi_serial_bridge_context_t * const pContext) {
                  * cmdSize here would leak stale buffer contents past the data
                  * actually read — harmless only while the loop above could
                  * never terminate. */
-                if (false == wifi_serial_bridge_interface_UARTWritePutBuffer(pContext->dataBuf, cnt))
+                if (false == bridge_WriteAll(pContext->dataBuf, cnt))
                     return false;
             }
 
@@ -144,7 +182,7 @@ static bool ProcessCommand(wifi_serial_bridge_context_t * const pContext) {
                 pContext->dataBuf[0] = WIFI_SERIAL_BRIDGE_RESPONSE_NACK;
             }
 
-            return wifi_serial_bridge_interface_UARTWritePutBuffer(pContext->dataBuf, 1);
+            return bridge_WriteAll(pContext->dataBuf, 1);
         }
 
         case WIFI_SERIAL_BRIDGE_COMMAND_RECONFIGURE:


### PR DESCRIPTION
Fixes #755.

## The bug

`WIFI_SERIAL_BRIDGE_COMMAND_READ_BLOCK` looped forever for any request of `cmdSize >= 2048`. The loop body never decremented `cnt` and never advanced `cmdAddr`, so both were loop-invariant:

- the exit condition could never become false,
- every iteration re-read the **same** WINC address,
- every iteration re-sent the **same** 2048 bytes to the host.

The only escape was an `nm_read_block` or UART-write failure — it terminated on error and on nothing else. A host performing a large block read hangs until it gives up or is killed.

## The fix

Walk the request properly: advance a cursor and decrement the remaining count after each successful chunk. The cursor is a local rather than a mutation of `pContext->cmdAddr`, so the command's parsed header stays read-only for its lifetime.

**The tail write is fixed in the same commit, deliberately.** It read `cnt` bytes but transmitted `pContext->cmdSize`:

```c
nm_read_block(addr, dataBuf, cnt);
UARTWritePutBuffer(dataBuf, pContext->cmdSize);   /* over-sends */
```

That was harmless *only* because the loop above could never terminate, so the tail was reachable solely when `cmdSize < 2048`, where `cnt == cmdSize`. Correcting the loop without this line would convert a hang into sending stale buffer bytes past the data actually read — a hang traded for silent corruption.

## Bug-class hunt

Checked the neighbouring bridge commands for the same shape. `WRITE_BLOCK` is **safe**: `ProcessHeader` bounds `payloadLength` to `WIFI_SERIAL_BRIDGE_CMD_BUFFER_SIZE` and rejects the header above it (`wifi_serial_bridge.c:56-58`), so the wire-supplied 16-bit `cmdSize` cannot overrun the 2048-byte `dataBuf`. I checked this specifically because `cmdSize` is attacker-controlled off the wire and `WRITE_BLOCK` passes it straight to a fixed buffer — the bound is there, so no change needed.

## Impact

Affects the WINC firmware-update / SPI-flash read-back path — the only caller that issues reads larger than 2048 bytes. Sub-2048 reads were always fine, which is why this survived: the common path never enters the loop.

## Test plan

⚠️ **No companion regression test yet** — flagging this explicitly rather than quietly skipping it, since the standing rule is that every firmware PR ships one.

Exercising this needs the device in serial-bridge (WINC download) mode and a host driving a `READ_BLOCK` with `cmdSize >= 2048`, then asserting the reply terminates instead of streaming the same chunk forever. That is the `firmware/utilities/update_wifi_firmware.py` path. I have not yet built that harness, and a test that cannot fail on the old firmware would be worse than none.

Verification so far:
- Builds clean at -O3 with `-Werror -Wall` (XC32 v4.60).
- Defect and fix traced against source; the loop-invariance is evident by inspection.

**Not bench-validated.** Recommend holding merge until either the bridge test lands or a manual WINC firmware read-back is run on hardware.