### PR TITLE
fix(release): assert p32MZ2048EFM144.ld is excluded before the flip (#767)

### DIFF
--- a/tools/release/cut_release.sh
+++ b/tools/release/cut_release.sh
@@ -141,7 +141,15 @@ EXLN="$(awk '
   indef && found && /ex="/ {print NR; exit}
 ' "$CFG")"
 [ -n "$EXLN" ] || die "could not locate the default-conf old_hv2_bootld.ld ex= attribute in $CFG"
-grep -q 'ex="true"' <(sed -n "${EXLN}p" "$CFG") || die "expected ex=\"true\" at line $EXLN (got: $(sed -n "${EXLN}p" "$CFG"))"
+EXLINE="$(sed -n "${EXLN}p" "$CFG")"
+# Plain expansion rather than `grep -q ... <(sed ...)`: process substitution
+# needs /dev/fd, which is not guaranteed in every environment this might run in,
+# and reading the line once means the check and the error message cannot
+# disagree about what was actually there.
+case "$EXLINE" in
+  *'ex="true"'*) : ;;
+  *) die "expected ex=\"true\" at line $EXLN (got: $EXLINE)" ;;
+esac
 sed -i "${EXLN}s/ex=\"true\"/ex=\"false\"/" "$CFG"
 echo "  old_hv2_bootld.ld -> included (line $EXLN)"
 

--- a/tools/release/cut_release.sh
+++ b/tools/release/cut_release.sh
@@ -106,36 +106,38 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Assert p32MZ2048EFM144.ld is EXCLUDED before touching anything (#767).
+# Assert the starting state with the SAME checker CI uses (#767, #769).
 #
-# Step 1's header says "keep p32MZ excluded", but nothing checked it — and this
-# script only ever inspects old_hv2_bootld.ld. From a project where p32 is
-# selected, the flip below turns ONE selected script into TWO, and the produced
-# layout then depends on makefile regeneration order. Same block-scoped awk as
-# the old_hv2 lookup so both preconditions fail the same way.
-P32LN="$(awk '
-  /<conf name="default"/ {indef=1}
-  indef && /<\/conf>/      {indef=0}
-  indef && /p32MZ2048EFM144\.ld"/ {print NR; exit}
-' "$CFG")"
-[ -n "$P32LN" ] || die "could not locate default-conf p32MZ2048EFM144.ld item in $CFG"
-P32EXLN=$((P32LN + 1))
-grep -q 'ex="true"' <(sed -n "${P32EXLN}p" "$CFG") \
-  || die "p32MZ2048EFM144.ld must be ex=\"true\" (excluded) before a release cut; got line $P32EXLN: $(sed -n "${P32EXLN}p" "$CFG")
-  Flipping old_hv2_bootld.ld from here would leave BOTH linker scripts selected.
+# This began as a hand-rolled grep that only ever inspected old_hv2_bootld.ld
+# and assumed ex= sat on the line AFTER the path. Both assumptions were wrong.
+# Nothing verified p32MZ2048EFM144.ld was excluded, so the flip below could turn
+# ONE selected script into TWO. And configurations.xml contains both single-line
+# and wrapped <item> forms (129 vs 35 today), so an MPLAB X regen that emitted
+# these entries single-line would have aborted a perfectly valid release cut.
+#
+# check_build_config.py parses the file as XML, so attribute layout and ordering
+# cannot fool it, and it exits 0 only for the state this script requires: no
+# custom linker script selected in the default conf. It carries an 11-case
+# selftest. Reusing it keeps ONE definition of "releasable state" rather than
+# two that drift apart.
+python3 "$REPO/tools/release/check_build_config.py" "$CFG" \
+  || die "configurations.xml is not in a releasable state (detail above).
   Restore the bench default: git checkout -- $CFG"
 
-# Find old_hv2_bootld.ld inside the <conf name="default"> block and flip the ex=
-# flag on the line that follows it. Robust to line moves: locate by block, not
-# hardcoded line numbers. Bound the block by the </conf> close tag rather than
-# the name of the next conf (which could be renamed).
-LN="$(awk '
+# Locate the default-conf old_hv2_bootld.ld ex= attribute and flip it.
+#
+# Format-agnostic for the same reason as above: take ex= from the item's own
+# line when it is there, else the first ex= that follows. Scoped to the
+# <conf name="default"> block and bounded a few lines past the item so a
+# malformed file cannot run away.
+EXLN="$(awk '
   /<conf name="default"/ {indef=1}
-  indef && /<\/conf>/      {indef=0}
-  indef && /old_hv2_bootld\.ld"/ {print NR; exit}
+  indef && /<\/conf>/     {indef=0}
+  indef && found && NR > found + 4 {exit}
+  indef && /old_hv2_bootld\.ld"/ {found=NR; if ($0 ~ /ex="/) {print NR; exit} next}
+  found && /ex="/ {print NR; exit}
 ' "$CFG")"
-[ -n "$LN" ] || die "could not locate default-conf old_hv2_bootld.ld item in $CFG"
-EXLN=$((LN + 1))
+[ -n "$EXLN" ] || die "could not locate the default-conf old_hv2_bootld.ld ex= attribute in $CFG"
 grep -q 'ex="true"' <(sed -n "${EXLN}p" "$CFG") || die "expected ex=\"true\" at line $EXLN (got: $(sed -n "${EXLN}p" "$CFG"))"
 sed -i "${EXLN}s/ex=\"true\"/ex=\"false\"/" "$CFG"
 echo "  old_hv2_bootld.ld -> included (line $EXLN)"

--- a/tools/release/cut_release.sh
+++ b/tools/release/cut_release.sh
@@ -106,6 +106,25 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Assert p32MZ2048EFM144.ld is EXCLUDED before touching anything (#767).
+#
+# Step 1's header says "keep p32MZ excluded", but nothing checked it — and this
+# script only ever inspects old_hv2_bootld.ld. From a project where p32 is
+# selected, the flip below turns ONE selected script into TWO, and the produced
+# layout then depends on makefile regeneration order. Same block-scoped awk as
+# the old_hv2 lookup so both preconditions fail the same way.
+P32LN="$(awk '
+  /<conf name="default"/ {indef=1}
+  indef && /<\/conf>/      {indef=0}
+  indef && /p32MZ2048EFM144\.ld"/ {print NR; exit}
+' "$CFG")"
+[ -n "$P32LN" ] || die "could not locate default-conf p32MZ2048EFM144.ld item in $CFG"
+P32EXLN=$((P32LN + 1))
+grep -q 'ex="true"' <(sed -n "${P32EXLN}p" "$CFG") \
+  || die "p32MZ2048EFM144.ld must be ex=\"true\" (excluded) before a release cut; got line $P32EXLN: $(sed -n "${P32EXLN}p" "$CFG")
+  Flipping old_hv2_bootld.ld from here would leave BOTH linker scripts selected.
+  Restore the bench default: git checkout -- $CFG"
+
 # Find old_hv2_bootld.ld inside the <conf name="default"> block and flip the ex=
 # flag on the line that follows it. Robust to line moves: locate by block, not
 # hardcoded line numbers. Bound the block by the </conf> close tag rather than

--- a/tools/release/cut_release.sh
+++ b/tools/release/cut_release.sh
@@ -122,7 +122,10 @@ trap cleanup EXIT
 # two that drift apart.
 python3 "$REPO/tools/release/check_build_config.py" "$CFG" \
   || die "configurations.xml is not in a releasable state (detail above).
-  Restore the bench default: git checkout -- $CFG"
+  Nothing has been modified — this check runs before the linker flip, and
+  cleanup() restores the file from a per-run backup regardless. Fix the
+  selection in MPLAB X (or by hand) and re-run; do NOT 'git checkout' the
+  file unless you also mean to discard your own edits to it."
 
 # Locate the default-conf old_hv2_bootld.ld ex= attribute and flip it.
 #
@@ -135,7 +138,7 @@ EXLN="$(awk '
   indef && /<\/conf>/     {indef=0}
   indef && found && NR > found + 4 {exit}
   indef && /old_hv2_bootld\.ld"/ {found=NR; if ($0 ~ /ex="/) {print NR; exit} next}
-  found && /ex="/ {print NR; exit}
+  indef && found && /ex="/ {print NR; exit}
 ' "$CFG")"
 [ -n "$EXLN" ] || die "could not locate the default-conf old_hv2_bootld.ld ex= attribute in $CFG"
 grep -q 'ex="true"' <(sed -n "${EXLN}p" "$CFG") || die "expected ex=\"true\" at line $EXLN (got: $(sed -n "${EXLN}p" "$CFG"))"


### PR DESCRIPTION
Fixes #767.

## The gap

`cut_release.sh` step 1's header has always said *"keep p32MZ excluded"* — and that comment was the script's **only** mention of p32. The script inspects `old_hv2_bootld.ld` exclusively: asserts `ex="true"`, flips it to `ex="false"`, never looks at the other linker script.

So from a project where p32 is selected, the flip turns **one** selected script into **two**, and the produced layout depends on makefile regeneration order. The precondition the header claimed was simply not enforced.

Found by the pre-merge adversarial audit on #765.

## The fix

Assert it, using the same block-scoped `awk` as the `old_hv2` lookup so both preconditions are located and fail the same way, with the restore command in the message.

## Impact — low, stated plainly

Nothing mis-shaped could ship from this. `cut_release.sh` hard-verifies the artifact afterwards and `die`s on any mismatch: map origin `0x9d000480`, lowest address `0x1D000000`, exactly 408 reset-vector bytes, bulk from `0x1D000480`. The realistic outcome was a confusing aborted cut, or a build failure from two `-T` scripts. This turns that into a named precondition failure at the point of the assumption.

## Verification

Exercised both precondition blocks against fixtures with MPLAB-style multi-line `<item>` tags:

| fixture | result |
|---|---|
| both excluded (`main`'s state) | `PRECONDITIONS OK` |
| p32 selected — **the #767 case** | `DIE: p32 must be ex=true (excluded)` |
| old_hv2 selected | `DIE: old_hv2 must be ex=true` (pre-existing check, still works) |
| the committed `configurations.xml` | `PRECONDITIONS OK` |

## What I deliberately did NOT add

A post-regen check that `Makefile-default.mk` does not reference `p32MZ2048EFM144.ld`, mirroring the existing `old_hv2_bootld` post-regen grep. Makefiles are gitignored, so I could not verify such a grep wouldn't false-positive on XC32's own device linker script of the same name. Adding an unverifiable check to a release script is worse than not adding it. Noted on #767 if someone wants it with a regenerated makefile in hand.

## Relationship to #765

Complements `tools/release/check_build_config.py`, which rejects the same state at PR time. This is the defense-in-depth half: `cut_release.sh` can be run from any working state, not only one that passed CI.

## Test plan

Shell-only release tooling, no firmware change — exempt from the hardware-regression rule. Verified by `bash -n` plus the fixture matrix above. The next real release cut exercises it end to end.