### PR TITLE
fix(pb): report analog_in_res for NQ3 so hosts stop scaling 4x low (#697)

### DIFF
--- a/firmware/src/services/DaqifiPB/DaqifiOutMessage.proto
+++ b/firmware/src/services/DaqifiPB/DaqifiOutMessage.proto
@@ -36,8 +36,8 @@ message DaqifiOutMessage
 	repeated float analog_in_port_av_range_priv = 24;		//	Private analog in port voltage range (volts span:RSE 0 to range, NON-RSE -(range/2) to (range/2))
 	repeated float analog_in_port_range = 25;				//	Analog in port voltage range (volts span:RSE 0 to range, NON-RSE -(range/2) to (range/2))
 	repeated float analog_in_port_range_priv = 26;			//	Private analog in port voltage range (volts span:RSE 0 to range, NON-RSE -(range/2) to (range/2))
-	uint32 analog_in_res = 27;						//  Public analog in (ADC) resolution (bits used to convert from integer value to volts)
-	uint32 analog_in_res_priv = 28;				//  Private analog in (ADC) resolution (bits used to convert from integer value to volts)
+	uint32 analog_in_res = 27;						//  Public analog in (ADC) resolution as a CODE COUNT, not a bit width (12-bit -> 4096, 18-bit -> 262144). Scale: raw / analog_in_res * analog_in_port_range
+	uint32 analog_in_res_priv = 28;				//  Private analog in (ADC) resolution as a CODE COUNT, not a bit width (see analog_in_res)
 	repeated float analog_in_int_scale_m = 29;				//  Analog in port internal scale m value (should be applied to integer value before converting to volts)
 	repeated float analog_in_int_scale_m_priv = 30;			//  Private analog in port internal scale m value (should be applied to integer value before converting to volts)
 	repeated float analog_in_cal_m = 31;					//  Analog in port calibration m value (should be applied to integer value before converting to volts)

--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -739,8 +739,19 @@ size_t Nanopb_Encode(tBoardData* state,
                 /**
                  * @brief Encodes the resolution of the analog input channels.
                  *
-                 * This tag stores the resolution (in bits) of the analog input channels,
-                 * based on the ADC configuration for the active board variant.
+                 * Not "in bits" despite the older wording here: this is the raw
+                 * code COUNT (4096 for NQ1's 12-bit MC12b, 262144 for NQ3's
+                 * 18-bit AD7609). Consumers scale as
+                 * raw / resolution * portRange * calM + calB, so the units
+                 * matter — daqifi-core's DaqifiDevice.PopulateAnalogChannels
+                 * treats a 0 as "assume 65535".
+                 *
+                 * NQ3 (#697): this was commented out, so the field stayed 0 —
+                 * nanopb STATIC SINGULAR UINT32 has no presence bit — and every
+                 * AD7609 sample came out ~4x low on the host with no error
+                 * surfaced. The value was correct in board config all along
+                 * (NQ3BoardConfig.c .Resolution = 262144); it simply never
+                 * reached the wire.
                  */
 
                 switch (pBoardConfig->BoardVariant) {
@@ -748,10 +759,14 @@ size_t Nanopb_Encode(tBoardData* state,
                         message.analog_in_res = pBoardConfig->AInModules.Data[AIn_MC12bADC].Config.MC12b.Resolution;
                         break;
                     case 2:
-                        //message.analog_in_res = pBoardConfig->AInModules.Data[1].Config.AD7173.Resolution;
+                        /* NQ2 / AD7173 stays unencoded: AIn_AD7173 is commented
+                         * out of the AInType enum (AInConfig.h), so there is no
+                         * module slot to read and no NQ2 board config to read it
+                         * from. Restore this together with the enum entry, not
+                         * before — the index would otherwise shift AIn_AD7609. */
                         break;
                     case 3:
-                        //message.analog_in_res = pBoardConfig->AInModules.Data[1].Config.AD7609.Resolution;
+                        message.analog_in_res = pBoardConfig->AInModules.Data[AIn_AD7609].Config.AD7609.Resolution;
                         break;
                     default:
                         break;

--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -759,11 +759,16 @@ size_t Nanopb_Encode(tBoardData* state,
                         message.analog_in_res = pBoardConfig->AInModules.Data[AIn_MC12bADC].Config.MC12b.Resolution;
                         break;
                     case 2:
-                        /* NQ2 / AD7173 stays unencoded: AIn_AD7173 is commented
-                         * out of the AInType enum (AInConfig.h), so there is no
-                         * module slot to read and no NQ2 board config to read it
-                         * from. Restore this together with the enum entry, not
-                         * before — the index would otherwise shift AIn_AD7609. */
+                        /* NQ2 / AD7173 stays unencoded. The board config DOES
+                         * exist — NQ2BoardConfig.c carries .Type = AIn_AD7173
+                         * with .Resolution = 16777216 (24-bit) — but it is
+                         * ex="true" (excluded) in every configuration, and
+                         * AIn_AD7173 is commented out of AInType (AInConfig.h),
+                         * which is why that file compiles nowhere today.
+                         * Restoring NQ2 means restoring the enum entry AND the
+                         * build inclusion together; note the enum entry would
+                         * shift AIn_AD7609, so the case 3 line below must be
+                         * re-checked at the same time. */
                         break;
                     case 3:
                         message.analog_in_res = pBoardConfig->AInModules.Data[AIn_AD7609].Config.AD7609.Resolution;


### PR DESCRIPTION
Fixes #697.

## The bug

The BoardVariant 3 assignment was commented out, so `analog_in_res` stayed `0`. nanopb declares it `STATIC SINGULAR UINT32` — no presence bit — so a host cannot distinguish "not sent" from "zero". `daqifi-core`'s `PopulateAnalogChannels` does `analogInResolution > 0 ? analogInResolution : 65535`, so `0` silently becomes 16-bit.

Consumers scale as `raw / resolution * portRange * calM + calB`, making that substitution a straight multiplicative error on **every** analog sample:

| variant | true resolution | host assumed | error |
|---|---|---|---|
| NQ1 | 4096 (12-bit MC12b) | 4096 (reported) | correct |
| NQ3 | 262144 (18-bit AD7609) | 65535 (fallback) | **~4x low** |

The value was correct in board config the whole time (`NQ3BoardConfig.c` `.Resolution = 262144`) — it just never reached the wire.

## What I verified before changing the index

The commented-out line used a literal `[1]`. I used the named enum instead, matching the `analog_in_port_range` code a few lines above, and confirmed the slot rather than trusting the comment:

- `NQ3BoardConfig.c`: `AInModules.Data[0]` = MC12b (4096), `Data[1]` = AD7609 (262144)
- `AInConfig.h`: `AIn_AD7609 == 1`, because `AIn_AD7173` is **commented out** of `AInType`

That coupling is now called out in the variant-2 branch, since restoring AD7173 to the enum would shift `AIn_AD7609` and silently break this line. Variant 2 stays unencoded — there is no module slot and no NQ2 board config to read from.

## What I deliberately left alone

`analog_in_res_priv` reads MC12b for every variant, and that is **correct**: NQ3's private/monitoring channel *is* the internal MC12b (the board has 9 AD7609 channels and 1 MC12b). Changing it to match would have been the wrong symmetry.

I also corrected the doc comment's "resolution (in bits)" — the field carries the raw code **count**, and those units are the entire bug.

## ⚠️ Build status — please read

- **default config: builds clean** at -O3 with `-Werror -Wall` (XC32 v4.60).
- **Nq3 config: does NOT build** — and this is **pre-existing on `main`**, not caused by this change.

I verified that by stashing this edit and rebuilding clean `main`: identical failure. It dies compiling `drv_sdspi.c` (a file untouched here) with `fatal error: scpi/config.h: No such file or directory`, because the Nq3 compile line lacks the `-I".../libraries/scpi/libscpi/inc"` flag the default config has. Regenerating the makefiles with `prjMakefilesGenerator` does not fix it, so the gap is in `configurations.xml`'s Nq3 configuration, not a stale generated makefile.

**So the variant this change targets cannot currently be compiled or flashed.** Filed separately. I'm flagging it rather than quietly reporting a green build, because "fixes NQ3" is weaker than it sounds while NQ3 is unbuildable.

## Test plan

No companion regression test yet. Exercising this needs NQ3 hardware, and the NQ3 configuration does not build — so a test would be unrunnable on arrival. The assertion is straightforward once the build is fixed: connect to an NQ3, read the protobuf status message, assert `analog_in_res == 262144` (it reads `0` on old firmware).

Verification so far is static: the encoded value traced from `NQ3BoardConfig.c` through the enum to the protobuf field, plus a clean default-config build.