### PR TITLE
fix(sd): honour the transfer-abort flag in the directory listing path (#754)

### DIFF
--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -365,6 +365,13 @@ typedef void (*ListChunkCallback)(const uint8_t* data, size_t len);
 
 // Static callback for sending directory listing chunks
 static void sd_listdir_send_chunk(const uint8_t* data, size_t len) {
+    /* #754: once an abort is pending, stop handing chunks to a transport that
+     * is not draining. Each DataReadyCB burns USB_TRANSFER_MAX_RETRIES (~10 s)
+     * before giving up, so continuing to send is what turns one stalled peer
+     * into a multi-minute SD lockout for every other command. */
+    if (gTransferAbortRequested) {
+        return;
+    }
     if (len > 0) {
         LOG_D("[SD] Sending chunk: %d bytes\r\n", (int)len);
         sd_card_manager_DataReadyCB(SD_CARD_MANAGER_MODE_LIST_DIRECTORY, (uint8_t*)data, len);
@@ -390,6 +397,12 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
 
     memset(newPath, 0, sizeof (newPath));
     memset(&stat, 0, sizeof (stat));
+
+    /* Clear on entry, exactly as the READ_FROM_FILE loop does. An abort
+     * requested while no transfer was running would otherwise be latched and
+     * kill the NEXT listing instead of the one it was meant for (#754). */
+    gTransferAbortRequested = false;
+
     LOG_D("[SD] ListFiles: Opening directory '%s'\r\n", dirPath);
 
     SYS_FS_HANDLE rootHandle = SYS_FS_DirOpen(dirPath);
@@ -421,6 +434,29 @@ static void ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, 
     }
 
     while (sp >= 0) {
+        /* #754: the LIST path never consumed this flag — #753 added it with a
+         * single consumer at the top of the READ_FROM_FILE loop. So a listing
+         * to a connected-but-stalled peer walked the entire tree, ~10 s per
+         * chunk, holding gSDOpMutex throughout and rejecting every other SD
+         * command with "SD card busy".
+         *
+         * Unwind the WHOLE stack rather than returning directly: each frame
+         * holds an open SYS_FS directory handle, and bailing out without
+         * closing them leaks handles for the rest of the session. */
+        if (gTransferAbortRequested) {
+            gTransferAbortRequested = false;
+            LOG_E("[SD] ListFiles: ABORTED (peer not draining), closing %d dir handle(s)",
+                  sp + 1);
+            while (sp >= 0) {
+                if (SYS_FS_DirClose(gListDirStack[sp].handle) == SYS_FS_RES_FAILURE) {
+                    LOG_E("[SD] ListFiles: Failed to close directory on abort, error=%d",
+                          SYS_FS_Error());
+                }
+                sp--;
+            }
+            return;
+        }
+
         if (SYS_FS_DirRead(gListDirStack[sp].handle, &stat) == SYS_FS_RES_FAILURE) {
             SYS_FS_ERROR err = SYS_FS_Error();
             LOG_E("[SD] ListFiles: Failed to read directory '%s', error=%d",


### PR DESCRIPTION
Fixes #754.

## The defect

[PR #753](https://github.com/daqifi/daqifi-nyquist-firmware/pull/753) introduced `gTransferAbortRequested` with **exactly one consumer** — the top of the `READ_FROM_FILE` loop. But `sd_card_manager_DataReadyCB` has *two* callers, and the `LIST_DIRECTORY` one never read it.

So a listing to a peer that is connected but **not draining** burned the full `USB_TRANSFER_MAX_RETRIES` (~10 s) per chunk and simply walked on to the next. With `SD_CARD_MANAGER_CONF_RBUFFER_SIZE = 512` a large directory is many chunks, and `gSDOpMutex` is held for the whole traversal — so **every other SD command is rejected with "SD card busy"** for the duration. #689 already documents directories reaching hundreds of files.

The cost scales with directory size, not file size.

## The fix — three parts, all needed

1. **`sd_listdir_send_chunk` returns early** once an abort is pending, so no further chunk burns another ~10 s against a transport that is not draining.
2. **The traversal loop consumes the flag** and returns, mirroring the READ loop.
3. **`ListFilesInDirectoryChunked` clears the flag on ENTRY**, exactly as the READ loop does.

The third is easy to miss and matters: without it, an abort requested while no transfer was running stays latched and kills the **next** listing rather than the one it was meant for. The READ loop already had this entry-clear; the LIST path had neither half.

## Unwinding, not just returning

The abort closes the **whole frame stack** rather than returning directly:

```c
while (sp >= 0) {
    if (SYS_FS_DirClose(gListDirStack[sp].handle) == SYS_FS_RES_FAILURE) { ... }
    sp--;
}
```

Each frame holds an open `SYS_FS` directory handle. Bailing out without closing them would leak handles for the rest of the session — a worse outcome than the stall being fixed.

## Verification

Builds clean at -O3 with `-Werror -Wall` (XC32 v4.60). cppcheck reports 0 findings, baseline unchanged.

**Not yet bench-run.** The trigger (a peer alive but fully stalled across a multi-chunk listing) was traced in source by the #753 audit and has not been demonstrated on hardware — the issue says so explicitly and this PR does not change that.

## Companion test

[daqifi-python-test-suite PR](https://github.com/daqifi/daqifi-python-test-suite/pull/135) — opens a TCP peer that requests a listing and never reads, then races a cheap SD command over USB and **measures** how long the subsystem stays unavailable. Broken firmware fails by measuring the lockout (chunks × ~10 s) rather than by waiting out a hang, and the test re-checks SD health afterwards so a pass cannot mean "we broke the card instead".

It refuses to run unless the listing spans ≥ 8 chunks, since below that a correct and a broken firmware both finish fast and the result would prove nothing.

## Out of scope

#725 (mid-transfer `SD:GET` read error sends no terminator) is the sibling defect but is explicitly a **client-coordinated protocol change** — a new `__TRANSFER_ERROR__` marker that daqifi-core, python-core and desktop must all learn. Shipping it firmware-only would break the mechanism/policy split, so it stays open pending client-side issues.