### PR TITLE
fix(sd): kick the detect poll before answering "no card" (#756)

### DIFF
--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -79,6 +79,11 @@ bool __attribute__((weak)) DRV_SDSPI_GetCID(uint8_t* cidBuffer, size_t bufLen) {
 /* ************************************************************************** */
 #define LAN_ACTIVE_ERROR_MSG "\r\nError !! Please Disable LAN\r\n"
 #define SD_CARD_NOT_ENABLED_ERROR_MSG "\r\nError !! Please Enabled SD Card\r\n"
+/* #756: bounded re-check after a detect-poll kick. Short enough not to be
+ * felt as a hang on the SCPI path, long enough to cover a kicked poll. */
+#define SD_PRESENCE_RECHECK_MS        900u
+#define SD_PRESENCE_RECHECK_STEP_MS   100u
+
 #define SD_CARD_NOT_PRESENT_ERROR_MSG "\r\nError !! No SD Card Detected\r\n"
 
 // Log format for SD busy errors - use LOG_SD_BUSY("COMMAND") for consistency
@@ -91,6 +96,37 @@ bool __attribute__((weak)) DRV_SDSPI_GetCID(uint8_t* cidBuffer, size_t bufLen) {
  */
 static bool SCPI_CheckSDCardPresent(scpi_t *context) {
     if (!SYS_FS_MEDIA_MANAGER_MediaStatusGet(SD_CARD_MANAGER_DISK_DEV_NAME)) {
+        /* #756: do not answer "no card" off a stale view.
+         *
+         * When the slot last looked empty the driver backs the detect poll off
+         * to DRV_SDSPI_DETECT_BACKOFF_INTERVAL_MS (5 s, drv_sdspi_local.h).
+         * The thing that restores the fast cadence, DRV_SDSPI_DetectPollKick,
+         * is called from sd_card_manager_UpdateSettings — which runs AFTER
+         * this gate. So the first SD command of a session could fail on a
+         * stale DETACHED view and never kick the poll, leaving recovery to
+         * land wherever the backoff cycle happened to be. That is why a fixed
+         * client-side retry did not reliably rescue it.
+         *
+         * Kick the poll here and re-check briefly before declaring no card.
+         * The wait is bounded and only paid on the failing path — a present
+         * card that already reads ATTACHED never reaches this code. */
+        extern void DRV_SDSPI_DetectPollKick(SYS_MODULE_OBJ object);
+        DRV_SDSPI_DetectPollKick(0);
+
+        bool present = false;
+        for (uint32_t waited = 0u; waited < SD_PRESENCE_RECHECK_MS;
+             waited += SD_PRESENCE_RECHECK_STEP_MS) {
+            vTaskDelay(pdMS_TO_TICKS(SD_PRESENCE_RECHECK_STEP_MS));
+            if (SYS_FS_MEDIA_MANAGER_MediaStatusGet(SD_CARD_MANAGER_DISK_DEV_NAME)) {
+                present = true;
+                break;
+            }
+        }
+        if (present) {
+            LOG_I("SD - card detected after poll kick (first-access backoff, #756)");
+            return true;
+        }
+
         LOG_E("SD - No SD card detected\r\n");
         context->interface->write(context, SD_CARD_NOT_PRESENT_ERROR_MSG, strlen(SD_CARD_NOT_PRESENT_ERROR_MSG));
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);


### PR DESCRIPTION
Candidate fix for #756 — the first SD command of a WiFi/TCP session falsely answering `No SD Card Detected`.

## Read this first

**The mechanism is traced in source but NOT reproduced on hardware.** If the confirming experiment below shows otherwise, this fix is aimed at the wrong thing and should be closed rather than merged. I wrote the check so it is cheap to run.

## Mechanism

**V** — the gate answers straight off the media manager's current view (`SCPIStorageSD.c:92`, used by **10** handlers):

```c
if (!SYS_FS_MEDIA_MANAGER_MediaStatusGet(SD_CARD_MANAGER_DISK_DEV_NAME)) { ... "No SD Card Detected" ... }
```

**V** — when the slot last looked empty, the detect poll backs off to **5 s**: `DRV_SDSPI_DETECT_BACKOFF_INTERVAL_MS = 5000` (`drv_sdspi_local.h:146`), applied at `drv_sdspi.c:1715-1721`.

**V** — the call that restores the fast cadence, `DRV_SDSPI_DetectPollKick()`, lives in `sd_card_manager_UpdateSettings` (`sd_card_manager.c:2095`) — which runs **after** this gate.

**I** — so the first SD command of a session can fail on a stale `DETACHED` view **and never kick the poll**, leaving recovery to land wherever the backoff cycle happened to be.

## Why this explains the clue that rules out the obvious fix

The issue notes a client-side retry was implemented in `daqifi-core` and **did not reliably rescue the case** — which is what makes "the SD subsystem just needs a settle delay" wrong.

A backoff predicts exactly that: the recovery interval is not a constant, so a fixed ~1.2 s retry sometimes wins and sometimes does not. That asymmetry is the main reason I believe this is the right area.

## The change

Kick the detect poll at the point of failure, then re-check for up to 900 ms in 100 ms steps before declaring no card.

The cost is paid **only on the path that was already about to fail** — a present card reading `ATTACHED` never reaches this code. The wait is `vTaskDelay`, so it yields rather than spins, and SD commands are not issued mid-stream.

## The experiment that would confirm or kill this

On the bench, with `SYST:LOG:LEVel SD,3`: open a TCP session, wait past the backoff, issue **one** SD command, and read `SYST:LOG?`.

- `SDSPI detect-poll kick` appears **after** the failure → confirmed, this fix is correct.
- The kick already **precedes** the gate → mechanism is wrong, close this PR.

## Verification so far

Builds clean at -O3 with `-Werror -Wall` (XC32 v4.60); cppcheck 0 findings, baseline unchanged.

No companion regression test yet — the repro is WiFi and timing dependent, and I would rather write the test against a confirmed mechanism than guess at one.