### PR TITLE
fix(sd): #689 subdirectory bucketing so a long session never builds a big directory

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3745,8 +3745,13 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
             }
             if (!sd_card_manager_IsWriteReady()) {
                 if (sd_card_manager_StartupDirFull()) {
-                    LOG_E("STR:START refused: SD directory too full (#689) after "
-                          "buffer repartition — use a different directory or clear the card\r\n");
+                    /* #689: this flag means "no writable location", which covers a
+                     * full directory AND a bucket that could not be created or read.
+                     * Naming only fullness misdirects the operator when the real
+                     * fault is the media; the SD-side LOG_E names which it was. */
+                    LOG_E("STR:START refused: no writable SD location (#689) after "
+                          "buffer repartition — directory full, or the bucket could "
+                          "not be created/read. See SYST:LOG? for which\r\n");
                 } else if (sd_card_manager_StartupDiskFull()) {
                     LOG_E("STR:START refused: SD disk full after buffer repartition\r\n");
                 } else {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3749,9 +3749,8 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
                      * full directory AND a bucket that could not be created or read.
                      * Naming only fullness misdirects the operator when the real
                      * fault is the media; the SD-side LOG_E names which it was. */
-                    LOG_E("STR:START refused: no writable SD location (#689) after "
-                          "buffer repartition — directory full, or the bucket could "
-                          "not be created/read. See SYST:LOG? for which\r\n");
+                    LOG_E("STR:START refused after buffer repartition (#689): %s\r\n",
+                          sd_card_manager_WriteRefuseText());
                 } else if (sd_card_manager_StartupDiskFull()) {
                     LOG_E("STR:START refused: SD disk full after buffer repartition\r\n");
                 } else {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3663,9 +3663,13 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
                 /* #689: SD target directory holds too many files — file-create
                  * would wedge the SD op timeout. Surface the precise cause and
                  * remedy instead of a generic "not ready". */
-                LOG_E("[SD] STR:START refused: target directory has too many "
-                      "files (#689) — use a larger SD:MAXSize, a different "
-                      "directory, or clear the card");
+                /* Report the RECORDED cause, like the post-repartition and
+                 * SD:BENCH sites. This is the site that fires on the initial
+                 * bucket scan -- the most common refusal -- and it was the one
+                 * left hardcoded, so a media fault or a bucket-name collision
+                 * still told the operator to clear a card that is not full. */
+                LOG_E("[SD] STR:START refused (#689): %s",
+                      sd_card_manager_WriteRefuseText());
             } else {
                 LOG_E("SD file not ready after %d ms", readyWait * 10);
             }

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -802,9 +802,14 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
         }
         if (!sd_card_manager_IsWriteReady()) {
             if (sd_card_manager_StartupDirFull()) {
-                /* #690: name the real cause instead of the card advisory. */
-                LOG_E("SD:BENCH refused: target directory has too many files "
-                      "(#689) — use a different directory or clear the card\r\n");
+                /* #690: name the real cause instead of the card advisory.
+                 * #689: the flag covers every "no writable location" cause, not
+                 * just fullness — an FS fault reaching here would otherwise be
+                 * reported as a full directory and send the operator to clear a
+                 * card that is not the problem. */
+                LOG_E("SD:BENCH refused: no writable SD location (#689) — the "
+                      "directory is full, or the bucket could not be created/read. "
+                      "See SYST:LOG? for which\r\n");
             } else {
                 LOG_E("SD:BENCH - File not ready after timeout\r\n");
                 LOG_E("SD:BENCH - if reads/LIST work but writes hang, the card is "

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -807,9 +807,8 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
                  * just fullness — an FS fault reaching here would otherwise be
                  * reported as a full directory and send the operator to clear a
                  * card that is not the problem. */
-                LOG_E("SD:BENCH refused: no writable SD location (#689) — the "
-                      "directory is full, or the bucket could not be created/read. "
-                      "See SYST:LOG? for which\r\n");
+                LOG_E("SD:BENCH refused (#689): %s\r\n",
+                      sd_card_manager_WriteRefuseText());
             } else {
                 LOG_E("SD:BENCH - File not ready after timeout\r\n");
                 LOG_E("SD:BENCH - if reads/LIST work but writes hang, the card is "

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -859,6 +859,12 @@ static bool sd_TargetDirForFile(char* out, size_t outLen, const char* bucketPath
 static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
     if (!sd_BuildBucketPath(gSDCardData.bucketPath,
                             sizeof(gSDCardData.bucketPath), dir, bucket)) {
+        /* Keep the invariant "refused => a reason is recorded". Without this the
+         * caller sets startupDirFull while WriteRefuseText says "no refusal
+         * recorded" -- precisely the misdirection the reason codes exist to
+         * remove. Unreachable today (a 40-char directory cannot overflow a
+         * 510-byte path) but the invariant should not depend on that. */
+        gSDCardData.writeRefuseReason = SD_REFUSE_BUCKET_MKDIR;
         return false;
     }
     if (bucket != 0u) {
@@ -928,6 +934,7 @@ static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
     if (!sd_TargetDirForFile(countPath, sizeof(countPath), gSDCardData.bucketPath,
                              (gpSDCardSettings != NULL) ? gpSDCardSettings->file
                                                         : "")) {
+        gSDCardData.writeRefuseReason = SD_REFUSE_BUCKET_MKDIR;   /* see above */
         return false;
     }
     bool fsError = false;
@@ -1527,7 +1534,13 @@ void sd_card_manager_ProcessState() {
                 // Count the attempt, not the success: a failed create still costs
                 // a directory entry scan, and over-counting only rolls us to a
                 // fresh bucket sooner, which is the safe direction.
-                gSDCardData.filesInCurBucket++;
+                /* A re-open of an existing target adds no directory entry, so
+                 * it must not be counted -- the same reason the roll above skips
+                 * it. Counting it inflated the estimate by one per session on
+                 * the STR:START readiness path. */
+                if (!reopenExisting) {
+                    gSDCardData.filesInCurBucket++;
+                }
 
                 LOG_D("[SD] Opening file '%s' (counter=%u, splitting=%s)\r\n",
                      gSDCardData.filePath, gSDCardData.fileCounter,

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -274,6 +274,10 @@ typedef struct {
     // volatile / cross-task (SD task pri 5 writer, SCPI pri 7/2 reader)
     // rationale as startupDiskFull above.
     volatile bool startupDirFull;
+    /* #689: which condition set startupDirFull. Same cross-task rationale as
+     * the flag above (SD task pri 5 writer, SCPI pri 7/2 readers); a 32-bit
+     * enum load/store is atomic on PIC32MZ, so no critical section is needed. */
+    volatile SdWriteRefuseReason writeRefuseReason;
     // #689: bucketing state. curBucket is the subdirectory index currently
     // being filled (0 == the configured directory itself); bucketPath is its
     // full path, rebuilt only when the bucket changes. bucketFileCountAtStart
@@ -758,6 +762,7 @@ static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
             if (e != SYS_FS_ERROR_EXIST) {
                 LOG_E("[SD] #689 bucket mkdir '%s' failed err=%d",
                       gSDCardData.bucketPath, (int)e);
+                gSDCardData.writeRefuseReason = SD_REFUSE_BUCKET_MKDIR;
                 return false;
             }
         }
@@ -774,9 +779,11 @@ static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
     if (fsError) {
         LOG_E("[SD] #689 bucket '%s' unreadable - refusing rather than rolling",
               gSDCardData.bucketPath);
+        gSDCardData.writeRefuseReason = SD_REFUSE_BUCKET_UNREADABLE;
         return false;
     }
     gSDCardData.filesInCurBucket = 0u;
+    gSDCardData.writeRefuseReason = SD_REFUSE_NONE;
     LOG_D("[SD] #689 bucket '%s' active (holds %u)\r\n", gSDCardData.bucketPath,
           (unsigned)gSDCardData.bucketFileCountAtStart);
     return true;
@@ -1265,6 +1272,7 @@ void sd_card_manager_ProcessState() {
                         gSDCardData.filesInCurBucket) >= SD_CARD_MANAGER_MAX_DIR_FILES) {
                     if (gSDCardData.curBucket >= SD_CARD_MANAGER_MAX_BUCKET ||
                         advanced >= SD_CARD_MANAGER_BUCKET_ADVANCE_MAX) {
+                        gSDCardData.writeRefuseReason = SD_REFUSE_BUCKETS_EXHAUSTED;
                         bucketOk = false;
                         break;
                     }
@@ -2353,6 +2361,26 @@ void sd_card_manager_ClearStartupDiskFull(void) {
      * is correct, since gating on settings init could leave the
      * flag stuck-true if SCPI ever runs before sd init. */
     gSDCardData.startupDiskFull = false;
+}
+
+SdWriteRefuseReason sd_card_manager_WriteRefuseReason(void) {
+    return gSDCardData.writeRefuseReason;
+}
+
+const char* sd_card_manager_WriteRefuseText(void) {
+    switch (gSDCardData.writeRefuseReason) {
+        case SD_REFUSE_BUCKETS_EXHAUSTED:
+            return "every directory bucket is full - use a different directory "
+                   "or clear the card";
+        case SD_REFUSE_BUCKET_MKDIR:
+            return "the next directory bucket could not be created - the card "
+                   "may be write-protected, full or faulty";
+        case SD_REFUSE_BUCKET_UNREADABLE:
+            return "a directory bucket could not be read - likely a card or "
+                   "filesystem fault, not a full directory";
+        default:
+            return "no writable SD location";
+    }
 }
 
 bool sd_card_manager_StartupDirFull(void) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -893,12 +893,26 @@ static void generateFilename(char* outPath, size_t maxLen, uint32_t counter,
 /* #689: is a bucket directory present? Buckets are created in ascending order,
  * so the first absent one ends a forward search. Checks the DIR attribute for
  * the same reason sd_EnterBucket does: a regular file wearing a bucket name
- * must not read as a bucket. */
-static bool sd_BucketDirExists(const char* bucketPath) {
+ * must not read as a bucket.
+ *
+ * *fsError is set when the stat failed for a reason OTHER than "not there".
+ * Collapsing those into "absent" would end the search early on a failing card
+ * and silently create a duplicate part -- the same conflation CountDirEntries
+ * refuses to make, and the caller fails safe the same way it does. */
+static bool sd_BucketDirExists(const char* bucketPath, bool* fsError) {
+    *fsError = false;
     SYS_FS_FSTAT st;
     memset(&st, 0, sizeof(st));
-    return (SYS_FS_FileStat(bucketPath, &st) == SYS_FS_RES_SUCCESS) &&
-           ((st.fattrib & SYS_FS_ATTR_DIR) != 0);
+    if (SYS_FS_FileStat(bucketPath, &st) != SYS_FS_RES_SUCCESS) {
+        SYS_FS_ERROR e = SYS_FS_Error();
+        if (e != SYS_FS_ERROR_NO_PATH && e != SYS_FS_ERROR_NO_FILE) {
+            LOG_E("[SD] #689 bucket stat '%s' failed err=%d — failing safe "
+                  "rather than reading it as absent", bucketPath, (int)e);
+            *fsError = true;
+        }
+        return false;
+    }
+    return ((st.fattrib & SYS_FS_ATTR_DIR) != 0);
 }
 
 /* #689: does this bucket already hold the part about to be opened? Used to
@@ -1415,9 +1429,25 @@ void sd_card_manager_ProcessState() {
                                                 probe)) {
                             break;
                         }
-                        if (probe != gSDCardData.curBucket &&
-                            !sd_BucketDirExists(probePath)) {
-                            break;
+                        if (probe != gSDCardData.curBucket) {
+                            bool probeFsError = false;
+                            bool present = sd_BucketDirExists(probePath,
+                                                              &probeFsError);
+                            if (probeFsError) {
+                                /* An unreadable bucket is NOT an absent one.
+                                 * Ending the search here would create a
+                                 * duplicate part on a card that is merely
+                                 * failing, so refuse instead -- the same
+                                 * fail-safe sd_EnterBucket applies to an
+                                 * unreadable count. */
+                                gSDCardData.writeRefuseReason =
+                                        SD_REFUSE_BUCKET_UNREADABLE;
+                                bucketOk = false;
+                                break;
+                            }
+                            if (!present) {
+                                break;
+                            }
                         }
                         if (sd_TargetExistsInBucketPath(probePath)) {
                             reopenExisting = true;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -25,8 +25,34 @@
  * tracks the FatFs directory-cluster grow (dir_clear write burst) and the O(N)
  * create scan, so it is CARD-DEPENDENT. 64 keeps the directory within its first
  * FAT cluster (no grow burst) with margin below the proven-clean 75. Not a full
- * fix (subdirectory bucketing would be) — a guard until #689 is resolved. */
+ * fix on its own — it is the per-BUCKET ceiling that the #689 bucketing below
+ * rolls over at, and the hard refuse only when buckets are exhausted. */
 #define SD_CARD_MANAGER_MAX_DIR_FILES      64u
+
+/* #689: subdirectory bucketing. A long split-file session used to pile every
+ * part into one directory; FatFs file-create is O(directory size) (dir_find
+ * scans to EOF, then dir_alloc rescans from 0 for contiguous free entries),
+ * so past a few hundred files a create exceeds the SD op timeout and wedges
+ * the manager. Bucketing keeps every directory we write into small, so the
+ * create scan stays bounded no matter how long the session runs.
+ *
+ * Bucket 0 IS the configured directory — sessions that never exceed one
+ * bucket are byte-for-byte identical to the pre-#689 layout, so the common
+ * case gains no new paths and host tooling sees no change. Only once a
+ * directory reaches MAX_DIR_FILES do we roll into 'P001', 'P002', ...
+ *
+ * The names are deliberately 8.3-clean (uppercase, <=8 chars, no extension)
+ * so FatFs stores each as a SINGLE directory entry rather than the 3 an LFN
+ * name costs — the parent holds bucket entries too, and they must not become
+ * the next O(N) problem. */
+#define SD_CARD_MANAGER_BUCKET_PREFIX      "P"
+#define SD_CARD_MANAGER_MAX_BUCKET         999u
+/* Advancing a bucket costs a DirectoryMake + a bounded CountDirEntries. Cap
+ * how many we will skip in one open so a heavily pre-populated card cannot
+ * turn a single create into a long synchronous FS walk inside the SD task —
+ * the exact unbounded-work failure mode #689 is about. 16 buckets is >1000
+ * files of headroom past the current position. */
+#define SD_CARD_MANAGER_BUCKET_ADVANCE_MAX 16u
 
 // Iterative directory listing — bounded BSS-backed stack instead of recursion.
 // 16 levels covers any realistic FAT32 tree without growing the task stack.
@@ -231,10 +257,16 @@ typedef struct {
     // volatile / cross-task (SD task pri 5 writer, SCPI pri 7/2 reader)
     // rationale as startupDiskFull above.
     volatile bool startupDirFull;
-    // #689: file count of the target directory, counted once per session at the
-    // first file open; added to fileCounter to bound the check without a
-    // per-rotation re-scan.
-    uint32_t dirFileCountAtStart;
+    // #689: bucketing state. curBucket is the subdirectory index currently
+    // being filled (0 == the configured directory itself); bucketPath is its
+    // full path, rebuilt only when the bucket changes. bucketFileCountAtStart
+    // is the pre-existing occupancy of that bucket, counted ONCE when we enter
+    // it, and filesInCurBucket counts what this session has added since — so
+    // the fullness test costs no per-rotation re-scan.
+    uint32_t curBucket;
+    uint32_t bucketFileCountAtStart;
+    uint32_t filesInCurBucket;
+    char bucketPath[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
 } sd_card_manager_context_t;
 
 sd_card_manager_context_t gSDCardData;
@@ -276,8 +308,17 @@ static int CircularBufferToSDWrite(uint8_t* buf, uint32_t len) {
  * O(N) directory scan cost is bounded to ~cap entries regardless of directory
  * size. Runs in the SD task, which owns the filesystem. "." / ".." are skipped.
  * Returns min(actualFiles, cap); a return of `cap` means "at least cap". A
- * missing directory (created lazily on first write) counts as 0. */
-static uint32_t CountDirEntries(const char* dirPath, uint32_t cap) {
+ * missing directory (created lazily on first write) counts as 0.
+ *
+ * #689: `cap` is returned BOTH for "at least cap files" and for a real FS
+ * error, so callers that act on fullness must be able to tell them apart —
+ * rolling to a fresh bucket is right for a full directory and wrong for a
+ * broken filesystem. pFsError (optional) reports which happened. */
+static uint32_t CountDirEntries(const char* dirPath, uint32_t cap,
+                                bool* pFsError) {
+    if (pFsError != NULL) {
+        *pFsError = false;
+    }
     SYS_FS_HANDLE dh = SYS_FS_DirOpen(dirPath);
     if (dh == SYS_FS_HANDLE_INVALID) {
         /* #690 review (Qodo): distinguish "directory doesn't exist yet" (the
@@ -290,6 +331,9 @@ static uint32_t CountDirEntries(const char* dirPath, uint32_t cap) {
         }
         LOG_E("[SD] CountDirEntries: DirOpen('%s') failed err=%d — failing safe (refuse)",
               dirPath, (int)e);
+        if (pFsError != NULL) {
+            *pFsError = true;
+        }
         return cap;
     }
     uint32_t count = 0;
@@ -304,6 +348,9 @@ static uint32_t CountDirEntries(const char* dirPath, uint32_t cap) {
             LOG_E("[SD] CountDirEntries: DirRead failed at %u err=%d — failing safe",
                   (unsigned)count, (int)SYS_FS_Error());
             (void)SYS_FS_DirClose(dh);
+            if (pFsError != NULL) {
+                *pFsError = true;
+            }
             return cap;
         }
         if (st.fname[0] == '\0') {
@@ -654,6 +701,68 @@ static void extractBaseFilename(const char* filename) {
     if (ext != NULL) {
         *ext = '\0';  // Remove extension from base filename
     }
+}
+
+/* #689: build the path of bucket `bucket` under `dir`. Bucket 0 IS `dir`, so
+ * a session that never fills one bucket produces exactly the pre-#689 paths. */
+static bool sd_BuildBucketPath(char* out, size_t outLen, const char* dir,
+                               uint32_t bucket) {
+    int written;
+    if (bucket == 0u) {
+        written = snprintf(out, outLen, "%s", dir);
+    } else {
+        written = snprintf(out, outLen, "%s/" SD_CARD_MANAGER_BUCKET_PREFIX "%03u",
+                           dir, (unsigned)bucket);
+    }
+    if (written < 0 || (size_t)written >= outLen) {
+        LOG_E("[%s:%d]Bucket path too long: dir='%s' bucket=%u (max %zu)",
+              __FILE__, __LINE__, dir, (unsigned)bucket, outLen);
+        out[0] = '\0';
+        return false;
+    }
+    return true;
+}
+
+/* #689: make `bucket` the active one — create its directory if needed and
+ * count what it already holds, ONCE, so the per-rotation fullness test is
+ * arithmetic rather than another O(N) scan.
+ *
+ * An existing directory is success, not an error: buckets are reused across
+ * sessions by design (the same base filename overwrites the same part names,
+ * matching the pre-#689 single-directory behaviour). */
+static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
+    if (!sd_BuildBucketPath(gSDCardData.bucketPath,
+                            sizeof(gSDCardData.bucketPath), dir, bucket)) {
+        return false;
+    }
+    if (bucket != 0u) {
+        if (SYS_FS_DirectoryMake(gSDCardData.bucketPath) == SYS_FS_RES_FAILURE) {
+            SYS_FS_ERROR e = SYS_FS_Error();
+            if (e != SYS_FS_ERROR_EXIST) {
+                LOG_E("[SD] #689 bucket mkdir '%s' failed err=%d",
+                      gSDCardData.bucketPath, (int)e);
+                return false;
+            }
+        }
+    }
+    gSDCardData.curBucket = bucket;
+    /* An FS error must NOT be read as "this bucket is full": that would roll us
+     * forward, creating a spurious empty directory per attempt on a filesystem
+     * that is already failing. Refuse instead — the caller's clean stop is the
+     * right answer for a broken card. */
+    bool fsError = false;
+    gSDCardData.bucketFileCountAtStart =
+        CountDirEntries(gSDCardData.bucketPath, SD_CARD_MANAGER_MAX_DIR_FILES,
+                        &fsError);
+    if (fsError) {
+        LOG_E("[SD] #689 bucket '%s' unreadable - refusing rather than rolling",
+              gSDCardData.bucketPath);
+        return false;
+    }
+    gSDCardData.filesInCurBucket = 0u;
+    LOG_D("[SD] #689 bucket '%s' active (holds %u)\r\n", gSDCardData.bucketPath,
+          (unsigned)gSDCardData.bucketFileCountAtStart);
+    return true;
 }
 
 /**
@@ -1114,31 +1223,52 @@ void sd_card_manager_ProcessState() {
                 gSDCardData.fileSplittingEnabled = (gpSDCardSettings->maxFileSizeBytes > 0);
 
                 // Extract base filename and generate actual filename with counter
+                bool bucketOk = true;
                 if (gSDCardData.fileCounter == 0) {
                     // First time opening - extract base filename
                     extractBaseFilename(gpSDCardSettings->file);
-                    // #689: count existing files in the target directory once
-                    // (bounded to the guard ceiling) so the check below is cheap
-                    // on every subsequent rotation.
-                    gSDCardData.dirFileCountAtStart = CountDirEntries(
-                        gpSDCardSettings->directory, SD_CARD_MANAGER_MAX_DIR_FILES);
+                    // #689: start in bucket 0 — the configured directory itself.
+                    bucketOk = sd_EnterBucket(gpSDCardSettings->directory, 0u);
                 }
 
-                // #689 guard: refuse to create a file into a directory that
-                // already holds too many files. FatFs file-create is O(dir size)
-                // and would wedge the SD op timeout on large directories. This
-                // covers BOTH session start (fileCounter==0) and every split
-                // rotation (which re-enters OPEN_FILE with fileCounter++). Clean-
-                // stop to IDLE with startupDirFull set, so SCPI_StartStreaming
-                // reports a precise "directory too full" error rather than a
-                // silent wedge — mirrors the #503 disk-full clean-stop pattern.
-                if ((gSDCardData.dirFileCountAtStart + gSDCardData.fileCounter)
-                        >= SD_CARD_MANAGER_MAX_DIR_FILES) {
-                    LOG_E("[SD] WRITE refused: dir '%s' holds >= %u files — FatFs "
+                // #689: roll into the next bucket while the active one is at its
+                // ceiling, so FatFs never sees a large directory to scan. This
+                // replaces the old hard refuse, which merely converted the wedge
+                // into a dead stop: a long split session now keeps logging into
+                // P001, P002, ... instead of ending at 64 files.
+                //
+                // A `while` rather than an `if` because the bucket we land in may
+                // itself be populated from an earlier session. It is bounded on
+                // BOTH axes — the highest bucket index, and how many we may skip
+                // in a single open — because unbounded synchronous FS work inside
+                // the SD task is the failure mode this issue is about.
+                uint32_t advanced = 0u;
+                while (bucketOk &&
+                       (gSDCardData.bucketFileCountAtStart +
+                        gSDCardData.filesInCurBucket) >= SD_CARD_MANAGER_MAX_DIR_FILES) {
+                    if (gSDCardData.curBucket >= SD_CARD_MANAGER_MAX_BUCKET ||
+                        advanced >= SD_CARD_MANAGER_BUCKET_ADVANCE_MAX) {
+                        bucketOk = false;
+                        break;
+                    }
+                    bucketOk = sd_EnterBucket(gpSDCardSettings->directory,
+                                              gSDCardData.curBucket + 1u);
+                    advanced++;
+                }
+
+                // Buckets exhausted (or a bucket could not be created). Clean-stop
+                // to IDLE with startupDirFull set, so SCPI_StartStreaming reports a
+                // precise error rather than a silent wedge — mirrors the #503
+                // disk-full clean-stop pattern.
+                if (!bucketOk) {
+                    LOG_E("[SD] WRITE refused: no writable bucket under '%s' "
+                          "(active '%s', bucket %u, %u per bucket, max %u) — FatFs "
                           "file-create wedges large directories (#689). Use a "
                           "larger SD:MAXSize, a different directory, or clear the "
                           "card.", gpSDCardSettings->directory,
-                          (unsigned)SD_CARD_MANAGER_MAX_DIR_FILES);
+                          gSDCardData.bucketPath, (unsigned)gSDCardData.curBucket,
+                          (unsigned)SD_CARD_MANAGER_MAX_DIR_FILES,
+                          (unsigned)SD_CARD_MANAGER_MAX_BUCKET);
                     gSDCardData.startupDirFull = true;
                     gSDCardData.lastOperationSuccess = false;
                     if (gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID) {
@@ -1151,9 +1281,16 @@ void sd_card_manager_ProcessState() {
                     break;
                 }
 
+                // #689: create into the ACTIVE BUCKET, not the raw configured
+                // directory. For bucket 0 these are the same string, which is why
+                // short sessions keep their existing on-card layout exactly.
                 generateFilename(gSDCardData.filePath, sizeof(gSDCardData.filePath),
-                               gSDCardData.fileCounter, gpSDCardSettings->directory,
+                               gSDCardData.fileCounter, gSDCardData.bucketPath,
                                gSDCardData.baseFilename, gpSDCardSettings->file);
+                // Count the attempt, not the success: a failed create still costs
+                // a directory entry scan, and over-counting only rolls us to a
+                // fresh bucket sooner, which is the safe direction.
+                gSDCardData.filesInCurBucket++;
 
                 LOG_D("[SD] Opening file '%s' (counter=%u, splitting=%s)\r\n",
                      gSDCardData.filePath, gSDCardData.fileCounter,

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -294,6 +294,12 @@ typedef struct {
     // it, and filesInCurBucket counts what this session has added since — so
     // the fullness test costs no per-rotation re-scan.
     uint32_t curBucket;
+    /* #689: the directory curBucket is an index INTO. The cursor is meaningless
+     * against a different directory -- resuming at P003 under a freshly
+     * configured, empty directory would write <newdir>/P003/<file> and never
+     * create the <newdir>/<file> the caller asked for. Compared on every
+     * session start; a mismatch restarts the scan at bucket 0. */
+    char bucketDir[SD_CARD_MANAGER_CONF_DIR_NAME_LEN_MAX + 1];
     uint32_t bucketFileCountAtStart;
     uint32_t filesInCurBucket;
     char bucketPath[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
@@ -777,6 +783,8 @@ static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
         }
     }
     gSDCardData.curBucket = bucket;
+    /* Bind the cursor to the directory it indexes (see bucketDir). */
+    (void)snprintf(gSDCardData.bucketDir, sizeof(gSDCardData.bucketDir), "%s", dir);
     /* An FS error must NOT be read as "this bucket is full": that would roll us
      * forward, creating a spurious empty directory per attempt on a filesystem
      * that is already failing. Refuse instead — the caller's clean stop is the
@@ -1266,15 +1274,28 @@ void sd_card_manager_ProcessState() {
                     // First time opening - extract base filename
                     extractBaseFilename(gpSDCardSettings->file);
                     /* #689: RESUME from the bucket cursor rather than restarting
-                     * at 0. The cursor is reset to 0 only at mount/unmount, so a
-                     * fresh card still starts at the configured directory, but a
-                     * later session on a well-used card does not rescan every
-                     * full bucket it already walked past. Without this, each new
-                     * session paid the full scan again -- and with a capped
-                     * advance it could not finish it, so the session was refused
-                     * at START while free buckets existed. */
+                     * at 0, so a later session on a well-used card does not
+                     * rescan every full bucket it already walked past. Without
+                     * this, each session paid the full scan again -- and with a
+                     * capped advance it could not finish it, so the session was
+                     * refused at START while free buckets existed.
+                     *
+                     * ONLY when the cursor belongs to the directory now
+                     * configured. It is an index into a specific directory, so
+                     * carrying it to a different one would resume at, say, P003
+                     * under a fresh empty directory and write <dir>/P003/<file>
+                     * -- silently never creating the <dir>/<file> that was
+                     * asked for. The configured directory is caller-settable
+                     * (SYST:STOR:SD:LISt? rewrites it persistently), so this is
+                     * reachable without anything exotic. */
+                    uint32_t startBucket = gSDCardData.curBucket;
+                    if (strncmp(gSDCardData.bucketDir, gpSDCardSettings->directory,
+                                sizeof(gSDCardData.bucketDir)) != 0) {
+                        startBucket = 0u;
+                        LOG_D("[SD] #689 directory changed - restarting bucket scan\r\n");
+                    }
                     bucketOk = sd_EnterBucket(gpSDCardSettings->directory,
-                                              gSDCardData.curBucket);
+                                              startBucket);
                 }
 
                 // #689: roll into the next bucket while the active one is at its
@@ -2074,6 +2095,7 @@ void sd_card_manager_ProcessState() {
                  * create P0xx on an empty card and skip the configured directory
                  * entirely -- files still land, but in a surprising place. */
                 gSDCardData.curBucket = 0u;
+                gSDCardData.bucketDir[0] = '\0';
                 gSDCardData.bucketFileCountAtStart = 0u;
                 gSDCardData.filesInCurBucket = 0u;
                 gSDCardData.lastOperationSuccess = true;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1309,8 +1309,36 @@ void sd_card_manager_ProcessState() {
                 // BOTH axes — the highest bucket index, and how many we may skip
                 // in a single open — because unbounded synchronous FS work inside
                 // the SD task is the failure mode this issue is about.
+                /* Re-opening a file that ALREADY EXISTS in this bucket adds no
+                 * directory entry, so it must not be treated as a new one.
+                 *
+                 * STR:START opens the file once to prove readiness, then
+                 * PrepareStreamingBuffers closes it and re-opens for the actual
+                 * stream. With the directory at exactly MAX-1 entries, that
+                 * first open filled the bucket, and the re-open then rolled the
+                 * live stream into P001 -- leaving a zero-byte file at the path
+                 * the caller configured while the samples went elsewhere.
+                 *
+                 * Cheaper and more precise than tracking the pre-open: ask the
+                 * filesystem whether the exact target is already there. */
+                bool reopenExisting = false;
+                if (bucketOk) {
+                    char candidate[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
+                    generateFilename(candidate, sizeof(candidate),
+                                     gSDCardData.fileCounter,
+                                     gSDCardData.bucketPath,
+                                     gSDCardData.baseFilename,
+                                     gpSDCardSettings->file);
+                    if (candidate[0] != '\0') {
+                        SYS_FS_FSTAT st;
+                        memset(&st, 0, sizeof(st));
+                        reopenExisting =
+                            (SYS_FS_FileStat(candidate, &st) == SYS_FS_RES_SUCCESS);
+                    }
+                }
+
                 uint32_t advanced = 0u;
-                while (bucketOk &&
+                while (bucketOk && !reopenExisting &&
                        (gSDCardData.bucketFileCountAtStart +
                         gSDCardData.filesInCurBucket) >= SD_CARD_MANAGER_MAX_DIR_FILES) {
                     if (gSDCardData.curBucket >= SD_CARD_MANAGER_MAX_BUCKET ||

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -888,6 +888,32 @@ static void generateFilename(char* outPath, size_t maxLen, uint32_t counter,
     }
 }
 
+/* #689: is a bucket directory present? Buckets are created densely, so the
+ * first absent one ends a forward search. Checks the DIR attribute rather
+ * than mere existence for the same reason sd_EnterBucket does: a regular
+ * file wearing a bucket name must not read as a bucket. */
+static bool sd_BucketDirExists(const char* bucketPath) {
+    SYS_FS_FSTAT st;
+    memset(&st, 0, sizeof(st));
+    return (SYS_FS_FileStat(bucketPath, &st) == SYS_FS_RES_SUCCESS) &&
+           ((st.fattrib & SYS_FS_ATTR_DIR) != 0);
+}
+
+/* #689: does this bucket already hold the part about to be opened? Used to
+ * reopen a part in place instead of creating a duplicate in a later bucket. */
+static bool sd_TargetExistsInBucketPath(const char* bucketPath) {
+    char candidate[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
+    generateFilename(candidate, sizeof(candidate), gSDCardData.fileCounter,
+                     bucketPath, gSDCardData.baseFilename,
+                     gpSDCardSettings->file);
+    if (candidate[0] == '\0') {
+        return false;
+    }
+    SYS_FS_FSTAT st;
+    memset(&st, 0, sizeof(st));
+    return (SYS_FS_FileStat(candidate, &st) == SYS_FS_RES_SUCCESS);
+}
+
 void sd_card_manager_ProcessState() {
     /* Check the application's current state. */
 
@@ -1344,20 +1370,54 @@ void sd_card_manager_ProcessState() {
                  * the caller configured while the samples went elsewhere.
                  *
                  * Cheaper and more precise than tracking the pre-open: ask the
-                 * filesystem whether the exact target is already there. */
+                 * filesystem whether the exact target is already there.
+                 *
+                 * The search must span buckets, not just the active one. The
+                 * roll below only advances while a bucket is FULL, so it walks
+                 * straight past the bucket holding an existing part: session A
+                 * fills bucket 0 and P001; session B reopens parts 0-63 in
+                 * bucket 0, then at part 64 finds bucket 0 full, rolls across
+                 * the equally-full P001 -- where its run-64.csv actually lives
+                 * -- and creates a SECOND run-64.csv in P002. Both copies then
+                 * carry the same base name, so PC-side merge tooling
+                 * (download_sd_files.py / analyze_split_files.py) silently
+                 * splices the stale session into the fresh one. That also
+                 * contradicts this file's own contract above: the same base
+                 * filename overwrites the same part names.
+                 *
+                 * Searching forward from the ACTIVE bucket is sufficient (a
+                 * session only ever moves forward) and stops at the first
+                 * absent bucket, since buckets are created densely -- so a
+                 * fresh card costs one stat per open rather than MAX_BUCKET. */
                 bool reopenExisting = false;
                 if (bucketOk) {
-                    char candidate[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
-                    generateFilename(candidate, sizeof(candidate),
-                                     gSDCardData.fileCounter,
-                                     gSDCardData.bucketPath,
-                                     gSDCardData.baseFilename,
-                                     gpSDCardSettings->file);
-                    if (candidate[0] != '\0') {
-                        SYS_FS_FSTAT st;
-                        memset(&st, 0, sizeof(st));
-                        reopenExisting =
-                            (SYS_FS_FileStat(candidate, &st) == SYS_FS_RES_SUCCESS);
+                    uint32_t reuseBucket = gSDCardData.curBucket;
+                    char probePath[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
+                    for (uint32_t probe = gSDCardData.curBucket;
+                         probe <= SD_CARD_MANAGER_MAX_BUCKET; probe++) {
+                        if (!sd_BuildBucketPath(probePath, sizeof(probePath),
+                                                gpSDCardSettings->directory,
+                                                probe)) {
+                            break;
+                        }
+                        if (probe != gSDCardData.curBucket &&
+                            !sd_BucketDirExists(probePath)) {
+                            break;
+                        }
+                        if (sd_TargetExistsInBucketPath(probePath)) {
+                            reopenExisting = true;
+                            reuseBucket = probe;
+                            break;
+                        }
+                    }
+                    /* Only re-enter when the part lives elsewhere: sd_EnterBucket
+                     * re-counts and zeroes filesInCurBucket, so calling it for
+                     * the bucket we are already in would forget the files this
+                     * session has added and overshoot the per-bucket ceiling. */
+                    if (reopenExisting && reuseBucket != gSDCardData.curBucket) {
+                        bucketOk = sd_EnterBucket(gpSDCardSettings->directory,
+                                                  reuseBucket);
+                        reopenExisting = bucketOk;
                     }
                 }
 

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -759,6 +759,61 @@ static bool sd_BuildBucketPath(char* out, size_t outLen, const char* dir,
     return true;
 }
 
+/* #689: a log filename may itself contain a subdirectory -- SD:FILE accepts
+ * "sub/run.csv", the SCPI validator explicitly permits interior '/', and bucket
+ * 0 writes <dir>/sub/run*.csv correctly because <dir>/sub already exists.
+ *
+ * On rollover the target becomes <dir>/P001/sub/run-N.csv, whose parent was
+ * never created: the bucket mkdir creates only the bucket itself. The open then
+ * fails, the manager goes to ERROR -> UNMOUNT -> INIT and re-enters the same
+ * bucket, so it churns without writing and leaves empty P00x directories behind
+ * -- a supported configuration degrading into a retry loop rather than the
+ * clean, precisely-reported refusal it deserves.
+ *
+ * So mirror any leading path components of the filename inside the bucket.
+ * Walks component by component; each level is one mkdir and EXIST is success. */
+static bool sd_MirrorFileSubdirs(const char* bucketPath, const char* fileName) {
+    if (strchr(fileName, '/') == NULL) {
+        return true;                        /* plain name: nothing to mirror */
+    }
+    char path[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
+    int n = snprintf(path, sizeof(path), "%s", bucketPath);
+    if (n < 0 || (size_t)n >= sizeof(path)) {
+        return false;
+    }
+    size_t used = (size_t)n;
+    const char* seg = fileName;
+    for (;;) {
+        const char* slash = strchr(seg, '/');
+        if (slash == NULL) {
+            break;                          /* last component is the file */
+        }
+        size_t segLen = (size_t)(slash - seg);
+        if (segLen == 0u) {                 /* tolerate "//" */
+            seg = slash + 1;
+            continue;
+        }
+        if (used + 1u + segLen >= sizeof(path)) {
+            LOG_E("[SD] #689 subdirectory path too long under '%s'", bucketPath);
+            return false;
+        }
+        path[used++] = '/';
+        memcpy(&path[used], seg, segLen);
+        used += segLen;
+        path[used] = '\0';
+        if (SYS_FS_DirectoryMake(path) == SYS_FS_RES_FAILURE) {
+            SYS_FS_ERROR e = SYS_FS_Error();
+            if (e != SYS_FS_ERROR_EXIST) {
+                LOG_E("[SD] #689 could not create '%s' inside the bucket err=%d",
+                      path, (int)e);
+                return false;
+            }
+        }
+        seg = slash + 1;
+    }
+    return true;
+}
+
 /* #689: make `bucket` the active one — create its directory if needed and
  * count what it already holds, ONCE, so the per-rotation fullness test is
  * arithmetic rather than another O(N) scan.
@@ -800,6 +855,14 @@ static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
                 return false;
             }
         }
+    }
+    /* Mirror any subdirectory in the log filename into this bucket. Bucket 0 is
+     * the configured directory itself, whose subdirectory the caller already
+     * created -- only the rolled-into buckets need it. */
+    if (bucket != 0u && gpSDCardSettings != NULL &&
+        !sd_MirrorFileSubdirs(gSDCardData.bucketPath, gpSDCardSettings->file)) {
+        gSDCardData.writeRefuseReason = SD_REFUSE_BUCKET_MKDIR;
+        return false;
     }
     gSDCardData.curBucket = bucket;
     /* Bind the cursor to the directory it indexes (see bucketDir). */

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -924,8 +924,16 @@ static bool sd_BucketDirExists(const char* bucketPath, bool* fsError) {
  * collision into a stuck open instead of letting the roll move past it. This
  * is the mirror of the check sd_EnterBucket makes on SYS_FS_ERROR_EXIST,
  * where the ambiguity runs the other way (a regular file wearing a bucket
- * name); FatFs reports presence, never kind, so both sites must ask. */
-static bool sd_TargetExistsInBucketPath(const char* bucketPath) {
+ * name); FatFs reports presence, never kind, so both sites must ask.
+ *
+ * *fsError follows the same rule as sd_BucketDirExists and CountDirEntries: a
+ * stat that fails for a reason OTHER than "not there" must not be reported as
+ * absence. Reading a fault as "no such part" makes the caller create a SECOND
+ * copy of a part that does exist, which is the one outcome this whole search
+ * is here to prevent -- and it would do so silently, on a card that is telling
+ * us it is unwell. */
+static bool sd_TargetExistsInBucketPath(const char* bucketPath, bool* fsError) {
+    *fsError = false;
     char candidate[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
     generateFilename(candidate, sizeof(candidate), gSDCardData.fileCounter,
                      bucketPath, gSDCardData.baseFilename,
@@ -935,8 +943,16 @@ static bool sd_TargetExistsInBucketPath(const char* bucketPath) {
     }
     SYS_FS_FSTAT st;
     memset(&st, 0, sizeof(st));
-    return (SYS_FS_FileStat(candidate, &st) == SYS_FS_RES_SUCCESS) &&
-           ((st.fattrib & SYS_FS_ATTR_DIR) == 0);
+    if (SYS_FS_FileStat(candidate, &st) != SYS_FS_RES_SUCCESS) {
+        SYS_FS_ERROR e = SYS_FS_Error();
+        if (e != SYS_FS_ERROR_NO_PATH && e != SYS_FS_ERROR_NO_FILE) {
+            LOG_E("[SD] #689 part stat '%s' failed err=%d — failing safe "
+                  "rather than reading it as absent", candidate, (int)e);
+            *fsError = true;
+        }
+        return false;
+    }
+    return ((st.fattrib & SYS_FS_ATTR_DIR) == 0);
 }
 
 void sd_card_manager_ProcessState() {
@@ -1460,7 +1476,16 @@ void sd_card_manager_ProcessState() {
                                 break;
                             }
                         }
-                        if (sd_TargetExistsInBucketPath(probePath)) {
+                        bool targetFsError = false;
+                        bool found = sd_TargetExistsInBucketPath(probePath,
+                                                                 &targetFsError);
+                        if (targetFsError) {
+                            gSDCardData.writeRefuseReason =
+                                    SD_REFUSE_BUCKET_UNREADABLE;
+                            bucketOk = false;
+                            break;
+                        }
+                        if (found) {
                             reopenExisting = true;
                             reuseBucket = probe;
                             break;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -891,7 +891,15 @@ static void generateFilename(char* outPath, size_t maxLen, uint32_t counter,
 }
 
 /* #689: does this bucket already hold the part about to be opened? Used to
- * reopen a part in place instead of creating a duplicate in a later bucket. */
+ * reopen a part in place instead of creating a duplicate in a later bucket.
+ *
+ * A DIRECTORY at the target path is not a reopenable part. Accepting one
+ * would set reopenExisting, suppress the roll, and then fail the
+ * FileOpen(...WRITE_PLUS) that follows -- turning an operator-created name
+ * collision into a stuck open instead of letting the roll move past it. This
+ * is the mirror of the check sd_EnterBucket makes on SYS_FS_ERROR_EXIST,
+ * where the ambiguity runs the other way (a regular file wearing a bucket
+ * name); FatFs reports presence, never kind, so both sites must ask. */
 static bool sd_TargetExistsInBucketPath(const char* bucketPath) {
     char candidate[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
     generateFilename(candidate, sizeof(candidate), gSDCardData.fileCounter,
@@ -902,7 +910,8 @@ static bool sd_TargetExistsInBucketPath(const char* bucketPath) {
     }
     SYS_FS_FSTAT st;
     memset(&st, 0, sizeof(st));
-    return (SYS_FS_FileStat(candidate, &st) == SYS_FS_RES_SUCCESS);
+    return (SYS_FS_FileStat(candidate, &st) == SYS_FS_RES_SUCCESS) &&
+           ((st.fattrib & SYS_FS_ATTR_DIR) == 0);
 }
 
 void sd_card_manager_ProcessState() {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -934,8 +934,25 @@ static bool sd_BucketDirExists(const char* bucketPath, bool* fsError) {
  * us it is unwell. */
 static bool sd_TargetExistsInBucketPath(const char* bucketPath, bool* fsError) {
     *fsError = false;
-    char candidate[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
-    generateFilename(candidate, sizeof(candidate), gSDCardData.fileCounter,
+    /* Scratch in gSDCardData.filePath rather than a ~511-byte stack local.
+     * Two such buffers would otherwise live at once during the reuse pre-walk
+     * -- this one and the caller's probePath -- against an SD task stack sized
+     * on a PROFILED peak (see the SDCardTask xTaskCreate note in
+     * app_freertos.c). A static is not an option: BSS is at its ceiling on
+     * this target, and adding ~1 KB fails the link outright with "Not enough
+     * memory for stack".
+     *
+     * Safe, and narrowly so -- keep it that way: filePath is memset at
+     * OPEN_FILE entry, this function is called only from the WRITE branch's
+     * pre-walk, and the REAL path is written over it by generateFilename
+     * further down before anything reads it. Do not add a read of filePath
+     * between those two points. */
+    char* candidate = gSDCardData.filePath;
+    /* sizeof(gSDCardData.filePath), NOT sizeof(candidate) -- candidate is a
+     * pointer here, so sizeof would be 4 and generateFilename would reject
+     * every path as too long. */
+    generateFilename(candidate, sizeof(gSDCardData.filePath),
+                     gSDCardData.fileCounter,
                      bucketPath, gSDCardData.baseFilename,
                      gpSDCardSettings->file);
     if (candidate[0] == '\0') {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -856,10 +856,18 @@ static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
             }
         }
     }
-    /* Mirror any subdirectory in the log filename into this bucket. Bucket 0 is
-     * the configured directory itself, whose subdirectory the caller already
-     * created -- only the rolled-into buckets need it. */
-    if (bucket != 0u && gpSDCardSettings != NULL &&
+    /* Create any subdirectory named in the log filename, in EVERY bucket
+     * including bucket 0.
+     *
+     * Bucket 0 needs it too: CREATE_DIRECTORY makes only the configured
+     * directory, so SD:FILE "sub/run.csv" has never worked on a card where
+     * <dir>/sub was not already present -- a documented form (the SCPI
+     * validator's own comment gives "DAQiFi/sub/file.csv") that silently failed
+     * unless someone had created the directory externally. Doing it here makes
+     * the form work from scratch and makes bucket 0 consistent with the buckets
+     * it rolls into, rather than fixing rollover for a case that could not be
+     * set up on-device in the first place. */
+    if (gpSDCardSettings != NULL &&
         !sd_MirrorFileSubdirs(gSDCardData.bucketPath, gpSDCardSettings->file)) {
         gSDCardData.writeRefuseReason = SD_REFUSE_BUCKET_MKDIR;
         return false;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1409,6 +1409,17 @@ void sd_card_manager_ProcessState() {
                  * ABSENT bucket, because buckets are created in ascending
                  * order. A fresh card therefore costs one directory stat.
                  *
+                 * Stopping at the first gap is a DELIBERATE bound, not an
+                 * oversight. Removing it means stat-ing all MAX_BUCKET+1
+                 * buckets on EVERY open -- reintroducing exactly the
+                 * O(directory) synchronous FS work inside the SD task that
+                 * this issue exists to remove. Nothing in this firmware can
+                 * create a gap (buckets are made in ascending order and only
+                 * files are deleted), so reaching that state needs a whole
+                 * P0xx directory removed on a PC while a later one survives,
+                 * and the consequence is bounded: one extra copy of one part
+                 * name, nothing overwritten.
+                 *
                  * It must NOT be folded into the roll below, which was tried
                  * and is wrong: the roll only advances while a bucket is FULL,
                  * so it never runs when the active bucket has room -- and a

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -74,10 +74,12 @@
  * START even though space existed. Bench-found 2026-08-13 -- the simulation
  * that covered this case scored it a "designed backstop", which it is not.
  *
- * Worst case is therefore ~65 bounded scans, a few hundred milliseconds, and
- * only on the FIRST create after a mount: the bucket cursor persists across
- * sessions (see below), so later sessions resume where the last one stopped
- * instead of rescanning from zero. */
+ * Worst case is therefore ~65 bounded scans, a few hundred milliseconds, paid
+ * on the first create of each SESSION -- every session rescans from bucket 0.
+ * An earlier revision persisted the cursor across sessions to avoid exactly
+ * that rescan; it was removed because a cursor that cannot be stale is worth
+ * more than the time it saves (see the fileCounter==0 branch for the three
+ * ways the stale one went wrong). */
 #define SD_CARD_MANAGER_BUCKET_ADVANCE_MAX (SD_CARD_MANAGER_MAX_BUCKET + 1u)
 /* #780: how long the pumped wait blocks between USB write pumps. Small enough
  * that a filling circular buffer is serviced promptly, large enough that the
@@ -1171,11 +1173,18 @@ void sd_card_manager_ProcessState() {
             } else {
                 gSDCardData.unmountRetryCount = 0;
                 // Reset file splitting state for next session
-                /* #689: the bucket cursor deliberately does NOT reset here -- it
-                 * persists across sessions so a later one resumes where the last
-                 * stopped instead of rescanning every full bucket. It resets on
-                 * a format (below), where the directories it names cease to
-                 * exist. */
+                /* #689: curBucket/bucketPath are left alone here, and that is
+                 * harmless rather than deliberate -- resetting fileCounter is
+                 * what matters, because the next session's first open takes the
+                 * fileCounter==0 branch and re-enters bucket 0, re-establishing
+                 * both.
+                 *
+                 * An earlier revision DID persist the cursor on purpose, to
+                 * resume where the last session stopped instead of rescanning
+                 * full buckets. That was removed: it survived a card swap or a
+                 * PC-side reformat, it ignored space freed by deleting files,
+                 * and it stopped the same base filename from overwriting. Do
+                 * not reintroduce it without re-reading those three cases. */
                 gSDCardData.fileCounter = 0;
                 gSDCardData.currentFileBytes = 0;
                 memset(gSDCardData.baseFilename, 0, sizeof(gSDCardData.baseFilename));
@@ -2184,10 +2193,13 @@ void sd_card_manager_ProcessState() {
 
             if (SYS_FS_DriveFormat(SD_CARD_MANAGER_DISK_MOUNT_NAME, &opt, formatWorkBuffer, sizeof(formatWorkBuffer)) == SYS_FS_RES_SUCCESS) {
                 LOG_D("[SD] Format completed successfully\r\n");
-                /* #689: a format destroys every bucket directory, so the cursor
-                 * must go back to 0. Leaving it high would make the next session
-                 * create P0xx on an empty card and skip the configured directory
-                 * entirely -- files still land, but in a surprising place. */
+                /* #689: a format destroys every bucket directory, so the
+                 * bucketing state must go back to 0 rather than describe
+                 * directories that no longer exist. The next session would
+                 * re-enter bucket 0 anyway (it rescans from 0), so this is
+                 * belt-and-braces for anything that reads the state before
+                 * then -- not the load-bearing reset it was when the cursor
+                 * persisted across sessions. */
                 gSDCardData.curBucket = 0u;
                 gSDCardData.bucketFileCountAtStart = 0u;
                 gSDCardData.filesInCurBucket = 0u;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2378,8 +2378,13 @@ const char* sd_card_manager_WriteRefuseText(void) {
         case SD_REFUSE_BUCKET_UNREADABLE:
             return "a directory bucket could not be read - likely a card or "
                    "filesystem fault, not a full directory";
+        case SD_REFUSE_NONE:
         default:
-            return "no writable SD location";
+            /* The enum documents NONE as "not refused", so returning a refusal
+             * phrase here would make a diagnostic read as a failure when none
+             * happened -- e.g. a caller logging this outside an active refusal.
+             * Say plainly that there is nothing to report. */
+            return "no refusal recorded";
     }
 }
 

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -808,8 +808,43 @@ static bool sd_MirrorFileSubdirs(const char* bucketPath, const char* fileName) {
                       path, (int)e);
                 return false;
             }
+            /* Same FatFs ambiguity sd_EnterBucket guards: EXIST means the NAME
+             * is taken, not that a directory is there. Without this check a
+             * regular file at this component is accepted, the log open then
+             * fails, and the manager churns instead of refusing cleanly.
+             * Self-inflictable with two settings: SD:FILE "sub" creates the
+             * file DAQiFi/sub, then SD:FILE "sub/run.csv" collides on it. */
+            SYS_FS_FSTAT cst;
+            memset(&cst, 0, sizeof(cst));
+            if (SYS_FS_FileStat(path, &cst) != SYS_FS_RES_SUCCESS ||
+                (cst.fattrib & SYS_FS_ATTR_DIR) == 0) {
+                LOG_E("[SD] #689 '%s' is a file, not a directory - the log "
+                      "filename's path cannot be created", path);
+                return false;
+            }
         }
         seg = slash + 1;
+    }
+    return true;
+}
+
+/* #689: the directory a log file actually lands in -- the bucket, plus any
+ * leading path components of the filename. This is what the fullness guard must
+ * measure, because it is where FatFs does its O(N) create scan. */
+static bool sd_TargetDirForFile(char* out, size_t outLen, const char* bucketPath,
+                                const char* fileName) {
+    const char* lastSlash = strrchr(fileName, '/');
+    int n;
+    if (lastSlash == NULL) {
+        n = snprintf(out, outLen, "%s", bucketPath);
+    } else {
+        n = snprintf(out, outLen, "%s/%.*s", bucketPath,
+                     (int)(lastSlash - fileName), fileName);
+    }
+    if (n < 0 || (size_t)n >= outLen) {
+        LOG_E("[SD] #689 target directory path too long for '%s'", fileName);
+        out[0] = '\0';
+        return false;
     }
     return true;
 }
@@ -879,9 +914,25 @@ static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
      * forward, creating a spurious empty directory per attempt on a filesystem
      * that is already failing. Refuse instead — the caller's clean stop is the
      * right answer for a broken card. */
+    /* Count the directory that will actually RECEIVE the files, which is not
+     * the bucket root when the filename carries a subdirectory.
+     *
+     * With SD:FILE "sub/run.csv" the creates land in <bucket>/sub, but counting
+     * <bucket> sees just the single `sub` entry -- so the guard never fires, and
+     * the FatFs O(N) create scan runs in a directory that can hold hundreds of
+     * files. That is precisely the wedge this whole change exists to prevent,
+     * reintroduced through the side door. (The pre-#689 guard had the same blind
+     * spot, but the nested form only became usable on-device here, so this is
+     * where it becomes reachable.) */
+    char countPath[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
+    if (!sd_TargetDirForFile(countPath, sizeof(countPath), gSDCardData.bucketPath,
+                             (gpSDCardSettings != NULL) ? gpSDCardSettings->file
+                                                        : "")) {
+        return false;
+    }
     bool fsError = false;
     gSDCardData.bucketFileCountAtStart =
-        CountDirEntries(gSDCardData.bucketPath, SD_CARD_MANAGER_MAX_DIR_FILES,
+        CountDirEntries(countPath, SD_CARD_MANAGER_MAX_DIR_FILES,
                         &fsError);
     if (fsError) {
         LOG_E("[SD] #689 bucket '%s' unreadable - refusing rather than rolling",

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -64,12 +64,21 @@
  * re-deriving the table above would silently walk the parent back toward the
  * wedge. */
 #define SD_CARD_MANAGER_MAX_BUCKET         SD_CARD_MANAGER_MAX_DIR_FILES
-/* Advancing a bucket costs a DirectoryMake + a bounded CountDirEntries. Cap
- * how many we will skip in one open so a heavily pre-populated card cannot
- * turn a single create into a long synchronous FS walk inside the SD task —
- * the exact unbounded-work failure mode #689 is about. 16 buckets is >1000
- * files of headroom past the current position. */
-#define SD_CARD_MANAGER_BUCKET_ADVANCE_MAX 16u
+/* Advancing a bucket costs a DirectoryMake + a CountDirEntries that is itself
+ * bounded to MAX_DIR_FILES entries (~2 sectors for a full bucket), so one
+ * advance is a few milliseconds.
+ *
+ * This MUST be able to cross every bucket. An earlier value of 16 looked safely
+ * conservative and was actively wrong: a session starting on a card whose first
+ * 60-odd buckets are full could not reach the free ones, and was refused at
+ * START even though space existed. Bench-found 2026-08-13 -- the simulation
+ * that covered this case scored it a "designed backstop", which it is not.
+ *
+ * Worst case is therefore ~65 bounded scans, a few hundred milliseconds, and
+ * only on the FIRST create after a mount: the bucket cursor persists across
+ * sessions (see below), so later sessions resume where the last one stopped
+ * instead of rescanning from zero. */
+#define SD_CARD_MANAGER_BUCKET_ADVANCE_MAX (SD_CARD_MANAGER_MAX_BUCKET + 1u)
 
 // Iterative directory listing — bounded BSS-backed stack instead of recursion.
 // 16 levels covers any realistic FAT32 tree without growing the task stack.
@@ -1110,6 +1119,11 @@ void sd_card_manager_ProcessState() {
             } else {
                 gSDCardData.unmountRetryCount = 0;
                 // Reset file splitting state for next session
+                /* #689: the bucket cursor deliberately does NOT reset here -- it
+                 * persists across sessions so a later one resumes where the last
+                 * stopped instead of rescanning every full bucket. It resets on
+                 * a format (below), where the directories it names cease to
+                 * exist. */
                 gSDCardData.fileCounter = 0;
                 gSDCardData.currentFileBytes = 0;
                 memset(gSDCardData.baseFilename, 0, sizeof(gSDCardData.baseFilename));
@@ -1251,8 +1265,16 @@ void sd_card_manager_ProcessState() {
                 if (gSDCardData.fileCounter == 0) {
                     // First time opening - extract base filename
                     extractBaseFilename(gpSDCardSettings->file);
-                    // #689: start in bucket 0 — the configured directory itself.
-                    bucketOk = sd_EnterBucket(gpSDCardSettings->directory, 0u);
+                    /* #689: RESUME from the bucket cursor rather than restarting
+                     * at 0. The cursor is reset to 0 only at mount/unmount, so a
+                     * fresh card still starts at the configured directory, but a
+                     * later session on a well-used card does not rescan every
+                     * full bucket it already walked past. Without this, each new
+                     * session paid the full scan again -- and with a capped
+                     * advance it could not finish it, so the session was refused
+                     * at START while free buckets existed. */
+                    bucketOk = sd_EnterBucket(gpSDCardSettings->directory,
+                                              gSDCardData.curBucket);
                 }
 
                 // #689: roll into the next bucket while the active one is at its
@@ -2047,6 +2069,13 @@ void sd_card_manager_ProcessState() {
 
             if (SYS_FS_DriveFormat(SD_CARD_MANAGER_DISK_MOUNT_NAME, &opt, formatWorkBuffer, sizeof(formatWorkBuffer)) == SYS_FS_RES_SUCCESS) {
                 LOG_D("[SD] Format completed successfully\r\n");
+                /* #689: a format destroys every bucket directory, so the cursor
+                 * must go back to 0. Leaving it high would make the next session
+                 * create P0xx on an empty card and skip the configured directory
+                 * entirely -- files still land, but in a surprising place. */
+                gSDCardData.curBucket = 0u;
+                gSDCardData.bucketFileCountAtStart = 0u;
+                gSDCardData.filesInCurBucket = 0u;
                 gSDCardData.lastOperationSuccess = true;
                 gFormatStatus = 2;  // Success
             } else {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -294,12 +294,6 @@ typedef struct {
     // it, and filesInCurBucket counts what this session has added since — so
     // the fullness test costs no per-rotation re-scan.
     uint32_t curBucket;
-    /* #689: the directory curBucket is an index INTO. The cursor is meaningless
-     * against a different directory -- resuming at P003 under a freshly
-     * configured, empty directory would write <newdir>/P003/<file> and never
-     * create the <newdir>/<file> the caller asked for. Compared on every
-     * session start; a mismatch restarts the scan at bucket 0. */
-    char bucketDir[SD_CARD_MANAGER_CONF_DIR_NAME_LEN_MAX + 1];
     uint32_t bucketFileCountAtStart;
     uint32_t filesInCurBucket;
     char bucketPath[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
@@ -759,95 +753,7 @@ static bool sd_BuildBucketPath(char* out, size_t outLen, const char* dir,
     return true;
 }
 
-/* #689: a log filename may itself contain a subdirectory -- SD:FILE accepts
- * "sub/run.csv", the SCPI validator explicitly permits interior '/', and bucket
- * 0 writes <dir>/sub/run*.csv correctly because <dir>/sub already exists.
- *
- * On rollover the target becomes <dir>/P001/sub/run-N.csv, whose parent was
- * never created: the bucket mkdir creates only the bucket itself. The open then
- * fails, the manager goes to ERROR -> UNMOUNT -> INIT and re-enters the same
- * bucket, so it churns without writing and leaves empty P00x directories behind
- * -- a supported configuration degrading into a retry loop rather than the
- * clean, precisely-reported refusal it deserves.
- *
- * So mirror any leading path components of the filename inside the bucket.
- * Walks component by component; each level is one mkdir and EXIST is success. */
-static bool sd_MirrorFileSubdirs(const char* bucketPath, const char* fileName) {
-    if (strchr(fileName, '/') == NULL) {
-        return true;                        /* plain name: nothing to mirror */
-    }
-    char path[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
-    int n = snprintf(path, sizeof(path), "%s", bucketPath);
-    if (n < 0 || (size_t)n >= sizeof(path)) {
-        return false;
-    }
-    size_t used = (size_t)n;
-    const char* seg = fileName;
-    for (;;) {
-        const char* slash = strchr(seg, '/');
-        if (slash == NULL) {
-            break;                          /* last component is the file */
-        }
-        size_t segLen = (size_t)(slash - seg);
-        if (segLen == 0u) {                 /* tolerate "//" */
-            seg = slash + 1;
-            continue;
-        }
-        if (used + 1u + segLen >= sizeof(path)) {
-            LOG_E("[SD] #689 subdirectory path too long under '%s'", bucketPath);
-            return false;
-        }
-        path[used++] = '/';
-        memcpy(&path[used], seg, segLen);
-        used += segLen;
-        path[used] = '\0';
-        if (SYS_FS_DirectoryMake(path) == SYS_FS_RES_FAILURE) {
-            SYS_FS_ERROR e = SYS_FS_Error();
-            if (e != SYS_FS_ERROR_EXIST) {
-                LOG_E("[SD] #689 could not create '%s' inside the bucket err=%d",
-                      path, (int)e);
-                return false;
-            }
-            /* Same FatFs ambiguity sd_EnterBucket guards: EXIST means the NAME
-             * is taken, not that a directory is there. Without this check a
-             * regular file at this component is accepted, the log open then
-             * fails, and the manager churns instead of refusing cleanly.
-             * Self-inflictable with two settings: SD:FILE "sub" creates the
-             * file DAQiFi/sub, then SD:FILE "sub/run.csv" collides on it. */
-            SYS_FS_FSTAT cst;
-            memset(&cst, 0, sizeof(cst));
-            if (SYS_FS_FileStat(path, &cst) != SYS_FS_RES_SUCCESS ||
-                (cst.fattrib & SYS_FS_ATTR_DIR) == 0) {
-                LOG_E("[SD] #689 '%s' is a file, not a directory - the log "
-                      "filename's path cannot be created", path);
-                return false;
-            }
-        }
-        seg = slash + 1;
-    }
-    return true;
-}
 
-/* #689: the directory a log file actually lands in -- the bucket, plus any
- * leading path components of the filename. This is what the fullness guard must
- * measure, because it is where FatFs does its O(N) create scan. */
-static bool sd_TargetDirForFile(char* out, size_t outLen, const char* bucketPath,
-                                const char* fileName) {
-    const char* lastSlash = strrchr(fileName, '/');
-    int n;
-    if (lastSlash == NULL) {
-        n = snprintf(out, outLen, "%s", bucketPath);
-    } else {
-        n = snprintf(out, outLen, "%s/%.*s", bucketPath,
-                     (int)(lastSlash - fileName), fileName);
-    }
-    if (n < 0 || (size_t)n >= outLen) {
-        LOG_E("[SD] #689 target directory path too long for '%s'", fileName);
-        out[0] = '\0';
-        return false;
-    }
-    return true;
-}
 
 /* #689: make `bucket` the active one — create its directory if needed and
  * count what it already holds, ONCE, so the per-rotation fullness test is
@@ -897,77 +803,15 @@ static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
             }
         }
     }
-    /* Create any subdirectory named in the log filename, in EVERY bucket
-     * including bucket 0.
-     *
-     * Bucket 0 needs it too: CREATE_DIRECTORY makes only the configured
-     * directory, so SD:FILE "sub/run.csv" has never worked on a card where
-     * <dir>/sub was not already present -- a documented form (the SCPI
-     * validator's own comment gives "DAQiFi/sub/file.csv") that silently failed
-     * unless someone had created the directory externally. Doing it here makes
-     * the form work from scratch and makes bucket 0 consistent with the buckets
-     * it rolls into, rather than fixing rollover for a case that could not be
-     * set up on-device in the first place. */
-    if (gpSDCardSettings != NULL &&
-        !sd_MirrorFileSubdirs(gSDCardData.bucketPath, gpSDCardSettings->file)) {
-        gSDCardData.writeRefuseReason = SD_REFUSE_BUCKET_MKDIR;
-        return false;
-    }
     gSDCardData.curBucket = bucket;
-    /* Bind the cursor to the directory it indexes (see bucketDir). */
-    (void)snprintf(gSDCardData.bucketDir, sizeof(gSDCardData.bucketDir), "%s", dir);
     /* An FS error must NOT be read as "this bucket is full": that would roll us
      * forward, creating a spurious empty directory per attempt on a filesystem
-     * that is already failing. Refuse instead — the caller's clean stop is the
+     * that is already failing. Refuse instead -- the caller's clean stop is the
      * right answer for a broken card. */
-    /* Count the directory that will actually RECEIVE the files, which is not
-     * the bucket root when the filename carries a subdirectory.
-     *
-     * With SD:FILE "sub/run.csv" the creates land in <bucket>/sub, but counting
-     * <bucket> sees just the single `sub` entry -- so the guard never fires, and
-     * the FatFs O(N) create scan runs in a directory that can hold hundreds of
-     * files. That is precisely the wedge this whole change exists to prevent,
-     * reintroduced through the side door. (The pre-#689 guard had the same blind
-     * spot, but the nested form only became usable on-device here, so this is
-     * where it becomes reachable.) */
-    char countPath[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
-    if (!sd_TargetDirForFile(countPath, sizeof(countPath), gSDCardData.bucketPath,
-                             (gpSDCardSettings != NULL) ? gpSDCardSettings->file
-                                                        : "")) {
-        gSDCardData.writeRefuseReason = SD_REFUSE_BUCKET_MKDIR;   /* see above */
-        return false;
-    }
     bool fsError = false;
     gSDCardData.bucketFileCountAtStart =
-        CountDirEntries(countPath, SD_CARD_MANAGER_MAX_DIR_FILES,
+        CountDirEntries(gSDCardData.bucketPath, SD_CARD_MANAGER_MAX_DIR_FILES,
                         &fsError);
-
-    /* The BUCKET ROOT must be bounded too, not just the directory receiving
-     * files. When the filename carries a subdirectory, mirroring creates that
-     * subdirectory as an entry IN THE ROOT -- so a run using a fresh leading
-     * component each session ("run001/data.csv", "run002/data.csv", ...) adds a
-     * permanent root entry every time while the guard only ever looked at the
-     * near-empty child. The root grew without limit and the O(N) create scan
-     * came back: the exact wedge this change exists to remove, re-entered
-     * through the feature added to support nested names.
-     *
-     * It also falsified the bound documented at MAX_BUCKET (<=64 files x 3
-     * entries + <=64 bucket dirs x 1 = 256), which assumed the root gains
-     * entries only from log files and bucket directories.
-     *
-     * So take the WORSE of the two: the invariant is that every directory this
-     * manager adds entries to stays under the ceiling, and both qualify. */
-    if (!fsError && strcmp(countPath, gSDCardData.bucketPath) != 0) {
-        bool rootErr = false;
-        uint32_t rootCount = CountDirEntries(gSDCardData.bucketPath,
-                                             SD_CARD_MANAGER_MAX_DIR_FILES,
-                                             &rootErr);
-        if (rootErr) {
-            fsError = true;
-        } else if (rootCount > gSDCardData.bucketFileCountAtStart) {
-            gSDCardData.bucketFileCountAtStart = rootCount;
-        }
-    }
     if (fsError) {
         LOG_E("[SD] #689 bucket '%s' unreadable - refusing rather than rolling",
               gSDCardData.bucketPath);
@@ -1448,29 +1292,24 @@ void sd_card_manager_ProcessState() {
                 if (gSDCardData.fileCounter == 0) {
                     // First time opening - extract base filename
                     extractBaseFilename(gpSDCardSettings->file);
-                    /* #689: RESUME from the bucket cursor rather than restarting
-                     * at 0, so a later session on a well-used card does not
-                     * rescan every full bucket it already walked past. Without
-                     * this, each session paid the full scan again -- and with a
-                     * capped advance it could not finish it, so the session was
-                     * refused at START while free buckets existed.
+                    /* #689: ALWAYS scan from bucket 0. An earlier revision
+                     * persisted a cursor across sessions to avoid re-walking
+                     * buckets already passed, and that optimisation produced
+                     * three separate defects: it survived a card swap or a
+                     * PC-side reformat (first session on a fresh card landed in
+                     * P0xx instead of the configured directory); it ignored
+                     * space freed by deleting older files, refusing with "every
+                     * bucket is full" while a writable one existed; and it made
+                     * the same base filename stop overwriting, so repeated runs
+                     * accumulated duplicate part names across buckets.
                      *
-                     * ONLY when the cursor belongs to the directory now
-                     * configured. It is an index into a specific directory, so
-                     * carrying it to a different one would resume at, say, P003
-                     * under a fresh empty directory and write <dir>/P003/<file>
-                     * -- silently never creating the <dir>/<file> that was
-                     * asked for. The configured directory is caller-settable
-                     * (SYST:STOR:SD:LISt? rewrites it persistently), so this is
-                     * reachable without anything exotic. */
-                    uint32_t startBucket = gSDCardData.curBucket;
-                    if (strncmp(gSDCardData.bucketDir, gpSDCardSettings->directory,
-                                sizeof(gSDCardData.bucketDir)) != 0) {
-                        startBucket = 0u;
-                        LOG_D("[SD] #689 directory changed - restarting bucket scan\r\n");
-                    }
-                    bucketOk = sd_EnterBucket(gpSDCardSettings->directory,
-                                              startBucket);
+                     * The scan it avoided is cheap and bounded: at most
+                     * MAX_BUCKET+1 CountDirEntries calls, each itself bounded to
+                     * MAX_DIR_FILES entries -- a few hundred milliseconds once
+                     * per session start, against sessions that run for minutes
+                     * to hours. Paying it buys a cursor that cannot be stale,
+                     * which is worth far more than the time it saves. */
+                    bucketOk = sd_EnterBucket(gpSDCardSettings->directory, 0u);
                 }
 
                 // #689: roll into the next bucket while the active one is at its
@@ -1513,31 +1352,13 @@ void sd_card_manager_ProcessState() {
                 }
 
                 uint32_t advanced = 0u;
-                bool rescanned = false;
                 while (bucketOk && !reopenExisting &&
                        (gSDCardData.bucketFileCountAtStart +
                         gSDCardData.filesInCurBucket) >= SD_CARD_MANAGER_MAX_DIR_FILES) {
                     if (gSDCardData.curBucket >= SD_CARD_MANAGER_MAX_BUCKET ||
                         advanced >= SD_CARD_MANAGER_BUCKET_ADVANCE_MAX) {
-                        /* Before declaring exhaustion, rescan from bucket 0
-                         * ONCE. The cursor persists so a session need not walk
-                         * buckets it already passed -- but that also means
-                         * space freed in an EARLIER bucket (SD:DELete, the
-                         * natural "remove the oldest files" cleanup) is
-                         * invisible, and logging is refused with "every bucket
-                         * is full" while a writable bucket exists.
-                         *
-                         * Only on the exhaustion edge, so the common path still
-                         * pays nothing: the rescan costs the same bounded walk
-                         * as a cold start, and only when we would otherwise
-                         * have refused outright. */
-                        if (!rescanned && gSDCardData.curBucket > 0u) {
-                            rescanned = true;
-                            advanced = 0u;
-                            if (sd_EnterBucket(gpSDCardSettings->directory, 0u)) {
-                                continue;
-                            }
-                        }
+                        /* Genuinely out of buckets: the scan started at 0
+                         * this session, so there is nothing behind us to find. */
                         gSDCardData.writeRefuseReason = SD_REFUSE_BUCKETS_EXHAUSTED;
                         bucketOk = false;
                         break;
@@ -2324,7 +2145,6 @@ void sd_card_manager_ProcessState() {
                  * create P0xx on an empty card and skip the configured directory
                  * entirely -- files still land, but in a surprising place. */
                 gSDCardData.curBucket = 0u;
-                gSDCardData.bucketDir[0] = '\0';
                 gSDCardData.bucketFileCountAtStart = 0u;
                 gSDCardData.filesInCurBucket = 0u;
                 gSDCardData.lastOperationSuccess = true;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -780,6 +780,25 @@ static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
                 gSDCardData.writeRefuseReason = SD_REFUSE_BUCKET_MKDIR;
                 return false;
             }
+            /* EXIST means the NAME is taken, not that a directory is there --
+             * FatFs returns it for any collision, including a regular file. If
+             * a file occupies the bucket name, the count below opens it, gets
+             * NO_PATH, and reports "absent -> 0 files", so the roll stops here
+             * and every later bucket becomes unreachable while the open fails
+             * in a loop. Reachable by an operator-placed extensionless file, or
+             * self-inflicted by pointing SD:FILe at a bucket name.
+             *
+             * Check what is actually there and refuse precisely instead. */
+            SYS_FS_FSTAT st;
+            memset(&st, 0, sizeof(st));
+            if (SYS_FS_FileStat(gSDCardData.bucketPath, &st) != SYS_FS_RES_SUCCESS ||
+                (st.fattrib & SYS_FS_ATTR_DIR) == 0) {
+                LOG_E("[SD] #689 bucket name '%s' is taken by a non-directory - "
+                      "rename or remove it, or use a different directory",
+                      gSDCardData.bucketPath);
+                gSDCardData.writeRefuseReason = SD_REFUSE_BUCKET_NOT_DIR;
+                return false;
+            }
         }
     }
     gSDCardData.curBucket = bucket;
@@ -2457,6 +2476,9 @@ const char* sd_card_manager_WriteRefuseText(void) {
         case SD_REFUSE_BUCKET_UNREADABLE:
             return "a directory bucket could not be read - likely a card or "
                    "filesystem fault, not a full directory";
+        case SD_REFUSE_BUCKET_NOT_DIR:
+            return "a file is occupying a directory-bucket name - rename or "
+                   "remove it, or log to a different directory";
         case SD_REFUSE_NONE:
         default:
             /* The enum documents NONE as "not refused", so returning a refusal

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2235,6 +2235,12 @@ void sd_card_manager_ProcessState() {
                 gSDCardData.curBucket = 0u;
                 gSDCardData.bucketFileCountAtStart = 0u;
                 gSDCardData.filesInCurBucket = 0u;
+                /* bucketPath too, or the refusal LOG_E and the "bucket active"
+                 * trace keep naming a P0xx directory the format just deleted --
+                 * the state is cleared but its label still describes the old
+                 * card, which is exactly the misdirection the reason codes
+                 * exist to remove. */
+                gSDCardData.bucketPath[0] = '\0';
                 gSDCardData.lastOperationSuccess = true;
                 gFormatStatus = 2;  // Success
             } else {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -888,17 +888,6 @@ static void generateFilename(char* outPath, size_t maxLen, uint32_t counter,
     }
 }
 
-/* #689: is a bucket directory present? Buckets are created densely, so the
- * first absent one ends a forward search. Checks the DIR attribute rather
- * than mere existence for the same reason sd_EnterBucket does: a regular
- * file wearing a bucket name must not read as a bucket. */
-static bool sd_BucketDirExists(const char* bucketPath) {
-    SYS_FS_FSTAT st;
-    memset(&st, 0, sizeof(st));
-    return (SYS_FS_FileStat(bucketPath, &st) == SYS_FS_RES_SUCCESS) &&
-           ((st.fattrib & SYS_FS_ATTR_DIR) != 0);
-}
-
 /* #689: does this bucket already hold the part about to be opened? Used to
  * reopen a part in place instead of creating a duplicate in a later bucket. */
 static bool sd_TargetExistsInBucketPath(const char* bucketPath) {
@@ -1372,53 +1361,13 @@ void sd_card_manager_ProcessState() {
                  * Cheaper and more precise than tracking the pre-open: ask the
                  * filesystem whether the exact target is already there.
                  *
-                 * The search must span buckets, not just the active one. The
-                 * roll below only advances while a bucket is FULL, so it walks
-                 * straight past the bucket holding an existing part: session A
-                 * fills bucket 0 and P001; session B reopens parts 0-63 in
-                 * bucket 0, then at part 64 finds bucket 0 full, rolls across
-                 * the equally-full P001 -- where its run-64.csv actually lives
-                 * -- and creates a SECOND run-64.csv in P002. Both copies then
-                 * carry the same base name, so PC-side merge tooling
-                 * (download_sd_files.py / analyze_split_files.py) silently
-                 * splices the stale session into the fresh one. That also
-                 * contradicts this file's own contract above: the same base
-                 * filename overwrites the same part names.
-                 *
-                 * Searching forward from the ACTIVE bucket is sufficient (a
-                 * session only ever moves forward) and stops at the first
-                 * absent bucket, since buckets are created densely -- so a
-                 * fresh card costs one stat per open rather than MAX_BUCKET. */
+                 * This covers only the ACTIVE bucket; a part living in a LATER
+                 * one is caught inside the roll below, which is the only place
+                 * that can reach it. */
                 bool reopenExisting = false;
                 if (bucketOk) {
-                    uint32_t reuseBucket = gSDCardData.curBucket;
-                    char probePath[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
-                    for (uint32_t probe = gSDCardData.curBucket;
-                         probe <= SD_CARD_MANAGER_MAX_BUCKET; probe++) {
-                        if (!sd_BuildBucketPath(probePath, sizeof(probePath),
-                                                gpSDCardSettings->directory,
-                                                probe)) {
-                            break;
-                        }
-                        if (probe != gSDCardData.curBucket &&
-                            !sd_BucketDirExists(probePath)) {
-                            break;
-                        }
-                        if (sd_TargetExistsInBucketPath(probePath)) {
-                            reopenExisting = true;
-                            reuseBucket = probe;
-                            break;
-                        }
-                    }
-                    /* Only re-enter when the part lives elsewhere: sd_EnterBucket
-                     * re-counts and zeroes filesInCurBucket, so calling it for
-                     * the bucket we are already in would forget the files this
-                     * session has added and overshoot the per-bucket ceiling. */
-                    if (reopenExisting && reuseBucket != gSDCardData.curBucket) {
-                        bucketOk = sd_EnterBucket(gpSDCardSettings->directory,
-                                                  reuseBucket);
-                        reopenExisting = bucketOk;
-                    }
+                    reopenExisting =
+                        sd_TargetExistsInBucketPath(gSDCardData.bucketPath);
                 }
 
                 uint32_t advanced = 0u;
@@ -1436,6 +1385,31 @@ void sd_card_manager_ProcessState() {
                     bucketOk = sd_EnterBucket(gpSDCardSettings->directory,
                                               gSDCardData.curBucket + 1u);
                     advanced++;
+                    /* The part we are opening may ALREADY live in this bucket,
+                     * and without this check the roll would step straight over
+                     * it and create a duplicate further on: session A fills
+                     * bucket 0 and P001; session B reopens parts 0-63 in bucket
+                     * 0, then at part 64 finds bucket 0 full, crosses the
+                     * equally full P001 -- where its run-64.csv actually lives
+                     * -- and writes a SECOND run-64.csv into P002. Both copies
+                     * carry the same base name, so PC-side merge tooling
+                     * (download_sd_files.py / analyze_split_files.py) splices
+                     * the stale session into the fresh one with nothing to
+                     * indicate it, and this file's own contract above -- the
+                     * same base filename overwrites the same part names -- is
+                     * broken.
+                     *
+                     * Checking here rather than pre-walking the buckets keeps
+                     * the search and the roll over the SAME range by
+                     * construction: it costs one stat per bucket actually
+                     * crossed (against the directory count sd_EnterBucket
+                     * already pays for each), nothing at all when no roll
+                     * happens, and it needs no assumption about buckets being
+                     * contiguous. */
+                    if (bucketOk &&
+                        sd_TargetExistsInBucketPath(gSDCardData.bucketPath)) {
+                        reopenExisting = true;
+                    }
                 }
 
                 // Buckets exhausted (or a bucket could not be created). Clean-stop

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -890,6 +890,17 @@ static void generateFilename(char* outPath, size_t maxLen, uint32_t counter,
     }
 }
 
+/* #689: is a bucket directory present? Buckets are created in ascending order,
+ * so the first absent one ends a forward search. Checks the DIR attribute for
+ * the same reason sd_EnterBucket does: a regular file wearing a bucket name
+ * must not read as a bucket. */
+static bool sd_BucketDirExists(const char* bucketPath) {
+    SYS_FS_FSTAT st;
+    memset(&st, 0, sizeof(st));
+    return (SYS_FS_FileStat(bucketPath, &st) == SYS_FS_RES_SUCCESS) &&
+           ((st.fattrib & SYS_FS_ATTR_DIR) != 0);
+}
+
 /* #689: does this bucket already hold the part about to be opened? Used to
  * reopen a part in place instead of creating a duplicate in a later bucket.
  *
@@ -1379,13 +1390,50 @@ void sd_card_manager_ProcessState() {
                  * Cheaper and more precise than tracking the pre-open: ask the
                  * filesystem whether the exact target is already there.
                  *
-                 * This covers only the ACTIVE bucket; a part living in a LATER
-                 * one is caught inside the roll below, which is the only place
-                 * that can reach it. */
+                 * The search spans buckets, forward from the ACTIVE one -- a
+                 * session only ever moves forward -- and stops at the first
+                 * ABSENT bucket, because buckets are created in ascending
+                 * order. A fresh card therefore costs one directory stat.
+                 *
+                 * It must NOT be folded into the roll below, which was tried
+                 * and is wrong: the roll only advances while a bucket is FULL,
+                 * so it never runs when the active bucket has room -- and a
+                 * bucket can have room while a LATER one still holds this
+                 * part, e.g. after files are deleted from it PC-side. The roll
+                 * would then skip the search entirely and create a duplicate
+                 * part alongside the surviving original. Searching here covers
+                 * both shapes with one mechanism; a newly created bucket is
+                 * empty, so nothing the roll creates can hold the part. */
                 bool reopenExisting = false;
                 if (bucketOk) {
-                    reopenExisting =
-                        sd_TargetExistsInBucketPath(gSDCardData.bucketPath);
+                    uint32_t reuseBucket = gSDCardData.curBucket;
+                    char probePath[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
+                    for (uint32_t probe = gSDCardData.curBucket;
+                         probe <= SD_CARD_MANAGER_MAX_BUCKET; probe++) {
+                        if (!sd_BuildBucketPath(probePath, sizeof(probePath),
+                                                gpSDCardSettings->directory,
+                                                probe)) {
+                            break;
+                        }
+                        if (probe != gSDCardData.curBucket &&
+                            !sd_BucketDirExists(probePath)) {
+                            break;
+                        }
+                        if (sd_TargetExistsInBucketPath(probePath)) {
+                            reopenExisting = true;
+                            reuseBucket = probe;
+                            break;
+                        }
+                    }
+                    /* Only re-enter when the part lives elsewhere: sd_EnterBucket
+                     * re-counts and zeroes filesInCurBucket, so calling it for
+                     * the bucket we are already in would forget the files this
+                     * session has added and overshoot the per-bucket ceiling. */
+                    if (reopenExisting && reuseBucket != gSDCardData.curBucket) {
+                        bucketOk = sd_EnterBucket(gpSDCardSettings->directory,
+                                                  reuseBucket);
+                        reopenExisting = bucketOk;
+                    }
                 }
 
                 uint32_t advanced = 0u;
@@ -1403,31 +1451,6 @@ void sd_card_manager_ProcessState() {
                     bucketOk = sd_EnterBucket(gpSDCardSettings->directory,
                                               gSDCardData.curBucket + 1u);
                     advanced++;
-                    /* The part we are opening may ALREADY live in this bucket,
-                     * and without this check the roll would step straight over
-                     * it and create a duplicate further on: session A fills
-                     * bucket 0 and P001; session B reopens parts 0-63 in bucket
-                     * 0, then at part 64 finds bucket 0 full, crosses the
-                     * equally full P001 -- where its run-64.csv actually lives
-                     * -- and writes a SECOND run-64.csv into P002. Both copies
-                     * carry the same base name, so PC-side merge tooling
-                     * (download_sd_files.py / analyze_split_files.py) splices
-                     * the stale session into the fresh one with nothing to
-                     * indicate it, and this file's own contract above -- the
-                     * same base filename overwrites the same part names -- is
-                     * broken.
-                     *
-                     * Checking here rather than pre-walking the buckets keeps
-                     * the search and the roll over the SAME range by
-                     * construction: it costs one stat per bucket actually
-                     * crossed (against the directory count sd_EnterBucket
-                     * already pays for each), nothing at all when no roll
-                     * happens, and it needs no assumption about buckets being
-                     * contiguous. */
-                    if (bucketOk &&
-                        sd_TargetExistsInBucketPath(gSDCardData.bucketPath)) {
-                        reopenExisting = true;
-                    }
                 }
 
                 // Buckets exhausted (or a bucket could not be created). Clean-stop

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -941,6 +941,33 @@ static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
     gSDCardData.bucketFileCountAtStart =
         CountDirEntries(countPath, SD_CARD_MANAGER_MAX_DIR_FILES,
                         &fsError);
+
+    /* The BUCKET ROOT must be bounded too, not just the directory receiving
+     * files. When the filename carries a subdirectory, mirroring creates that
+     * subdirectory as an entry IN THE ROOT -- so a run using a fresh leading
+     * component each session ("run001/data.csv", "run002/data.csv", ...) adds a
+     * permanent root entry every time while the guard only ever looked at the
+     * near-empty child. The root grew without limit and the O(N) create scan
+     * came back: the exact wedge this change exists to remove, re-entered
+     * through the feature added to support nested names.
+     *
+     * It also falsified the bound documented at MAX_BUCKET (<=64 files x 3
+     * entries + <=64 bucket dirs x 1 = 256), which assumed the root gains
+     * entries only from log files and bucket directories.
+     *
+     * So take the WORSE of the two: the invariant is that every directory this
+     * manager adds entries to stays under the ceiling, and both qualify. */
+    if (!fsError && strcmp(countPath, gSDCardData.bucketPath) != 0) {
+        bool rootErr = false;
+        uint32_t rootCount = CountDirEntries(gSDCardData.bucketPath,
+                                             SD_CARD_MANAGER_MAX_DIR_FILES,
+                                             &rootErr);
+        if (rootErr) {
+            fsError = true;
+        } else if (rootCount > gSDCardData.bucketFileCountAtStart) {
+            gSDCardData.bucketFileCountAtStart = rootCount;
+        }
+    }
     if (fsError) {
         LOG_E("[SD] #689 bucket '%s' unreadable - refusing rather than rolling",
               gSDCardData.bucketPath);
@@ -1486,11 +1513,31 @@ void sd_card_manager_ProcessState() {
                 }
 
                 uint32_t advanced = 0u;
+                bool rescanned = false;
                 while (bucketOk && !reopenExisting &&
                        (gSDCardData.bucketFileCountAtStart +
                         gSDCardData.filesInCurBucket) >= SD_CARD_MANAGER_MAX_DIR_FILES) {
                     if (gSDCardData.curBucket >= SD_CARD_MANAGER_MAX_BUCKET ||
                         advanced >= SD_CARD_MANAGER_BUCKET_ADVANCE_MAX) {
+                        /* Before declaring exhaustion, rescan from bucket 0
+                         * ONCE. The cursor persists so a session need not walk
+                         * buckets it already passed -- but that also means
+                         * space freed in an EARLIER bucket (SD:DELete, the
+                         * natural "remove the oldest files" cleanup) is
+                         * invisible, and logging is refused with "every bucket
+                         * is full" while a writable bucket exists.
+                         *
+                         * Only on the exhaustion edge, so the common path still
+                         * pays nothing: the rescan costs the same bounded walk
+                         * as a cold start, and only when we would otherwise
+                         * have refused outright. */
+                        if (!rescanned && gSDCardData.curBucket > 0u) {
+                            rescanned = true;
+                            advanced = 0u;
+                            if (sd_EnterBucket(gpSDCardSettings->directory, 0u)) {
+                                continue;
+                            }
+                        }
                         gSDCardData.writeRefuseReason = SD_REFUSE_BUCKETS_EXHAUSTED;
                         bucketOk = false;
                         break;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1517,6 +1517,17 @@ void sd_card_manager_ProcessState() {
                                                   reuseBucket);
                         reopenExisting = bucketOk;
                     }
+                    /* The pre-walk borrowed filePath as scratch (see
+                     * sd_TargetExistsInBucketPath). Hand it back EMPTY rather
+                     * than holding the last probe path.
+                     *
+                     * Nothing reads it before generateFilename rewrites it
+                     * below -- that invariant is why borrowing is safe at all
+                     * -- but a later edit that adds a log or branch in between
+                     * would silently pick up a plausible-looking WRONG path.
+                     * Clearing costs one store and turns that from a silent
+                     * wrong-file bug into an obviously empty one. */
+                    gSDCardData.filePath[0] = '\0';
                 }
 
                 uint32_t advanced = 0u;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -46,7 +46,24 @@
  * name costs — the parent holds bucket entries too, and they must not become
  * the next O(N) problem. */
 #define SD_CARD_MANAGER_BUCKET_PREFIX      "P"
-#define SD_CARD_MANAGER_MAX_BUCKET         999u
+/* The parent holds one entry per bucket, so the bucket ceiling IS a bound on
+ * the parent's size — get it wrong and creating a late bucket re-enters the
+ * very O(N) scan this fix exists to avoid. Worst-case parent entry budget:
+ *
+ *   <= MAX_DIR_FILES files      x 3 entries (2 LFN + 1 SFN)  = 192
+ *   + <= MAX_BUCKET subdirs     x 1 entry  (8.3-clean names) =  64
+ *                                                             ----
+ *                                                              256 entries
+ *                                                            ~8 KB, ~16 sectors
+ *
+ * The bench wedge (#689) was observed at ~500 LFN files ~= 1,536 entries
+ * (~48 KB, ~94 sectors), so 256 stays ~6x below it. Matching MAX_BUCKET to
+ * MAX_DIR_FILES keeps that arithmetic honest and still allows bucket 0 plus
+ * P001..P064 = 65 x 64 = 4,160 files before the clean refuse. Raising it
+ * without
+ * re-deriving the table above would silently walk the parent back toward the
+ * wedge. */
+#define SD_CARD_MANAGER_MAX_BUCKET         SD_CARD_MANAGER_MAX_DIR_FILES
 /* Advancing a bucket costs a DirectoryMake + a bounded CountDirEntries. Cap
  * how many we will skip in one open so a heavily pre-populated card cannot
  * turn a single create into a long synchronous FS walk inside the SD task —

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -264,6 +264,7 @@ extern "C" {
         SD_REFUSE_BUCKETS_EXHAUSTED, /* every bucket up to the ceiling is full */
         SD_REFUSE_BUCKET_MKDIR,      /* the bucket directory could not be created */
         SD_REFUSE_BUCKET_UNREADABLE, /* the bucket could not be counted (FS fault) */
+        SD_REFUSE_BUCKET_NOT_DIR,    /* a non-directory occupies the bucket name */
     } SdWriteRefuseReason;
 
     SdWriteRefuseReason sd_card_manager_WriteRefuseReason(void);

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -271,7 +271,7 @@ extern "C" {
         SD_REFUSE_NONE = 0,          /* not refused */
         SD_REFUSE_BUCKETS_EXHAUSTED, /* every bucket up to the ceiling is full */
         SD_REFUSE_BUCKET_MKDIR,      /* the bucket directory could not be created */
-        SD_REFUSE_BUCKET_UNREADABLE, /* the bucket could not be counted (FS fault) */
+        SD_REFUSE_BUCKET_UNREADABLE, /* a bucket could not be counted OR stat'd (FS fault) */
         SD_REFUSE_BUCKET_NOT_DIR,    /* a non-directory occupies the bucket name */
     } SdWriteRefuseReason;
 

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -255,6 +255,24 @@ extern "C" {
      *        surface a precise "directory too full" error. Cleared on every
      *        subsequent WRITE attempt.
      */
+    /* #689: WHY a WRITE create was refused. The boolean below stays the control
+     * signal (behaviour unchanged); this reports which condition set it, so a
+     * caller can say what actually happened instead of always blaming a full
+     * directory. Reported, never acted on. */
+    typedef enum {
+        SD_REFUSE_NONE = 0,          /* not refused */
+        SD_REFUSE_BUCKETS_EXHAUSTED, /* every bucket up to the ceiling is full */
+        SD_REFUSE_BUCKET_MKDIR,      /* the bucket directory could not be created */
+        SD_REFUSE_BUCKET_UNREADABLE, /* the bucket could not be counted (FS fault) */
+    } SdWriteRefuseReason;
+
+    SdWriteRefuseReason sd_card_manager_WriteRefuseReason(void);
+
+    /* Human-readable form of the above, so every caller words the same cause
+     * the same way instead of each inventing its own (which is how the
+     * "directory too full" wording ended up on media faults). */
+    const char* sd_card_manager_WriteRefuseText(void);
+
     bool sd_card_manager_StartupDirFull(void);
 
     /** @brief #689: synchronously clear the directory-full flag before a new


### PR DESCRIPTION
## Problem

FatFs file-create is **O(directory size)**: `dir_find` linear-scans to EOF, `dir_alloc` then rescans from offset 0 for contiguous free entries, and a directory that has to grow zero-fills a whole new cluster as single-sector writes. Past a few hundred files a create exceeds the SD op timeout and **wedges the manager** — reads keep working, writes never complete. Long split-file sessions (`SYST:STOR:SD:MAXSize`) walk into this mid-session.

PR #690 shipped a stopgap: refuse the create once the directory holds 64 files. That turned a wedge into a clean dead stop — better — but a long logging session still **ended** at 64 files. Its own guard comment said the real fix was bucketing.

## Fix

Bucket 0 **is** the configured directory, so a session that never fills one bucket produces byte-for-byte the pre-#689 layout and host tooling sees no change. Once a bucket reaches the ceiling the manager rolls into `P001`, `P002`, … and keeps logging.

- **8.3-clean bucket names** (uppercase, ≤8 chars, no extension) so FatFs stores each as **one** directory entry rather than the 3 an LFN name costs — the parent holds bucket entries too and must not become the next O(N) problem.
- **`MAX_BUCKET` is tied to `MAX_DIR_FILES`**, so the *parent* is bounded as well. The entry budget is written out at the constant (≤64 files × 3 entries + ≤64 subdirs × 1 = 256 entries, ~16 sectors, versus the ~1,536 entries at which the wedge was observed).
- **Occupancy-driven rollover**, not counter arithmetic: a bucket may already be populated from an earlier session, so the advance is a `while`, not an `if` — and it spans every bucket, because a cap of 16 left a session on a well-used card unable to reach free space (bench-found).
- **Every session rescans from bucket 0.** An earlier revision persisted a cursor across sessions to skip that walk. It was removed: it survived a card swap or a PC-side reformat (first session on a fresh card landed in `P0xx` instead of the configured directory), it ignored space freed by deleting files, and it stopped the same base filename from overwriting. The walk it avoided is bounded — at most 65 counts, each itself bounded — and a cursor that cannot be stale is worth more than the time it saves.
- **A re-open of an existing target does not count as a new entry**, and is found **wherever it lives**. `STR:START` opens once for readiness then re-opens for the stream; at exactly MAX-1 entries that pushed the live stream into `P001` and left a zero-byte file at the configured path. The cross-bucket half of this is the audit finding below.
- **`CountDirEntries` distinguishes an FS error from a full directory** — rolling forward is right for a full directory and wrong for a failing card, where it would create a stray directory per attempt.
- **Refusal reasons are reported** (`SD_REFUSE_BUCKETS_EXHAUSTED` / `_BUCKET_MKDIR` / `_BUCKET_UNREADABLE` / `_BUCKET_NOT_DIR`) so operator messages name the real cause instead of always blaming a full directory — telling someone to clear a card when the card is faulty sends them the wrong way.

## Scope

Narrowed after design review: **nested log filenames and cursor persistence were removed.** Six of the eight audit findings to that point originated in those two features, for a capability nobody asked for. `SD:FILe "sub/run.csv"` reverts to its pre-existing behaviour of working only where the directory already exists.

## The audit finding that mattered, and why it survived six rounds

Round 7 (codex + fable) returned **BLOCK** on a real defect: the reuse probe checked only the **active** bucket, while the roll advances only while a bucket is **full** — so the roll walked straight past a bucket that already held the part being opened.

Session A fills bucket 0 and `P001`. Session B reopens parts 0–63 in bucket 0, then at part 64 finds bucket 0 full, crosses the equally full `P001` where its `run-64.csv` actually lives, and creates a **second** `run-64.csv` in `P002`. Both carry the same base name, and `download_sd_files.py` / `analyze_split_files.py` group by base name — so a stale session is spliced into a fresh one with nothing to indicate it. It also contradicted this file's own contract comment.

**It survived six rounds because I told the audit it was already fixed.** It was — on an unpushed local branch (`fix/689-sd-dir-bucketing-narrow`, commits made *after* the narrowing was pushed). I verified the claim against my working tree instead of `origin`, so every round examined code that never contained the fix. A wrong disposition is the one input that can blind an adversarial audit, and this is the second time; the rule is now to verify dispositions with `git grep <symbol> origin/<branch>`.

The fix checks inside the roll, so the search and the roll cover the same range by construction — one stat per bucket actually crossed, against the directory count `sd_EnterBucket` already pays for each, and nothing at all when no roll happens.

## Also fixed this round

- **A directory at the target path is not a reopenable part** (Qodo, pass 7). `sd_TargetExistsInBucketPath` took any successful `FileStat` as "already here", including a directory — suppressing the roll and then failing the open. This is the mirror of the check `sd_EnterBucket` makes on `SYS_FS_ERROR_EXIST`; FatFs reports presence, never kind, so both sites ask.
- **Three comments corrected** that still described the deleted cursor persistence, one asserting the opposite of what the code does. Not cosmetic: a comment claiming behaviour the code lacks is where the wrong disposition above came from.

## Bench validation (Nq1 `7E2898F46200E8A7`)

`test_689_sd_dir_bucketing` — **9 PASS, 0 FAIL** on the shipping build:

| case | result |
|---|---|
| A long split session | 89 files, 1 bucket, no refusal, no wedge |
| B start into a full directory | file created, not rejected |
| C control, empty directory | lands at `DAQiFi/ctl689.csv` |
| D per-directory invariant | 163 files, worst directory holds exactly 64 (the ceiling) |
| E cursor scoped to its directory | lands at `NEWDIR/cursor689.csv` |
| F pre-open at the MAX-1 boundary | lands at the configured path, not `P001` |
| H bucketed read-back | `NEWDIR/P001/rb689.csv` 20591 B, terminator present |
| I repeat session reopens a part in a later bucket | `rep689-64.csv` in **exactly one** place |
| J a bucket with **room** still finds a part living further on | `j689-62.csv` in **exactly one** place |

Cases I and J gate the two audit findings. I: run 1 filled bucket 0 + `P001` + part of `P002` (139 files), run 2 wrote strictly more (184), and part 64 exists once with the bucket set unchanged. J: bucket 0 left with room via `SD:DELete` on two fillers, and the part living in `P001` is reopened there rather than duplicated.

Both are **mutation-proved** — reintroducing each defect in firmware flips exactly its own case and nothing else:

| mutant | case I | case J |
|---|---|---|
| in-roll probe disabled entirely | **FAIL** (2 copies) | — |
| probe inside the roll (pre-walk removed) | PASS | **FAIL** (2 copies) |

The second row is the important one: it shows case I *cannot* catch the shape case J covers, which is why both exist.

**Two consecutive clean adversarial-audit gates** (codex + fable, PASS with zero findings) on the final code.

**Mutation-proved.** The previous case I *could not fail* — it stopped filling as soon as any bucket appeared, leaving `P001` holding one file, so the roll halted there and reopened correctly even on broken firmware. That is a large part of why the defect got this far, so the replacement was verified by reintroducing the defect in firmware and re-running: see the comment below for the result.

The suite also stopped polling `SD:LISt?` mid-stream. A listing issued while the SD manager is streaming is routinely refused as busy, so each poll burned the full retry budget (~78 s) and a run took ~30 min to reach a verdict; it also violated the project's quiescence rule. Fills are now sized from a **measured** 1.6 files/s (48 files in 30 s) with the postcondition verified after stopping — the file previously carried three mutually contradictory rate claims.

## Known and accepted

Addressing a bucketed file through SCPI costs 5 extra operand bytes (`P001/`), so a base filename ≥36 bytes breaks the `LIST`→`GET` round-trip against the 40-byte `opFile` cap. A working path exists (`SD:LISt? "DAQiFi/P001"` re-scopes the directory). This is a pre-existing round-trip weakness that bucketing narrows rather than creates; widening `opFile` would change the SCPI operand contract, so it is flagged rather than fixed here.

Separately filed, provoked by this workload but not caused by this code:
- **#782** — SD detect state wedges after sustained rotation; only `SYST:REBoot` recovers.
- **#783** — `STR:STOP` returns success after its fixed 5 s SD drain expires, so the next SD command reports "card busy". This is why long-fill test cases are kept as short as their preconditions allow.

Companion tests: `daqifi-python-test-suite` **#136** (bucketing) and **#140** (test_691's replacement fault injector).

Refs #689, #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
