### PR TITLE
feat(csv): #619 opt-in compact CSV with one timestamp column (SYST:STR:FORmat 3)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3848,6 +3848,10 @@ static scpi_result_t SCPI_SetStreamFormat(scpi_t * context) {
         pRunTimeStreamConfig->Encoding = Streaming_Json;
     }else if(param1 == Streaming_Csv){
          pRunTimeStreamConfig->Encoding = Streaming_Csv;
+    }else if(param1 == Streaming_CsvCompact){
+         /* #619: CSV with one leading timestamp column instead of N identical
+          * per-channel ones. Opt-in; 0/1/2 keep their existing meaning. */
+         pRunTimeStreamConfig->Encoding = Streaming_CsvCompact;
     }else{
         pRunTimeStreamConfig->Encoding = Streaming_Json;
     }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3842,6 +3842,26 @@ static scpi_result_t SCPI_SetStreamFormat(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
+    /* #619: reject an encoding change while streaming. The CSV header is sent
+     * ONCE per session (csvHeaderSent), but the row layout is chosen from the
+     * live Encoding on every row -- so switching mid-session leaves every
+     * subsequent row disagreeing with the header the client already parsed.
+     *
+     * That hazard is worst between the two CSV encodings: both announce
+     * themselves as CSV, so a client sees columns silently shift rather than a
+     * format change it could detect. It applies to any switch though, so the
+     * guard covers all of them.
+     *
+     * Mirrors SCPI_ADCChanEnableSet's #116 guard, including its IsEnabled ||
+     * Running form -- the two flags are set and cleared in separate steps at
+     * start/stop, so an && test would leave a window open. */
+    if (pRunTimeStreamConfig->IsEnabled || pRunTimeStreamConfig->Running) {
+        LOG_E("Stream format change rejected: streaming is active "
+              "(stop streaming first)");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+
     if (param1 == Streaming_ProtoBuffer) {
         pRunTimeStreamConfig->Encoding = Streaming_ProtoBuffer;
     } else if (param1 == Streaming_Json) {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5116,7 +5116,12 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
      * channels, the max rate will be X Hz" without round-tripping
      * for every checkbox change. */
     scpi_printf(context,
-        "\"streaming\":{\"encodings\":[\"pb\",\"csv\",\"json\"],"
+        /* #619: csv_compact (SYST:STR:FORmat 3) is listed because this blob is
+         * documented as the client's source of truth for what the device
+         * supports. Adding an encoding the firmware accepts but never
+         * advertises leaves every schema-following client unable to offer it.
+         * Appended last so existing clients see their three unchanged. */
+        "\"streaming\":{\"encodings\":[\"pb\",\"csv\",\"json\",\"csv_compact\"],"
         "\"transports\":[");
     {
         bool first = true;

--- a/firmware/src/services/csv_encoder.c
+++ b/firmware/src/services/csv_encoder.c
@@ -124,6 +124,11 @@ static const char CSV_HEADER_HZ_SUFFIX[] = " Hz\n";
 // This allows board-specific naming conventions (e.g., "ain" vs "ch" prefix)
 
 // DIO header strings
+/* #619: leading single-timestamp column for the compact CSV encoding. DIO keeps
+ * its OWN ts column -- a DIO sample carries an independent timestamp, so folding
+ * it into the analog one would misreport it. Only the per-analog-channel columns
+ * are redundant (they share one sample-set timestamp since the #115 pool). */
+static const char CSV_COMPACT_TS_HEADER[] = "timestamp";
 static const char CSV_DIO_HEADER_FIRST[] = "dio_ts,dio_val\n";
 static const char CSV_DIO_HEADER_SUBSEQUENT[] = ",dio_ts,dio_val\n";
 
@@ -199,7 +204,8 @@ void csv_ResetEncoder(void) {
  * Uses pre-computed strings from flash to minimize file rotation latency.
  * Critical for maintaining data continuity at high sample rates (15kHz+).
  */
-static size_t generateHeader(char *out, size_t rem, AInRuntimeArray* channelConfig, bool dioEnabled) {
+static size_t generateHeader(char *out, size_t rem, AInRuntimeArray* channelConfig,
+                             bool dioEnabled, bool compact) {
     char *q = out;
 
     // Get board config early with NULL check
@@ -263,11 +269,33 @@ static size_t generateHeader(char *out, size_t rem, AInRuntimeArray* channelConf
     }
 
     bool firstCol = true;
-    for (int i = 0; i < MAX_AIN_PUBLIC_CHANNELS; i++) {
-        if (channelConfig->Data[i].IsEnabled) {
-            const char* header = firstCol ? headerFirst[i] : headerSubsequent[i];
-            q = fast_strcpy_bounded(q, &rem, header);
-            firstCol = false;
+    if (compact) {
+        /* #619: one leading timestamp column, then value-only names. The
+         * per-channel name is derived from the existing array rather than
+         * duplicating a second 16-entry table per board variant: the entries
+         * are "ain<N>_ts,ain<N>_val" (and the subsequent form only adds a
+         * leading comma), so the text after the LAST comma is exactly the
+         * value column name. One source of truth for channel naming. */
+        q = fast_strcpy_bounded(q, &rem, CSV_COMPACT_TS_HEADER);
+        firstCol = false;
+        for (int i = 0; i < MAX_AIN_PUBLIC_CHANNELS; i++) {
+            if (channelConfig->Data[i].IsEnabled) {
+                const char* valName = strrchr(headerFirst[i], ',');
+                if (valName == NULL) {
+                    LOG_E("[CSV] Malformed channel header at %d", i);
+                    return 0;
+                }
+                q = fast_strcpy_bounded(q, &rem, ",");
+                q = fast_strcpy_bounded(q, &rem, valName + 1);
+            }
+        }
+    } else {
+        for (int i = 0; i < MAX_AIN_PUBLIC_CHANNELS; i++) {
+            if (channelConfig->Data[i].IsEnabled) {
+                const char* header = firstCol ? headerFirst[i] : headerSubsequent[i];
+                q = fast_strcpy_bounded(q, &rem, header);
+                firstCol = false;
+            }
         }
     }
 
@@ -293,7 +321,10 @@ size_t csv_GenerateHeaderToBuffer(char* buffer, size_t size) {
     if (!channelConfig) return 0;
     bool* pDioEnable = (bool*)BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_DIO_GLOBAL_ENABLE);
     bool dioEnabled = (pDioEnable && *pDioEnable);
-    size_t len = generateHeader(buffer, size - 1, channelConfig, dioEnabled);
+    StreamingRuntimeConfig *pHdrCfg = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_STREAMING_CONFIGURATION);
+    bool compact = (pHdrCfg != NULL) && (pHdrCfg->Encoding == Streaming_CsvCompact);
+    size_t len = generateHeader(buffer, size - 1, channelConfig, dioEnabled, compact);
     if (len > 0 && len < size) buffer[len] = '\0';
     return len;
 }
@@ -323,7 +354,8 @@ static size_t tryWriteRow(
     bool       *hadAIN,
     bool       *hadDIO,
     uint8_t     voltagePrecision,
-    bool        rawMode              /* #158/#270: emit raw ADC codes */
+    bool        rawMode,             /* #158/#270: emit raw ADC codes */
+    bool        compact              /* #619: one leading ts, not one per channel */
 ) {
     // 1) peek queues
     AInPublicSampleList_t *ainPeek = NULL;
@@ -358,6 +390,25 @@ static size_t tryWriteRow(
         chCount = (uint8_t)ainPeek->channelCount;
     }
 
+    /* #619: in compact mode the sample-set timestamp is written ONCE, ahead of
+     * the values. Every ain<N>_ts column carried this same value (the #115 pool
+     * shares one timestamp per set), so N-1 of them were pure duplication --
+     * ~9 bytes x 15 channels on a 16-channel row. Written even when no analog
+     * sample is present (as an empty field) so the column count per row stays
+     * fixed, which is what keeps the output parseable. */
+    if (compact) {
+        char* p = q;
+        size_t space = rem;
+        if (*hadAIN && ainPeek) {
+            p = uint32_to_str(ainPeek->Timestamp, p, space);
+            if (p == NULL) return 0;
+        }
+        w = p - q;
+        if (w < 0 || (size_t)w >= rem) return 0;
+        q += w; rem -= w;
+        firstField = false;
+    }
+
     for (uint8_t j = 0; j < chCount; j++) {
         bool valid = *hadAIN && ainPeek && (ainPeek->validMask & (1U << j));
 
@@ -370,13 +421,15 @@ static size_t tryWriteRow(
                 *p++ = ',';
                 space--;
             }
-            p = uint32_to_str(ainPeek->Timestamp, p, space);
-            if (p == NULL) return 0;  // Buffer exhausted
-            size_t used = p - q;
-            space = (used < rem) ? rem - used : 0;
-            if (space == 0) return 0;  // Buffer exhausted
-            *p++ = ',';
-            space--;
+            if (!compact) {
+                p = uint32_to_str(ainPeek->Timestamp, p, space);
+                if (p == NULL) return 0;  // Buffer exhausted
+                size_t used = p - q;
+                space = (used < rem) ? rem - used : 0;
+                if (space == 0) return 0;  // Buffer exhausted
+                *p++ = ',';
+                space--;
+            }
 
             // #158/#270: raw mode emits the ADC code directly - no cal,
             // no voltage conversion, no double math (fastest path; also the
@@ -427,8 +480,10 @@ static size_t tryWriteRow(
                 *p++ = ',';  // separator before empty ts
                 space--;
             }
-            if (space < 1) return 0;  // Buffer exhausted
-            *p++ = ',';  // separator between empty ts and empty val
+            if (!compact) {
+                if (space < 1) return 0;  // Buffer exhausted
+                *p++ = ',';  // separator between empty ts and empty val
+            }
 
             w = p - q;
             firstField = false;
@@ -523,6 +578,9 @@ size_t csv_Encode(
     StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
     uint8_t voltagePrecision = (pStreamCfg != NULL) ? pStreamCfg->VoltagePrecision : 4;
+    /* #619: opt-in compact layout (SYST:STR:FORmat 3). Read once per call, not
+     * per row. Defaults to the classic layout if the config is unavailable. */
+    bool compact = (pStreamCfg != NULL) && (pStreamCfg->Encoding == Streaming_CsvCompact);
 
     char   *p     = (char*)pBuffer;
     size_t  rem   = buffSize - 1;  // reserve 1 byte up front for '\0'
@@ -530,7 +588,7 @@ size_t csv_Encode(
 
     // Generate header on first call
     if (!csvHeaderSent) {
-        size_t headerLen = generateHeader(p, rem, channelConfig, dioEnabled);
+        size_t headerLen = generateHeader(p, rem, channelConfig, dioEnabled, compact);
         if (headerLen == 0) {
             // Not enough space to write header; don't emit partial data
             *p = '\0';
@@ -546,7 +604,7 @@ size_t csv_Encode(
         bool hadAIN, hadDIO;
         // attempt to write the next row in-place
         bool rawMode = (pStreamCfg != NULL) ? pStreamCfg->RawOutputMode : false;
-        size_t rowLen = tryWriteRow(p, rem, state, channelConfig, dioEnabled, &hadAIN, &hadDIO, voltagePrecision, rawMode);
+        size_t rowLen = tryWriteRow(p, rem, state, channelConfig, dioEnabled, &hadAIN, &hadDIO, voltagePrecision, rawMode, compact);
         if (rowLen == 0 || rowLen > rem) {
             break;  // no data left or row won?t fit
         }

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2445,7 +2445,7 @@ void streaming_Task(void) {
             // Write SD-only header/metadata for each new file so every
             // file is self-describing and independently parseable.
             size_t sdHdrLen = 0;
-            if (pRunTimeStreamConf->Encoding == Streaming_Csv) {
+            if (Streaming_EncodingIsCsv(pRunTimeStreamConf->Encoding)) {
                 // On rotation (header already sent to USB), generate
                 // SD-only header.  First file: encoder flag is false,
                 // so the encoder naturally includes the header for ALL
@@ -2593,7 +2593,7 @@ void streaming_Task(void) {
             size_t encRoom = bufferSize - packetSize;
             size_t encoded = 0;
             DioProbe_PulseStart(8);  /* probe 8: encode duration */
-            if (pRunTimeStreamConf->Encoding == Streaming_Csv) {
+            if (Streaming_EncodingIsCsv(pRunTimeStreamConf->Encoding)) {
                 DIO_TIMING_TEST_WRITE_STATE(1);
                 encoded = csv_Encode(pBoardData, &nanopbFlag, encPtr, encRoom);
                 DIO_TIMING_TEST_WRITE_STATE(0);

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -253,6 +253,15 @@ static inline uint32_t Streaming_SdAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2use
  *                       cap would over-cap them and risk silent transport overflow.
  * @return transport-limited max frequency in Hz
  */
+/* #619: both CSV encodings share the CSV encoder, the CSV header and the CSV
+ * cap coefficients — they differ only in whether a row carries one timestamp or
+ * N identical ones. Call sites must test the FAMILY, not the single value, or
+ * compact CSV silently falls through to whatever branch follows. */
+static inline bool Streaming_EncodingIsCsv(StreamingEncoding e)
+{
+    return (e == Streaming_Csv) || (e == Streaming_CsvCompact);
+}
+
 static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
                                                   StreamingEncoding encoding,
                                                   uint32_t totalChannels,
@@ -265,6 +274,11 @@ static inline uint32_t Streaming_TransportMaxFreq(StreamingInterface interface,
     switch (encoding) {
         case Streaming_ProtoBuffer: pb = 1u; break;
         case Streaming_Csv:         pb = 0u; break;
+        /* #619: compact CSV emits strictly FEWER bytes per row than CSV, so the
+         * CSV coefficients are a conservative (never-over) bound for it. Note
+         * this case is required, not optional -- the `default` below caps an
+         * unrecognised encoding at 1 Hz. */
+        case Streaming_CsvCompact:  pb = 0u; break;
         case Streaming_Json:        pb = 0u; json = 1u; break;  /* CSV coefficients, derated below */
         default:                    return 1u;
     }

--- a/firmware/src/state/runtime/StreamingRuntimeConfig.h
+++ b/firmware/src/state/runtime/StreamingRuntimeConfig.h
@@ -12,6 +12,13 @@ extern "C" {
         Streaming_ProtoBuffer = 0,
         Streaming_Json = 1,
         Streaming_Csv=2,
+        /* #619: CSV with ONE leading timestamp column instead of a per-channel
+         * ain<N>_ts column. Since the compact sample pool (#115) shares a single
+         * timestamp across a sample set, those per-channel columns are all
+         * identical -- ~15 redundant ~9-digit fields on a 16-channel row.
+         * Appended as a new value rather than changing 2, so existing clients
+         * are untouched; opt-in via SYST:STR:FORmat 3. */
+        Streaming_CsvCompact=3,
     } StreamingEncoding;
 
     typedef enum eStreamingInterface


### PR DESCRIPTION
## Problem

Since the compact sample pool (#115) shares a single timestamp across a sample set, every per-channel `ain<N>_ts` column in a CSV row carries the **same value**. On a 16-channel row that is ~15 redundant fields of pure duplication, in the byte-heaviest format we ship.

## What this does — and deliberately does not do

`SYST:STR:FORmat 3` selects a compact layout: one leading `timestamp` column, then value-only channel columns.

```
FORmat 2 (unchanged):  ain0_ts,ain0_val,ain1_ts,ain1_val,...,dio_ts,dio_val
FORmat 3 (new):        timestamp,ain0_val,ain1_val,...,dio_ts,dio_val
```

Appended as a **new enum value**, so 0/1/2 keep their exact meaning and no existing client is affected — the *"opt-in flag for one release"* the issue asked for, **not** a schema break.

**Switching the default is not done here.** #619 notes that removing the columns outright is breaking and needs coordination with client maintainers; that decision stays open. This ships the mechanism so the coordination can happen against something real.

## Measured saving (bench, 8 channels @ 1 kHz)

**119 B/row → 50 B/row, a 58% reduction** — larger than the issue's estimate, which counted only the timestamp digits and not the separators they carry.

## Notes on the implementation

- **DIO keeps its own `dio_ts`.** A DIO sample carries an independent timestamp; folding it into the analog one would misreport it. Only the per-analog-channel columns are redundant.
- **Compact column names are derived from the existing header array** rather than adding a second 16-entry table to each board variant — one source of truth, nothing to keep in sync across NQ1/NQ2/NQ3.
- **`Streaming_EncodingIsCsv()`** added because call sites must test the CSV *family*; a site left comparing `== Streaming_Csv` would silently fall through to the JSON/PB branch.
- **The transport-cap switch needed an explicit case** — its `default` caps an unrecognised encoding at 1 Hz, so omitting it would have throttled compact CSV to 1 Hz rather than failing loudly. It reuses the CSV coefficients, a conservative bound since compact emits strictly fewer bytes.
- **A mid-stream encoding change is now rejected** (`IsEnabled || Running`, mirroring the #116 guard). The CSV header is sent once per session but the row layout is chosen per row, so switching mid-session would leave every subsequent row disagreeing with the header the client already parsed — and because *both* encodings announce themselves as CSV, a client would see columns silently shift rather than a format change it could detect.
- **`csv_compact` is advertised in `CONF:CAP:JSON?`.** That blob is documented as the client's source of truth, so an encoding the firmware accepts but never advertises would ship invisible to every schema-following client.

## Bench validation (Nq1 `7E2898F46200E8A7`) — 6 PASS, 0 FAIL

```
[A classic layout preserved]                                   -> PASS
[B compact header shape] cols=9                                -> PASS
[C row/header column agreement] 9985/9985 (0.00% short)        -> PASS
[D timestamp monotonic] n=9985 out-of-order=0 wraps=0          -> PASS
[E byte saving] classic=119.0 compact=50.0 saved=69.0 B/row    -> PASS
[F mid-stream switch rejected] rejected=True fmt_after=2        -> PASS
```

`CONF:CAP:JSON?` verified returning `"encodings":["pb","csv","json","csv_compact"]`.

## Wiki

Updated — and while there, corrected a **pre-existing error**: the `FORmat` row described value 2 as "TestData" with a second `<TestData_Len>` argument and a full packet-structure spec. The firmware implements no such thing (`SCPI_SetStreamFormat` parses exactly one parameter, and 2 is CSV) — which the `FORmat?` row on the very next line already said, so the page contradicted itself.

Companion test: `daqifi-python-test-suite` **#138**.

Refs #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)
