### PR TITLE
fix(usb): #780 pump USB writes while a SCPI SD reply waits, breaking a self-deadlock

### DIFF
--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -594,8 +594,12 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_LIST_DIRECTORY;
     sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
 
-    // Wait for sd_card_manager to complete listing (up to 10 seconds for large directories)
-    if (!sd_card_manager_WaitForCompletion(SCPI_SD_LIST_TIMEOUT_MS)) {
+    // Wait for sd_card_manager to complete listing (up to 10 seconds for large
+    // directories). #780: PUMPED — a listing is delivered through DataReadyCB
+    // while we wait, and over USB this same task is what drains it. A plain
+    // block deadlocks the two until the timeout fires, so every listing larger
+    // than the idle USB buffer took exactly 10 s and reported failure.
+    if (!sd_card_manager_WaitForCompletionPumped(SCPI_SD_LIST_TIMEOUT_MS)) {
         LOG_E("SD:LIST? - Operation timeout\r\n");
         pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
         sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -1287,6 +1287,25 @@ void UsbCdc_Initialize() {
 
 }
 
+void UsbCdc_PumpWrite(void) {
+    /* Same guard order as the write branch of UsbCdc_ProcessState: only in
+     * PROCESS state, and only when no transfer is already in flight (the
+     * driver allows a single outstanding write). BeginWrite re-checks the
+     * state itself; the check here keeps the intent readable at the call site.
+     *
+     * Safe to call from within a SCPI callback: that runs on this same task,
+     * so there is no concurrent writer, and the outer ProcessState iteration
+     * is suspended inside FinalizeRead rather than mid-BeginWrite. */
+    if (gRunTimeUsbSttings.state != USB_CDC_STATE_PROCESS) {
+        return;
+    }
+    if (gRunTimeUsbSttings.writeTransferHandle !=
+            USB_DEVICE_CDC_TRANSFER_HANDLE_INVALID) {
+        return;                 /* a write is already in flight */
+    }
+    (void)UsbCdc_BeginWrite(&gRunTimeUsbSttings);
+}
+
 void UsbCdc_ProcessState() {
 
     UNUSED(UsbCdc_WaitForRead); // We dont want to block on the read so this is currently not used

--- a/firmware/src/services/UsbCdc/UsbCdc.c
+++ b/firmware/src/services/UsbCdc/UsbCdc.c
@@ -1293,9 +1293,25 @@ void UsbCdc_PumpWrite(void) {
      * driver allows a single outstanding write). BeginWrite re-checks the
      * state itself; the check here keeps the intent readable at the call site.
      *
-     * Safe to call from within a SCPI callback: that runs on this same task,
-     * so there is no concurrent writer, and the outer ProcessState iteration
-     * is suspended inside FinalizeRead rather than mid-BeginWrite. */
+     * Safe to call from within a SCPI callback, but NOT because it is always
+     * the same task -- it is not. SYST:STOR:SD:LISt? also serves TCP origin
+     * (SCPIStorageSD.c) and is dispatched on app_WifiTask (pri 2) since #353,
+     * so this can run concurrently with app_USBDeviceTask (pri 7) doing its own
+     * ProcessState -> BeginWrite. Concurrent BeginWrite is tolerated because:
+     *   - the consumer side runs under wMutex, the external serialization
+     *     CircularBuffer.h requires for multiple consumers;
+     *   - the DMA submit is claimed under the #127 writeInProgress flag inside
+     *     a critical section, so the loser's callback returns -1 and
+     *     CircularBuf_ProcessBytes consumes nothing on a negative return --
+     *     no lost bytes, no double-consume;
+     *   - -1 is not a USB_ERROR_* value (those are SCHAR_MIN-based), so it
+     *     falls through BeginWrite's switch as "no action" and cannot trip the
+     *     BEGIN_CLOSE arms.
+     * Cross-task BeginWrite already exists on main (SYST:STR:STOP over TCP ->
+     * UsbCdc_FlushWriteBuffer), so this adds an instance of a tolerated class,
+     * not a new one. Do NOT weaken that locking on the belief that this is
+     * single-task. Same-task re-entry is separately clean: over USB the SCPI
+     * callback runs inside FinalizeRead, never with BeginWrite on the stack. */
     if (gRunTimeUsbSttings.state != USB_CDC_STATE_PROCESS) {
         return;
     }

--- a/firmware/src/services/UsbCdc/UsbCdc.h
+++ b/firmware/src/services/UsbCdc/UsbCdc.h
@@ -160,6 +160,19 @@ extern "C" {
      */
     void UsbCdc_ProcessState();
 
+    /* #780: run ONLY the write half of the CDC state machine.
+     *
+     * app_USBDeviceTask both hosts the SCPI handler chain and drains the USB
+     * circular buffer. A SCPI callback that blocks (an SD reply waiting on the
+     * SD task) therefore stops the drain the SD task is waiting for — the
+     * producer waits on a consumer that is waiting on the producer, broken only
+     * by a 10 s timeout. Calling this from such a wait keeps output flowing.
+     *
+     * Deliberately NOT UsbCdc_ProcessState(): that also runs FinalizeRead,
+     * which dispatches SCPI, so calling it from inside a SCPI callback would
+     * re-enter the parser. This touches no read state. */
+    void UsbCdc_PumpWrite(void);
+
     /**
      * Indicates whether USB is up and active
      */

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2159,12 +2159,20 @@ bool sd_card_manager_WaitForCompletionPumped(uint32_t timeoutMs) {
      * and 2 ticks of wall time (the wait starts mid-tick), so the nominal
      * timeout could expire up to ~2x early. The caller documents "up to N ms";
      * honour it. */
+    /* Only the USB reply path needs pumping. A TCP-targeted reply is drained by
+     * a different task, so pumping USB there is pure waste on every slice -- and
+     * it is the case where this runs on app_WifiTask rather than the USB task,
+     * so not pumping also keeps the common path single-task. */
+    const bool toUsb = (gpSDCardSettings == NULL) ||
+                       (gpSDCardSettings->replyTarget != SD_CARD_REPLY_WIFI_TCP);
     const TickType_t start = xTaskGetTickCount();
     for (;;) {
         if (xSemaphoreTake(gSDCardData.opCompleteSemaphore, slice) == pdTRUE) {
             return true;
         }
-        UsbCdc_PumpWrite();
+        if (toUsb) {
+            UsbCdc_PumpWrite();
+        }
         if (limit != portMAX_DELAY) {
             /* Wrap-safe elapsed comparison (project rule: (now - start) < window). */
             if ((TickType_t)(xTaskGetTickCount() - start) >= limit) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -28,6 +28,11 @@
  * fix (subdirectory bucketing would be) — a guard until #689 is resolved. */
 #define SD_CARD_MANAGER_MAX_DIR_FILES      64u
 
+/* #780: how long the pumped wait blocks between USB write pumps. Small enough
+ * that a filling circular buffer is serviced promptly, large enough that the
+ * wait is not a busy-spin against the SD task. */
+#define SD_WAIT_PUMP_SLICE_MS              2u
+
 // Iterative directory listing — bounded BSS-backed stack instead of recursion.
 // 16 levels covers any realistic FAT32 tree without growing the task stack.
 #define SD_CARD_MANAGER_MAX_LIST_DEPTH     16
@@ -2121,6 +2126,41 @@ bool sd_card_manager_IsIdle() {
             gSDCardData.currentProcessState == SD_CARD_MANAGER_PROCESS_STATE_INIT);
 }
 
+
+bool sd_card_manager_WaitForCompletionPumped(uint32_t timeoutMs) {
+    /* #780: identical to WaitForCompletion, except it keeps the USB write half
+     * running while it waits.
+     *
+     * The caller here is app_USBDeviceTask, which is BOTH the SCPI host and the
+     * task that drains the USB circular buffer. Blocking it outright stops the
+     * drain that the SD task needs in order to hand over its reply, so a reply
+     * larger than the idle buffer could only complete by burning the full
+     * timeout. Pumping breaks that cycle: the producer's chunks keep leaving.
+     *
+     * Poll in short slices rather than one long block; each slice pumps. The
+     * slice is the resolution of the timeout, so keep it small. */
+    if (sd_card_manager_IsIdle()) {
+        return true;
+    }
+    const TickType_t slice = pdMS_TO_TICKS(SD_WAIT_PUMP_SLICE_MS);
+    TickType_t waited = 0;
+    const TickType_t limit = (timeoutMs == 0) ? portMAX_DELAY
+                                              : pdMS_TO_TICKS(timeoutMs);
+    for (;;) {
+        if (xSemaphoreTake(gSDCardData.opCompleteSemaphore, slice) == pdTRUE) {
+            return true;
+        }
+        UsbCdc_PumpWrite();
+        if (limit != portMAX_DELAY) {
+            waited += slice;
+            if (waited >= limit) {
+                break;
+            }
+        }
+    }
+    LOG_E("[SD] WaitForCompletion (pumped) timeout after %u ms\r\n", timeoutMs);
+    return false;
+}
 
 bool sd_card_manager_WaitForCompletion(uint32_t timeoutMs) {
     if (sd_card_manager_IsIdle()) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -30,7 +30,13 @@
 
 /* #780: how long the pumped wait blocks between USB write pumps. Small enough
  * that a filling circular buffer is serviced promptly, large enough that the
- * wait is not a busy-spin against the SD task. */
+ * wait is not a busy-spin against the SD task.
+ *
+ * The slice is clamped to >= 1 tick at use. At the current 1000 Hz tick this is
+ * 2 ticks, but if configTICK_RATE_HZ ever dropped below 500, pdMS_TO_TICKS(2)
+ * would round to 0 -- a zero-timeout take never blocks, so the pri-7 waiter
+ * would busy-spin and starve the pri-5 SD task that has to give the semaphore.
+ * That is a livelock for the whole timeout, and forever when timeoutMs == 0. */
 #define SD_WAIT_PUMP_SLICE_MS              2u
 
 // Iterative directory listing — bounded BSS-backed stack instead of recursion.
@@ -2142,18 +2148,26 @@ bool sd_card_manager_WaitForCompletionPumped(uint32_t timeoutMs) {
     if (sd_card_manager_IsIdle()) {
         return true;
     }
-    const TickType_t slice = pdMS_TO_TICKS(SD_WAIT_PUMP_SLICE_MS);
-    TickType_t waited = 0;
+    TickType_t slice = pdMS_TO_TICKS(SD_WAIT_PUMP_SLICE_MS);
+    if (slice == 0u) {
+        slice = 1u;                 /* never a non-blocking take -- see above */
+    }
     const TickType_t limit = (timeoutMs == 0) ? portMAX_DELAY
                                               : pdMS_TO_TICKS(timeoutMs);
+    /* Measure ELAPSED ticks, not slices-attempted. Counting a full slice per
+     * failed take over-counts: a 2-tick take returns after between just-over-1
+     * and 2 ticks of wall time (the wait starts mid-tick), so the nominal
+     * timeout could expire up to ~2x early. The caller documents "up to N ms";
+     * honour it. */
+    const TickType_t start = xTaskGetTickCount();
     for (;;) {
         if (xSemaphoreTake(gSDCardData.opCompleteSemaphore, slice) == pdTRUE) {
             return true;
         }
         UsbCdc_PumpWrite();
         if (limit != portMAX_DELAY) {
-            waited += slice;
-            if (waited >= limit) {
+            /* Wrap-safe elapsed comparison (project rule: (now - start) < window). */
+            if ((TickType_t)(xTaskGetTickCount() - start) >= limit) {
                 break;
             }
         }

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -214,6 +214,14 @@ extern "C" {
      */
     bool sd_card_manager_WaitForCompletion(uint32_t timeoutMs);
 
+    /* #780: use this instead when the CALLER is app_USBDeviceTask and the
+     * operation produces a reply through sd_card_manager_DataReadyCB. That task
+     * also drains the USB circular buffer, so a plain block stops the drain the
+     * SD task needs to finish -- a reply larger than the idle buffer then takes
+     * the full timeout to deliver. This variant pumps the USB write half while
+     * waiting. WiFi/TCP callers do not need it (a different task drains). */
+    bool sd_card_manager_WaitForCompletionPumped(uint32_t timeoutMs);
+
     /**
      * @brief Gets the result of the last completed operation.
      *


### PR DESCRIPTION
Fixes #780. **Blocks — and is required by — #778.**

## The bug

`app_USBDeviceTask` (priority 7) does **two** jobs: it hosts the USB SCPI handler chain, *and* it drains the USB circular buffer to hardware (`UsbCdc_ProcessState` → `BeginWrite`, once per `vTaskDelay(1)`).

`SYST:STOR:SD:LISt?` runs on that task and blocks in `sd_card_manager_WaitForCompletion` — a bare `xSemaphoreTake` — so **the drain stops for as long as it waits**. Meanwhile the SD task (priority 5) pushes the listing through `sd_card_manager_DataReadyCB`. Once the idle USB circular buffer (`STREAMING_USB_MIN` = 2048 B) fills, `sd_reply_write_usb` returns 0 and the callback retries `USB_TRANSFER_MAX_RETRIES` × `vTaskDelay(1)` = **10 s**.

The producer waits for a drain that cannot run until the consumer stops waiting for the producer. Only the timeout breaks it.

**The data is not lost** — the timeout fires, the task resumes, the buffer drains, and the whole listing appears at once. But it arrives 10 s late and the operation reports `SCPI -200` plus a misleading *"operations hanging / card may be SPI-incompatible"* advisory, pointing at the card instead of the scheduler.

## Why now

PR #690's files-per-directory cap was doing **undocumented double duty**: it bounded the FatFs O(N) create scan (its stated job) *and* incidentally kept every listing under 2048 B. #689 bucketing removes it for writes — correctly — and exposes the read side.

## Evidence (E — bench Nq1 `7E2898F46200E8A7`, same card, adjacent runs)

Time-to-first-byte measured separately from wall time, reader draining from byte 0. A deadlock broken by a timeout delivers at *exactly* the timeout and never earlier — that is the fingerprint, and total wall time alone does not show it.

**`main` (64-file cap keeps listings under the buffer):**

| occupancy | files | listing | first byte | fw timeout |
|---|--:|--:|--:|---|
| empty | 0 | 30 B | 0.1 s | no |
| ~30 files | 42 | 1066 B | 0.0 s | no |
| at the cap | 63 | 1579 B | 0.0 s | no |

**#689 bucketing alone → the cliff appears where listing size crosses 2048 B:**

| occupancy | files | first byte | fw timeout |
|---|--:|--:|---|
| 42 | 42 | 0.0 s | no |
| **111** | 111 | **10.0 s** | **yes** |
| **202** | 202 | **10.0 s** | **yes** |

**#689 + this fix:**

| occupancy | files | first byte | fw timeout |
|---|--:|--:|---|
| 42 | 42 | 0.0 s | no |
| 110 | 110 | **0.0 s** | no |
| 201 | 201 | **0.0 s** | no |

`SYST:STOR:SD:SPACe?` stayed healthy throughout, so the card and FS were never implicated.

## The fix

`UsbCdc_PumpWrite()` runs **only** the write half of the CDC state machine; `sd_card_manager_WaitForCompletionPumped()` calls it between short semaphore slices, and the LIST path uses it.

Deliberately **not** `UsbCdc_ProcessState()` — that also runs `FinalizeRead`, which dispatches SCPI, so calling it from inside a SCPI callback would re-enter the parser.

Rejected: raising `STREAMING_USB_MIN` only moves the threshold (a 4160-file listing is ~140 KB and cannot be buffered at any plausible size).

## Independent audit — three findings, all applied

1. **My safety comment was wrong.** It claimed the caller is always `app_USBDeviceTask` "so there is no concurrent writer". It is not: this handler also serves TCP origin and dispatches on `app_WifiTask` since #353. The code is safe anyway — the consumer side runs under `wMutex`, the DMA submit is claimed under the #127 `writeInProgress` flag, the loser's `-1` makes `CircularBuf_ProcessBytes` consume nothing, and `-1` is not a `USB_ERROR_*` value so it cannot trip the `BEGIN_CLOSE` arms. Cross-task `BeginWrite` already exists on main (`STR:STOP` over TCP). The comment now states the real reasons — a comment asserting single-task ownership is worse than none, because someone could remove that locking believing it redundant.
2. **Sliced timeout could expire ~2× early.** Counting a full slice per failed take over-counts, since a 2-tick take returns after between just-over-1 and 2 ticks. Now measured as elapsed ticks using the project's wrap-safe `(now - start)` form.
3. **`pdMS_TO_TICKS(2)` rounds to 0 below a 500 Hz tick**, making the take non-blocking — the priority-7 waiter would busy-spin and starve the priority-5 task that must give the semaphore. Clamped to ≥1 tick.

The audit also confirmed `SD:DELete` / `SD:SPACe?` cannot self-deadlock (they produce no `DataReadyCB` reply) and `SD:GET` is async by design, so LIST was the only site needing conversion.

## Companion test

`daqifi-python-test-suite` **test_780_sd_reply_pump.py** — measures time to first byte and fails if it lands near the budget. Verified in both directions on hardware:

- bucketing **alone** → `0 PASS, 2 FAIL` (first byte 10.0 s, timeout logged)
- bucketing **+ this fix** → `2 PASS, 0 FAIL` (first byte 0.0 s)

## Status

- ✅ Builds clean at -O3, `-Werror`
- ✅ Bench-validated on Nq1 `7E2898F46200E8A7`, both directions
- ✅ Independently audited; all findings applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
