### PR TITLE
fix(sd): #725 emit __TRANSFER_ERROR__ when SD:GET fails mid-transfer

### DIFF
--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1630,6 +1630,10 @@ void sd_card_manager_ProcessState() {
             // Declared before the buffer-size check so the terminal bail
             // below (#703) can also emit it.
             static const char eofMarker[] = "__END_OF_FILE__";
+            /* #725: mid-transfer failure terminator. Distinct from the EOF
+             * marker so a host can tell "complete" from "aborted with partial
+             * data" -- see the read-error path below. */
+            static const char transferErrorMarker[] = "__TRANSFER_ERROR__";
 
             // Calculate safe read size based on buffer capacity
             size_t maxRead = gSdSharedBufferSize;
@@ -1731,11 +1735,29 @@ void sd_card_manager_ProcessState() {
                 size_t bytesRead = SYS_FS_FileRead(gSDCardData.fileHandle, gSdSharedBuffer, maxRead);
 
                 if (bytesRead == (size_t) - 1) {
-                    // Read error - log only, don't send error text through data stream
                     LOG_E("[SD] Transfer ERROR: %u MB, read#%u", totalBytesRead/(1024*1024), readCount);
 
                     // Wait for USB to drain any pending data before closing
                     sd_wait_usb_drain();
+
+                    /* #725: send a DISTINGUISHABLE terminator, not silence and
+                     * not __END_OF_FILE__.
+                     *
+                     * Sending nothing (the old behaviour) leaves the host
+                     * waiting forever for a terminator that never arrives -- a
+                     * hang, with no way to tell it from a slow transfer.
+                     * Sending the normal EOF marker would be worse: the host
+                     * would accept a TRUNCATED file as complete, which on a
+                     * data-acquisition product means silently losing the tail
+                     * of a measurement. #703/PR #723 made the PRE-transfer
+                     * failures terminal for the same reason but deliberately
+                     * left this path alone rather than take that trade.
+                     *
+                     * A separate marker lets the host do the right thing: stop
+                     * waiting, and know the data is incomplete. */
+                    sd_card_manager_DataReadyCB(SD_CARD_MANAGER_MODE_READ,
+                            (uint8_t*)transferErrorMarker,
+                            sizeof(transferErrorMarker) - 1);
 
                     // Close file handle to prevent resource leak
                     if (SYS_FS_FileClose(gSDCardData.fileHandle) == SYS_FS_RES_FAILURE) {


### PR DESCRIPTION
Fixes #725.

## The bug

A mid-transfer read error on the `SD:GET` path (`SYS_FS_FileRead` returns -1 after content has already been sent) closed the file and returned **without any terminator**. The host then waited forever for one that never came — a hang indistinguishable from a slow transfer.

## Why not just send `__END_OF_FILE__`

Because that trades a *detectable hang* for a **silently truncated file that looks complete**. On a data-acquisition product that means losing the tail of a measurement with nothing to indicate it. #703 (PR #723) made the pre-transfer failures terminal but deliberately left this path alone rather than take that trade — the issue says so explicitly.

So the terminator is **distinguishable**: `__TRANSFER_ERROR__`. The host learns both facts it needs — stop waiting, and the data is incomplete — neither of which was available before.

## Additive by construction

The marker appears only where the host previously received **nothing at all**. A client that does not know it is no worse off than today (it still times out); an updated client gets a clean, immediate error. Client rollout (daqifi-core / python-core / desktop) is tracked on the issue.

## Companion test

`daqifi-python-test-suite` **test_725_sd_get_transfer_error.py**:

| | assertion |
|---|---|
| A | a healthy GET ends with `__END_OF_FILE__` and does **not** contain the error marker |
| B | a GET for a **missing** file still comes back terminated (marker or SCPI error) rather than hanging |

**Stated plainly in the test: the mid-transfer error path itself is not exercised.** Provoking `SYS_FS_FileRead(-1)` needs a failing card or fault injection the firmware does not expose. Case A guards the realistic regression instead — a careless change here leaking the error marker into healthy transfers, which would make every client treat complete data as aborted. Claiming coverage I do not have would be worse than naming the gap.

(Case B originally compared two constants defined in the test script, which cannot fail against any firmware. It now asks the device.)

## Status

- ✅ Builds clean at -O3, `-Werror`
- ⛔ Not bench-run yet; the companion test is committed and queued behind the #778 validation currently occupying the bench

🤖 Generated with [Claude Code](https://claude.com/claude-code)
