### PR TITLE
fix(scpi): #783 report a stalled SD close instead of swallowing it

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3843,15 +3843,24 @@ static scpi_result_t SCPI_StopStreaming(scpi_t * context) {
                 vTaskDelay(pdMS_TO_TICKS(10));
                 idleWait++;
             }
-            /* Ask WHY the loop exited rather than inferring it from the
-             * counter. Both clauses can be true at idleWait == 500: the
-             * condition re-tests IsIdle() first, so a drain that lands in the
-             * final 10 ms slice exits idle-but-at-the-limit. Reading the
-             * counter alone then reports a timeout that did not happen --
-             * setting bit 11, latching a phantom 0->1 into the OPER EVENt
-             * register, and logging "SD commands will be refused" when they
-             * are not. */
-            const bool sdStillBusy = !sd_card_manager_IsIdle();
+            /* BOTH conditions, and neither alone is right.
+             *
+             * The counter alone over-reports: the loop re-tests IsIdle()
+             * first, so at idleWait == 500 a drain landing in the final 10 ms
+             * slice exits idle-but-at-the-limit, and calling that a timeout
+             * sets bit 11 and latches a phantom 0->1 into the OPER EVENt
+             * register while SD is genuinely idle.
+             *
+             * A fresh IsIdle() check alone ALSO over-reports, in the opposite
+             * direction: the loop can exit early and idle, and an unrelated SD
+             * operation starting before this line would then read as busy --
+             * setting bit 11 and logging "after 5s" for a wait that never
+             * expired.
+             *
+             * The condition being reported is "the bounded wait ran out AND
+             * the close is still in flight", so test exactly that. */
+            const bool sdStillBusy = (idleWait >= 500) &&
+                                     !sd_card_manager_IsIdle();
             if (sdStillBusy) {
                 /* #783: do not swallow this. STR:STOP still reports success --
                  * the STREAM did stop, and failing the command would be a lie

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -64,6 +64,16 @@
 // SCPI STATus:OPERation condition register bit assignments (IEEE 488.2 Sec 11.6.1)
 #define OPER_MEASURING   (1 << 4)   // Bit 4: streaming/measuring active
 #define OPER_SD_LOGGING  (1 << 10)  // Bit 10: SD card logging active
+/* Bit 11: the previous session's SD close did not finish inside STR:STOP's
+ * bounded wait, so the SD manager is STILL FINALISING. #783.
+ *
+ * Reported rather than waited out. Bench-measured 2026-08-14: after a 195 s
+ * torture-rotation fill the drain refused every SD command for over 100 s and
+ * then recovered on its own -- so a wait long enough to cover it would block
+ * the SCPI task for minutes, which is far worse than the condition it hides.
+ * A client polls this bit instead and knows both that waiting is the right
+ * move and when it is over. */
+#define OPER_SD_FINALIZING (1 << 11)
 
 // SCPI STATus:QUEStionable condition register bit assignments
 // These must match the QUES_BIT_* defines in streaming.c
@@ -3041,6 +3051,15 @@ static void SCPI_SyncOperSdBit(void) {
     } else {
         SCPI_ClearOperBits(OPER_SD_LOGGING);
     }
+
+    /* #783: clear the finalising bit once the manager actually reaches idle.
+     * Doing it HERE rather than in the stop path is what makes the bit usable:
+     * this runs on every OPER query, so a client polling STAT:OPER:COND? sees
+     * the bit drop by itself the moment the drain completes. Set in one place
+     * (the stop path, on expiry), cleared in one place (here, on idle). */
+    if (sd_card_manager_IsIdle()) {
+        SCPI_ClearOperBits(OPER_SD_FINALIZING);
+    }
 }
 
 static scpi_result_t SCPI_OperConditionQ(scpi_t * context) {
@@ -3812,7 +3831,25 @@ static scpi_result_t SCPI_StopStreaming(scpi_t * context) {
                 idleWait++;
             }
             if (idleWait >= 500) {
-                LOG_E("[SD] StopStreaming: SD idle timeout after 5s");
+                /* #783: do not swallow this. STR:STOP still reports success --
+                 * the STREAM did stop, and failing the command would be a lie
+                 * about the wrong thing -- but the SD close is genuinely still
+                 * in flight, and every SD command until it lands is refused as
+                 * "busy". Previously that surfaced only as an error on some
+                 * later, unrelated command, which reads as "the card broke"
+                 * rather than "the previous stop is still finishing".
+                 *
+                 * Publish it instead: OPER bit 11 stays set until the manager
+                 * reaches idle (cleared in SCPI_SyncOperSdBit), so a client can
+                 * poll STAT:OPER:COND? and know both that waiting is correct
+                 * and when it is over. Bench-measured drains have exceeded
+                 * 100 s, so a longer bounded wait here is not the answer. */
+                SCPI_SetOperBits(OPER_SD_FINALIZING);
+                LOG_E("[SD] StopStreaming: SD still finalising after 5s - "
+                      "OPER bit 11 (SD finalising) set; SD commands will be "
+                      "refused until it clears. Poll STAT:OPER:COND?");
+            } else {
+                SCPI_ClearOperBits(OPER_SD_FINALIZING);
             }
         }
     }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3797,6 +3797,19 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     if (sdLoggingRequested) {
         SCPI_SetOperBits(OPER_SD_LOGGING);
     }
+    /* #783: a successful START PROVES the previous session's SD finalise
+     * completed -- PrepareStreamingBuffers -> QuiesceAndResetCoherentPool
+     * aborts the start unless the manager reaches idle first -- so clear the
+     * finalising bit here.
+     *
+     * Without this the bit latches stale-true across an entire healthy
+     * session: its only other clear runs when an OPER query happens to land
+     * while the manager is idle, and a logging session sits in WRITE_TO_FILE,
+     * never idle. A client that did not poll DURING the drain (one retrying
+     * START against -200 does exactly that) would then read bit 11 mid-session
+     * for hours and believe the previous stop was still finalising -- the
+     * precise misreading this bit exists to prevent. */
+    SCPI_ClearOperBits(OPER_SD_FINALIZING);
 
     return SCPI_RES_OK;
 }
@@ -3830,7 +3843,16 @@ static scpi_result_t SCPI_StopStreaming(scpi_t * context) {
                 vTaskDelay(pdMS_TO_TICKS(10));
                 idleWait++;
             }
-            if (idleWait >= 500) {
+            /* Ask WHY the loop exited rather than inferring it from the
+             * counter. Both clauses can be true at idleWait == 500: the
+             * condition re-tests IsIdle() first, so a drain that lands in the
+             * final 10 ms slice exits idle-but-at-the-limit. Reading the
+             * counter alone then reports a timeout that did not happen --
+             * setting bit 11, latching a phantom 0->1 into the OPER EVENt
+             * register, and logging "SD commands will be refused" when they
+             * are not. */
+            const bool sdStillBusy = !sd_card_manager_IsIdle();
+            if (sdStillBusy) {
                 /* #783: do not swallow this. STR:STOP still reports success --
                  * the STREAM did stop, and failing the command would be a lie
                  * about the wrong thing -- but the SD close is genuinely still
@@ -3840,10 +3862,15 @@ static scpi_result_t SCPI_StopStreaming(scpi_t * context) {
                  * rather than "the previous stop is still finishing".
                  *
                  * Publish it instead: OPER bit 11 stays set until the manager
-                 * reaches idle (cleared in SCPI_SyncOperSdBit), so a client can
-                 * poll STAT:OPER:COND? and know both that waiting is correct
-                 * and when it is over. Bench-measured drains have exceeded
-                 * 100 s, so a longer bounded wait here is not the answer. */
+                 * reaches idle, so a client can poll STAT:OPER:COND? and know
+                 * both that waiting is correct and when it is over.
+                 * Bench-measured drains have exceeded 100 s, so a longer
+                 * bounded wait here is not the answer.
+                 *
+                 * Cleared in three places, all meaning "the finalise is done":
+                 * SCPI_SyncOperSdBit when the manager is idle, the else branch
+                 * below when a later stop drains in time, and STR:START, which
+                 * cannot succeed unless the manager reached idle first. */
                 SCPI_SetOperBits(OPER_SD_FINALIZING);
                 LOG_E("[SD] StopStreaming: SD still finalising after 5s - "
                       "OPER bit 11 (SD finalising) set; SD commands will be "


### PR DESCRIPTION
Fixes #783.

## The bug

`SYST:STR:STOP` gives the SD manager a bounded **5 s** to drain its buffer, close the file and go idle. After a long split session that expires — and the firmware logged it and **returned success anyway**. Every SD command until the close landed was then refused with `-200` / "SD card busy", so the failure surfaced on some later, unrelated command and read as *"the card broke"* rather than *"the previous stop is still finishing"*.

A client had no signal to wait on and no way to tell those apart. Neither did a test: this exact condition produced, in one night, a **FAIL against correct bucketing firmware** (a refused `SD:LISt?` parsed as an empty card) and an **ABORT blaming a pre-fill that had in fact written ~4 MB**.

## The fix

`STR:STOP` **still reports success** — the *stream* did stop, and failing the command would be a lie about the wrong thing. The condition is **published** instead, on **OPER bit 11 (SD finalising)**:

- set when the bounded wait expires
- cleared in `SCPI_SyncOperSdBit()` once the manager reaches idle

Because that sync already runs on every OPER query, a client polling `STAT:OPER:COND?` sees the bit drop by itself the moment the drain completes. Set in one place, cleared in one place.

This **extends an existing surface rather than adding a command**, per the standing rule — clients already poll `STAT:OPER:COND?`.

## Deliberately not a longer wait

Bench-measured 2026-08-14: after a 195 s torture-rotation fill the drain refused every SD command for **over 100 s**, then recovered on its own. A bounded wait long enough to cover that would block the SCPI task for minutes — worse than the condition it hides.

## Bench validation (Nq1 `7E2898F46200E8A7`)

On a run that induced the drain:

| case | result |
|---|---|
| A `STR:STOP` still succeeds | **PASS** |
| B condition is reported while SD refuses | **PASS** — `OPER=0x0800`, bit 11 set |
| C bit tracks the manager | INCONCLUSIVE — the manager never recovered at all (#782) |

Case C is worth reading carefully: it first looked like a defect in this fix ("the bit never cleared"). Probing the device showed SD still refusing minutes later with the bit still set — so **the bit was telling the truth**; the manager genuinely had not reached idle. That is #782, a separate defect. The test now distinguishes all four outcomes rather than conflating "never cleared" with "broken".

**Inducing the drain is probabilistic and the companion test says so.** Three runs on a freshly formatted card (150 s at a 20 KB split, 150 s and 210 s at a 1 KB split) all completed the close inside the bounded wait and reported INCONCLUSIVE rather than a vacuous pass. The reproductions came late in long sessions on a card hammered repeatedly without reformat, so the trigger is cumulative FAT state rather than one session's length. I raised the fill twice and then stopped, rather than tune indefinitely toward a state that is genuinely intermittent.

## Companion test

`daqifi-python-test-suite` **test_783_sd_finalize_visible.py** (registered in the release gate). Case B discriminates against old firmware **without depending on the bit existing**: the drain is detected independently — an SD command is refused, so the manager is demonstrably busy — and only then is the bit required. Old firmware refuses and leaves it clear → FAIL.

## Wiki

`01-SCPI-Interface.md` updated: bit 11 added to the OPER table, with the poll recipe, why the wait was not lengthened, and the #782 distinction when the bit never clears.

Refs #783, #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)