### PR TITLE
feat(sd): #782 name the SD state and mode in every busy refusal

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3881,9 +3881,14 @@ static scpi_result_t SCPI_StopStreaming(scpi_t * context) {
                  * below when a later stop drains in time, and STR:START, which
                  * cannot succeed unless the manager reached idle first. */
                 SCPI_SetOperBits(OPER_SD_FINALIZING);
-                LOG_E("[SD] StopStreaming: SD still finalising after 5s - "
-                      "OPER bit 11 (SD finalising) set; SD commands will be "
-                      "refused until it clears. Poll STAT:OPER:COND?");
+                /* Kept under LOG_MESSAGE_SIZE (128) with the longest state
+                 * name: the previous wording was 149 chars and lost its own
+                 * "Poll STAT:OPER:COND?" advice to truncation. */
+                LOG_E("[SD] StopStreaming: SD still finalising in state=%s "
+                      "mode=%s; OPER bit 11 set until idle. "
+                      "Poll STAT:OPER:COND?",
+                      sd_card_manager_GetStateName(),
+                      sd_card_manager_GetModeName());
             } else {
                 SCPI_ClearOperBits(OPER_SD_FINALIZING);
             }

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -82,8 +82,9 @@ bool __attribute__((weak)) DRV_SDSPI_GetCID(uint8_t* cidBuffer, size_t bufLen) {
 #define SD_CARD_NOT_PRESENT_ERROR_MSG "\r\nError !! No SD Card Detected\r\n"
 
 // Log format for SD busy errors - use LOG_SD_BUSY("COMMAND") for consistency.
-// #782: the state name is what makes a refusal actionable - every busy state
-// returns the same -200, so without it "busy" cannot be told from "wedged".
+// #782: the state/mode pair is what makes a refusal actionable - every busy
+// state returns the same -200, so without it "busy" cannot be told from
+// "wedged". Both are logged because IsBusy() has two independent causes.
 #define LOG_SD_BUSY(cmd) LOG_E("SD:" cmd " - SD card busy, state=%s mode=%s\r\n", \
                                sd_card_manager_GetStateName(), \
                                sd_card_manager_GetModeName())

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -81,8 +81,12 @@ bool __attribute__((weak)) DRV_SDSPI_GetCID(uint8_t* cidBuffer, size_t bufLen) {
 #define SD_CARD_NOT_ENABLED_ERROR_MSG "\r\nError !! Please Enabled SD Card\r\n"
 #define SD_CARD_NOT_PRESENT_ERROR_MSG "\r\nError !! No SD Card Detected\r\n"
 
-// Log format for SD busy errors - use LOG_SD_BUSY("COMMAND") for consistency
-#define LOG_SD_BUSY(cmd) LOG_E("SD:" cmd " - SD card busy with current operation\r\n")
+// Log format for SD busy errors - use LOG_SD_BUSY("COMMAND") for consistency.
+// #782: the state name is what makes a refusal actionable - every busy state
+// returns the same -200, so without it "busy" cannot be told from "wedged".
+#define LOG_SD_BUSY(cmd) LOG_E("SD:" cmd " - SD card busy, state=%s mode=%s\r\n", \
+                               sd_card_manager_GetStateName(), \
+                               sd_card_manager_GetModeName())
 
 /**
  * @brief Check if SD card media is present

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2645,7 +2645,6 @@ const char *sd_card_manager_GetModeName(void) {
     return "UNKNOWN";
 }
 
-
 bool sd_card_manager_WaitForCompletionPumped(uint32_t timeoutMs) {
     /* #780: identical to WaitForCompletion, except it keeps the USB write half
      * running while it waits.

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2593,6 +2593,58 @@ bool sd_card_manager_IsIdle() {
             gSDCardData.currentProcessState == SD_CARD_MANAGER_PROCESS_STATE_INIT);
 }
 
+/* #782: from outside the manager every stuck state looks identical - the
+ * command is refused with -200 and nothing says which state refused it. The
+ * switch (rather than a lookup table) is deliberate: -Wswitch is an error
+ * here, so a state added without a name fails the build instead of silently
+ * reporting "UNKNOWN" from the field. */
+const char *sd_card_manager_GetStateName(void) {
+    switch (gSDCardData.currentProcessState) {
+        case SD_CARD_MANAGER_PROCESS_STATE_INIT:             return "INIT";
+        case SD_CARD_MANAGER_PROCESS_STATE_MOUNT_DISK:       return "MOUNT";
+        case SD_CARD_MANAGER_PROCESS_STATE_UNMOUNT_DISK:     return "UNMOUNT";
+        case SD_CARD_MANAGER_PROCESS_STATE_CURRENT_DRIVE:    return "CURDRIVE";
+        case SD_CARD_MANAGER_PROCESS_STATE_CHECK_DISK_FULL:  return "CHKFULL";
+        case SD_CARD_MANAGER_PROCESS_STATE_CREATE_DIRECTORY: return "MKDIR";
+        case SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE:        return "OPEN";
+        case SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE:    return "WRITE";
+        case SD_CARD_MANAGER_PROCESS_STATE_READ_FROM_FILE:   return "READ";
+        case SD_CARD_MANAGER_PROCESS_STATE_LIST_DIR:         return "LISTDIR";
+        case SD_CARD_MANAGER_PROCESS_STATE_DELETE_FILE:      return "DELETE";
+        case SD_CARD_MANAGER_PROCESS_STATE_FORMAT:           return "FORMAT";
+        case SD_CARD_MANAGER_PROCESS_STATE_GET_SPACE:        return "GETSPACE";
+        case SD_CARD_MANAGER_PROCESS_STATE_COMPUTE_CRC:      return "CRC";
+        case SD_CARD_MANAGER_PROCESS_STATE_DEINIT:           return "DEINIT";
+        case SD_CARD_MANAGER_PROCESS_STATE_IDLE:             return "IDLE";
+        case SD_CARD_MANAGER_PROCESS_STATE_ERROR:            return "ERROR";
+    }
+    /* Unreachable while the switch is exhaustive; keeps the compiler happy
+     * about a corrupted value read from RAM. */
+    return "UNKNOWN";
+}
+
+/* #782: sd_card_manager_IsBusy() is true when EITHER the requested mode is
+ * still set OR the state machine is off idle - two independent causes that
+ * produce the identical -200. Reporting the state alone cannot tell
+ * "mode left armed with the machine parked at IDLE" from "machine genuinely
+ * stuck mid-operation", and those need different fixes. */
+const char *sd_card_manager_GetModeName(void) {
+    if (gpSDCardSettings == NULL) {
+        return "UNINIT";
+    }
+    switch (gpSDCardSettings->mode) {
+        case SD_CARD_MANAGER_MODE_NONE:           return "NONE";
+        case SD_CARD_MANAGER_MODE_READ:           return "READ";
+        case SD_CARD_MANAGER_MODE_WRITE:          return "WRITE";
+        case SD_CARD_MANAGER_MODE_LIST_DIRECTORY: return "LIST";
+        case SD_CARD_MANAGER_MODE_DELETE_FILE:    return "DELETE";
+        case SD_CARD_MANAGER_MODE_FORMAT:         return "FORMAT";
+        case SD_CARD_MANAGER_MODE_GET_SPACE:      return "GETSPACE";
+        case SD_CARD_MANAGER_MODE_COMPUTE_CRC:    return "CRC";
+    }
+    return "UNKNOWN";
+}
+
 
 bool sd_card_manager_WaitForCompletionPumped(uint32_t timeoutMs) {
     /* #780: identical to WaitForCompletion, except it keeps the USB write half

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -207,6 +207,36 @@ extern "C" {
     bool sd_card_manager_IsIdle(void);
 
     /**
+     * @brief Returns the manager's current process state as a short name.
+     *
+     * Diagnostic only (#782). Every busy state refuses SCPI commands with the
+     * same -200, so the name is what distinguishes "draining a write" from
+     * "stuck unmounting". Returns a pointer to a string literal - never NULL,
+     * safe to log directly.
+     *
+     * The value is a snapshot: the manager runs on its own task, so the state
+     * may already have advanced by the time the caller uses it.
+     *
+     * @return State name, e.g. "IDLE", "WRITE", "UNMOUNT"
+     */
+    const char *sd_card_manager_GetStateName(void);
+
+    /**
+     * @brief Returns the manager's currently requested mode as a short name.
+     *
+     * Diagnostic only (#782), and the necessary companion to
+     * sd_card_manager_GetStateName(): sd_card_manager_IsBusy() reports busy
+     * when EITHER the mode is still set OR the state machine is off idle, so
+     * the state alone cannot distinguish those two causes.
+     *
+     * Returns a pointer to a string literal - never NULL, safe to log
+     * directly. "UNINIT" means settings are not yet bound.
+     *
+     * @return Mode name, e.g. "NONE", "WRITE", "FORMAT"
+     */
+    const char *sd_card_manager_GetModeName(void);
+
+    /**
      * @brief Waits for the current SD card operation to complete.
      *
      * @param[in] timeoutMs Maximum time to wait in milliseconds (0 = wait forever)


### PR DESCRIPTION
Closes the observability half of [#782 — SD detect wedges after sustained rotation](https://github.com/daqifi/daqifi-nyquist-firmware/issues/782). Does **not** fix the wedge; makes it identifiable.

## The gap

The SD manager has 17 process states and every busy one refuses SCPI commands with the identical `-200`. There was no getter, no SCPI query and no log line reporting which state refused. From outside the device, "draining a write" and "wedged in unmount" are the same observation — which is why #782 could not be diagnosed without a debug build, and why its plausible causes (stuck `WRITE_TO_FILE`, stuck `DEINIT`, a semaphore never signalled, a mode/state pair no transition covers) could not be told apart.

## What this adds

`sd_card_manager_GetStateName()` and `sd_card_manager_GetModeName()`, reported in the two places that **already** log a refusal:

- `LOG_SD_BUSY` — one macro edit covers all 10 call sites
- the #783 stall line in `SCPI_StopStreaming`

```
SD:SPACe - SD card busy, state=FORMAT mode=FORMAT
```

**No new SCPI command.** Per the standing "extend an existing surface" rule, the existing log surfaces carry it. Polling a refusable command emits a fresh line each time, so a wedged manager can be *sampled* over time:

```
SYST:STOR:SD:SPACe?     # refused; emits the line
SYST:LOG?               # read it (destructive, so read every time)
```

## Why the mode is reported too, and not just the state

`sd_card_manager_IsBusy()` returns true when **either** the requested mode is still set **or** the state machine is off idle — two independent causes behind one `-200`. The SCPI handler arms the mode *before* the SD task advances the state, so `state=IDLE mode=FORMAT` is a real, correct reading during that window.

The state alone therefore cannot separate **"mode left armed with the machine parked at IDLE"** from **"machine genuinely stuck mid-operation"**, and those need different fixes. Reporting both makes the refusal self-describing.

## Small things

- Both getters `switch` on the enum rather than indexing a table. `-Wswitch` is an error in this build, so a state added later without a name **fails the build** instead of silently reporting `UNKNOWN` from the field.
- The `StopStreaming` stall line was shortened. `LOG_MESSAGE_SIZE` is 128 and that message was already **149 chars**, so it had been truncating away its own `Poll STAT:OPER:COND?` advice. It now fits at 121 with the longest names — a pre-existing defect this change would otherwise have made worse.
- Both getters read a plain enum without a critical section: 32-bit reads are atomic on PIC32MZ, the value is documented as a snapshot, and this matches what `IsBusy()` already does.

## Test plan

Companion: [daqifi-python-test-suite#143 — assert a busy SD refusal names the state and mode](https://github.com/daqifi/daqifi-python-test-suite/pull/143).

**Mutation-proved on the bench (Nq1 `7E2898F46200E8A7`, USB), both directions in one session:**

| firmware | result |
|---|---|
| this branch | **2 PASS** — `state=FORMAT mode=FORMAT` |
| macro reverted to pre-#782 text, reflashed | **0 PASS, 1 FAIL, 1 SKIPPED** |
| restored, reflashed | **2 PASS** |

The mutant fails for the *right* reason: case A still observes the refusal and reports "no `state=` appears in the log — this is the pre-#782 behaviour". A test that passed because nothing happened would have reported INCONCLUSIVE instead.

- cppcheck baseline unchanged (0 findings)
- Build: `-O3 -Wall -Werror`, clean

## What this does NOT do

The wedge itself is unfixed, and this run **falsified my own reproduction recipe** for it (retracted on the issue): the 200 s torture fill at `SD:MAXSize 1000` gave `OPER=0` immediately after stop — the drain finished inside the bounded wait. The trigger remains uncharacterised; that is now the blocking unknown on #782, not the observability.

No wiki change: no SCPI command added or modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
