### PR TITLE
fix(sd): #782 do not lose an SD teardown to a concurrent file open

### DIFF
--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1661,15 +1661,21 @@ void sd_card_manager_ProcessState() {
 
                 if (openAborted) {
                     if (gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID) {
-                        /* Deliberately (void): the file was created empty by
-                         * the WRITE_PLUS open above and is being abandoned,
-                         * so a close failure changes nothing we would do
-                         * differently -- UNMOUNT_DISK follows either way.
-                         * Cast explicitly rather than dropping the result
-                         * silently, matching the other abandon-path close in
-                         * this file. */
-                        (void)SYS_FS_FileClose(gSDCardData.fileHandle);
-                        gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
+                        /* Invalidate ONLY on a successful close. UNMOUNT_DISK
+                         * gates its whole drain-and-close block on
+                         * fileHandle != INVALID, so clearing the handle after
+                         * a FAILED close would skip the retry that block
+                         * exists to perform, and the file could stay open
+                         * across the unmount. Leaving it set costs nothing:
+                         * DEINIT -> UNMOUNT_DISK runs next either way. */
+                        if (SYS_FS_FileClose(gSDCardData.fileHandle)
+                                == SYS_FS_RES_FAILURE) {
+                            LOG_E("[SD] open-abort close failed err=%d - "
+                                  "leaving the handle for UNMOUNT_DISK",
+                                  SYS_FS_Error());
+                        } else {
+                            gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
+                        }
                     }
                     LOG_I("[SD] open aborted: session torn down mid-open "
                           "(mode=%s)", sd_card_manager_GetModeName());

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1638,8 +1638,28 @@ void sd_card_manager_ProcessState() {
                  * re-initialises the manager. Rotation made this likely
                  * because it re-enters OPEN_FILE roughly every MAXSize bytes.
                  * Re-check the mode we were dispatched on and honour the
-                 * teardown instead of clobbering it. */
-                if (gpSDCardSettings->mode != SD_CARD_MANAGER_MODE_WRITE) {
+                 * teardown instead of clobbering it.
+                 *
+                 * The check and the state write must be ONE atomic step. A
+                 * plain "if (mode != WRITE) ... else state = WRITE_TO_FILE"
+                 * only narrows the window: SCPI can still land between the
+                 * comparison and the assignment, and the assignment then
+                 * clobbers the DEINIT exactly as before. Both operands are
+                 * 32-bit and individually atomic on PIC32MZ, but this is a
+                 * read-decide-write across two variables, which is the case
+                 * the project's atomicity rules reserve a critical section
+                 * for. It spans one compare and one store; the file close and
+                 * the log stay outside it. */
+                bool openAborted;
+                taskENTER_CRITICAL();
+                openAborted = (gpSDCardSettings->mode
+                               != SD_CARD_MANAGER_MODE_WRITE);
+                gSDCardData.currentProcessState = openAborted
+                        ? SD_CARD_MANAGER_PROCESS_STATE_DEINIT
+                        : SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE;
+                taskEXIT_CRITICAL();
+
+                if (openAborted) {
                     if (gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID) {
                         /* Deliberately (void): the file was created empty by
                          * the WRITE_PLUS open above and is being abandoned,
@@ -1653,15 +1673,13 @@ void sd_card_manager_ProcessState() {
                     }
                     LOG_I("[SD] open aborted: session torn down mid-open "
                           "(mode=%s)", sd_card_manager_GetModeName());
-                    gSDCardData.currentProcessState =
-                            SD_CARD_MANAGER_PROCESS_STATE_DEINIT;
                     break;
                 }
 
-                // Transition to WRITE_TO_FILE — IsWriteReady() becomes
-                // true after this point.  The streaming task detects the
-                // transition and writes SD-only headers at byte 0.
-                gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE;
+                /* State is already WRITE_TO_FILE from the block above --
+                 * IsWriteReady() becomes true at that point, and the
+                 * streaming task detects the transition and writes SD-only
+                 * headers at byte 0. */
                 gSDCardData.totalBytesFlushPending = 0;
                 gSDCardData.currentFileBytes = 0;  // Reset byte counter for new file
                 gSDCardData.lastFlushMillis = pdTICKS_TO_MS(xTaskGetTickCount());

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1641,7 +1641,14 @@ void sd_card_manager_ProcessState() {
                  * teardown instead of clobbering it. */
                 if (gpSDCardSettings->mode != SD_CARD_MANAGER_MODE_WRITE) {
                     if (gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID) {
-                        SYS_FS_FileClose(gSDCardData.fileHandle);
+                        /* Deliberately (void): the file was created empty by
+                         * the WRITE_PLUS open above and is being abandoned,
+                         * so a close failure changes nothing we would do
+                         * differently -- UNMOUNT_DISK follows either way.
+                         * Cast explicitly rather than dropping the result
+                         * silently, matching the other abandon-path close in
+                         * this file. */
+                        (void)SYS_FS_FileClose(gSDCardData.fileHandle);
                         gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
                     }
                     LOG_I("[SD] open aborted: session torn down mid-open "

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1627,6 +1627,30 @@ void sd_card_manager_ProcessState() {
                 gSDCardData.fileHandle = SYS_FS_FileOpen(gSDCardData.filePath,
                         (SYS_FS_FILE_OPEN_WRITE_PLUS));
 
+                /* #782: a teardown may have landed while this open was in
+                 * flight. SCPI (pri 7) preempts this task (pri 5), and
+                 * sd_card_manager_UpdateSettings() tears the session down by
+                 * clearing mode and forcing currentProcessState = DEINIT. An
+                 * unconditional assignment here overwrites that DEINIT, and
+                 * the session is then stranded in WRITE_TO_FILE with
+                 * mode == NONE: nothing re-arms a write, so IsBusy() stays
+                 * true and every SD command is refused until something
+                 * re-initialises the manager. Rotation made this likely
+                 * because it re-enters OPEN_FILE roughly every MAXSize bytes.
+                 * Re-check the mode we were dispatched on and honour the
+                 * teardown instead of clobbering it. */
+                if (gpSDCardSettings->mode != SD_CARD_MANAGER_MODE_WRITE) {
+                    if (gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID) {
+                        SYS_FS_FileClose(gSDCardData.fileHandle);
+                        gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
+                    }
+                    LOG_I("[SD] open aborted: session torn down mid-open "
+                          "(mode=%s)", sd_card_manager_GetModeName());
+                    gSDCardData.currentProcessState =
+                            SD_CARD_MANAGER_PROCESS_STATE_DEINIT;
+                    break;
+                }
+
                 // Transition to WRITE_TO_FILE — IsWriteReady() becomes
                 // true after this point.  The streaming task detects the
                 // transition and writes SD-only headers at byte 0.
@@ -1743,6 +1767,30 @@ void sd_card_manager_ProcessState() {
             break;
         case SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE:
         {
+            /* #782: this state had no exit for a cleared mode. Its only
+             * transition to IDLE is the split-limit path below, which needs
+             * writes that will never arrive once the session is torn down --
+             * so a teardown that landed here left the manager busy forever,
+             * refusing every SD command until something re-initialised it.
+             *
+             * The guard in OPEN_FILE should keep us out of that window, but
+             * this is the state that has to be survivable: it is reachable
+             * from any future caller that clears the mode, and being wrong
+             * here is permanent rather than momentary.
+             *
+             * Route to DEINIT (-> UNMOUNT_DISK) rather than draining here:
+             * that path already flushes the pending write buffer AND the
+             * circular buffer before closing the file, without the
+             * sector-alignment the steady-state loop uses, which is exactly
+             * what a stop needs to avoid truncating a sub-sector tail. */
+            if (gpSDCardSettings->mode != SD_CARD_MANAGER_MODE_WRITE) {
+                LOG_I("[SD] write session ended (mode=%s) - finalising",
+                      sd_card_manager_GetModeName());
+                gSDCardData.currentProcessState =
+                        SD_CARD_MANAGER_PROCESS_STATE_DEINIT;
+                break;
+            }
+
             /* If read was success, try writing to the new file */
             int writeLen = -2;
             

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1670,9 +1670,16 @@ void sd_card_manager_ProcessState() {
                          * DEINIT -> UNMOUNT_DISK runs next either way. */
                         if (SYS_FS_FileClose(gSDCardData.fileHandle)
                                 == SYS_FS_RES_FAILURE) {
-                            LOG_E("[SD] open-abort close failed err=%d - "
-                                  "leaving the handle for UNMOUNT_DISK",
-                                  SYS_FS_Error());
+                            /* Name the file, matching the other close-failure
+                             * logs here -- "a close failed" is not actionable
+                             * without knowing which. Sized to fit
+                             * LOG_MESSAGE_SIZE (128) for a realistic path
+                             * (~101 chars at 35 path chars); a pathological
+                             * one truncates, which every path-bearing log in
+                             * this file already shares. */
+                            LOG_E("[SD] open-abort close failed '%s' err=%d - "
+                                  "handle kept for UNMOUNT",
+                                  gSDCardData.filePath, SYS_FS_Error());
                         } else {
                             gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
                         }

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1660,30 +1660,21 @@ void sd_card_manager_ProcessState() {
                 taskEXIT_CRITICAL();
 
                 if (openAborted) {
-                    if (gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID) {
-                        /* Invalidate ONLY on a successful close. UNMOUNT_DISK
-                         * gates its whole drain-and-close block on
-                         * fileHandle != INVALID, so clearing the handle after
-                         * a FAILED close would skip the retry that block
-                         * exists to perform, and the file could stay open
-                         * across the unmount. Leaving it set costs nothing:
-                         * DEINIT -> UNMOUNT_DISK runs next either way. */
-                        if (SYS_FS_FileClose(gSDCardData.fileHandle)
-                                == SYS_FS_RES_FAILURE) {
-                            /* Name the file, matching the other close-failure
-                             * logs here -- "a close failed" is not actionable
-                             * without knowing which. Sized to fit
-                             * LOG_MESSAGE_SIZE (128) for a realistic path
-                             * (~101 chars at 35 path chars); a pathological
-                             * one truncates, which every path-bearing log in
-                             * this file already shares. */
-                            LOG_E("[SD] open-abort close failed '%s' err=%d - "
-                                  "handle kept for UNMOUNT",
-                                  gSDCardData.filePath, SYS_FS_Error());
-                        } else {
-                            gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
-                        }
-                    }
+                    /* Deliberately do NOT close here. DEINIT -> UNMOUNT_DISK
+                     * runs next and is the single owner of closing this
+                     * handle: it drains, closes, and invalidates in one
+                     * place. Closing here meant reasoning about UNMOUNT's
+                     * gate (it skips its whole block when the handle is
+                     * already INVALID), which is what produced two separate
+                     * defects in review -- a discarded close result, then an
+                     * invalidation that suppressed UNMOUNT's retry.
+                     *
+                     * Note this is about single ownership, not data
+                     * recovery: nothing can be pending at this point. The
+                     * circular buffer and the write pipeline are reset a few
+                     * lines above, and the abort path never sets
+                     * WRITE_TO_FILE, so sd_card_manager_IsWriteReady() stays
+                     * false and the streaming task cannot have written. */
                     LOG_I("[SD] open aborted: session torn down mid-open "
                           "(mode=%s)", sd_card_manager_GetModeName());
                     break;


### PR DESCRIPTION
Fixes [#782 — SD detect wedges after sustained rotation](https://github.com/daqifi/daqifi-nyquist-firmware/issues/782).

After a rotating SD session, `SYST:STR:STOP` could leave the manager busy **forever**: every SD command refused with `-200`, OPER bit 11 stuck set, and only a re-initialisation (`SD:ENAble 0/1` or a reboot) recovering it.

## The teardown mechanism already existed — it was being overwritten

`sd_card_manager_UpdateSettings()` clears the mode and forces `currentProcessState = DEINIT`, and the callers depend on exactly that. Both `SCPI_QuiesceAndResetCoherentPool()` (`SCPIInterface.c:3271`) and `SCPI_StopStreaming()` set `mode = NONE`, call `UpdateSettings`, then wait up to 5 s for `IsIdle()` — the expiry of that wait is what sets OPER bit 11.

What went wrong is `OPEN_FILE` (`sd_card_manager.c:1633`):

```c
gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE;
```

unconditional, and re-reading nothing. The SD task runs at **priority 5** (`app_freertos.c:889`); SCPI runs at **7**, so SCPI preempts it. A stop landing mid-open had its `DEINIT` overwritten, stranding the session in `WRITE_TO_FILE` with `mode == NONE` — a state whose only exit to `IDLE` is the split-limit path at `:1996`, which needs writes that will never arrive.

**Rotation is what made it likely.** At `SD:MAXSize 1000` the machine re-enters `OPEN_FILE` roughly every kilobyte, so the window is open almost continuously. That explains why it needed rotation to reproduce, why it was probabilistic, and why fill duration never predicted it — an earlier 200 s run missed it entirely while a 60 s run hit on the first stop.

## Two layers

| | |
|---|---|
| **`OPEN_FILE` re-checks the mode** it was dispatched on and honours a teardown instead of clobbering it | the actual defect |
| **`WRITE_TO_FILE` exits on a cleared mode** | the safety net |

The second is not redundant. The guard above should keep us out of that window, but `WRITE_TO_FILE` is reachable from any future caller that clears the mode, and being wrong *there* is permanent rather than momentary.

That exit routes to `DEINIT` → `UNMOUNT_DISK` rather than draining in place, because `UNMOUNT_DISK` already flushes the pending write buffer **and** the circular buffer before closing, *without* the sector-alignment the steady-state loop uses — which is exactly what a stop needs so a sub-sector tail is not truncated.

**Known, bounded artifact:** the abort closes a handle `SYS_FS_FILE_OPEN_WRITE_PLUS` has already created, leaving a 0-byte file. Checking *before* the open would avoid that but would **not** close the race, since the open itself is the widest preemption window — so the after-open check is the load-bearing one. One stray empty file per raced stop, and #689's bucketing already handles directory growth.

## Evidence

**Pre-fix** (Nq1 `7E2898F46200E8A7`): a rotation soak caught the wedge on its **first** stop and held `state=WRITE mode=NONE` across 13+ minutes of continuous polling with no stop/start issued — the state/mode pair being readable at all is thanks to [#786](https://github.com/daqifi/daqifi-nyquist-firmware/pull/786), which shipped a few hours earlier.

**Post-fix: 23 clean rotating stops, zero catches**, across two soak runs (8 + 15). Both runs ended not from a wedge but from #689's bucket ceiling (65 buckets × 64 files), with the manager **idle and answering** — worth knowing, because past that point a rotation soak silently becomes a test of #689 instead of #782.

Then, on the exact hex this PR ships:

```
[setup] formatting the card for a clean baseline
  [PASS] rotating stops leave the manager idle: 8/8 returned to idle within 20s
  [PASS] the workload actually rotated: split files present in the listing
===== 782_sd_teardown_race: 2 PASS, 0 FAIL =====
```

**On what that does and does not prove.** The defect is a race, so a clean run only shows the stop did not land in the window. At the roughly-0.5 per-stop rate seen pre-fix (n=2 — weakly characterised), 23 clean stops give ~1e-7 odds of a false clean; at a rate of 0.2 it would be ~0.6%. I would not call it certainty, but the pre/post contrast is stark: the first stop wedged before, and 31 stops have not since.

- cppcheck baseline unchanged (0 findings)
- Build `-O3 -Wall -Werror`, clean

## Test plan

Companion: [daqifi-python-test-suite#143](https://github.com/daqifi/daqifi-python-test-suite/pull/143) — `test_782_sd_teardown_race.py`, plus the `soak_782_sd_wedge.py` diagnostic that located this.

The test formats the card at start, which is load-bearing rather than tidiness: split files left by an earlier run would satisfy its rotation proof without this run having rotated, and the format also keeps it clear of #689's ceiling. It additionally requires OPER bit 10 after `START`, so a swallowed `SYST:STR:INT` rejection cannot leave it passing while streaming somewhere other than SD. Merge this PR first — that test is designed to fail without this fix.

Not in scope, filed separately: [#787](https://github.com/daqifi/daqifi-nyquist-firmware/issues/787) (29 `LOG_*` literals across 14 files carry non-ASCII that mangles and truncates `SYST:LOG?` on a cp1252 console — found while reading the #689 refusal above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
