### PR TITLE
docs: correct the SD split-file naming example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1206,7 +1206,7 @@ SYST:STOR:SD:MAXSize?               # Query current setting
 
 **File Naming:**
 - First file: Uses original name (e.g., `experiment.csv`)
-- Split files: Sequential 4-digit numbering (e.g., `experiment-0001.csv`, `experiment-0002.csv`)
+- Split files: Sequential numbering, **not** zero-padded (e.g., `experiment-1.csv`, `experiment-2.csv`) — `generateFilename` formats `"%s/%s-%u%s"` (`sd_card_manager.c`)
 - Supports up to 9999 files per session (~39TB @ 3.9GB each)
 
 **CSV Headers:**

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -840,7 +840,8 @@ static bool sd_EnterBucket(const char* dir, uint32_t bucket) {
 /**
  * @brief Generates filename with sequential numbering.
  *
- * Format: basename-NNN.ext (e.g., "data-001.csv", "data-002.csv")
+ * Format: basename-N.ext, NOT zero-padded (e.g., "data-1.csv", "data-2.csv",
+ * ... "data-10.csv") -- the counter is written with a plain %u below.
  *
  * @param outPath Output buffer for full path
  * @param maxLen Maximum length of output buffer


### PR DESCRIPTION
CLAUDE.md documented SD split files as zero-padded 4-digit names. They are not.

```diff
- Split files: Sequential 4-digit numbering (e.g., `experiment-0001.csv`, `experiment-0002.csv`)
+ Split files: Sequential numbering, **not** zero-padded (e.g., `experiment-1.csv`, `experiment-2.csv`)
```

**V** — `generateFilename` (`sd_card_manager.c`) formats `"%s/%s-%u%s"`, a plain `%u`, and there is no `%04` anywhere under `firmware/src/services/sd_card_services/`.

**E** — confirmed on the bench rather than by reading alone. After a rotation run, `SYST:STOR:SD:LISt?` returns:

```
DAQiFi/w001.csv
DAQiFi/w001-1.csv
DAQiFi/w001-2.csv
```

with no zero-padded form present anywhere in the listing.

## Why it mattered

Found while writing the [#782 regression test](https://github.com/daqifi/daqifi-python-test-suite/pull/143), whose rotation proof matches split filenames to confirm the workload actually rotated. A regex built from the documented form would have matched nothing and reported "no rotation" on a card that had rotated thousands of times — turning a real assertion into a permanent false failure.

The adjacent "up to 9999 files per session" claim **is** correct (`SD_CARD_MANAGER_MAX_SPLIT_FILES`) and is left alone.

Docs-only: no behavior change, so no companion regression test (per the standing carve-out in CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
