### PR TITLE
fix(log): #787 make all device text ASCII, and gate it in CI

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -44,6 +44,18 @@ jobs:
             exit 1
           fi
 
+      # #787: log text reaches operators over SYST:LOG?, where non-ASCII is
+      # mangled on a cp1252 console, can throw outright in a Python client,
+      # and eats the firmware's 128-byte LOG_MESSAGE_SIZE (so it truncates
+      # the rest of the message too). CLAUDE.md documented the rule long
+      # before this gate existed and 35 sites accumulated anyway, which is
+      # why it is enforced rather than only written down.
+      # Runs before cppcheck: it needs no toolchain and fails in under a
+      # second, so a violation reports immediately instead of after the
+      # slower analysis.
+      - name: Check log literals are ASCII
+        run: python3 tools/lint/check_log_ascii.py
+
       - name: Run cppcheck
         run: bash tools/lint/cppcheck.sh /tmp/cppcheck-current.txt
 

--- a/firmware/src/HAL/ADC/MC12bADC.c
+++ b/firmware/src/HAL/ADC/MC12bADC.c
@@ -342,7 +342,7 @@ void MC12b_ApplyScanList(uint32_t css1, uint32_t css2) {
         uint32_t spin = 500000u;
         while ((ADCCON3bits.UPDRDY == 0) && (--spin != 0u)) { }
         if (spin == 0u) {
-            LOG_E("ADC CSS update: UPDRDY timeout — scan list unchanged");
+            LOG_E("ADC CSS update: UPDRDY timeout - scan list unchanged");
             ADCCON3bits.TRGSUSP = 0;
             return;
         }

--- a/firmware/src/HAL/BQ24297/BQ24297.c
+++ b/firmware/src/HAL/BQ24297/BQ24297.c
@@ -251,7 +251,7 @@ void BQ24297_Config_Settings(void) {
     if (GPIO_PinInterruptCallbackRegister(BATT_MAN_INT_PIN, BQ24297_IntCallback, 0)) {
         GPIO_PinIntEnable(BATT_MAN_INT_PIN, GPIO_INTERRUPT_ON_FALLING_EDGE);
     } else {
-        LOG_E("BQ24297_Config_Settings: INT callback register failed — poll only");
+        LOG_E("BQ24297_Config_Settings: INT callback register failed - poll only");
     }
 
     // Mark initialization complete

--- a/firmware/src/HAL/UserEdge/UserEdge.c
+++ b/firmware/src/HAL/UserEdge/UserEdge.c
@@ -726,7 +726,7 @@ void UserEdge_IsrEvent(uint8_t unit) {
         IEC0CLR = r->ieMask;          /* stop the flood; pin stays claimed and the count
                                        * is preserved until a re-arm resets it to resume */
         gIntState[unit].stormed = true;
-        LOG_E("DIO event: edge storm — pin auto-muted, re-arm to resume");
+        LOG_E("DIO event: edge storm - pin auto-muted, re-arm to resume");
     }
 }
 

--- a/firmware/src/HAL/UserIC/UserIC.c
+++ b/firmware/src/HAL/UserIC/UserIC.c
@@ -343,7 +343,7 @@ static bool ic_Run(uint8_t dio, uint32_t icm, bool fedge, uint16_t minEdges,
          * busy error instead of blocking this SCPI task — the lock is shared
          * across the USB and WiFi SCPI paths, so blocking here would freeze a
          * whole interface for the duration of the other's measurement. */
-        if (err) { *err = "IC: busy — another measurement in progress"; }
+        if (err) { *err = "IC: busy - another measurement in progress"; }
         return false;
     }
 
@@ -495,7 +495,7 @@ static bool ic_Run(uint8_t dio, uint32_t icm, bool fedge, uint16_t minEdges,
      * every measurement is broken. Fail regardless of how many were stored,
      * rather than return a plausible-but-wrong value (#666 audit). */
     if (ov) {
-        if (err) { *err = "IC: FIFO overflow — signal too fast for this range"; }
+        if (err) { *err = "IC: FIFO overflow - signal too fast for this range"; }
         return false;
     }
     if (n < minEdges) {
@@ -539,7 +539,7 @@ bool UserIC_MeasureFrequency(uint8_t dio, uint32_t gate_ms, double* hz,
         return false;
     }
     if (!ic_Monotonic(ts, n)) {
-        if (err) { *err = "IC: non-monotonic capture (timing glitch) — retry"; }
+        if (err) { *err = "IC: non-monotonic capture (timing glitch) - retry"; }
         return false;
     }
     double span = (double)(ts[n - 1] - ts[0]);          /* timer counts */
@@ -554,7 +554,7 @@ bool UserIC_MeasurePeriod(uint8_t dio, double* us, const char** err) {
         return false;
     }
     if (!ic_Monotonic(ts, n)) {
-        if (err) { *err = "IC: non-monotonic capture (timing glitch) — retry"; }
+        if (err) { *err = "IC: non-monotonic capture (timing glitch) - retry"; }
         return false;
     }
     double span = (double)(ts[n - 1] - ts[0]);
@@ -574,7 +574,7 @@ bool UserIC_MeasurePulseWidth(uint8_t dio, uint8_t polarity, double* us,
         return false;
     }
     if (!ic_Monotonic(ts, n)) {
-        if (err) { *err = "IC: non-monotonic capture (timing glitch) — retry"; }
+        if (err) { *err = "IC: non-monotonic capture (timing glitch) - retry"; }
         return false;
     }
     int anchor = -1; uint8_t aLvl = 0;
@@ -603,7 +603,7 @@ bool UserIC_MeasureDuty(uint8_t dio, double* percent, const char** err) {
         return false;
     }
     if (!ic_Monotonic(ts, n)) {
-        if (err) { *err = "IC: non-monotonic capture (timing glitch) — retry"; }
+        if (err) { *err = "IC: non-monotonic capture (timing glitch) - retry"; }
         return false;
     }
     int anchor = -1; uint8_t aLvl = 0;

--- a/firmware/src/HAL/UserSpi/UserSpi.c
+++ b/firmware/src/HAL/UserSpi/UserSpi.c
@@ -332,7 +332,7 @@ static bool spi_EnableLocked(const char** err) {
     /* Pre-check every needed pin before claiming any, so a failure leaves
      * nothing half-claimed. */
     if (spi_PinInUse(USER_SPI_SCK_DIO)) {
-        if (err != NULL) { *err = "SCK/DIO0 in use (probe or PWM ch0) — free it first"; }
+        if (err != NULL) { *err = "SCK/DIO0 in use (probe or PWM ch0) - free it first"; }
         return false;
     }
     if (gCfg.mosiDio != USER_SPI_PIN_NONE && spi_PinInUse(gCfg.mosiDio)) {

--- a/firmware/src/Util/StreamingBufferPool.c
+++ b/firmware/src/Util/StreamingBufferPool.c
@@ -80,7 +80,7 @@ void StreamingBufferPool_Partition(uint32_t usbSize, uint32_t wifiSize,
      * override is diagnosable. */
     uint32_t bufTotal = usbSize + wifiSize + encoderSize + sdCircularSize;
     if (bufTotal > gPoolSize) {
-        LOG_E("Streaming buffers overcommit pool (%u > %u) — falling back to minimums",
+        LOG_E("Streaming buffers overcommit pool (%u > %u) - falling back to minimums",
               (unsigned)bufTotal, (unsigned)gPoolSize);
         usbSize = (usbSize > STREAMING_USB_MIN) ? STREAMING_USB_ACTIVE_MIN
                                                 : STREAMING_USB_MIN;
@@ -119,7 +119,7 @@ void StreamingBufferPool_Partition(uint32_t usbSize, uint32_t wifiSize,
     gSampleCount = sampleCount;
     gSampleElementSize = sampleElementSize;
 
-    LOG_I("Pool partition: USB=%u WiFi=%u enc=%u sdCirc=%u samples=%u×%u (of %u max, %u pool)",
+    LOG_I("Pool partition: USB=%u WiFi=%u enc=%u sdCirc=%u samples=%ux%u (of %u max, %u pool)",
           (unsigned)usbSize, (unsigned)wifiSize, (unsigned)encoderSize,
           (unsigned)sdCircularSize, (unsigned)sampleCount, (unsigned)sampleElementSize,
           (unsigned)maxSamples, (unsigned)gPoolSize);

--- a/firmware/src/app_freertos.c
+++ b/firmware/src/app_freertos.c
@@ -710,7 +710,7 @@ void app_SystemInit() {
     if (!TimerApi_ClockMatchesBuild()) {
         LOG_E("Clock mismatch (#716): PBCLK3 is %u Hz, image built for %u Hz. "
               "Device configuration words hold an older PLL and cannot be "
-              "updated by a firmware update — reprogram with a PICkit/IPE to "
+              "updated by a firmware update - reprogram with a PICkit/IPE to "
               "reach the intended clock. Rates are derived from the ACTUAL "
               "clock, so streaming is accurate but ceilings are lower.",
               (unsigned)TimerApi_PeripheralClockHz(),

--- a/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
+++ b/firmware/src/config/default/driver/sdspi/src/drv_sdspi.c
@@ -516,7 +516,7 @@ static void lDRV_SDSPI_CommandSend
             if (sCmdTimeoutLogs < 4U)
             {
                 sCmdTimeoutLogs++;
-                LOG_E("SD: cmd bus-completion timeout — forcing error path");
+                LOG_E("SD: cmd bus-completion timeout - forcing error path");
             }
             DRV_SDSPI_AbortedXferRecord(dObj);
             dObj->spiTransferStatus = DRV_SDSPI_SPI_TRANSFER_STATUS_ERROR;

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -533,7 +533,7 @@ scpi_result_t SCPI_ADCChanRangeSet(scpi_t * context) {
     // Store range value after hardware has settled
     pRuntimeModules->Data[moduleIndex].Range = rangeVoltage;
 
-    LOG_I("AD7609 module range set to ±%.1fV", rangeVoltage);
+    LOG_I("AD7609 module range set to +/-%.1fV", rangeVoltage);
 
     return SCPI_RES_OK;
 }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2525,7 +2525,7 @@ static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
             // SAME freq once; only lock saturation if it trips again (#520 HW
             // tuning 2026-05-31: 1/5 runs collapsed to 900 Hz on a transient).
             confirmTrip = true;
-            LOG_I("WIFI:FIND %u Hz: trip — re-testing (debounce)", (unsigned)freq);
+            LOG_I("WIFI:FIND %u Hz: trip - re-testing (debounce)", (unsigned)freq);
             vTaskDelay(pdMS_TO_TICKS(FIND_INTERSTEP_MS));
             // freq unchanged → loop re-measures this step
         } else {
@@ -3433,7 +3433,7 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     if (currentInterfaceAtCheck == StreamingInterface_WiFi) {
         size_t heapFreeAtStart = xPortGetFreeHeapSize();
         if (heapFreeAtStart < MIN_HEAP_FREE_FOR_STREAM_START_BYTES) {
-            LOG_E("WiFi streaming start rejected: free heap %u < floor %u (#475 — bounce LAN:APPLY or reboot)",
+            LOG_E("WiFi streaming start rejected: free heap %u < floor %u (#475 - bounce LAN:APPLY or reboot)",
                   (unsigned)heapFreeAtStart,
                   (unsigned)MIN_HEAP_FREE_FOR_STREAM_START_BYTES);
             SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
@@ -4546,7 +4546,7 @@ static bool PrepareStreamingBuffers(uint32_t poolCount, size_t sampleElemSize) {
      * BufferOpInFlight — it's the caller's own logging setup, the intended
      * consumer of the new partition.) */
     if (sd_card_manager_BufferOpInFlight()) {
-        LOG_E("PrepareStreamingBuffers: refused — SD read/list/CRC in flight; "
+        LOG_E("PrepareStreamingBuffers: refused - SD read/list/CRC in flight; "
               "cannot re-partition the SD read buffer (#703)");
         return false;
     }
@@ -4609,7 +4609,7 @@ static bool PrepareStreamingBuffers(uint32_t poolCount, size_t sampleElemSize) {
      * release, then reads from the NEW buffer size (consistent). Released on every
      * exit path after this point. */
     if (!sd_card_manager_TryLockBuffer()) {
-        LOG_E("PrepareStreamingBuffers: refused — SD read/list/CRC holds the buffer lock (#703)");
+        LOG_E("PrepareStreamingBuffers: refused - SD read/list/CRC holds the buffer lock (#703)");
         return false;
     }
 

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -488,7 +488,7 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
      * from ever tripping in practice; it's the host-visible mirror of the SD-task
      * terminal bail so a client gets an error instead of a bare EOF marker. */
     if (!sd_card_manager_ReadBufferReady()) {
-        LOG_E("[SD] GET rejected: read buffer too small — start an SD-logging "
+        LOG_E("[SD] GET rejected: read buffer too small - start an SD-logging "
               "session or reboot to restore the SD buffer");
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         result = SCPI_RES_ERR;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -371,7 +371,7 @@ static uint32_t CountDirEntries(const char* dirPath, uint32_t cap,
         if (e == SYS_FS_ERROR_NO_PATH || e == SYS_FS_ERROR_NO_FILE) {
             return 0;                       // directory absent -> no files
         }
-        LOG_E("[SD] CountDirEntries: DirOpen('%s') failed err=%d — failing safe (refuse)",
+        LOG_E("[SD] CountDirEntries: DirOpen('%s') failed err=%d - failing safe (refuse)",
               dirPath, (int)e);
         if (pFsError != NULL) {
             *pFsError = true;
@@ -387,7 +387,7 @@ static uint32_t CountDirEntries(const char* dirPath, uint32_t cap,
              * fail safe (refuse) rather than proceed on a partial count. Log
              * SYS_FS_Error() so a real media/FS fault is distinguishable in the
              * field from a genuinely full directory (both take the refuse path). */
-            LOG_E("[SD] CountDirEntries: DirRead failed at %u err=%d — failing safe",
+            LOG_E("[SD] CountDirEntries: DirRead failed at %u err=%d - failing safe",
                   (unsigned)count, (int)SYS_FS_Error());
             (void)SYS_FS_DirClose(dh);
             if (pFsError != NULL) {
@@ -907,7 +907,7 @@ static bool sd_BucketDirExists(const char* bucketPath, bool* fsError) {
     if (SYS_FS_FileStat(bucketPath, &st) != SYS_FS_RES_SUCCESS) {
         SYS_FS_ERROR e = SYS_FS_Error();
         if (e != SYS_FS_ERROR_NO_PATH && e != SYS_FS_ERROR_NO_FILE) {
-            LOG_E("[SD] #689 bucket stat '%s' failed err=%d — failing safe "
+            LOG_E("[SD] #689 bucket stat '%s' failed err=%d - failing safe "
                   "rather than reading it as absent", bucketPath, (int)e);
             *fsError = true;
         }
@@ -964,7 +964,7 @@ static bool sd_TargetExistsInBucketPath(const char* bucketPath, bool* fsError) {
     if (SYS_FS_FileStat(candidate, &st) != SYS_FS_RES_SUCCESS) {
         SYS_FS_ERROR e = SYS_FS_Error();
         if (e != SYS_FS_ERROR_NO_PATH && e != SYS_FS_ERROR_NO_FILE) {
-            LOG_E("[SD] #689 part stat '%s' failed err=%d — failing safe "
+            LOG_E("[SD] #689 part stat '%s' failed err=%d - failing safe "
                   "rather than reading it as absent", candidate, (int)e);
             *fsError = true;
         }
@@ -1554,7 +1554,7 @@ void sd_card_manager_ProcessState() {
                 // disk-full clean-stop pattern.
                 if (!bucketOk) {
                     LOG_E("[SD] WRITE refused: no writable bucket under '%s' "
-                          "(active '%s', bucket %u, %u per bucket, max %u) — FatFs "
+                          "(active '%s', bucket %u, %u per bucket, max %u) - FatFs "
                           "file-create wedges large directories (#689). Use a "
                           "larger SD:MAXSize, a different directory, or clear the "
                           "card.", gpSDCardSettings->directory,
@@ -2149,7 +2149,7 @@ void sd_card_manager_ProcessState() {
                  * this is now practically unreachable, but keep it terminal as
                  * defense in depth. Mirror the normal-exit ordering:
                  * drain -> marker -> close -> priority -> mutex -> mode/state. */
-                LOG_E("[SD] Buffer too small for read (%u < %u) — aborting GET",
+                LOG_E("[SD] Buffer too small for read (%u < %u) - aborting GET",
                       (unsigned)gSdSharedBufferSize, (unsigned)SD_READ_ALIGNMENT_SIZE);
                 sd_wait_usb_drain();
                 sd_card_manager_DataReadyCB(SD_CARD_MANAGER_MODE_READ,
@@ -2210,7 +2210,7 @@ void sd_card_manager_ProcessState() {
                         sd_card_manager_DataReadyCB(SD_CARD_MANAGER_MODE_READ,
                                 (uint8_t*)eofMarker, sizeof(eofMarker) - 1);
                     } else {
-                        LOG_E("[SD] aborted after %u bytes — no terminator sent "
+                        LOG_E("[SD] aborted after %u bytes - no terminator sent "
                               "(a plain EOF would look like a complete file; "
                               "#725 tracks a distinguishable one)",
                               (unsigned)totalBytesRead);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1307,7 +1307,7 @@ static size_t Streaming_WriteWithRetry(StreamWriteFn writeFn,
         if (cfg && !cfg->IsEnabled) return STREAM_WRITE_RETURN_STOPPED;
     }
 
-    LOG_E("Output write timeout (%u ms, %u bytes) — interface dead",
+    LOG_E("Output write timeout (%u ms, %u bytes) - interface dead",
           STREAM_WRITE_TIMEOUT_MS, (unsigned)len);
     return STREAM_WRITE_RETURN_TIMEOUT;
 }
@@ -2407,7 +2407,7 @@ void streaming_Task(void) {
             taskENTER_CRITICAL();
             gQuesBits |= QUES_BIT_TRANSPORT_DOWN;
             taskEXIT_CRITICAL();
-            LOG_E("Streaming: all configured transports down >%u s — auto-stop",
+            LOG_E("Streaming: all configured transports down >%u s - auto-stop",
                   (unsigned)gTransportGraceSec);
             pRunTimeStreamConf->IsEnabled = false;
             Streaming_Stop();

--- a/firmware/src/services/wifi_services/iperf2/iperf2.c
+++ b/firmware/src/services/wifi_services/iperf2/iperf2.c
@@ -176,11 +176,11 @@ static void FinalizeStats(void) {
 // DISCONNECTED but the WINC isn't actually up yet).
 static bool RequireWifiConnected(const char* where) {
     if (wifi_manager_GetWiFiStatus() != WIFI_STATUS_CONNECTED) {
-        LOG_E("iperf2: %s refused — WiFi not CONNECTED", where);
+        LOG_E("iperf2: %s refused - WiFi not CONNECTED", where);
         return false;
     }
     if (m2m_wifi_get_state() != WIFI_STATE_START) {
-        LOG_E("iperf2: %s refused — WINC not started", where);
+        LOG_E("iperf2: %s refused - WINC not started", where);
         return false;
     }
     return true;
@@ -188,11 +188,11 @@ static bool RequireWifiConnected(const char* where) {
 
 static bool RequireWifiReadyForSockets(const char* where) {
     if (wifi_manager_GetWiFiStatus() == WIFI_STATUS_DISABLED) {
-        LOG_E("iperf2: %s refused — WiFi DISABLED", where);
+        LOG_E("iperf2: %s refused - WiFi DISABLED", where);
         return false;
     }
     if (m2m_wifi_get_state() != WIFI_STATE_START) {
-        LOG_E("iperf2: %s refused — WINC not started", where);
+        LOG_E("iperf2: %s refused - WINC not started", where);
         return false;
     }
     return true;
@@ -412,7 +412,7 @@ bool Iperf2_StartUdpClient(const char* remote_ip, uint16_t remote_port,
     gCtx.udp_fin_count = 0;
     gCtx.last_stats.active = true;
     gCtx.last_stats.completed = false;
-    LOG_I("iperf2: UDP client → %s:%u for %u s", remote_ip,
+    LOG_I("iperf2: UDP client -> %s:%u for %u s", remote_ip,
           (unsigned)remote_port, (unsigned)duration_sec);
     return true;
 }

--- a/firmware/src/services/wifi_services/mdns_responder.c
+++ b/firmware/src/services/wifi_services/mdns_responder.c
@@ -597,7 +597,7 @@ void mdns_responder_HandleSocketEvent(SOCKET sock, uint8_t msgType, void *pvMsg)
              * needsReopen and permanently disable the self-heal this PR adds
              * (#692). Close the socket and schedule a rate-limited re-open so
              * ServiceHealth() recovers it, same as a recvfrom re-arm failure. */
-            LOG_E("[mDNS] bind failed — scheduling self-heal retry");
+            LOG_E("[mDNS] bind failed - scheduling self-heal retry");
             mdns_close_socket();
             /* Set ONLY needsReopen (a single atomic store), exactly like the
              * recvfrom re-arm failure path: ServiceHealth() does a prompt first

--- a/firmware/src/services/wifi_services/wifi_manager.c
+++ b/firmware/src/services/wifi_services/wifi_manager.c
@@ -1106,7 +1106,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     SendEvent(WIFI_MANAGER_EVENT_WIFI_FW_UPDATE_INIT);
                     break;
                 }
-                LOG_E("FW-update entry: driver still BUSY after 3 s — arming bridge anyway");
+                LOG_E("FW-update entry: driver still BUSY after 3 s - arming bridge anyway");
             }
             sFwUpdInitWaiting = false;
             sysObj.drvWifiWinc = WDRV_WINC_Initialize(0, NULL);
@@ -1925,7 +1925,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                     if (wifi_tcp_server_HasActiveClient() ||
                         GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_TCP_SOCKET_OPEN) ||
                         GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
-                        LOG_E("STA reconfig with bound socket — diverting to HardReset (#435/#437b)");
+                        LOG_E("STA reconfig with bound socket - diverting to HardReset (#435/#437b)");
                         wifi_tcp_server_CloseSocket();
                         if (GetEventFlagStatus(pInstance->eventFlags, WIFI_MANAGER_STATE_FLAG_UDP_SOCKET_OPEN)) {
                             CloseUdpSocket(&pInstance->udpServerSocket);
@@ -1965,7 +1965,7 @@ static wifi_manager_stateMachineReturnStatus_t MainState(stateMachineInst_t * co
                             // and the only recovery is SYST:REBoot — log
                             // explicitly so the user sees it in SYST:LOG?.
                             if (!SendEvent(WIFI_MANAGER_EVENT_ERROR)) {
-                                LOG_E("HardReset divert: ERROR fallback also failed; manager may be stuck — SYST:REBoot");
+                                LOG_E("HardReset divert: ERROR fallback also failed; manager may be stuck - SYST:REBoot");
                             }
                         }
                         break;
@@ -2530,7 +2530,7 @@ bool wifi_manager_PowerOn(void) {
         GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_INITIALIZED) &&
         (GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_AP_STARTED) ||
          GetEventFlagStatus(gStateMachineContext.eventFlags, WIFI_MANAGER_STATE_FLAG_STA_STARTED))) {
-        LOG_I("WiFi: power-up requested but WINC already powered/up — no-op (#637)");
+        LOG_I("WiFi: power-up requested but WINC already powered/up - no-op (#637)");
         return true;
     }
     taskENTER_CRITICAL();
@@ -2920,7 +2920,7 @@ static void wifi_manager_ServiceConsoleIdleTimeout(void)
     // client's immediate reconnect. The read is a 32-bit aligned atomic.
     if (idle > deadline &&
         gStateMachineContext.pTcpServerContext->client.lastActivityTick == last) {
-        LOG_I("TCP: console idle %us > %us deadline — closing (connect-and-never-send guard, #663)",
+        LOG_I("TCP: console idle %us > %us deadline - closing (connect-and-never-send guard, #663)",
               (unsigned)(idle / configTICK_RATE_HZ),
               (unsigned)(deadline / configTICK_RATE_HZ));
         gStateMachineContext.pTcpServerContext->client.idleClosed++;
@@ -2962,7 +2962,7 @@ static void wifi_manager_ProcessStateImpl(bool drainTcpRx) {
     if (gProcessStateMutex != NULL) {
         if (xSemaphoreTakeRecursive(gProcessStateMutex,
                                     pdMS_TO_TICKS(250)) != pdTRUE) {
-            LOG_E("WiFi ProcessState: mutex timeout — skipping iteration");
+            LOG_E("WiFi ProcessState: mutex timeout - skipping iteration");
             return;
         }
     }

--- a/firmware/src/state/data/AInSample.c
+++ b/firmware/src/state/data/AInSample.c
@@ -213,7 +213,7 @@ void AInSampleList_InitializeExternal(void* poolMem, int16_t* freeMem,
     poolActive = true;
     xSemaphoreGive(poolMutex);
 
-    LOG_I("Sample pool: %u samples × %u bytes (external memory)",
+    LOG_I("Sample pool: %u samples x %u bytes (external memory)",
           (unsigned)poolCapacity, (unsigned)poolElementStride);
 }
 

--- a/tools/lint/check_log_ascii.py
+++ b/tools/lint/check_log_ascii.py
@@ -74,34 +74,77 @@ HINTS = {
 }
 
 
-ESCAPE_RE = re.compile(
-    r"\\(?:x[0-9a-fA-F]{1,2}|[0-7]{1,3}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})")
-
-
 def escaped_nonascii(lit):
-    """Return escape sequences in `lit` that encode a byte/codepoint > 127.
+    """Return escape sequences in `lit` that encode a value > 127.
 
-    A literal written as "\\xE2\\x80\\x94" contains only ASCII source
-    characters, so an ord(ch) > 127 test passes it -- and it compiles to an em
-    dash all the same. Checking only what the eye can see would leave an easy
-    and completely silent way back to the defect.
+    Walks the literal instead of regex-scanning it, because a regex gets three
+    things wrong here -- all three were caught by an adversarial audit, and the
+    third would have failed CI on perfectly good code:
+
+    * ESCAPED BACKSLASH. In "literal \\\\xE2 token" the compiler emits the ASCII
+      bytes \\, x, E, 2. A regex retries after a failed match and finds "\\xE2"
+      starting at the SECOND backslash, so it reports non-ASCII in a string
+      that has none. Consuming \\\\ as a unit is the only way to be right.
+    * MAXIMAL MUNCH. C99 6.4.4.4: a hex escape consumes ALL following hex
+      digits. "\\x0E2" is one byte 0xE2, not \\x0E followed by '2'. A {1,2}
+      slice sees 0x0E (14) and passes an em dash straight through.
+    * LINE SPLICES. Translation phase 2 removes backslash-newline before
+      tokenizing, so "\\x" + splice + "E2" is really \\xE2. Handled by the
+      caller, which strips splices before this runs.
     """
     out = []
-    for m in ESCAPE_RE.finditer(lit):
-        esc = m.group(0)
-        body = esc[1:]
-        try:
-            if body[0] in "xX":
-                val = int(body[1:], 16)
-            elif body[0] in "uU":
-                val = int(body[1:], 16)
-            else:
-                val = int(body, 8)
-        except ValueError:
+    i, n = 0, len(lit)
+    while i < n:
+        if lit[i] != "\\":
+            i += 1
             continue
-        if val > 127:
-            out.append(esc)
+        i += 1                              # consume the backslash
+        if i >= n:
+            break
+        c = lit[i]
+        if c == "\\":                        # escaped backslash: consume BOTH
+            i += 1
+            continue
+        if c in "xX":
+            j = i + 1
+            while j < n and lit[j] in "0123456789abcdefABCDEF":
+                j += 1                      # maximal munch, per C99
+            if j > i + 1 and int(lit[i + 1:j], 16) > 127:
+                out.append(lit[i - 1:j])
+            i = j
+        elif c in "01234567":
+            j = i
+            while j < n and j < i + 3 and lit[j] in "01234567":
+                j += 1                      # octal is capped at 3 digits
+            if int(lit[i:j], 8) > 127:
+                out.append(lit[i - 1:j])
+            i = j
+        elif c in "uU":
+            width = 4 if c == "u" else 8
+            j, k = i + 1, i + 1 + width
+            digits = lit[j:k]
+            if len(digits) == width and all(
+                    d in "0123456789abcdefABCDEF" for d in digits):
+                if int(digits, 16) > 127:
+                    out.append(lit[i - 1:k])
+                i = k
+            else:
+                i += 1
+        else:
+            i += 1                          # \\n, \\t, \\", ... : ordinary
     return out
+
+
+def has_line_splice(lit):
+    """True if the literal contains a backslash-newline line splice.
+
+    The compiler removes these before tokenizing, so they can hide an escape
+    from any scanner that reads unspliced source. Rather than decode around
+    them, the caller fails closed and asks for the splice to be removed --
+    they do not occur anywhere in this codebase and have no legitimate use
+    inside a log string.
+    """
+    return "\\\n" in lit or "\\\r\n" in lit
 
 
 def string_literals(src):
@@ -168,6 +211,8 @@ def main():
         for off, lit in string_literals(src):
             bad = sorted({ch for ch in lit if ord(ch) > 127})
             bad += escaped_nonascii(lit)
+            if has_line_splice(lit):
+                bad.append("<line-splice>")
             if bad:
                 offenders.append((path, src.count("\n", 0, off) + 1, bad,
                                   lit.strip('"')[:60]))

--- a/tools/lint/check_log_ascii.py
+++ b/tools/lint/check_log_ascii.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Fail if any string literal in our firmware source contains non-ASCII (#787).
+
+Device text reaches operators over `SYST:LOG?` and `SYST:ERR?`. A non-ASCII
+byte there is unreadable on a cp1252 console, throws `UnicodeEncodeError`
+outright in a Python client, AND costs extra bytes against the firmware's
+128-byte `LOG_MESSAGE_SIZE` -- so it truncates the rest of the message too.
+That combination is how #787 surfaced: a client reading the log died, and the
+line it died on had already lost its explanation to truncation.
+
+WHY ALL LITERALS AND NOT JUST LOG_* CALLS
+    The first version of this checker inspected only text inside `LOG_*(...)`.
+    It reported the tree clean while SEVEN em dashes still reached the log,
+    because they lived in strings assigned to a variable:
+
+        *err = "IC: busy - another measurement in progress";   (UserIC.c)
+        ...
+        SCPI_ExecutionError(context, err);                     (SCPIDIO.c)
+        -> static inline: LOG_E("SCPI exec error: %s", reason) (SCPIInterface.h)
+
+    A checker scoped to the call site cannot see that. "No non-ASCII in any
+    string literal we compile" is both simpler to state and impossible to
+    sidestep by indirection -- and on a bare-metal target whose only text
+    output is a serial console, there is no legitimate exception.
+
+WHY COMMENTS ARE SKIPPED
+    Comments never reach the device. Failing CI for an em dash in prose would
+    be a false failure, and this file is littered with them on purpose.
+    Literals are therefore extracted with a small scanner that skips `//`,
+    `/* */` and character literals rather than by regex.
+
+SCOPE
+    firmware/src, excluding third_party/ and libraries/ -- vendored code we do
+    not own, matching tools/lint/cppcheck.sh's exclusions.
+
+Usage:
+    python3 tools/lint/check_log_ascii.py [ROOT]     # default firmware/src
+Exit codes:
+    0 = clean, 1 = offending literals found, 2 = usage/IO error
+"""
+import sys
+from pathlib import Path
+
+DEFAULT_ROOT = Path("firmware/src")
+EXCLUDED_PREFIXES = ("third_party/", "libraries/")
+
+# Advisory replacements for characters seen in this codebase. Any non-ASCII
+# is a failure whether or not it appears here.
+HINTS = {
+    "—": "-",     # em dash
+    "–": "-",     # en dash
+    "→": "->",    # rightwards arrow
+    "⇒": "=>",    # rightwards double arrow
+    "×": "x",     # multiplication sign
+    "±": "+/-",   # plus-minus
+    "≥": ">=",
+    "≤": "<=",
+    "≈": "~",
+    "…": "...",
+}
+
+
+def string_literals(src):
+    """Yield (offset, text) for each string literal, skipping comments.
+
+    Deliberately a scanner, not a regex: a regex that ignores comments
+    matches the span between two unrelated quote characters in prose, which
+    during development produced 14 bogus "literals" out of 21 candidates.
+    """
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c == '"':
+            j = i + 1
+            while j < n:
+                if src[j] == "\\":
+                    j += 2
+                    continue
+                if src[j] == '"':
+                    j += 1
+                    break
+                j += 1
+            yield i, src[i:j]
+            i = j
+        elif c == "'":                      # char literal: skip, don't report
+            j = i + 1
+            while j < n:
+                if src[j] == "\\":
+                    j += 2
+                    continue
+                if src[j] == "'":
+                    j += 1
+                    break
+                j += 1
+            i = j
+        elif src.startswith("//", i):
+            j = src.find("\n", i)
+            i = n if j < 0 else j
+        elif src.startswith("/*", i):
+            j = src.find("*/", i + 2)
+            i = n if j < 0 else j + 2
+        else:
+            i += 1
+
+
+def main():
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_ROOT
+    if not root.exists():
+        print(f"check_log_ascii: root not found: {root}", file=sys.stderr)
+        return 2
+
+    offenders = []
+    scanned = 0
+    for path in sorted(root.rglob("*.c")) + sorted(root.rglob("*.h")):
+        rel = path.relative_to(root).as_posix()
+        if any(rel.startswith(p) for p in EXCLUDED_PREFIXES):
+            continue
+        scanned += 1
+        try:
+            src = path.read_text(encoding="utf-8", errors="surrogateescape")
+        except OSError as e:
+            print(f"check_log_ascii: cannot read {path}: {e}", file=sys.stderr)
+            return 2
+        for off, lit in string_literals(src):
+            bad = sorted({ch for ch in lit if ord(ch) > 127})
+            if bad:
+                offenders.append((path, src.count("\n", 0, off) + 1, bad,
+                                  lit.strip('"')[:60]))
+
+    if not offenders:
+        print(f"check_log_ascii: clean - no non-ASCII in any string literal "
+              f"({scanned} files scanned)")
+        return 0
+
+    print(f"check_log_ascii: {len(offenders)} string literal(s) contain "
+          f"non-ASCII\n")
+    for path, line, bad, preview in offenders:
+        for ch in bad:
+            hint = HINTS.get(ch)
+            suffix = f"  (use {hint!r})" if hint else ""
+            print(f"::error file={path},line={line}::non-ASCII "
+                  f"U+{ord(ch):04X} {ch!r} in a string literal{suffix}"
+                  f"  --  {preview!r}")
+    print("\nDevice text is read over SYST:LOG? / SYST:ERR?, where non-ASCII "
+          "is mangled on a cp1252 console, can throw in a client, and eats "
+          "the 128-byte LOG_MESSAGE_SIZE budget. See #787.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lint/check_log_ascii.py
+++ b/tools/lint/check_log_ascii.py
@@ -89,8 +89,10 @@ def escaped_nonascii(lit):
       digits. "\\x0E2" is one byte 0xE2, not \\x0E followed by '2'. A {1,2}
       slice sees 0x0E (14) and passes an em dash straight through.
     * LINE SPLICES. Translation phase 2 removes backslash-newline before
-      tokenizing, so "\\x" + splice + "E2" is really \\xE2. Handled by the
-      caller, which strips splices before this runs.
+      tokenizing, so "\\x" + splice + "E2" is really \\xE2. This function does
+      NOT decode around that. It does not have to: main() rejects any literal
+      containing a splice outright (see has_line_splice), so a spliced escape
+      never reaches a scanner that would misread it.
     """
     out = []
     i, n = 0, len(lit)
@@ -211,20 +213,24 @@ def main():
         for off, lit in string_literals(src):
             bad = sorted({ch for ch in lit if ord(ch) > 127})
             bad += escaped_nonascii(lit)
-            if has_line_splice(lit):
-                bad.append("<line-splice>")
-            if bad:
+            # A splice is a DIFFERENT violation from a non-ASCII byte -- it is
+            # "this literal cannot be checked", not "this literal is bad". It
+            # is carried separately rather than as a sentinel in `bad` so the
+            # reporter can say so; a sentinel string lands in the escape
+            # branch below and prints the flatly untrue "escape encodes a
+            # byte > 127".
+            splice = has_line_splice(lit)
+            if bad or splice:
                 offenders.append((path, src.count("\n", 0, off) + 1, bad,
-                                  lit.strip('"')[:60]))
+                                  splice, lit.strip('"')[:60]))
 
     if not offenders:
         print(f"check_log_ascii: clean - no non-ASCII in any string literal "
               f"({scanned} files scanned)")
         return 0
 
-    print(f"check_log_ascii: {len(offenders)} string literal(s) contain "
-          f"non-ASCII\n")
-    for path, line, bad, preview in offenders:
+    print(f"check_log_ascii: {len(offenders)} string literal(s) rejected\n")
+    for path, line, bad, splice, preview in offenders:
         for ch in bad:
             if len(ch) == 1:
                 hint = HINTS.get(ch)
@@ -235,6 +241,12 @@ def main():
                 what = f"non-ASCII escape {ch!r}"
             print(f"::error file={path},line={line}::{what} in a string "
                   f"literal{suffix}  --  {preview!r}")
+        if splice:
+            print(f"::error file={path},line={line}::line splice "
+                  f"(backslash-newline) in a string literal  (remove it: the "
+                  f"compiler joins the lines before tokenizing, so an escape "
+                  f"can straddle the split and evade this check)  --  "
+                  f"{preview!r}")
     print("\nDevice text is read over SYST:LOG? / SYST:ERR?, where non-ASCII "
           "is mangled on a cp1252 console, can throw in a client, and eats "
           "the 128-byte LOG_MESSAGE_SIZE budget. See #787.")

--- a/tools/lint/check_log_ascii.py
+++ b/tools/lint/check_log_ascii.py
@@ -30,19 +30,33 @@ WHY COMMENTS ARE SKIPPED
     `/* */` and character literals rather than by regex.
 
 SCOPE
-    firmware/src, excluding third_party/ and libraries/ -- vendored code we do
-    not own, matching tools/lint/cppcheck.sh's exclusions.
+    firmware/src, excluding third_party/, libraries/ and config/ -- vendored
+    code we do not own. Same exclusions as tools/lint/cppcheck.sh.
+
+    config/ is excluded for a concrete reason, not by analogy: vendored FatFs
+    (config/default/system/fs/fat_fs/file_system/ff.c) embeds a boot-sector
+    jump instruction as "\xEB\x76\x90". That is binary data in a string
+    literal, entirely legitimate, and scanning it turns this gate red on
+    correct code. An earlier revision did include config/ and did exactly
+    that.
+
+    CAVEAT worth knowing: one real violation was fixed under config/
+    (config/default/driver/sdspi/src/drv_sdspi.c) and is therefore NOT
+    guarded against regression here. MCC regeneration is retired, so that
+    file changes only by hand -- but a hand edit could reintroduce it
+    silently.
 
 Usage:
     python3 tools/lint/check_log_ascii.py [ROOT]     # default firmware/src
 Exit codes:
     0 = clean, 1 = offending literals found, 2 = usage/IO error
 """
+import re
 import sys
 from pathlib import Path
 
 DEFAULT_ROOT = Path("firmware/src")
-EXCLUDED_PREFIXES = ("third_party/", "libraries/")
+EXCLUDED_PREFIXES = ("third_party/", "libraries/", "config/")
 
 # Advisory replacements for characters seen in this codebase. Any non-ASCII
 # is a failure whether or not it appears here.
@@ -58,6 +72,36 @@ HINTS = {
     "≈": "~",
     "…": "...",
 }
+
+
+ESCAPE_RE = re.compile(
+    r"\\(?:x[0-9a-fA-F]{1,2}|[0-7]{1,3}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})")
+
+
+def escaped_nonascii(lit):
+    """Return escape sequences in `lit` that encode a byte/codepoint > 127.
+
+    A literal written as "\\xE2\\x80\\x94" contains only ASCII source
+    characters, so an ord(ch) > 127 test passes it -- and it compiles to an em
+    dash all the same. Checking only what the eye can see would leave an easy
+    and completely silent way back to the defect.
+    """
+    out = []
+    for m in ESCAPE_RE.finditer(lit):
+        esc = m.group(0)
+        body = esc[1:]
+        try:
+            if body[0] in "xX":
+                val = int(body[1:], 16)
+            elif body[0] in "uU":
+                val = int(body[1:], 16)
+            else:
+                val = int(body, 8)
+        except ValueError:
+            continue
+        if val > 127:
+            out.append(esc)
+    return out
 
 
 def string_literals(src):
@@ -123,6 +167,7 @@ def main():
             return 2
         for off, lit in string_literals(src):
             bad = sorted({ch for ch in lit if ord(ch) > 127})
+            bad += escaped_nonascii(lit)
             if bad:
                 offenders.append((path, src.count("\n", 0, off) + 1, bad,
                                   lit.strip('"')[:60]))
@@ -136,11 +181,15 @@ def main():
           f"non-ASCII\n")
     for path, line, bad, preview in offenders:
         for ch in bad:
-            hint = HINTS.get(ch)
-            suffix = f"  (use {hint!r})" if hint else ""
-            print(f"::error file={path},line={line}::non-ASCII "
-                  f"U+{ord(ch):04X} {ch!r} in a string literal{suffix}"
-                  f"  --  {preview!r}")
+            if len(ch) == 1:
+                hint = HINTS.get(ch)
+                suffix = f"  (use {hint!r})" if hint else ""
+                what = f"non-ASCII U+{ord(ch):04X} {ch!r}"
+            else:
+                suffix = "  (escape encodes a byte > 127)"
+                what = f"non-ASCII escape {ch!r}"
+            print(f"::error file={path},line={line}::{what} in a string "
+                  f"literal{suffix}  --  {preview!r}")
     print("\nDevice text is read over SYST:LOG? / SYST:ERR?, where non-ASCII "
           "is mangled on a cp1252 console, can throw in a client, and eats "
           "the 128-byte LOG_MESSAGE_SIZE budget. See #787.")


### PR DESCRIPTION
Fixes [#787](https://github.com/daqifi/daqifi-nyquist-firmware/issues/787).

Non-ASCII in device text is unreadable on a cp1252 console, throws `UnicodeEncodeError` **outright** in a Python client reading `SYST:LOG?`, and costs extra bytes against the 128-byte `LOG_MESSAGE_SIZE` — so it truncates the rest of the message too. Both halves were observed together: a client died reading the log, and the line it died on had already lost its trailing explanation to truncation.

**42 replacements across 16 files** — em dash → `-`, arrow → `->`, multiply → `x`, plus-minus → `+/-`. **Comments are untouched**: they never reach the device, and this codebase uses em dashes in prose deliberately.

## Two corrections to the issue as I filed it

Both found by checking my own work rather than trusting the first result.

**1. "29 sites in 14 files" was an undercount.** That came from a *line-based* regex, which cannot see a call whose text continues onto the next line. A paren-matching parser found **35 in 15 files** — including an entire file (`app_freertos.c`) the regex-derived file list never mentioned.

**2. Fixing only `LOG_*()` call sites was not enough.** Seven em dashes still reached the log through a variable:

```c
*err = "IC: busy — another measurement in progress";   // UserIC.c
SCPI_ExecutionError(context, err);                     // SCPIDIO.c
  └─> static inline: LOG_E("SCPI exec error: %s", reason)   // SCPIInterface.h
```

A checker scoped to the call site is blind to that. So the rule is now **"no non-ASCII in any string literal we compile"** — simpler to state, and impossible to sidestep by indirection. On a bare-metal target whose only text output is a serial console, there is no legitimate exception.

I caught this because the fixed binary still contained the offending byte sequences, which contradicted the "clean" verdict my first guard gave. That disagreement is what exposed the indirection path.

## The CI guard

`tools/lint/check_log_ascii.py`, wired into the **existing** cppcheck workflow (already triggered by `firmware/src/**` and `tools/lint/**` — no new job, no new trigger):

- scans **all** string literals, not just log calls, so the indirection class above cannot regress;
- **skips comments** with a small scanner rather than a regex — a comment-blind regex matched the span between two unrelated quotes in prose and produced **14 bogus hits out of 21** candidates, and would have failed CI on an em dash in a code comment;
- excludes `third_party/` and `libraries/`, matching `cppcheck.sh`;
- runs **before** cppcheck: no toolchain, sub-second, so a violation reports immediately rather than after the slower analysis.

**Mutation-proved in three directions**, because a guard that cannot fail is worse than no guard:

| case | expected | got |
|---|---|---|
| real tree (404 files) | clean | exit 0 |
| variable-indirection literal | caught | exit 1, names file/line/char |
| commented-out log line | **not** flagged | exit 0 |

## Test plan

Companion: [daqifi-python-test-suite#145 — assert device log and error text decode as strict ASCII](https://github.com/daqifi/daqifi-python-test-suite/pull/145).

Bench (Nq1 `7E2898F46200E8A7`): provoked real SD busy refusals and an execution error, read `SYST:LOG?` **as bytes** and decoded with `errors='strict'` — 266 bytes, 0 non-ASCII, no exception; `SYST:ERR?` likewise. The test FAILs rather than skips if too little log text comes back, so "nothing to decode" cannot read as "clean".

- Build clean at `-O3 -Wall -Werror`
- cppcheck baseline unchanged (0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
