### PR TITLE
fix(sd): a read-only SD:LISt? must not create the directory it reads (#797)

### DIFF
--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1515,10 +1515,21 @@ void sd_card_manager_ProcessState() {
             {
                 sd_card_manager_mode_t dirMode;
                 bool skipCreate;
+                char dirName[SD_CARD_MANAGER_CONF_DIR_NAME_LEN_MAX + 1];
 
                 taskENTER_CRITICAL();
                 dirMode = gpSDCardSettings->mode;
                 skipCreate = (dirMode != SD_CARD_MANAGER_MODE_WRITE);
+                /* Snapshot the NAME too, not just the mode. A preempting
+                 * sd_card_manager_UpdateSettings() memcpy's the WHOLE settings
+                 * struct, so passing &gpSDCardSettings->directory[0] straight
+                 * into SYS_FS_DirectoryMake hands FatFs a string that can be
+                 * rewritten underneath it during a long filesystem call --
+                 * creating a directory under a torn name. Copy once, under the
+                 * same lock that decided to create. */
+                (void)strncpy(dirName, gpSDCardSettings->directory,
+                              sizeof(dirName) - 1u);
+                dirName[sizeof(dirName) - 1u] = '\0';
                 if (skipCreate) {
                     /* #797: only a WRITE may create the directory. Every mode
                      * routes through this state, so a read-only operation used
@@ -1546,24 +1557,30 @@ void sd_card_manager_ProcessState() {
                 if (skipCreate) {
                     /* Logging stays OUTSIDE the critical section. */
                     LOG_D("[SD] Not creating '%s': mode %d is read-only\r\n",
-                          gpSDCardSettings->directory, (int)dirMode);
+                          dirName, (int)dirMode);
                     break;
                 }
-            }
 
-            if (SYS_FS_DirectoryMake(gpSDCardSettings->directory) == SYS_FS_RES_FAILURE) {
+            if (SYS_FS_DirectoryMake(dirName) == SYS_FS_RES_FAILURE) {
                 if (SYS_FS_Error() == SYS_FS_ERROR_EXIST) {
-                    LOG_D("[SD] Directory '%s' already exists\r\n", gpSDCardSettings->directory);
+                    LOG_D("[SD] Directory '%s' already exists\r\n", dirName);
                     SD_PublishPostCreateState(SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE);
                 } else {
-                    gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
-                    LOG_E("[%s:%d]Invalid SD Card Directory name '%s'", __FILE__, __LINE__, gpSDCardSettings->directory);
+                    /* Guarded like the success paths: if a teardown landed
+                     * during the create, the operation is already dead and
+                     * DEINIT -> UNMOUNT is the clean exit. Recording ERROR
+                     * over it would strand the manager in ERROR for work
+                     * nobody is waiting on -- the same clobber #782 is about,
+                     * just with a different value. */
+                    SD_PublishPostCreateState(SD_CARD_MANAGER_PROCESS_STATE_ERROR);
+                    LOG_E("[%s:%d]Invalid SD Card Directory name '%s'", __FILE__, __LINE__, dirName);
                 }
                 /* Error while creating a new drive */
             } else {
-                LOG_D("[SD] Created directory '%s'\r\n", gpSDCardSettings->directory);
+                LOG_D("[SD] Created directory '%s'\r\n", dirName);
                 /* Open a file for writing. */
                 SD_PublishPostCreateState(SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE);
+            }
             }
             break;
 

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1074,6 +1074,21 @@ static bool sd_TargetExistsInBucketPath(const char* bucketPath, bool* fsError) {
     return ((st.fattrib & SYS_FS_ATTR_DIR) == 0);
 }
 
+/* #798: publish a post-DirectoryMake state without clobbering a teardown.
+ * SYS_FS_DirectoryMake is a filesystem round-trip, so it is the WIDEST window
+ * in this state for SCPI to preempt and force DEINIT -- wider than the compare
+ * the read-only branch above protects. Honour the teardown rather than
+ * overwrite it. Same read-decide-write shape, same reason, as #782 at
+ * OPEN_FILE. */
+static void SD_PublishPostCreateState(sd_card_manager_processState_t next)
+{
+    taskENTER_CRITICAL();
+    if (gpSDCardSettings->mode != SD_CARD_MANAGER_MODE_NONE) {
+        gSDCardData.currentProcessState = next;
+    }   /* else: a teardown landed during the create -- leave DEINIT standing */
+    taskEXIT_CRITICAL();
+}
+
 void sd_card_manager_ProcessState() {
     /* Check the application's current state. */
 
@@ -1481,16 +1496,65 @@ void sd_card_manager_ProcessState() {
              * look`, which is what #796's FAILED marker already means. A
              * WRITE still creates its target directory, so the first stream
              * after a format works exactly as before. */
-            if (gpSDCardSettings->mode != SD_CARD_MANAGER_MODE_WRITE) {
-                LOG_D("[SD] Not creating '%s': mode %d is read-only\r\n",
-                      gpSDCardSettings->directory, (int)gpSDCardSettings->mode);
-                gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE;
-                break;
+            /* Decide and publish in ONE atomic step, for the reason #782
+             * documents at OPEN_FILE below: SCPI (pri 7) preempts this task
+             * (pri 5), and sd_card_manager_UpdateSettings() tears a session
+             * down by clearing mode and forcing currentProcessState = DEINIT
+             * (tail of that function). A plain compare-then-assign only
+             * narrows the window -- SCPI can land between the two, and the
+             * assignment then clobbers the DEINIT, so a torn-down operation
+             * walks on into OPEN_FILE, opens a file nobody is waiting for, and
+             * ends in ERROR instead of unmounting cleanly.
+             *
+             * The teardown signature here is mode == NONE, NOT mode != WRITE.
+             * That differs from the OPEN_FILE precedent, where the dispatch
+             * mode WAS WRITE so anything else meant torn-down. In this state
+             * every read-only operation (LIST, READ, CRC, DELETE) legitimately
+             * arrives with mode != WRITE, and testing that would route normal
+             * traffic into DEINIT. */
+            {
+                sd_card_manager_mode_t dirMode;
+                bool skipCreate;
+
+                taskENTER_CRITICAL();
+                dirMode = gpSDCardSettings->mode;
+                skipCreate = (dirMode != SD_CARD_MANAGER_MODE_WRITE);
+                if (skipCreate) {
+                    /* #797: only a WRITE may create the directory. Every mode
+                     * routes through this state, so a read-only operation used
+                     * to CREATE the thing it had been asked to look at --
+                     * `SD:LISt? "TYPO"` made TYPO, then truthfully reported it
+                     * empty, and left it on the card. Two bugs in one: a query
+                     * that modifies the card, and a host that cannot tell
+                     * "that directory is empty" from "that directory is not
+                     * there", because the firmware had just made the second
+                     * answer into the first.
+                     *
+                     * With the create gone, DirOpen fails for a path that is
+                     * not there and the walk reports SD_LISTDIR_FAILED -- `I
+                     * could not look`, which is what #796's FAILED marker
+                     * already means. A WRITE still creates its target
+                     * directory, so the first stream after a format works
+                     * exactly as before. */
+                    gSDCardData.currentProcessState =
+                            (dirMode == SD_CARD_MANAGER_MODE_NONE)
+                            ? SD_CARD_MANAGER_PROCESS_STATE_DEINIT
+                            : SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE;
+                }
+                taskEXIT_CRITICAL();
+
+                if (skipCreate) {
+                    /* Logging stays OUTSIDE the critical section. */
+                    LOG_D("[SD] Not creating '%s': mode %d is read-only\r\n",
+                          gpSDCardSettings->directory, (int)dirMode);
+                    break;
+                }
             }
+
             if (SYS_FS_DirectoryMake(gpSDCardSettings->directory) == SYS_FS_RES_FAILURE) {
                 if (SYS_FS_Error() == SYS_FS_ERROR_EXIST) {
                     LOG_D("[SD] Directory '%s' already exists\r\n", gpSDCardSettings->directory);
-                    gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE;
+                    SD_PublishPostCreateState(SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE);
                 } else {
                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                     LOG_E("[%s:%d]Invalid SD Card Directory name '%s'", __FILE__, __LINE__, gpSDCardSettings->directory);
@@ -1499,7 +1563,7 @@ void sd_card_manager_ProcessState() {
             } else {
                 LOG_D("[SD] Created directory '%s'\r\n", gpSDCardSettings->directory);
                 /* Open a file for writing. */
-                gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE;
+                SD_PublishPostCreateState(SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE);
             }
             break;
 

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1467,6 +1467,26 @@ void sd_card_manager_ProcessState() {
             break;
 
         case SD_CARD_MANAGER_PROCESS_STATE_CREATE_DIRECTORY:
+            /* #797: only a WRITE may create the directory. Every mode routes
+             * through this state, so a read-only operation used to CREATE the
+             * thing it had been asked to look at -- `SD:LISt? "TYPO"` made
+             * TYPO, then truthfully reported it empty, and left it on the
+             * card. Two bugs in one: a query that modifies the card, and a
+             * host that cannot tell "that directory is empty" from "that
+             * directory is not there", because the firmware had just made the
+             * second answer into the first.
+             *
+             * With the create gone, DirOpen fails for a path that is not
+             * there and the walk reports SD_LISTDIR_FAILED -- `I could not
+             * look`, which is what #796's FAILED marker already means. A
+             * WRITE still creates its target directory, so the first stream
+             * after a format works exactly as before. */
+            if (gpSDCardSettings->mode != SD_CARD_MANAGER_MODE_WRITE) {
+                LOG_D("[SD] Not creating '%s': mode %d is read-only\r\n",
+                      gpSDCardSettings->directory, (int)gpSDCardSettings->mode);
+                gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE;
+                break;
+            }
             if (SYS_FS_DirectoryMake(gpSDCardSettings->directory) == SYS_FS_RES_FAILURE) {
                 if (SYS_FS_Error() == SYS_FS_ERROR_EXIST) {
                     LOG_D("[SD] Directory '%s' already exists\r\n", gpSDCardSettings->directory);

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1562,7 +1562,13 @@ void sd_card_manager_ProcessState() {
                 }
 
             if (SYS_FS_DirectoryMake(dirName) == SYS_FS_RES_FAILURE) {
-                if (SYS_FS_Error() == SYS_FS_ERROR_EXIST) {
+                /* Read the error ONCE. SYS_FS_Error() returns a shared global,
+                 * so calling it again for the log can report a different fault
+                 * than the one that selected the branch -- which is worse than
+                 * no code at all, because it looks authoritative. */
+                SYS_FS_ERROR mkdirErr = SYS_FS_Error();
+
+                if (mkdirErr == SYS_FS_ERROR_EXIST) {
                     LOG_D("[SD] Directory '%s' already exists\r\n", dirName);
                     SD_PublishPostCreateState(SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE);
                 } else {
@@ -1579,7 +1585,7 @@ void sd_card_manager_ProcessState() {
                      * asserting "invalid name" sent operators after a naming
                      * problem that usually is not there. */
                     LOG_E("[%s:%d]SD DirectoryMake('%s') failed, SYS_FS_Error=%d",
-                          __FILE__, __LINE__, dirName, (int)SYS_FS_Error());
+                          __FILE__, __LINE__, dirName, (int)mkdirErr);
                 }
                 /* Error while creating a new drive */
             } else {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1573,7 +1573,13 @@ void sd_card_manager_ProcessState() {
                      * nobody is waiting on -- the same clobber #782 is about,
                      * just with a different value. */
                     SD_PublishPostCreateState(SD_CARD_MANAGER_PROCESS_STATE_ERROR);
-                    LOG_E("[%s:%d]Invalid SD Card Directory name '%s'", __FILE__, __LINE__, dirName);
+                    /* Report the FS error code. This branch is reached for
+                     * every DirectoryMake failure that is not EXIST -- media
+                     * faults, a full root directory, an I/O error -- so
+                     * asserting "invalid name" sent operators after a naming
+                     * problem that usually is not there. */
+                    LOG_E("[%s:%d]SD DirectoryMake('%s') failed, SYS_FS_Error=%d",
+                          __FILE__, __LINE__, dirName, (int)SYS_FS_Error());
                 }
                 /* Error while creating a new drive */
             } else {


### PR DESCRIPTION
Fixes #797.

## The issue said "SD:LISt? cannot tell empty from missing". The card said something worse.

`SYST:STOR:SD:LISt? "NOSUCHDIR"` returns a complete, empty listing — on #796 firmware, literally `__END_OF_LIST__ OK` with zero entries. The issue assumed `SYS_FS_DirOpen` was returning a valid handle for a path that is not on the card. It is not. Bench-traced with `SYST:LOG:LEVel SD,3` on `7E2898F46200E8A7` (E, 2026-08-19):

```
SYST:STOR:SD:LISt? "NOSUCHDIR797"   ->  __END_OF_LIST__ OK   (0 entries)

SYST:LOG?                           ->  [SD] Created directory 'NOSUCHDIR797'
                                        [SD] ListFiles: Opening directory 'NOSUCHDIR797'
                                        [SD] ListFiles: End of directory 'NOSUCHDIR797'
```

The listing **created** the directory it had been asked to look at, then truthfully reported it empty. Two defects wearing one symptom:

1. **A query modified the card.** Every mistyped or stale path left a permanent empty directory behind — on a device whose #689 bucketing already cares how many entries a directory walk has to cross, and where `SD:LISt?`'s operand *persists* into the logging directory setting, so the junk directory also becomes where the next log goes until something changes it back.
2. **The host could not distinguish the two answers**, because the firmware had turned the second into the first.

## The fix

Every mode routes through `SD_CARD_MANAGER_PROCESS_STATE_CREATE_DIRECTORY`. Only `WRITE` may create now; the read-only modes fall straight through to `OPEN_FILE`.

With the create gone, `SYS_FS_DirOpen` fails for a path that is not there, and `ListFilesInDirectoryChunked` reports `SD_LISTDIR_FAILED` through plumbing that already exists — the existing `[Error:%d]Failed to open directory [%s]` line and `__END_OF_LIST__ FAILED`. That is exactly what the issue asked for; the missing piece was never the reporting, it was that the directory got made first.

`FAILED` already means *"I could not look"* (wiki, `SYSTem:STORage:SD:LISt?`). Until now it was reachable only from a path too long or an I/O error — not from the most ordinary way a caller gets a directory wrong.

A `WRITE` still creates its target, so the first stream after a format behaves exactly as before.

## ⚠️ Client impact — read before merging

On a **freshly formatted card**, `daqifi-core`'s `GetSdCardFilesAsync` sends `SYST:STOR:SD:LISt?` with no operand, the device uses its configured directory (`DAQiFi`), and that directory does not exist yet. Today the firmware silently creates it and answers empty. After this change it answers `FAILED`, and `ThrowIfSdCardListError` turns the `Failed to open directory` line into an `SdCardFilesystemException` — so the desktop app would show an error where it used to show an empty card.

That is the firmware telling the truth and the client rendering it badly, which is the documented split (firmware ships mechanism, client owns policy). **A companion `daqifi-core` change should land first**, rendering "that directory is not present" as an empty listing rather than an error — the same ordering [#796](https://github.com/daqifi/daqifi-nyquist-firmware/pull/796) needed with [daqifi-core#550](https://github.com/daqifi/daqifi-core/pull/550), and for the same reason: firmware truth that arrives before the client understands it is a regression for users.

I have not opened that PR yet because I cannot verify either half on hardware right now (below).

## Test plan

- **Companion regression test**: [daqifi-python-test-suite#157 — `test_797_sd_list_missing_dir.py`](https://github.com/daqifi/daqifi-python-test-suite/pull/157). Three cases: an absent directory reports `FAILED`; **listing it a second time still reports `FAILED`**, which is what proves the query did not create it; and a `WRITE` still creates its target, which guards against over-applying the fix into "never create anything" and breaking logging to a fresh card. It fails on pre-#797 firmware, where the first listing makes the directory and both answer `OK`.
- **Build**: clean at `-O3 -Werror` (XC32 v4.60, MPLAB X v6.30), `default` configuration.
- **Hardware — BLOCKED, not skipped.** The bench Nq1's SD card stopped being detected partway through this session: `SYST:STOR:SD:SPACe?` answers `Error !! No SD Card Detected` and `SYST:LOG?` shows `SD - No SD card detected` from the detect layer. It survived six `ENAble 0/1` cycles with settles, a `SYST:REBoot`, and **an A/B against a different firmware image** — the pre-change build reports the identical failure, so this is the card or its socket, not any firmware in flight. It needs a physical reseat or a replacement, which I cannot do. The mechanism above **was** captured on hardware before the card went; the fix's effect was not. **Do not merge on my say-so that it works** — the run is queued and I will post it here.

Also unverified for the same reason: `__END_OF_LIST__ FAILED` has never been emitted on real hardware. #796 shipped with `FAILED` explicitly called out as unreachable from this bench; this PR is what makes it reachable, so its first real exercise is the queued run.

## Related

- #794 / #796 — a listing that *stops* vs one that *finished*. This is the same confusion one level down: a listing that finished over **nothing** vs one that finished over an **empty** directory.
- The operand persistence (`SCPI_StorageSDListDir` copies its argument into `pSDCardRuntimeConfig->directory`, the field logging writes to) is untouched here and still deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)