### PR TITLE
fix(scpi): reject an unrecognised stream format instead of silently picking JSON (#801)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3964,19 +3964,32 @@ static scpi_result_t SCPI_SetStreamFormat(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
-    if (param1 == Streaming_ProtoBuffer) {
-        pRunTimeStreamConfig->Encoding = Streaming_ProtoBuffer;
-    } else if (param1 == Streaming_Json) {
-        pRunTimeStreamConfig->Encoding = Streaming_Json;
-    }else if(param1 == Streaming_Csv){
-         pRunTimeStreamConfig->Encoding = Streaming_Csv;
-    }else if(param1 == Streaming_CsvCompact){
-         /* #619: CSV with one leading timestamp column instead of N identical
-          * per-channel ones. Opt-in; 0/1/2 keep their existing meaning. */
-         pRunTimeStreamConfig->Encoding = Streaming_CsvCompact;
-    }else{
-        pRunTimeStreamConfig->Encoding = Streaming_Json;
+    /* #801: reject an unrecognised encoding rather than quietly picking one.
+     *
+     * This used to fall through to Streaming_Json and return OK, so
+     * `SYST:STR:FORmat 99` selected JSON while the caller believed it had
+     * selected something else -- and JSON is the byte-heaviest encoding
+     * (3.11x CSV per sample at 1 channel, #529) sitting on the least
+     * characterised cap, so the silent choice was also the most expensive
+     * one. Every sibling setter in this file already rejects out-of-range:
+     * SCPI_SetStreamInterface and SCPI_SetTestPattern both push
+     * ILLEGAL_PARAMETER_VALUE, and this was the odd one out.
+     *
+     * A range check rather than a switch because eStreamingEncoding is
+     * contiguous, and because the case that matters is a client sending a
+     * value THIS firmware does not know yet -- a range check stays correct
+     * when a fifth encoding is appended, and an enumerated list would have to
+     * be remembered. */
+    if (param1 < (int)Streaming_ProtoBuffer || param1 > (int)Streaming_CsvCompact) {
+        LOG_E("Stream format %d is not a known encoding (0=PB, 1=JSON, "
+              "2=CSV, 3=CsvCompact)", param1);
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
     }
+
+    /* Assigned only after the range check, so a rejected set cannot leave the
+     * encoding half-changed: FORmat? still reports what it reported before. */
+    pRunTimeStreamConfig->Encoding = (StreamingEncoding)param1;
 
     return SCPI_RES_OK;
 }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3978,9 +3978,14 @@ static scpi_result_t SCPI_SetStreamFormat(scpi_t * context) {
      * A range check rather than a switch because eStreamingEncoding is
      * contiguous, and because the case that matters is a client sending a
      * value THIS firmware does not know yet -- a range check stays correct
-     * when a fifth encoding is appended, and an enumerated list would have to
-     * be remembered. */
-    if (param1 < (int)Streaming_ProtoBuffer || param1 > (int)Streaming_CsvCompact) {
+     * when a fifth encoding is appended, where an enumerated list has to be
+     * remembered.
+     *
+     * Bounded by the enum's own COUNT rather than by naming the highest
+     * encoding here, so adding one does not leave a second place to update
+     * (Qodo). */
+    if (param1 < (int)Streaming_ProtoBuffer
+            || param1 >= (int)Streaming_Encoding_COUNT) {
         LOG_E("Stream format %d is not a known encoding (0=PB, 1=JSON, "
               "2=CSV, 3=CsvCompact)", param1);
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);

--- a/firmware/src/state/runtime/StreamingRuntimeConfig.h
+++ b/firmware/src/state/runtime/StreamingRuntimeConfig.h
@@ -19,6 +19,20 @@ extern "C" {
          * Appended as a new value rather than changing 2, so existing clients
          * are untouched; opt-in via SYST:STR:FORmat 3. */
         Streaming_CsvCompact=3,
+        /* NOT an encoding -- the count, for bounds checks. Keep it last, and
+         * add new encodings ABOVE it so it stays one past the end.
+         *
+         * #801: SCPI_SetStreamFormat used to name the highest encoding
+         * directly in its range check, which is a second place to remember
+         * when a fifth is added -- and the case that check exists for is
+         * precisely a value the firmware does not know yet. Deriving the
+         * bound from the enum means the two cannot disagree.
+         *
+         * Safe for the switch in Streaming_TransportMaxFreq: it has a
+         * `default` that caps an unrecognised encoding at 1 Hz, so this
+         * member needs no case of its own and could not over-cap if it
+         * somehow arrived. */
+        Streaming_Encoding_COUNT
     } StreamingEncoding;
 
     typedef enum eStreamingInterface


### PR DESCRIPTION
Fixes #801.

## The defect

`SCPI_SetStreamFormat` ended its value chain with a bare `else`:

```c
    }else if(param1 == Streaming_CsvCompact){
         pRunTimeStreamConfig->Encoding = Streaming_CsvCompact;
    }else{
        pRunTimeStreamConfig->Encoding = Streaming_Json;
    }
    return SCPI_RES_OK;
```

So `SYST:STR:FORmat 99` — or any value a client guesses at, **including one a future firmware defines** — silently selected JSON and reported success, while `FORmat?` disagreed with what the caller asked for and its parser saw something else entirely.

Three things wrong with it, in increasing order of cost:

1. **It contradicts our own SCPI rule.** CLAUDE.md: *"prevent users from operating with improper settings (return SCPI errors for config problems ...)"*.
2. **Every sibling setter in the same file already rejects out-of-range.** `SCPI_SetStreamInterface` and `SCPI_SetTestPattern` both push `ILLEGAL_PARAMETER_VALUE`; `SCPI_SetBenchmarkMode` uses `DATA_OUT_OF_RANGE`. This was the only one of the four that swallowed a bad value.
3. **The fallback picked the worst possible target.** JSON is the byte-heaviest encoding — bench-measured at **3.11× CSV per sample** at one channel ([#529](https://github.com/daqifi/daqifi-nyquist-firmware/issues/529)) — and sits on the least characterised cap, still a `CSV × 0.5` placeholder. A fat-fingered format number therefore chose the most expensive encoding on the least validated limit.

## The fix

A range check rather than a switch, because `eStreamingEncoding` is contiguous and because **the case that matters is a client sending a value this firmware does not know yet**. A range check stays correct when a fifth encoding is appended; an enumerated list has to be remembered.

The assignment moved *after* the check, so a rejected set cannot leave the encoding half-changed.

## Bench results

Nq1 `7E2898F46200E8A7` on COM3, with the companion test:

**Before — 1 PASS / 2 FAIL:**
```
B: out-of-range (-1, 4, 99) -> ['-1: err=0', '4: err=0', '99: err=0']
C: encoding after each rejection -> ['-1: encoding 2 -> 1', '4: encoding 2 -> 1', '99: encoding 2 -> 1']
```

`encoding 2 -> 1` is the defect caught in the act — CSV silently becoming JSON, three times, with `err=0` each time.

**After — 3 PASS / 0 FAIL:**
```
A: defined encodings 0-3 -> all accepted and read back
B: out-of-range (-1, 4, 99) -> all rejected with -224
C: encoding after each rejection -> unchanged
```

## Test plan

- **Companion regression test:** [daqifi-python-test-suite#161 — `test_801_stream_format_validation.py`](https://github.com/daqifi/daqifi-python-test-suite/pull/161). Case A pins that the four defined encodings still round-trip, so the fix cannot be "reject everything"; B pins `-224`; C pins that a rejected set does not mutate the encoding, entered from CSV rather than JSON so the old fallback target cannot hide it.
- **Build:** clean at `-O3 -Werror` (XC32 v4.60, MPLAB X v6.30), `default` configuration.
- **Hardware: run, both directions.** Baseline on `main` fails B and C; the fix passes all three.
- **No SD needed** — USB only, so this was runnable while the bench SD card is out ([test-suite #158](https://github.com/daqifi/daqifi-python-test-suite/issues/158)).

## Behaviour change — worth a release note

A client currently sending an out-of-range value gets JSON and success; it will now get `-224` and no change. That is the point, and per the "firmware ships mechanism, client owns policy" split it is the firmware telling the truth — but it is a visible change and should be called out rather than slipped in. The wiki also documents the old behaviour (*"An unrecognised value falls back to JSON"*) and needs the corresponding edit on merge.

I checked the client risk rather than assuming it:

- **`daqifi-core`** — `ScpiMessageProducer.SetStreamFormat(int)` is **`internal`**, so no external caller reaches it. Its named properties pass literals `0`/`1`/`2`, and the single variable call site is `SdCardOperations.cs:627`, casting `SdCardLogFormat` — an enum of exactly `{Protobuf=0, Json=1, Csv=2}`.
- **`daqifi-python-core`** and the **test suite** interpolate a `fmt` loop variable, but always over a controlled list of known encodings.

One honest caveat rather than a claim of impossibility: a C# enum cast does not validate, so `(SdCardLogFormat)99` is legal and would reach the device. Today that silently yields JSON; after this change it yields `-224`. That is the improvement, not a new risk — but it is the one path by which an existing client could newly see an error, so it belongs in the release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
