### PR TITLE
docs(edge): TMR6 free-runs from boot, so idle edge timestamps are valid (#731)

### DIFF
--- a/firmware/src/HAL/UserEdge/UserEdge.c
+++ b/firmware/src/HAL/UserEdge/UserEdge.c
@@ -14,8 +14,16 @@
  *     boot (PMD4<T8MD,T9MD>) and MUST be PMD-ungated before their SFRs respond.
  *   - Timestamps come from TMR6 read directly — the streaming timebase
  *     (TSTimerIndex = TMR_INDEX_6), so an edge and an ADC sample carry the same
- *     clock and correlate by construction. TMR6 only runs while streaming, so a
- *     timestamp is meaningful during a stream; the edge COUNT is the idle signal.
+ *     clock and correlate by construction. TMR6 free-runs from BOOT, not only
+ *     during a stream: Streaming_Init calls TimestampTimer_Init, which ends in
+ *     TimerApi_Start(TSTimerIndex), and nothing ever stops it again
+ *     (Streaming_Stop stops only TimerIndex, the stream trigger). So an idle
+ *     edge timestamp is just as valid and monotonic as one taken mid-stream --
+ *     it simply has no ADC samples to correlate against until a stream runs.
+ *     The counter is 32-bit and wraps, so a consumer differencing two stamps
+ *     must use unsigned wrap arithmetic; the wrap period follows from the
+ *     device-reported timestamp frequency (#730, SYST:SYSInfoPB? timestamp_freq)
+ *     rather than any figure assumed here.
  *
  * Concurrency: the four INT ISRs and the two rollover ISRs all run at priority 3.
  * Equal-priority interrupts do not preempt one another on this MIPS core, so the


### PR DESCRIPTION
Refs #731, #667. **Comment-only** — no behavior change.

## The false statement, on main today

`UserEdge.c:17-18`:

> *"TMR6 only runs while streaming, so a timestamp is meaningful during a stream; the edge COUNT is the idle signal."*

This is wrong, and it **under-claims a shipped feature**. `DIO:EVENt:*` is live on main (`SCPIDIO.c`, and `UserEdge.c` is in `configurations.xml`), so anyone building against it would read this and conclude idle edge timestamps are useless.

## Verified in source (V)

| claim | evidence |
|---|---|
| `Streaming_Init` runs at boot | `streaming.c:1928`, called from `app_freertos.c:720` |
| it starts the TS timer | `TimestampTimer_Init` at `:1995` ends in `TimerApi_Start(TSTimerIndex)` at `:2897` |
| nothing ever stops it | the `TimerApi_Stop(TSTimerIndex)` at `:2891` is the stop half of init's own stop/re-init/start; it is the **only** `Stop` on `TSTimerIndex` in the whole tree |
| `Streaming_Stop` doesn't touch it | it stops only `TimerIndex`, the stream trigger (`:1834`, `:1996`) |

**TMR6 starts at boot and free-runs.** An idle edge timestamp is as valid and monotonic as a mid-stream one — it simply has no ADC samples to correlate against until a stream runs.

## The code was already correct

I checked whether anything *enforced* the false belief, since that would make this a behavior bug rather than a comment fix:

- `UserEdge_EventNext` applies **no** streaming gate — it returns stamps whenever events exist.
- `edge_Streaming()` (`UserEdge.c:234`) is used only to reject **arm/disarm** mid-stream, which is deliberate and documented.

So the capability was always there; only the comment mis-described it. **Nothing about device behavior changes.**

## One thing the old text never said

The counter is 32-bit and **wraps**, so a consumer differencing two stamps must use unsigned wrap arithmetic. I deliberately did *not* hardcode a wrap period in MHz — the #487 clock change would have invalidated exactly that kind of baked-in figure — and instead point at the device-reported `timestamp_freq` (#730).

## Why this was orphaned

#731's audit found it and tracked the fix to the #667 branch, [PR #705](https://github.com/daqifi/daqifi-nyquist-firmware/pull/705). **That PR is closed**, so the correction was never made while the false comment shipped to main.

## Test plan

**Comment-only — exempt from the companion-regression-test rule** (which exempts docs/comment-only PRs with no behavior change). There is no behavior to pin: the diff touches a block comment and nothing else.

The underlying claim *is* bench-verifiable — arm an edge event with no stream running and confirm `DIO:EVENt:NEXT?` returns advancing stamps — but that needs a DIO edge source, and the bench is mid-soak. Noted as a follow-up on #667 rather than blocked on here, since no code in this PR could fail it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)