### PR TITLE
fix(scpi): a not-implemented command must not explain itself in the stream

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -442,12 +442,33 @@ static scpi_result_t SCPI_Reset(scpi_t * context) {
 }
 
 /**
- * Placeholder for un-implemented SCPI commands
+ * Placeholder for un-implemented SCPI commands.
+ *
+ * These stay registered rather than being deleted: SCPI_Help enumerates them under
+ * its "Not Implemented:" heading, which is how a caller discovers that a command is
+ * planned-but-absent rather than simply unknown. Deleting them would answer -113
+ * ("Undefined header") for free, but would also delete that record.
+ *
  * @param context The SCPI context
- * @return always SCPI_RES_ERROR
+ * @return always SCPI_RES_ERR
  */
 static scpi_result_t SCPI_NotImplemented(scpi_t * context) {
-    context->interface->write(context, "Not Implemented!", 16);
+    /* Safe to dereference: libscpi reaches this callback THROUGH param_list.cmd
+     * (processCommand, parser.c), so it cannot be NULL here. */
+    LOG_E("SCPI: '%s' is registered but not implemented",
+          context->param_list.cmd->pattern);
+
+    /* Pushed explicitly rather than left to parser.c's default. Pushing sets
+     * cmd_error (error.c), and parser.c only supplies its own -200 when that flag
+     * is clear -- so the queue still holds exactly one -200, unchanged for callers.
+     *
+     * What changes is that the explanation no longer goes out on the wire. The old
+     * body wrote a bare "Not Implemented!" onto the interface, which is neither a
+     * SCPI response nor terminated, so it ran straight into the transport's own
+     * error line and a client read "Not Implemented!**ERROR: -200, ...". Per the
+     * project rule, an error travels as a code and is explained via SYST:LOG?,
+     * never as data in the response stream. */
+    SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
     return SCPI_RES_ERR;
 }
 


### PR DESCRIPTION
Fixes #806.

## The defect

`firmware/src/services/SCPI/SCPIInterface.c`:

```c
static scpi_result_t SCPI_NotImplemented(scpi_t * context) {
    context->interface->write(context, "Not Implemented!", 16);
    return SCPI_RES_ERR;
}
```

That string is not a SCPI response and is not terminated, so it ran directly into the transport's own error line and a client read:

```
Not Implemented!**ERROR: -200, "Execution error"
```

Two things wrong with it:

1. **It contradicts our own rule.** CLAUDE.md: *"All errors go through the error logging function and are never sent out in the stream. On error, the SCPI command returns the error through its own handling; the user calls `SYSTem:LOG?` to learn what the error was."* This did the opposite — the explanation went out as data, where a client parsing a reply reads it as a value.
2. **Nothing logged it.** The one place the rule says to look held nothing, so the only account of what happened was the token in the stream.

**Reach: 8 registered commands**, including the `LAN:HOST` and `LAN:MAC` **setters** — a caller gets a stream token instead of a typed error and may not notice the setting never took.

## What the issue left open, now answered on hardware

The issue flagged one unknown (tagged **I**): whether `SYST:ERR?` reported anything at all, since the callback returned `SCPI_RES_ERR` without pushing. **It does** — the queue held `-200,"Execution error"`, so this was "wrong channel", not "wrong channel *and* invisible". That narrowed the fix considerably.

Two things the bench probe also corrected about my own reading of the code (**V**/**E**):

- **`**ERROR:` is not this callback's doing.** It is written by the transport layer (`UsbCdc.c:1135`, `wifi_tcp_server.c:235`) for *every* SCPI error — an unregistered header prints `**ERROR: -113, "Undefined header"` the same way. So the defect is narrower than "it prints an error inline": it is the *bare, unterminated, non-conformant token* that concatenates onto that line.
- **`SCPI_Help` enumerates these commands** under a `Not Implemented:` heading. That is an argument the issue did not have for **keeping** the registrations rather than deleting them: deleting would answer `-113` for free and shrink the command surface, but would also delete the record that tells a caller these are planned-but-absent rather than unknown.

## The fix

Push the error explicitly, name the command in the log, drop the inline write.

The explicit push is deliberate rather than left to the default: `SCPI_ErrorPush` sets `cmd_error` (`error.c:199`), and `parser.c:144-147` only supplies its own `-200` when that flag is **clear** — so the queue still holds exactly **one** `-200`. **The error code a client sees is unchanged;** only the stream token goes away.

`context->param_list.cmd` needs no NULL guard: `processCommand` dereferences it to reach this callback in the first place (`parser.c:127,143`).

## Bench results

Nq1 `7E2898F46200E8A7` on COM3, **same session, same board**, baseline built from this same worktree with the change stashed — so the two images differ only by this commit.

| | reply | `SYST:ERR?` | second `SYST:ERR?` | `SYST:LOG?` |
|---|---|---|---|---|
| **before** | `Not Implemented!**ERROR: -200, "Execution error"` | `-200` | `0,"No error"` | *silent* |
| **after** | `**ERROR: -200, "Execution error"` | `-200` | `0,"No error"` | `SCPI: 'SYSTem:COMMunicate:LAN:CONnected?' is registered but not implemented` |

Exactly one error queued either way, and an unregistered header still answers `-113` — a placeholder and an absent command stay distinguishable.

## Test plan

- **Companion regression test:** [daqifi-python-test-suite#166](https://github.com/daqifi/daqifi-python-test-suite/pull/166) — **3 PASS / 2 FAIL on `main`, 5 PASS / 0 FAIL with this change.** Three of its five cases pass on both firmwares on purpose: they pin that the command still *fails*, that exactly one error is queued, and that an unregistered header is still `-113`. Without those, "the token is gone" would also be satisfied by a command that silently succeeded.
- **Build:** clean at `-O3 -Werror` (XC32 v4.60, MPLAB X v6.30), `default` configuration.
- **Hardware: run in both directions**, not just after.

## Wiki

The wiki distinguished "not registered" from "registered against a placeholder callback" but never said what a placeholder *returns*. A note has been prepared for `01-SCPI-Interface.md` documenting `-200` vs `-113` and pointing at `SYST:LOG?`, to push **on merge**. Checked against the #805 sync gate: `OK: the wiki and the command table agree`.

## Client risk

Low, and checked rather than assumed. These eight commands never did anything; the only visible change is that a client which was *parsing the reply text* no longer sees the `Not Implemented!` token. Any client keying off the SCPI error code is unaffected — it was `-200` before and is `-200` now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
