### PR TITLE
harden(sd): fail the build if SYS_FS_FSTAT.lfname ever overlaps FILINFO

### DIFF
--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -11,6 +11,31 @@
 #include "services/UsbCdc/UsbCdc.h"
 #include "Util/CRC32.h"   /* #306 */
 #include "services/streaming.h"  // For Streaming_ResetSdPbMetadata on file rotation
+#include <stddef.h>
+#include "ff.h"   /* #810: FILINFO, for the layout assert below */
+
+/* #810: FATFS_readdir (sys_fs_fat_interface.c) hands ONE buffer to f_readdir as a
+ * FILINFO and then reinterprets it as a SYS_FS_FSTAT, reading lfname out of it and
+ * writing through it:
+ *
+ *     res = f_readdir(dp, finfo);
+ *     if ((res == FR_OK) && (fileStat->lfname != NULL)) { fileStat->lfname[0] = '\0'; }
+ *
+ * That is safe only while lfname sits past everything f_readdir writes. If it ever
+ * lands inside fname[], lfname becomes four FILENAME CHARACTERS reinterpreted as a
+ * pointer and the line above is a wild one-byte write to a card-content-derived
+ * address -- intermittent, far from its cause, and with no diagnostic.
+ *
+ * Today it holds by coincidence: SYS_FS_FILE_NAME_LEN (MCC-generated
+ * configuration.h) happens to agree with FF_LFN_BUF (ffconf.h). Nothing ties those
+ * two files together, so an MCC regeneration, a FatFs bump, or someone shortening
+ * the name limit to reclaim RAM would break it silently.
+ *
+ * This is a compile-time invariant check, not a defensive runtime guard: the
+ * invariant is undocumented, unenforced, and split across two generated files. */
+_Static_assert(offsetof(SYS_FS_FSTAT, lfname) >= sizeof(FILINFO),
+               "SYS_FS_FSTAT.lfname overlaps what f_readdir writes: FATFS_readdir "
+               "would write through a pointer built from filename bytes");
 
 #define SD_CARD_MANAGER_CIRCULAR_BUFFER_SIZE SD_CARD_MANAGER_DEFAULT_CIRCULAR_SIZE
 #define SD_CARD_MANAGER_FILE_PATH_LEN_MAX (SYS_FS_FILE_NAME_LEN*2)


### PR DESCRIPTION
Fixes #810.

Found while eliminating hypotheses on [#795](https://github.com/daqifi/daqifi-nyquist-firmware/issues/795). **Not a live defect** — a latent one that is safe today only by coincidence, with no diagnostic if the coincidence ends.

## The hazard

`FATFS_readdir` (`sys_fs_fat_interface.c:386-408`) hands **one** buffer to `f_readdir` as a `FILINFO`, then reinterprets the same bytes as a `SYS_FS_FSTAT`, reads `lfname` out of it, and **writes through it**:

```c
res = f_readdir(dp, finfo);
if ((res == FR_OK) && (fileStat->lfname != NULL)) {
    fileStat->lfname[0] = '\0';
}
```

Safe only while `lfname` sits past everything `f_readdir` writes. If it ever lands inside `fname[]`, `lfname` is **four filename characters reinterpreted as a pointer**, and that line is a wild one-byte write to an address derived from whatever is on the card — intermittent, nowhere near its cause, no diagnostic.

## Why it holds today, and why that is not enough

```
                        FILINFO            SYS_FS_FSTAT
fname[256]              22                 22   -> ends at 278
lfname                   -                280   (4-byte aligned, PAST FILINFO's 280)
```

It works because `SYS_FS_FILE_NAME_LEN` (255, MCC-generated `configuration.h`) happens to agree with `FF_LFN_BUF` (255, `ffconf.h`). **Nothing ties those two files together.** Any of these breaks it silently:

- an MCC regeneration changing the name limit — and MCC regeneration is a known routine hazard in this repo (see the wolfSSL pin note in CLAUDE.md)
- a FatFs bump altering `FILINFO`
- someone shortening `SYS_FS_FILE_NAME_LEN` to reclaim RAM — a *reasonable-looking* change, since 288 bytes per `FSTAT` is not nothing on this part and five of them are stack locals in `sd_card_manager.c`

## The change

One `_Static_assert` in **our** file (not the generated tree, which regenerates), next to the code that consumes the struct.

**This is a compile-time invariant check, not a defensive runtime guard.** The project declines the latter on documented invariants; this invariant is undocumented, unenforced, and split across two files owned by different generators. Zero runtime cost, zero flash cost.

## Verification — mutation-proved, not assumed

```
SYS_FS_FILE_NAME_LEN 255  ->  build clean (make exit 0)
SYS_FS_FILE_NAME_LEN 100  ->  make exit 2:
    sd_card_manager.c:36:1: error: static assertion failed:
    "SYS_FS_FSTAT.lfname overlaps what f_readdir writes: FATFS_readdir would
     write through a pointer built from filename bytes"
restored to 255           ->  build clean again
```

That is the whole test: the guard fires on exactly the change it exists to catch, and does not fire otherwise.

## No companion regression test

Deliberate, and I would rather state the reasoning than let it look like an omission. The change has **no runtime behaviour** — it emits no code. There is nothing for a `daqifi-python-test-suite` script to send to a device or assert about a reply. Its correctness is established at build time and is demonstrated by the mutation above, which is a stronger check than a bench test could offer for this class of change.

Build: clean at `-O3 -Werror` (XC32 v4.60, MPLAB X v6.30), `default` configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
