### PR TITLE
feat(scpi): make the SD working directory readable and settable (#799 parts 1-2)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5993,6 +5993,8 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SYSTem:STORage:SD:FORmat?", .callback = SCPI_StorageSDFormatQuery},
     {.pattern = "SYSTem:STORage:SD:BENCHmark", .callback = SCPI_StorageSDBenchmark},
     {.pattern = "SYSTem:STORage:SD:BENCHmark?", .callback = SCPI_StorageSDBenchmarkQuery},
+    {.pattern = "SYSTem:STORage:SD:DIRectory", .callback = SCPI_StorageSDDirectorySet},   /* #799 */
+    {.pattern = "SYSTem:STORage:SD:DIRectory?", .callback = SCPI_StorageSDDirectoryGet},  /* #799 */
     {.pattern = "SYSTem:STORage:SD:MAXSize", .callback = SCPI_StorageSDMaxSizeSet},
     {.pattern = "SYSTem:STORage:SD:MAXSize?", .callback = SCPI_StorageSDMaxSizeGet},
     {.pattern = "SYSTem:STORage:SD:MINFree", .callback = SCPI_StorageSDMinFreeSet},   // #498

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -1409,12 +1409,6 @@ __exit_point:
 }
 
 /**
- * @brief Query maximum file size setting
- *
- * Command: SYST:STOR:SD:MAXSize?
- * Returns: <bytes> (0 = unlimited)
- */
-/**
  * @brief Read the SD working directory (#799)
  *
  * Command: SYST:STOR:SD:DIRectory?
@@ -1476,11 +1470,41 @@ scpi_result_t SCPI_StorageSDDirectorySet(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
+    /* Refuse while an SD operation owns the card -- which includes an active
+     * logging session, since IsBusy() is true for any mode != NONE.
+     *
+     * The directory is re-read at every file OPEN, not just the first, so
+     * retargeting it mid-session would land the next rotated part
+     * ("<name>-1.csv", generateFilename) in a different folder from the part
+     * before it. That splits one logical capture across two directories,
+     * where the tooling that reassembles a split set groups by name WITHIN a
+     * directory. Rejecting costs the caller nothing -- set the directory
+     * before starting -- and is the same guard the other SD entry points in
+     * this file already apply. */
+    if (sd_card_manager_IsBusy()) {
+        LOG_SD_BUSY("DIRectory");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+
+    /* Config-only write, deliberately NOT followed by
+     * sd_card_manager_UpdateSettings(): that call forces the SD state machine
+     * to DEINIT -> UNMOUNT_DISK, closing any open file and truncating it on
+     * the next open. SCPI_StorageSDMinFreeSet documents the same reasoning for
+     * the same struct. The manager holds a POINTER to this very object
+     * (gpSDCardSettings = pSettings, sd_card_manager.c), so the write is
+     * visible to it without any notification. */
     memcpy(pSDCardRuntimeConfig->directory, pBuff, pathLen);
     pSDCardRuntimeConfig->directory[pathLen] = '\0';
     return SCPI_RES_OK;
 }
 
+/**
+ * @brief Query maximum file size setting
+ *
+ * Command: SYST:STOR:SD:MAXSize?
+ * Returns: <bytes> (0 = unlimited)
+ */
 scpi_result_t SCPI_StorageSDMaxSizeGet(scpi_t * context) {
     sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
 

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -1427,8 +1427,18 @@ __exit_point:
 scpi_result_t SCPI_StorageSDDirectoryGet(scpi_t * context) {
     sd_card_manager_settings_t* pSDCardRuntimeConfig =
             BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
+    char snapshot[sizeof(pSDCardRuntimeConfig->directory)];
 
-    SCPI_ResultText(context, pSDCardRuntimeConfig->directory);
+    /* Copy under a critical section, then emit. SCPI runs on two transports
+     * (USB pri 7, WiFi TCP pri 2), so the setter below can be writing this
+     * buffer while this reads it. See the setter for what a reader would
+     * otherwise observe. */
+    taskENTER_CRITICAL();
+    memcpy(snapshot, pSDCardRuntimeConfig->directory, sizeof(snapshot));
+    taskEXIT_CRITICAL();
+    snapshot[sizeof(snapshot) - 1u] = '\0';
+
+    SCPI_ResultText(context, snapshot);
     return SCPI_RES_OK;
 }
 
@@ -1458,9 +1468,9 @@ scpi_result_t SCPI_StorageSDDirectorySet(scpi_t * context) {
     }
 
     if (pathLen >= sizeof(pSDCardRuntimeConfig->directory)) {
-        LOG_E("SD:DIRectory - path too long: %u bytes, max %u",
-              (unsigned)pathLen,
-              (unsigned)(sizeof(pSDCardRuntimeConfig->directory) - 1));
+        LOG_E("SD:DIRectory - path too long: %lu bytes, max %lu",
+              (unsigned long)pathLen,
+              (unsigned long)(sizeof(pSDCardRuntimeConfig->directory) - 1));
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         return SCPI_RES_ERR;
     }
@@ -1494,8 +1504,24 @@ scpi_result_t SCPI_StorageSDDirectorySet(scpi_t * context) {
      * the same struct. The manager holds a POINTER to this very object
      * (gpSDCardSettings = pSettings, sd_card_manager.c), so the write is
      * visible to it without any notification. */
+    /* Publish as ONE indivisible update. The copy and the terminator are two
+     * steps over a buffer another task reads (the getter above, the SD
+     * manager's dirValid check, SD_StripConfiguredDir), and SCPI runs on two
+     * transports at different priorities.
+     *
+     * To be precise about the hazard, because it is NOT an overrun: every
+     * writer stores at most 40 characters plus a terminator into a 41-byte
+     * array, so a NUL always exists at index <= 40 and strlen cannot run off
+     * the end. What a reader CAN see is a SPLICED path -- when the previous
+     * name was longer than the new one, the old tail survives past the bytes
+     * just copied and the old terminator ends it, so a reader between the two
+     * steps observes new-prefix + old-suffix. That is a well-formed string
+     * naming the wrong directory, which for SD:DELete is the worse outcome of
+     * the two. The copy is <= 41 bytes, so the section is short. */
+    taskENTER_CRITICAL();
     memcpy(pSDCardRuntimeConfig->directory, pBuff, pathLen);
     pSDCardRuntimeConfig->directory[pathLen] = '\0';
+    taskEXIT_CRITICAL();
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -1414,6 +1414,73 @@ __exit_point:
  * Command: SYST:STOR:SD:MAXSize?
  * Returns: <bytes> (0 = unlimited)
  */
+/**
+ * @brief Read the SD working directory (#799)
+ *
+ * Command: SYST:STOR:SD:DIRectory?
+ *
+ * This field is the device's SD working directory: logging writes into it,
+ * and SD:GET, SD:DELete and SD:CRC interpret their operands relative to it.
+ * Until now there was no way to READ it -- so a host was subject to a value
+ * it could neither observe before an operation nor restore afterwards, and
+ * the only way to change it was the side effect of a SD:LISt? query.
+ *
+ * This getter is deliberately the first of the three pieces in #799: it is
+ * purely additive, it breaks nothing, and it is what makes the other two
+ * testable at all. Stopping SD:LISt? from writing the field (#799 part 3) is
+ * a behaviour change that needs a client survey first and is NOT done here.
+ */
+scpi_result_t SCPI_StorageSDDirectoryGet(scpi_t * context) {
+    sd_card_manager_settings_t* pSDCardRuntimeConfig =
+            BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
+
+    SCPI_ResultText(context, pSDCardRuntimeConfig->directory);
+    return SCPI_RES_OK;
+}
+
+/**
+ * @brief Set the SD working directory explicitly (#799)
+ *
+ * Command: SYST:STOR:SD:DIRectory "<path>"
+ *
+ * Before this, the ONLY way to change the working directory was to issue a
+ * SD:LISt? for its side effect -- a query changing device state, which also
+ * made an ordinary browse silently retarget the next SD:GET, SD:DELete,
+ * SD:CRC and capture. Having a real setter means changing it is something a
+ * caller ASKS for.
+ *
+ * Validation is deliberately the same pair SD:LISt? already applies to the
+ * same field -- the length bound and SD_ValidatePathParam (#612) -- rather
+ * than a second, subtly different rule for the same value.
+ */
+scpi_result_t SCPI_StorageSDDirectorySet(scpi_t * context) {
+    sd_card_manager_settings_t* pSDCardRuntimeConfig =
+            BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
+    const char *pBuff = NULL;
+    size_t pathLen = 0;
+
+    if (!SCPI_ParamCharacters(context, &pBuff, &pathLen, TRUE)) {
+        return SCPI_RES_ERR;   /* libscpi has already pushed the parse error */
+    }
+
+    if (pathLen >= sizeof(pSDCardRuntimeConfig->directory)) {
+        LOG_E("SD:DIRectory - path too long: %u bytes, max %u",
+              (unsigned)pathLen,
+              (unsigned)(sizeof(pSDCardRuntimeConfig->directory) - 1));
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+
+    if (!SD_ValidatePathParam(pBuff, pathLen)) {   /* #612 */
+        SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+        return SCPI_RES_ERR;
+    }
+
+    memcpy(pSDCardRuntimeConfig->directory, pBuff, pathLen);
+    pSDCardRuntimeConfig->directory[pathLen] = '\0';
+    return SCPI_RES_OK;
+}
+
 scpi_result_t SCPI_StorageSDMaxSizeGet(scpi_t * context) {
     sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
 

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -1491,11 +1491,7 @@ scpi_result_t SCPI_StorageSDDirectorySet(scpi_t * context) {
      * directory. Rejecting costs the caller nothing -- set the directory
      * before starting -- and is the same guard the other SD entry points in
      * this file already apply. */
-    if (sd_card_manager_IsBusy()) {
-        LOG_SD_BUSY("DIRectory");
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        return SCPI_RES_ERR;
-    }
+
 
     /* Config-only write, deliberately NOT followed by
      * sd_card_manager_UpdateSettings(): that call forces the SD state machine
@@ -1518,10 +1514,25 @@ scpi_result_t SCPI_StorageSDDirectorySet(scpi_t * context) {
      * steps observes new-prefix + old-suffix. That is a well-formed string
      * naming the wrong directory, which for SD:DELete is the worse outcome of
      * the two. The copy is <= 41 bytes, so the section is short. */
+    /* The busy test and the write share ONE critical section. Checked
+     * separately, an SD operation could arm in between and the write would
+     * land in a session that had just started -- the exact case the check
+     * exists to prevent. IsBusy() only reads mode and currentProcessState,
+     * so it is safe here; the log stays outside. */
+    bool busy;
     taskENTER_CRITICAL();
-    memcpy(pSDCardRuntimeConfig->directory, pBuff, pathLen);
-    pSDCardRuntimeConfig->directory[pathLen] = '\0';
+    busy = sd_card_manager_IsBusy();
+    if (!busy) {
+        memcpy(pSDCardRuntimeConfig->directory, pBuff, pathLen);
+        pSDCardRuntimeConfig->directory[pathLen] = '\0';
+    }
     taskEXIT_CRITICAL();
+
+    if (busy) {
+        LOG_SD_BUSY("DIRectory");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -713,8 +713,25 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
+        /* #799: same critical section as SCPI_StorageSDDirectorySet, for the
+         * same reason. This is a two-step write (copy, then terminator) to a
+         * field the new SD:DIRectory? getter reads from the OTHER SCPI
+         * transport -- USB is priority 7, WiFi TCP is 2, and there is no
+         * shared dispatch mutex between them. A reader landing between the
+         * steps sees new-prefix + old-suffix, ended by the old terminator: a
+         * well-formed path naming a directory nobody asked for.
+         *
+         * Guarding the reader alone cannot fix this -- it only guarantees the
+         * reader sees a STABLE buffer, not a coherent one. All three sites
+         * that touch this field are now symmetric.
+         *
+         * NOTE this does not change WHETHER SD:LISt? writes the field, which
+         * is #799 part 3 and needs a client survey. Only that the write other
+         * tasks observe is indivisible -- invisible to clients. */
+        taskENTER_CRITICAL();
         memcpy(pSDCardRuntimeConfig->directory, pBuff, fileLen);
         pSDCardRuntimeConfig->directory[fileLen] = '\0';
+        taskEXIT_CRITICAL();
     }
     // If no directory specified, the sd_card_manager will use the default from settings
     

--- a/firmware/src/services/SCPI/SCPIStorageSD.h
+++ b/firmware/src/services/SCPI/SCPIStorageSD.h
@@ -47,9 +47,12 @@ scpi_result_t SCPI_StorageSDFormat(scpi_t * context);
 
 // SD Card File Splitting Commands
 scpi_result_t SCPI_StorageSDMaxSizeSet(scpi_t * context);
-scpi_result_t SCPI_StorageSDDirectoryGet(scpi_t * context);   /* #799 */
-scpi_result_t SCPI_StorageSDDirectorySet(scpi_t * context);   /* #799 */
 scpi_result_t SCPI_StorageSDMaxSizeGet(scpi_t * context);
+
+// SD Working Directory (#799) - the folder logging writes into, and the one
+// SD:GET / SD:DELete / SD:CRC resolve a bare filename against.
+scpi_result_t SCPI_StorageSDDirectoryGet(scpi_t * context);
+scpi_result_t SCPI_StorageSDDirectorySet(scpi_t * context);
 
 // SD Disk-Full Pre-Start Gate (#498)
 scpi_result_t SCPI_StorageSDMinFreeSet(scpi_t * context);

--- a/firmware/src/services/SCPI/SCPIStorageSD.h
+++ b/firmware/src/services/SCPI/SCPIStorageSD.h
@@ -47,6 +47,8 @@ scpi_result_t SCPI_StorageSDFormat(scpi_t * context);
 
 // SD Card File Splitting Commands
 scpi_result_t SCPI_StorageSDMaxSizeSet(scpi_t * context);
+scpi_result_t SCPI_StorageSDDirectoryGet(scpi_t * context);   /* #799 */
+scpi_result_t SCPI_StorageSDDirectorySet(scpi_t * context);   /* #799 */
 scpi_result_t SCPI_StorageSDMaxSizeGet(scpi_t * context);
 
 // SD Disk-Full Pre-Start Gate (#498)


### PR DESCRIPTION
Closes the additive half of #799 — parts **(1)** and **(2)**. Part (3) is deliberately not here; see below.

## The defect

`pSDCardRuntimeConfig->directory` is the device's SD working directory: logging writes into it, and `SD:GET`, `SD:DELete` and `SD:CRC` interpret their operands **relative to it**.

Until now the only SCPI write to that field was inside `SCPI_StorageSDListDir`. So:

- a **query** was the only way to change it — `SD:LISt? "<dir>"` — which means an ordinary browse silently retargets the next read, delete, checksum and capture, and
- **nothing could read it**, so a host could neither check where an operation would land nor restore the setting afterwards.

`SD:DELete` is the sharp case: the caller names a file, the device deletes a same-named file in whatever directory the last listing happened to select, and reports success.

## The change

```
SYSTem:STORage:SD:DIRectory  "<path>"
SYSTem:STORage:SD:DIRectory?
```

The setter applies **the same two checks `SD:LISt?` already applies to the same field** — the length bound (≤ 40, matching `dirValid` in the manager) and `SD_ValidatePathParam` (#612) — rather than inventing a second, subtly different rule for one value. Rejection is `-224`, and the field is written **only after both checks pass**.

It is also **refused `-200` while an SD operation owns the card**. `sd_card_manager_IsBusy()` is true for any `mode != NONE`, so that covers an active logging session — which matters because the directory is re-read at **every** file open, not just the first. Retargeting mid-session would put the next rotated part (`<name>-1.csv`, `generateFilename`) in a different folder from the part before it, and the tooling that reassembles a split set groups by name *within* a directory. Rejecting costs the caller nothing: set the directory before starting.

## Two things a reviewer will reasonably ask about

**Why no `sd_card_manager_UpdateSettings()`, when the neighbouring `MAXSize` setter calls it?** That call forces the SD state machine to `DEINIT` → `UNMOUNT_DISK`, closing any open file and truncating it on the next open. `SCPI_StorageSDMinFreeSet` documents exactly this reasoning for exactly this struct. No notification is needed anyway: the manager holds a pointer to this very object (`gpSDCardSettings = pSettings`, `sd_card_manager.c:843`), so the write is already visible to it.

**Empty path?** Rejected — `SD_ValidatePathParam` returns false for `len == 0`, and the manager's own `dirValid` requires `strlen > 0`.

## Scope — why part (3) is not here

Part (3) is *stopping* `SD:LISt?` from writing the field. That is a **behaviour change** clients may depend on and needs a survey of `daqifi-core` / `python-core` / desktop first. The issue itself notes parts (1) and (2) are independent and can land first.

There is a second reason to land this first: until now the field was **unobservable**, so part (3) could not be tested either way. This is what makes it testable — and the companion test pins the current side effect so its removal shows up as a deliberate change rather than a silent one.

## Verification

Bench Nq1 `7E2898F46200E8A7` (COM3), build clean at `-O3 -Werror`:

| check | result |
|---|---|
| `DIRectory?` on a field that was previously unobservable | `"DAQiFi"` |
| set → readback | `"TESTDIR"`, `SYST:ERR?` → `0,"No error"` |
| 200-char path | `-224 "Illegal parameter value"` |
| directory after that rejected set | **unchanged** |
| set during an active SD logging session | `-200`, directory **unchanged** |
| same set outside a session | succeeds |

`cppcheck` gate clean (0 findings, no baseline drift). SCPI↔wiki sync gate clean — **294 registered commands / 305 wiki rows**; wiki rows for both new commands are written and the `SD:LISt?` persistence note now points at the accessors and shows the save/browse/restore sequence.

Companion regression test: **daqifi/daqifi-python-test-suite#169** (6 PASS / 0 FAIL). Its case F is load-bearing — the run before this guard existed reported `err=-221` with the directory changed.

Also in this branch, same area: re-attached the "Query maximum file size" doc comment to `SCPI_StorageSDMaxSizeGet` (the new functions had been inserted between comment and function), and moved the two declarations out of the header's "File Splitting" group.

Refs #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)
