### PR TITLE
fix(scpi): disabling the SD card must not strand streaming on SD (#759)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4162,27 +4162,51 @@ static scpi_result_t SCPI_SetStreamInterface(scpi_t * context) {
     sd_card_manager_settings_t* pSDCardSettings =
         BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
 
-    // Check if SD card is enabled when trying to use SD or USB+SD interfaces
-    if (param1 == StreamingInterface_SD || param1 == StreamingInterface_UsbAndSd) {
-        if (!pSDCardSettings->enable) {
-            LOG_E("Cannot set SD/USB+SD interface - SD card not enabled. Use SYSTem:STORage:SD:ENAble 1");
-            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-            return SCPI_RES_ERR;
-        }
-    }
+    /* #759: test the card's state and publish the selection in ONE atomic
+     * step. Checked separately, the SD-enabled test below and the store at the
+     * end are ~20 lines apart, and an SD disable can land between them --
+     * either SYST:STOR:SD:ENAble 0 from the other SCPI transport, or the SD
+     * task's own auto-disable on a mount failure. The release helper those
+     * paths call cannot see a selection that has passed its check but not yet
+     * been stored, so the store lands afterwards and recreates exactly the
+     * ActiveInterface = SD, SD disabled pairing this refusal exists to
+     * prevent -- the #759 strand, through the one door the helper cannot
+     * watch.
+     *
+     * Both operands are 32-bit and individually atomic on PIC32MZ; it is the
+     * read-decide-write across two objects that is not.
+     *
+     * Logging and the SCPI error stay OUTSIDE the section. */
+    bool rejectSdNotEnabled = false;
+    bool rejectWifiDuringSdWrite = false;
 
-    /* WiFi+SD SPI conflict: only a risk when switching explicitly to
-     * WiFi while SD is actively writing. Interface_All is USB+SD now
-     * (no WiFi), so no check needed for All. */
-    if (param1 == StreamingInterface_WiFi) {
-        if (pSDCardSettings->enable && pSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
-            LOG_E("Cannot switch to WiFi while SD streaming is active (SPI bus conflict). Stop streaming first.");
-            SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-            return SCPI_RES_ERR;
-        }
+    taskENTER_CRITICAL();
+    if ((param1 == StreamingInterface_SD ||
+         param1 == StreamingInterface_UsbAndSd) && !pSDCardSettings->enable) {
+        // Cannot stream to a card that is not enabled.
+        rejectSdNotEnabled = true;
+    } else if (param1 == StreamingInterface_WiFi &&
+               pSDCardSettings->enable &&
+               pSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
+        /* WiFi+SD SPI conflict: only a risk when switching explicitly to
+         * WiFi while SD is actively writing. Interface_All is USB+SD now
+         * (no WiFi), so no check needed for All. */
+        rejectWifiDuringSdWrite = true;
+    } else {
+        pRunTimeStreamConfig->ActiveInterface = (StreamingInterface) param1;
     }
+    taskEXIT_CRITICAL();
 
-    pRunTimeStreamConfig->ActiveInterface = (StreamingInterface) param1;
+    if (rejectSdNotEnabled) {
+        LOG_E("Cannot set SD/USB+SD interface - SD card not enabled. Use SYSTem:STORage:SD:ENAble 1");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+    if (rejectWifiDuringSdWrite) {
+        LOG_E("Cannot switch to WiFi while SD streaming is active (SPI bus conflict). Stop streaming first.");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -302,6 +302,35 @@ scpi_result_t SCPI_StorageSDEnableSet(scpi_t * context){
         }
         LOG_D("SD:ENAble - Disabling SD card manager\r\n");
         pSDCardRuntimeConfig->enable = false;
+
+        /* #759: do not leave streaming aimed at an interface that can no
+         * longer deliver. SCPI_SetStreamInterface REFUSES to select SD or
+         * USB+SD while SD is disabled -- so that combination is already
+         * understood to be invalid; it was simply still reachable by
+         * disabling SD afterwards, and nothing put it right.
+         *
+         * The consequence was silent, which is what made it expensive. The
+         * streaming task gates the USB write on ActiveInterface == USB, so a
+         * client that reconnects over USB and starts a stream gets a
+         * SUCCESSFUL start, `SYST:ERRor?` reading 0,"No error", and no data
+         * at all -- which reaches the host as "the device did not report its
+         * channel configuration". Measured on the bench: 5169 bytes in 2 s
+         * with the interface on USB, 8 bytes (the echo alone) with a
+         * stranded SD selection, 5130 bytes again once it is put back.
+         *
+         * Fall back to USB rather than to the streaming default, because USB
+         * is the interface that is always available. Only the two SD-bearing
+         * selections are touched; WiFi is left alone, since disabling the SD
+         * card says nothing about it. */
+        StreamingRuntimeConfig *pStreamCfg =
+                BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
+        if (pStreamCfg->ActiveInterface == StreamingInterface_SD ||
+            pStreamCfg->ActiveInterface == StreamingInterface_UsbAndSd) {
+            LOG_E("SD:ENAble 0 - streaming interface was %d (SD); falling back "
+                  "to USB so the stream still has somewhere to go (#759)",
+                  (int)pStreamCfg->ActiveInterface);
+            pStreamCfg->ActiveInterface = StreamingInterface_USB;
+        }
     }
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
     sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -303,34 +303,12 @@ scpi_result_t SCPI_StorageSDEnableSet(scpi_t * context){
         LOG_D("SD:ENAble - Disabling SD card manager\r\n");
         pSDCardRuntimeConfig->enable = false;
 
-        /* #759: do not leave streaming aimed at an interface that can no
-         * longer deliver. SCPI_SetStreamInterface REFUSES to select SD or
-         * USB+SD while SD is disabled -- so that combination is already
-         * understood to be invalid; it was simply still reachable by
-         * disabling SD afterwards, and nothing put it right.
-         *
-         * The consequence was silent, which is what made it expensive. The
-         * streaming task gates the USB write on ActiveInterface == USB, so a
-         * client that reconnects over USB and starts a stream gets a
-         * SUCCESSFUL start, `SYST:ERRor?` reading 0,"No error", and no data
-         * at all -- which reaches the host as "the device did not report its
-         * channel configuration". Measured on the bench: 5169 bytes in 2 s
-         * with the interface on USB, 8 bytes (the echo alone) with a
-         * stranded SD selection, 5130 bytes again once it is put back.
-         *
-         * Fall back to USB rather than to the streaming default, because USB
-         * is the interface that is always available. Only the two SD-bearing
-         * selections are touched; WiFi is left alone, since disabling the SD
-         * card says nothing about it. */
-        StreamingRuntimeConfig *pStreamCfg =
-                BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
-        if (pStreamCfg->ActiveInterface == StreamingInterface_SD ||
-            pStreamCfg->ActiveInterface == StreamingInterface_UsbAndSd) {
-            LOG_E("SD:ENAble 0 - streaming interface was %d (SD); falling back "
-                  "to USB so the stream still has somewhere to go (#759)",
-                  (int)pStreamCfg->ActiveInterface);
-            pStreamCfg->ActiveInterface = StreamingInterface_USB;
-        }
+        /* #759: the card is going away -- do not leave streaming aimed at it.
+         * The same release is needed from the SD task's two internal
+         * auto-disables (mount failure, unsupported filesystem), which an
+         * adversarial audit found the first version of this fix had missed, so
+         * the logic lives in one helper rather than three copies. */
+        Streaming_SdInterfaceReleased();
     }
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
     sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1220,6 +1220,9 @@ void sd_card_manager_ProcessState() {
                         if (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
                             LOG_E("[SD] SD disabled - re-run SYST:STOR:SD:ENAble 1 after inserting/fixing the card");
                             gpSDCardSettings->enable = false;
+                            /* #759: the card is gone; do not leave streaming
+                             * aimed at it (see Streaming_SdInterfaceReleased). */
+                            Streaming_SdInterfaceReleased();
                         }
                         gSDCardData.lastOperationSuccess = false;
                         gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
@@ -1245,6 +1248,8 @@ void sd_card_manager_ProcessState() {
                          * enable; a read-only query must not disarm SD. */
                         if (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
                             gpSDCardSettings->enable = false;
+                            /* #759: unusable filesystem is unusable card. */
+                            Streaming_SdInterfaceReleased();
                         }
                         gSDCardData.lastOperationSuccess = false;
                         gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2043,6 +2043,42 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     gpRuntimeConfigStream->Running = false;
 }
 
+/* #759: the SD card has become unavailable -- release any streaming selection
+ * that points at it.
+ *
+ * SCPI_SetStreamInterface REFUSES to select SD or USB+SD while the card is
+ * disabled, so that pairing is already understood to be invalid. It was still
+ * reachable by disabling the card AFTER selecting it, and the auto-detect in
+ * SCPI_StartStreaming deliberately preserves an explicit non-USB choice, so it
+ * survived every later start.
+ *
+ * The result was silent: the streaming task gates the USB write on
+ * ActiveInterface == USB, so a client that reconnected over USB got a
+ * SUCCESSFUL start, SYST:ERRor? reading 0,"No error", and no data at all.
+ *
+ * This lives here, and takes no arguments, because THREE call sites need it and
+ * an adversarial audit found the first version of the fix had patched only one:
+ * the SCPI setter, plus the SD task's two internal auto-disables (mount failure
+ * after retries, and an unsupported filesystem). Those two are the more likely
+ * field triggers -- a card that is missing or wrongly formatted needs no user
+ * action at all. One helper rather than three copies, so a fourth site cannot
+ * drift out of sync.
+ *
+ * Falls back to USB because USB is always there. WiFi and USB selections are
+ * deliberately untouched: losing the SD card says nothing about them, and
+ * clobbering a WiFi selection would be the same bug wearing different clothes. */
+void Streaming_SdInterfaceReleased(void) {
+    if (gpRuntimeConfigStream == NULL) {
+        return;   /* before Streaming_Init; nothing to release */
+    }
+    StreamingInterface active = gpRuntimeConfigStream->ActiveInterface;
+    if (active == StreamingInterface_SD || active == StreamingInterface_UsbAndSd) {
+        LOG_E("SD unavailable - streaming interface was %d (SD); falling back to "
+              "USB so the stream still has somewhere to go (#759)", (int)active);
+        gpRuntimeConfigStream->ActiveInterface = StreamingInterface_USB;
+    }
+}
+
 void Streaming_ResetSdPbMetadata(void) {
     gSdPbMetadataSent = false;
     gSdFileWasReady = false;

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2071,11 +2071,31 @@ void Streaming_SdInterfaceReleased(void) {
     if (gpRuntimeConfigStream == NULL) {
         return;   /* before Streaming_Init; nothing to release */
     }
-    StreamingInterface active = gpRuntimeConfigStream->ActiveInterface;
-    if (active == StreamingInterface_SD || active == StreamingInterface_UsbAndSd) {
+    /* Decide and publish in ONE atomic step. This is a read-decide-write on a
+     * field three contexts touch -- USB SCPI (pri 7), WiFi SCPI (pri 2) and
+     * the SD task (pri 5) -- so a plain compare-then-assign can land between
+     * another task's SYST:STR:INT and clobber the choice it just made with
+     * USB. The store itself is a single 32-bit write and atomic on PIC32MZ;
+     * it is the read-decide-write pair that is not, which is the case the
+     * project's atomicity rules reserve a critical section for.
+     *
+     * The section spans one compare and one store. The log stays outside it,
+     * so interrupt latency does not pay for the message. */
+    StreamingInterface active;
+    bool released;
+
+    taskENTER_CRITICAL();
+    active = gpRuntimeConfigStream->ActiveInterface;
+    released = (active == StreamingInterface_SD ||
+                active == StreamingInterface_UsbAndSd);
+    if (released) {
+        gpRuntimeConfigStream->ActiveInterface = StreamingInterface_USB;
+    }
+    taskEXIT_CRITICAL();
+
+    if (released) {
         LOG_E("SD unavailable - streaming interface was %d (SD); falling back to "
               "USB so the stream still has somewhere to go (#759)", (int)active);
-        gpRuntimeConfigStream->ActiveInterface = StreamingInterface_USB;
     }
 }
 

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -497,6 +497,11 @@ void TimestampTimer_Init( void );
  * Resets the SD protobuf metadata flag so the next SD log file
  * gets a self-describing metadata header as its first message.
  */
+/* #759: release a streaming selection that points at the SD card once the card
+ * is no longer available. Safe to call from any task; no-op unless the active
+ * interface is SD or USB+SD. */
+void Streaming_SdInterfaceReleased(void);
+
 void Streaming_ResetSdPbMetadata(void);
 
 // #388 — Compile-time profiling counters for the PB streaming hot path.


### PR DESCRIPTION
Fixes #759. Likely also the field manifestation in [daqifi-desktop#668](https://github.com/daqifi/daqifi-desktop/issues/668) (*"Device 'com6' did not report its channel configuration within 8s"*).

## The defect

`SYST:STR:INTerface` persists across sessions **by design**, and `SCPI_SetStreamInterface` **refuses** to select SD or USB+SD while the card is disabled:

```c
if (param1 == StreamingInterface_SD || param1 == StreamingInterface_UsbAndSd) {
    if (!pSDCardSettings->enable) {
        LOG_E("Cannot set SD/USB+SD interface - SD card not enabled...");
        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
        return SCPI_RES_ERR;
    }
}
```

So *"streaming interface = SD, SD disabled"* is a combination the firmware **already treats as invalid**. It was simply reachable the other way round — select SD legitimately, then disable the card — and nothing put it right. The auto-detect in `SCPI_StartStreaming` deliberately keeps an explicit non-USB choice, so it survived every subsequent start:

```c
if (currentInterface == detectedInterface || currentInterface == StreamingInterface_USB) {
    pRunTimeStreamConfig->ActiveInterface = detectedInterface;   // else keep the explicit choice
}
```

`SD` is neither `== detected(USB)` nor `== USB`, so the stranded selection is kept.

## Why it was expensive to diagnose

**It fails silently.** The streaming task gates the USB write on `ActiveInterface == USB`, so a client reconnecting over USB and starting a stream gets:

- a **successful** start,
- `SYST:ERRor?` reading `0,"No error"`,
- and **no data at all**.

Nothing in the device's replies says anything is wrong. The host waits out its own timeout and reports *"did not report its channel configuration"*, which reads as a device fault — and a power cycle "fixes" it, which reinforces that reading.

## Reproduced deterministically over USB alone

The issue was reported against a macOS host doing serial-vs-TCP comparisons. No WiFi, no desktop client, and no second transport are needed — 2 s of protobuf at 200 Hz, counting bytes that actually arrive:

| state | USB bytes |
|---|---|
| interface USB | **5169** |
| stranded SD selection | **8** (the command echo alone) |
| interface put back | **5130** |

## The fix

Fall back to USB when the card is disabled out from under an SD-bearing selection. USB because it is the interface that is always there.

**Only `SD` and `USB+SD` are touched.** Disabling the SD card says nothing about WiFi, and clobbering a WiFi selection would be a new bug of exactly the same shape — case **C** of the companion test exists to catch that.

## Verification

Companion regression test: **daqifi/daqifi-python-test-suite#171**, mutation-proven both directions on the same bench and in the same session:

```
unfixed main (71a42ac):  A -> 2,  B -> 8 bytes        2 PASS, 2 FAIL
with this fix         :  A -> 0,  B -> 4353 bytes     4 PASS, 0 FAIL
```

Cases C (WiFi untouched) and D (`STR:INT 2` still refused while SD is disabled) pass on **both** builds — they are the boundary the fix must not cross, not evidence for it.

## What this does NOT change

The interface still **persists across sessions** when the selection remains valid. That is deliberate — it is how you stream to the card while controlling over USB — so a client that wants USB data still has to ask for it. This PR only stops the setting surviving into a state where it cannot deliver anything at all.

Whether `daqifi-core` should also set the interface on connect is a separate, client-side question; I have not assumed an answer to it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
