### PR TITLE
tools(release): reject a release hex carrying boot-flash records (#764)

### DIFF
--- a/tools/release/cut_release.sh
+++ b/tools/release/cut_release.sh
@@ -227,8 +227,12 @@ boot_records=[(a,b) for a,b in spans if b>BOOT_FLASH_LO]
 boot_bytes=sum(b-max(a,BOOT_FLASH_LO) for a,b in boot_records)
 boot_msg='no records at/above 0x1FC00000 (boot flash)'
 if boot_records:
-    boot_msg += ' -- found %d span(s), %d byte(s), first at 0x%08X' % (
-        len(boot_records), boot_bytes, boot_records[0][0])
+    # Report the first OFFENDING address, not the span start: a span may
+    # straddle the boundary (start below 0x1FC00000, end above), and printing
+    # its start contradicts the message and points at an address that is not
+    # the problem.
+    boot_msg += ' -- found %d span(s), %d byte(s), first offending addr 0x%08X' % (
+        len(boot_records), boot_bytes, max(boot_records[0][0], BOOT_FLASH_LO))
 chk(not boot_records, boot_msg)
 sys.exit(0 if ok else 1)
 PY

--- a/tools/release/cut_release.sh
+++ b/tools/release/cut_release.sh
@@ -211,6 +211,25 @@ bulk_starts=sorted(s for s,e in spans if s>=RESET_HI)
 chk(lo==RESET_LO, f"lowest phys addr 0x{lo:08X} == 0x1D000000")
 chk(reset_bytes==408, f"reset vector [0x1D000000,0x1D000480) = {reset_bytes} bytes == 408")
 chk(bool(bulk_starts) and bulk_starts[0]==RESET_HI, f"bulk starts at 0x{(bulk_starts[0] if bulk_starts else 0):08X} == 0x1D000480")
+# #764: NOTHING may live in boot flash. The bootloader can only write program
+# flash 0x9D000000-0x9D1FFFFF, so any record at or above 0x1FC00000 is SILENTLY
+# DROPPED by the in-field updater -- the hex verifies fine, the device accepts
+# the update, and the dropped content simply never arrives. That is how a bench
+# image and a fielded image diverge with nobody seeing it: the config words stay
+# whatever the bootloader burned, permanently (erratum #45, RTSP of
+# Configuration Words, no workaround).
+#
+# A bootloader-linked build has no boot-flash records at all, so this must be
+# zero. If it is not, the hex is a standalone build wearing the right reset
+# vector, and shipping it means shipping content the customer cannot receive.
+BOOT_FLASH_LO=0x1FC00000
+boot_records=[(a,b) for a,b in spans if b>BOOT_FLASH_LO]
+boot_bytes=sum(b-max(a,BOOT_FLASH_LO) for a,b in boot_records)
+boot_msg='no records at/above 0x1FC00000 (boot flash)'
+if boot_records:
+    boot_msg += ' -- found %d span(s), %d byte(s), first at 0x%08X' % (
+        len(boot_records), boot_bytes, boot_records[0][0])
+chk(not boot_records, boot_msg)
 sys.exit(0 if ok else 1)
 PY
 

--- a/tools/release/selftest_release_hex_layout.py
+++ b/tools/release/selftest_release_hex_layout.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Self-test for the release-hex layout validator inside cut_release.sh.
+
+Runs the REAL validator rather than a copy: the python block is extracted from
+cut_release.sh between its heredoc markers and executed. A duplicated copy
+would drift from the shipping check, and this repo has been bitten by exactly
+that before (a from-scratch check_release_hex.py that re-implemented checks
+cut_release.sh already made).
+
+Cases, all synthetic Intel-HEX:
+  1 a well-formed BOOTLOADER-LINKED image                 -> pass
+  2 the same image plus one boot-flash record @0x1FC00000 -> FAIL (#764)
+  3 a STANDALONE image (bulk at 0x1D000000)               -> fail
+  4 a truncated reset vector (407 bytes)                  -> fail
+
+Usage: python3 tools/release/selftest_release_hex_layout.py
+"""
+import io, os, re, subprocess, sys, tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CUT = os.path.join(HERE, "cut_release.sh")
+
+
+def extract_validator():
+    src = io.open(CUT, encoding="utf-8", errors="replace").read().replace("\r\n", "\n")
+    m = re.search(r"python3 - \"\$HEX\" <<'PY'.*?\n(.*?)\nPY\n", src, re.S)
+    if not m:
+        raise SystemExit("FAIL: could not locate the validator heredoc in cut_release.sh")
+    return m.group(1)
+
+
+def hex_records(chunks):
+    """chunks: list of (addr, nbytes). Emits minimal Intel-HEX."""
+    out = []
+    cur_base = None
+    for addr, n in chunks:
+        base = addr >> 16
+        if base != cur_base:
+            payload = "%04X" % base
+            b = 2 + 0 + 4 + int(payload[0:2], 16) + int(payload[2:4], 16)
+            out.append(":02000004%s%02X" % (payload, ((~b + 1) & 0xFF)))
+            cur_base = base
+        off = addr & 0xFFFF
+        while n > 0:
+            take = min(n, 16)
+            data = "00" * take
+            s = take + ((off >> 8) & 0xFF) + (off & 0xFF) + 0 + 0
+            out.append(":%02X%04X00%s%02X" % (take, off, data, ((~s + 1) & 0xFF)))
+            off += take
+            n -= take
+    out.append(":00000001FF")
+    return "\n".join(out) + "\n"
+
+
+def run(validator, chunks):
+    with tempfile.NamedTemporaryFile("w", suffix=".hex", delete=False) as f:
+        f.write(hex_records(chunks))
+        path = f.name
+    try:
+        p = subprocess.run([sys.executable, "-c", validator, path],
+                           capture_output=True, text=True)
+        return p.returncode, p.stdout
+    finally:
+        os.unlink(path)
+
+
+GOOD = [(0x1D000000, 408), (0x1D000480, 256)]
+CASES = [
+    ("bootloader-linked image",              GOOD,                                   0),
+    ("boot-flash record present (#764)",     GOOD + [(0x1FC00000, 16)],              1),
+    ("standalone image (bulk at base)",      [(0x1D000000, 256)],                    1),
+    ("truncated reset vector (407 B)",       [(0x1D000000, 407), (0x1D000480, 256)], 1),
+]
+
+def main():
+    validator = extract_validator()
+    if "BOOT_FLASH_LO" not in validator:
+        print("FAIL: the extracted validator has no boot-flash check (#764)")
+        return 1
+    failures = 0
+    for name, chunks, want in CASES:
+        rc, out = run(validator, chunks)
+        ok = (rc == 0) if want == 0 else (rc != 0)
+        print("  %-38s rc=%d want=%s -> %s" % (name, rc, "pass" if want == 0 else "fail",
+                                               "PASS" if ok else "FAIL"))
+        if not ok:
+            failures += 1
+            print(out.rstrip())
+    print("\n===== selftest_release_hex_layout: %d PASS, %d FAIL ====="
+          % (len(CASES) - failures, failures))
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release/selftest_release_hex_layout.py
+++ b/tools/release/selftest_release_hex_layout.py
@@ -59,7 +59,10 @@ def run(validator, chunks):
     try:
         p = subprocess.run([sys.executable, "-c", validator, path],
                            capture_output=True, text=True)
-        return p.returncode, p.stdout
+        # Return BOTH streams. If the extracted validator raises, the traceback
+        # goes to stderr -- dropping it leaves a failing test with nothing to
+        # debug from, which is the failure mode this self-test exists to catch.
+        return p.returncode, (p.stdout or '') + (p.stderr or '')
     finally:
         os.unlink(path)
 


### PR DESCRIPTION
Closes work item 2 of #764.

## The gap

The in-field updater can only write program flash `0x9D000000`–`0x9D1FFFFF`. **Any record at or above `0x1FC00000` is silently dropped** — the hex verifies, the device accepts the update, and the dropped content simply never arrives.

That is how a bench image and a fielded image diverge with nobody seeing it: the config words stay whatever the bootloader burned, permanently (erratum #45, RTSP of Configuration Words, *no workaround*).

## What was already there

`cut_release.sh` is not starting from nothing — it already asserts:

- lowest physical address `0x1D000000`
- exactly **408** bytes in `[0x1D000000, 0x1D000480)`
- bulk starts at `0x1D000480`
- `.map` `kseg0_program_mem` origin `0x9d000480`

The one assertion from #764's work item 2 that was **missing** is *"zero records at or above `0x1FC00000`"*. This adds it.

## The self-test runs the real validator, not a copy

`selftest_release_hex_layout.py` extracts the python block from `cut_release.sh` between its heredoc markers and executes it. A duplicated copy would drift from the shipping check — and this repo has been bitten by exactly that before, when a from-scratch `check_release_hex.py` re-implemented checks `cut_release.sh` already made.

```
  bootloader-linked image                rc=0 want=pass -> PASS
  boot-flash record present (#764)       rc=1 want=fail -> PASS
  standalone image (bulk at base)        rc=1 want=fail -> PASS
  truncated reset vector (407 B)         rc=1 want=fail -> PASS

  ===== selftest_release_hex_layout: 4 PASS, 0 FAIL =====
```

## Mutation-proven

Ran the **pre-change** validator (from `origin/main`) against a hex containing a `0x1FC00000` record:

```
pre-change  vs boot-flash hex : rc=0  ACCEPTED (the bug)
post-change vs the same hex   : rc=1  REJECTED (fixed)
```

So the new assertion is load-bearing, not decorative.

## Companion test

Tooling-only; no device behaviour changes, so the `daqifi-python-test-suite` rule does not apply. The self-test lives beside the tool it checks, alongside the existing `selftest_build_config.py`.

## Not addressed here

#764's other work items stand. Item 1 — verify the end-to-end update path on real hardware **through the bootloader/desktop path** — is the acceptance test that actually proves customers are unblocked, and it needs the customer update flow rather than a PICkit. Item 3 (make the default build config unambiguous) is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
