### PR TITLE
fix(sd): drop listing entries whose names FAT could not have stored (#795)

### DIFF
--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -530,6 +530,38 @@ typedef struct {
 
 static ListDirFrame gListDirStack[SD_CARD_MANAGER_MAX_LIST_DEPTH];
 
+/* #795: true if every byte of `name` is one FAT/exFAT can actually store.
+ * Illegal in a long file name: the C0 controls (< 0x20), DEL, and
+ * " * / : < > ? \ | . Bytes >= 0x80 ARE legal (OEM code page / UTF-8), so
+ * they must not be rejected.
+ *
+ * `/` is rejected here because this sees ONE entry NAME from
+ * SYS_FS_DirRead, never a path -- a slash inside a name is as impossible
+ * as a newline. A host-side check on the printed reply must allow it,
+ * since by then it is the separator in `DAQiFi/file.csv`.
+ *
+ * This exists because a name FAT cannot store did not come from a directory
+ * entry, so emitting it tells the host a file exists that does not. #795
+ * observed 45 such entries after a day of logging -- names carrying a raw
+ * 0x0A and "sizes" that decode to this device's own CSV header text, while
+ * SPACe? reported the card nearly empty. Whatever produced them (still open:
+ * five hypotheses eliminated, the card has not been read on a PC), a host
+ * cannot reject them by shape -- `DAQiFi/3214741.021 825373450` parses as a
+ * perfectly well-formed `<path> <size>` line. This filter is correct
+ * independent of that root cause. */
+static bool sd_listdir_name_is_storable(const char *name)
+{
+    for (const unsigned char *p = (const unsigned char *)name; *p != '\0'; p++) {
+        if (*p < 0x20u || *p == 0x7Fu) {
+            return false;
+        }
+        if (strchr("\"*/:<>?\\|", (int)*p) != NULL) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static ListDirResult ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, size_t strBuffSize, ListChunkCallback sendChunk) {
     SYS_FS_FSTAT stat;
     size_t strBuffIndex = 0;
@@ -537,6 +569,12 @@ static ListDirResult ListFilesInDirectoryChunked(const char* dirPath, uint8_t *p
      * it could not read or open, a path or entry that did not fit. The walk
      * still finishes; the reply just cannot claim to be the whole card. */
     bool skipped = false;
+    /* #795: entries dropped for carrying a name FAT cannot store. Counted
+     * separately from `skipped` so the summary can report how many, and so
+     * the detailed diagnostic below is emitted only for the first one -- a
+     * corrupt directory produced 45 of them, which would evict every other
+     * message from the 64-entry log buffer. */
+    unsigned rejectedNames = 0;
     ListDirResult result = SD_LISTDIR_OK;
     char newPath[SD_CARD_MANAGER_FILE_PATH_LEN_MAX + 1];
     int sp = -1;  // Stack pointer: -1 = empty, 0..MAX-1 = current frame
@@ -653,6 +691,29 @@ static ListDirResult ListFilesInDirectoryChunked(const char* dirPath, uint8_t *p
 
         LOG_D("[SD] ListFiles: Read entry '%s'\r\n", stat.fname);
 
+        if (!sd_listdir_name_is_storable(stat.fname)) {
+            /* Log the raw bytes once. This is the observation #795 has been
+             * missing: if they decode to file content the read path handed
+             * back a data sector, if they look like FAT structures the
+             * on-card directory is damaged. The issue cannot currently tell
+             * those apart, and they lead opposite ways. */
+            if (rejectedNames == 0) {
+                char hex[3 * 16 + 1];
+                size_t i = 0;
+                while (i < 16u && stat.fname[i] != '\0') {
+                    snprintf(hex + i * 3u, 4u, "%02X ", (unsigned)(unsigned char)stat.fname[i]);
+                    i++;
+                }
+                hex[i * 3u] = '\0';
+                LOG_E("[SD] ListFiles: #795 unstorable name in '%s' -- bytes: %s(attrib=0x%02X size=%u)",
+                      gListDirStack[sp].path, hex, (unsigned)stat.fattrib,
+                      (unsigned)stat.fsize);
+            }
+            rejectedNames++;
+            skipped = true;     /* #794: the reply is not the whole card */
+            continue;
+        }
+
         if (strcmp(stat.fname, ".") == 0 || strcmp(stat.fname, "..") == 0) {
             continue;
         }
@@ -756,6 +817,11 @@ static ListDirResult ListFilesInDirectoryChunked(const char* dirPath, uint8_t *p
                 skipped = true;     /* #794 */
             }
         }
+    }
+
+    if (rejectedNames > 0) {
+        LOG_E("[SD] ListFiles: #795 dropped %u entry/entries with unstorable names",
+              rejectedNames);
     }
 
     if (skipped && result == SD_LISTDIR_OK) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -532,8 +532,9 @@ static ListDirFrame gListDirStack[SD_CARD_MANAGER_MAX_LIST_DEPTH];
 
 /* #795: true if every byte of `name` is one FAT/exFAT can actually store.
  * Illegal in a long file name: the C0 controls (< 0x20), DEL, and
- * " * / : < > ? \ | . Bytes >= 0x80 ARE legal (OEM code page / UTF-8), so
- * they must not be rejected.
+ * these eight: " * / : < > ? \ | -- note '.' is NOT among them, it is the
+ * ordinary extension separator. Bytes >= 0x80 are also legal (OEM code
+ * page / UTF-8) and must not be rejected.
  *
  * `/` is rejected here because this sees ONE entry NAME from
  * SYS_FS_DirRead, never a path -- a slash inside a name is as impossible
@@ -549,17 +550,27 @@ static ListDirFrame gListDirStack[SD_CARD_MANAGER_MAX_LIST_DEPTH];
  * cannot reject them by shape -- `DAQiFi/3214741.021 825373450` parses as a
  * perfectly well-formed `<path> <size>` line. This filter is correct
  * independent of that root cause. */
-static bool sd_listdir_name_is_storable(const char *name)
+static bool sd_listdir_name_is_storable(const char *name, size_t maxLen)
 {
-    for (const unsigned char *p = (const unsigned char *)name; *p != '\0'; p++) {
-        if (*p < 0x20u || *p == 0x7Fu) {
+    for (size_t i = 0; i < maxLen; i++) {
+        const unsigned char c = (const unsigned char)name[i];
+        if (c == '\0') {
+            return true;                /* terminated, every byte legal */
+        }
+        if (c < 0x20u || c == 0x7Fu) {
             return false;
         }
-        if (strchr("\"*/:<>?\\|", (int)*p) != NULL) {
+        if (strchr("\"*/:<>?\\|", (int)c) != NULL) {
             return false;
         }
     }
-    return true;
+    /* No terminator inside the field. SYS_FS_FSTAT.fname is a fixed 256-byte
+     * array followed by lfname/lfsize, so walking to a NUL would run off it
+     * into adjacent struct members and then the stack -- and this helper is
+     * called precisely on entries already suspected of being corrupt. An
+     * unterminated name is also not a real directory entry, so rejecting it
+     * is both the safe answer and the correct one. */
+    return false;
 }
 
 static ListDirResult ListFilesInDirectoryChunked(const char* dirPath, uint8_t *pStrBuff, size_t strBuffSize, ListChunkCallback sendChunk) {
@@ -691,7 +702,7 @@ static ListDirResult ListFilesInDirectoryChunked(const char* dirPath, uint8_t *p
 
         LOG_D("[SD] ListFiles: Read entry '%s'\r\n", stat.fname);
 
-        if (!sd_listdir_name_is_storable(stat.fname)) {
+        if (!sd_listdir_name_is_storable(stat.fname, sizeof(stat.fname))) {
             /* Log the raw bytes once. This is the observation #795 has been
              * missing: if they decode to file content the read path handed
              * back a data sector, if they look like FAT structures the

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -700,8 +700,6 @@ static ListDirResult ListFilesInDirectoryChunked(const char* dirPath, uint8_t *p
             continue;
         }
 
-        LOG_D("[SD] ListFiles: Read entry '%s'\r\n", stat.fname);
-
         if (!sd_listdir_name_is_storable(stat.fname, sizeof(stat.fname))) {
             /* Log the raw bytes once. This is the observation #795 has been
              * missing: if they decode to file content the read path handed
@@ -724,6 +722,13 @@ static ListDirResult ListFilesInDirectoryChunked(const char* dirPath, uint8_t *p
             skipped = true;     /* #794: the reply is not the whole card */
             continue;
         }
+
+        /* Logged AFTER validation, deliberately. This is a %s on a name the
+         * walk does not yet trust: before the check it could be unterminated
+         * (a read past the field) and could carry control bytes that corrupt
+         * the terminal. A name that fails validation is reported above as hex
+         * instead, which is the useful form for #795 anyway. */
+        LOG_D("[SD] ListFiles: Read entry '%s'\r\n", stat.fname);
 
         if (strcmp(stat.fname, ".") == 0 || strcmp(stat.fname, "..") == 0) {
             continue;


### PR DESCRIPTION
Closes #795 as far as it can be closed without a root cause — see "What this does and does not claim".

## The problem

After a day of SD logging on the bench Nq1, `SYST:STOR:SD:LISt?` returned **45 entries that do not exist** while `SD:SPACe?` reported the card essentially empty:

```
SYST:STOR:SD:SPACe?  ->  25162481664,25162711040     (229,376 B used)
SYST:STOR:SD:LISt?   ->  45 entries, including:
  'DAQiFi/ber:7E2.898 1835103347'
  'DAQiFi/\n3214741.021 825373450'
```

Two things there cannot come from a filesystem: the paths contain a literal `0x0A`, which FAT32 cannot store in a name; and the "sizes" are ASCII text read as integers — `1835103347` is `0x6D626572`, `"mber"`, the tail of this device's own CSV header. The sizes summed to tens of GB against a card reporting 229 KB used.

## Why this is worth fixing before the root cause is known

A host **cannot reject these by shape**. `DAQiFi/3214741.021 825373450` parses as a perfectly well-formed `<path> <size>` line, and daqifi-core turns any first token into a filename — so a desktop user sees files they can neither open nor delete. This is strictly worse than a truncated reply (#794), which at least announces itself.

A name FAT cannot store did not come from a directory entry. That is true regardless of what corrupted it, so the filter is correct independent of the open investigation.

## What changed

The walk drops such an entry and sets the existing #794 `skipped` flag, so the reply reads `__END_OF_LIST__ INCOMPLETE` instead of `OK`. **A silent wrong answer becomes an explicit partial answer.**

No new wire syntax. The diagnostic goes to `LOG_E`, per the project rule that errors are logged and retrieved with `SYST:LOG?` rather than injected into a reply — adding a line to the listing would itself be parsed as a file.

**The first rejected name is logged with its raw bytes in hex, plus attrib and size.** That is the observation #795 has been missing: bytes decoding to file content mean the read path handed back a data sector; bytes looking like FAT structures mean the on-card directory is damaged. Those lead opposite ways and the issue currently cannot tell them apart. Only the first is logged in full, with a count at the end — the reported failure produced 45 entries, which would evict every other message from the 64-entry log buffer.

### Deliberate non-choices

- **Bytes `>= 0x80` are NOT rejected** — legal in a long file name via the OEM code page. Rejecting them would be a bug.
- **`/` IS rejected** — this sees one entry *name* from `SYS_FS_DirRead`, never a path, so a slash is as impossible as a newline. (The host-side check must allow it, since by then it is the separator.)
- **`CountDirEntries` is left alone** — it only counts for the #689 bucket cap and never emits names to the host; changing its count would change bucketing behavior.

## What this does and does not claim

It does **not** fix the root cause, and does not pretend to. Five hypotheses are eliminated on the issue with source citations: listing path reading the wrong buffer, cross-task FatFs race, missing D-cache invalidate, `FILINFO`/`SYS_FS_FSTAT` type-pun, and stale `FATFS` across a format. Settling it needs the card read on a PC during a recurrence — one card reader, not more static analysis. **This PR makes that recurrence diagnosable** (the hex dump) **and non-damaging to the host** (the drop plus INCOMPLETE) in the meantime.

## Verification

- Builds clean at `-O3 -Werror -Wall`, zero diagnostics.
- Flashed to Nq1 `7E2898F46200E8A7` and exercised on a card holding 30 real files.
- **The `OK` marker is the negative control**: had the filter rejected any legitimate entry, `skipped` would have flipped the reply to `INCOMPLETE`. It read `OK`, and `SYST:LOG?` came back empty — the filter fired zero times on a healthy card.

```
  PASS  1. reply carries __END_OF_LIST__ OK
entries: 30   unparsed lines: 0
  PASS  2. all 30 path(s) storable by FAT
  PASS  3. every line parses as "<path> <size>"
  PASS  4. sizes sum 737652 <= used 25853952
  PASS  5. marker says OK and the listing is clean
```

The reject path itself is **not** exercised — a healthy card cannot produce an unstorable name, and staging one needs a card reader. Stated rather than glossed.

Companion regression test: [daqifi-python-test-suite#173](https://github.com/daqifi/daqifi-python-test-suite/pull/173).

🤖 Generated with [Claude Code](https://claude.com/claude-code)