### PR TITLE
feat(streaming): report a railed channel so a clipped sample is visible (#814)

### DIFF
--- a/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
+++ b/firmware/src/services/DaqifiPB/NanoPB_Encoder.c
@@ -514,6 +514,26 @@ size_t Nanopb_Encode(tBoardData* state,
                         flag |= 0x00000004;
                     }
                 }
+                /* #814: 0x100 -- one or more channels are AT A RAIL right
+                 * now. Live per-frame state, not a sticky latch, and
+                 * deliberately bit 8 rather than 3 so 0x08-0x80 stay free for
+                 * connection-state growth. A consumer that does not know the
+                 * bit ignores it, so this is backward compatible.
+                 *
+                 * It exists because a railed sample is indistinguishable from
+                 * a real reading once it leaves the device: a genuine
+                 * full-scale value and a clamped one are the same number on
+                 * the wire. Riding the status word means a plot can mark the
+                 * affected span as it happens, which an on-device counter
+                 * alone can never do. Shares its meaning with the Gloor IAQ
+                 * board so the apps parse one convention (#814).
+                 *
+                 * The cumulative view is SYST:STR:STATS? ClippedSamples /
+                 * ClippedChannelMask -- deliberately folded into the existing
+                 * stats reply rather than given new SCPI commands. */
+                if (Streaming_IsClipping()) {
+                    flag |= 0x00000100;
+                }
                 message.device_status = flag;
             }
                 break;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -80,6 +80,12 @@
 
 // SCPI STATus:QUEStionable condition register bit assignments
 // These must match the QUES_BIT_* defines in streaming.c
+/* Bit 0 is IEEE 488.2's VOLTAGE summary bit, which is exactly what this means:
+ * a channel is sitting at a rail, so the voltage being reported is not a
+ * trustworthy measurement (#814). Derived live in SCPI_SyncQuesBits from
+ * Streaming_IsClipping() rather than latched in gQuesBits -- same treatment as
+ * QUES_ANALOG_LIMIT, and the reason a stopped stream reports it as clear. */
+#define QUES_VOLT_CLIPPED   (1 << 0)   // Bit 0: a channel is at a rail right now (#814)
 #define QUES_DATA_LOSS      (1 << 4)   // Bit 4: windowed sample loss >= 5%
 #define QUES_USB_OVERFLOW   (1 << 8)   // Bit 8: USB buffer overflow
 #define QUES_WIFI_OVERFLOW  (1 << 9)   // Bit 9: WiFi buffer overflow
@@ -90,7 +96,8 @@
 #define QUES_ANALOG_LIMIT   (1 << 14)  // Bit 14: an ADC digital-comparator threshold has tripped (#670)
 #define QUES_ALL_BITS       (QUES_DATA_LOSS | QUES_USB_OVERFLOW | QUES_WIFI_OVERFLOW | \
                              QUES_SD_OVERFLOW | QUES_ENCODER_FAIL | QUES_TRANSPORT_DOWN | \
-                             QUES_SPI_BUS_FAULT | QUES_ANALOG_LIMIT)
+                             QUES_SPI_BUS_FAULT | QUES_ANALOG_LIMIT | \
+                             QUES_VOLT_CLIPPED)
 
 #define UNUSED(x) (void)(x)
 //
@@ -368,6 +375,15 @@ static void SCPI_SyncQuesBits(void) {
     // rather than stored in gQuesBits: the trip ISR only touches its own latch,
     // and the condition persists until CONF:ADC:THREshold:CLEar (not stream stop).
     if (AdcThreshold_AnyLatched()) { bits |= QUES_ANALOG_LIMIT; }
+    /* #814: also derived rather than stored. The streaming protobuf frames do
+     * not carry device_status (the fast encoder emits only timestamp, analog,
+     * digital and port-dir to keep the hot path small), and a mid-stream
+     * SYST:SYSInfoPB? reply arrives buried in streaming frames -- so on this
+     * platform the status word is not a practical carrier for a live signal.
+     * The QUES condition register is: it is small, it is the register that
+     * already means 'this measurement is suspect', and it is queryable at any
+     * time with STAT:QUES:COND?. */
+    if (Streaming_IsClipping()) { bits |= QUES_VOLT_CLIPPED; }
     UsbCdcData_t* usb = UsbCdc_GetSettings();
     wifi_tcp_server_context_t* wifi = wifi_manager_GetTcpServerContext();
     // Replace streaming-related QUES bits in a single write to avoid
@@ -3227,6 +3243,12 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
     // still streamed, just with frozen data; same exclusion as EosOverruns).
     // ~0 with the scan cap in place; non-zero flags over-rate / NOCAP scan-busy.
     scpi_printf(context, "ScanStaleDropped=%u\r\n", (unsigned)s.scanStaleDropped);
+    /* #814: NOT loss -- a clipped sample is delivered, it is just untrustworthy
+     * as a measurement, so it is absent from every loss percentage below. The
+     * mask is over sample-list SLOTS (bit j = the j-th enabled channel in this
+     * session), matching validMask, not over board channel numbers. */
+    scpi_printf(context, "ClippedSamples=%u\r\n", (unsigned)s.clippedSamples);
+    scpi_printf(context, "ClippedChannelMask=%u\r\n", (unsigned)s.clippedChannelMask);
     // #541 D-A diag: ticks where a T1 result was not ready (ARDY clear) at
     // the deferred task's direct read.  Expected 0; non-zero ticks emitted
     // that channel with its validMask bit clear.

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3247,7 +3247,7 @@ scpi_result_t SCPI_GetStreamStats(scpi_t * context) {
      * as a measurement, so it is absent from every loss percentage below. The
      * mask is over sample-list SLOTS (bit j = the j-th enabled channel in this
      * session), matching validMask, not over board channel numbers. */
-    scpi_printf(context, "ClippedSamples=%u\r\n", (unsigned)s.clippedSamples);
+    scpi_printf(context, "ClippedSamples=%llu\r\n", (unsigned long long)s.clippedSamples);
     scpi_printf(context, "ClippedChannelMask=%u\r\n", (unsigned)s.clippedChannelMask);
     // #541 D-A diag: ticks where a T1 result was not ready (ARDY clear) at
     // the deferred task's direct read.  Expected 0; non-zero ticks emitted

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -830,6 +830,15 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             // the field on Timestamp==0), which retires the old post-loop net.
             pPublicSampleList->Timestamp = trigStamp;
 
+            /* #814: snapshot the mode globals ONCE for this whole sample.
+             * Both are written from the SCPI task, so re-reading them per
+             * branch lets a mid-frame change disagree with itself: the
+             * signedness decision could say 'synthetic' while the value
+             * branch produced a sign-extended ADC read, or vice versa. It
+             * would also let two channels of the SAME frame take different
+             * generator branches. One read, used everywhere below. */
+            const uint32_t framePattern = gTestPattern;      /* both are volatile uint32_t */
+            const uint32_t frameBenchMode = gBenchmarkMode;
             uint32_t clipMask = 0;   /* #814: rails seen in THIS sample */
             for (uint8_t j = 0; j < mapping->count; j++) {
                 uint8_t cfgIdx = mapping->configIndices[j];
@@ -862,7 +871,7 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                  * two's-complement range -- so judging those as signed would
                  * read a perfectly ordinary pattern value as a negative rail. */
                 const bool valueIsSynthetic =
-                        (gBenchmarkMode == BENCHMARK_PIPELINE) || (gTestPattern != 0);
+                        (frameBenchMode == BENCHMARK_PIPELINE) || (framePattern != 0);
                 if (pBoardConfig->AInChannels.Data[cfgIdx].Type == AIn_AD7609) {
                     adcMax = 262143u;  // 18-bit AD7609
                     adcIsSigned = !valueIsSynthetic;
@@ -871,24 +880,24 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                     adcIsSigned = false;
                 }
 
-                if (gBenchmarkMode == BENCHMARK_PIPELINE) {
+                if (frameBenchMode == BENCHMARK_PIPELINE) {
                     // Pipeline: skip ADC entirely, generate synthetic data directly.
                     // Timestamp comes from the streaming timer tick captured by
                     // Streaming_TimerHandler (BOARDDATA_STREAMING_TIMESTAMP) — same
                     // source the ADC ISR uses for AInSample.Timestamp in normal
                     // operation, so PB/CSV/JSON output is consistent across modes.
                     pPublicSampleList->Values[j] =
-                        Streaming_GenerateTestValue(gTestPattern,
+                        Streaming_GenerateTestValue(framePattern,
                             mapping->channelIds[j],
                             gTestPatternSampleCount, adcMax);
                     pPublicSampleList->validMask |= (1U << j);
-                } else if (gTestPattern != 0) {
+                } else if (framePattern != 0) {
                     // Test pattern: always produce deterministic data regardless
                     // of ADC state. Packet Timestamp is the deterministic
                     // trigStamp set once before the loop (#717) — no ADC read
                     // needed here for the timestamp.
                     pPublicSampleList->Values[j] =
-                        Streaming_GenerateTestValue(gTestPattern,
+                        Streaming_GenerateTestValue(framePattern,
                             mapping->channelIds[j],
                             gTestPatternSampleCount, adcMax);
                     pPublicSampleList->validMask |= (1U << j);
@@ -1198,7 +1207,12 @@ pool_done:
                 DioProbe_PulseEnd(4);
             }
 
-            // Increment test pattern counter once per ISR tick (after all channels)
+            // Increment test pattern counter once per ISR tick (after all channels).
+            // Deliberately reads the global, NOT the frame snapshot: -Werror
+            // showed this point is reachable on paths where the snapshot block
+            // never ran, so the snapshot is not in scope here. The counter is
+            // per-tick bookkeeping rather than part of the frame's value
+            // decision, so the global is the right read.
             if (gTestPattern != 0) {
                 taskENTER_CRITICAL();
                 gTestPatternSampleCount++;

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -834,10 +834,20 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                  * is also the worst moment to add work.
                  *
                  * A consumer can still tell 'not clipping' from 'not knowable'
-                 * without a third state: this window always coincides with
-                 * QueueDropped/PoolExhausted rising and QUES loss bits 4/8-13
-                 * being set. Bit 0 reading 0 while those are set means 'no
-                 * current measurement', not 'measured and clean'. */
+                 * without a third state, but the signal to use is the STATS
+                 * COUNTERS, not the QUES bits: PoolExhaustedSamples and
+                 * QueueDroppedSamples are incremented unconditionally right
+                 * here, every affected tick. Bit 0 reading 0 while
+                 * PoolExhaustedSamples is climbing means 'no current
+                 * measurement', not 'measured and clean'.
+                 *
+                 * Deliberately NOT the QUES loss bits, which an earlier
+                 * revision of this comment wrongly promised: this path reaches
+                 * only Streaming_UpdateFlowWindow(true), which touches bit 4
+                 * alone -- and even that only at a window boundary and only
+                 * once windowed loss crosses gLossThresholdPct (default 5%),
+                 * so it lags and can stay clear. Bits 8-13 are transport and
+                 * bus faults and are never set from here. */
                 gClipLiveMask = 0;
                 taskEXIT_CRITICAL();
                 LOG_E_SESSION(LOG_SESSION_POOL_EXHAUST, "Streaming: Sample pool exhausted");

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -835,6 +835,10 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                 uint8_t cfgIdx = mapping->configIndices[j];
 
                 uint32_t adcMax;
+                /* #814: AD7609 codes are SIGNED; MC12b codes are unsigned.
+                 * The rail test below has to know which, so record it here
+                 * alongside adcMax rather than re-deriving it. */
+                bool adcIsSigned;
                 // #368: this task is registered as pure-integer (see comment
                 // at top of _Streaming_Deferred_Interrupt_Task — no
                 // portTASK_USES_FLOATING_POINT()).  The historical bug:
@@ -853,8 +857,10 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                 // by reverting one of the two.
                 if (pBoardConfig->AInChannels.Data[cfgIdx].Type == AIn_AD7609) {
                     adcMax = 262143u;  // 18-bit AD7609
+                    adcIsSigned = true;
                 } else {
                     adcMax = 4095u;    // 12-bit MC12bADC
+                    adcIsSigned = false;
                 }
 
                 if (gBenchmarkMode == BENCHMARK_PIPELINE) {
@@ -965,7 +971,33 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                  * FPU out of this loop (#368/#369). */
                 if (pPublicSampleList->validMask & (1U << j)) {
                     const uint32_t v = pPublicSampleList->Values[j];
-                    if (v == 0u || v >= adcMax) {
+                    bool railed;
+                    if (adcIsSigned) {
+                        /* AD7609 stores an 18-bit two's-complement code
+                         * SIGN-EXTENDED into this uint32_t (AD7609.c:454 ORs
+                         * AD7609_SIGN_EXTEND 0xFFFC0000 when bit 17 is set),
+                         * so the code range is -131072..+131071 and the rails
+                         * are those extremes -- NOT 0 and adcMax.
+                         *
+                         * Comparing it unsigned against adcMax is wrong in
+                         * both directions and neither failure is quiet: every
+                         * ordinary NEGATIVE reading sign-extends to a huge
+                         * unsigned value and would be flagged clipped (about
+                         * half of all samples on a bipolar +/-10 V board),
+                         * while true positive full scale, 131071, is below
+                         * adcMax and would never be flagged at all. 0 is
+                         * mid-scale here, not a rail.
+                         *
+                         * Bounds derived from adcMax so they cannot drift from
+                         * the board config's Resolution (262144 -> +/-131072). */
+                        const int32_t sv = (int32_t)v;
+                        const int32_t posRail = (int32_t)(adcMax >> 1);       /* +131071 */
+                        const int32_t negRail = -(int32_t)((adcMax >> 1) + 1); /* -131072 */
+                        railed = (sv >= posRail) || (sv <= negRail);
+                    } else {
+                        railed = (v == 0u) || (v >= adcMax);
+                    }
+                    if (railed) {
                         clipMask |= (1U << j);
                     }
                 }

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -167,19 +167,24 @@ static volatile uint32_t gScanStaleDropped = 0;  // ticks scan armed but no new 
  * consumer reading device_status sees the current frame's state rather than a
  * latch it must learn to clear. The other two accumulate for SYST:STR:STATS?.
  *
- * All three are published ONLY for a sample that is actually delivered --
+ * The cumulative pair lives in gStreamStats (clippedSamples /
+ * clippedChannelMask) rather than in globals beside this one: they are
+ * ordinary session statistics, so the struct's bulk snapshot and its memset
+ * reset cover them for free and there is no second copy to fall out of step.
+ * Only the LIVE mask needs to be separate -- it is read outside the stats
+ * snapshot, by the protobuf encoder and SCPI_SyncQuesBits.
+ *
+ * Both are published ONLY for a sample that is actually delivered --
  * see the publish block next to gStreamStats.totalSamplesStreamed++. A frame
  * suppressed by the priming gate or lost to a full queue describes nothing
  * the consumer ever sees, and the priming window in particular can present
  * a stale cache value that looks exactly like the bottom rail.
  *
  * They are updated inside the same taskENTER_CRITICAL as that counter, which
- * the 64-bit gClippedSamples requires anyway (CLAUDE.md: 64-bit operations
+ * the 64-bit clippedSamples requires anyway (CLAUDE.md: 64-bit operations
  * always need one) and which makes the two RMWs consistent with their
  * neighbours rather than relying on a single-writer argument. */
 static volatile uint32_t gClipLiveMask = 0;      // channels at a rail THIS tick
-static volatile uint64_t gClippedSamples = 0;    // samples with >=1 railed channel
-static volatile uint32_t gClipChannelMask = 0;   // OR of every slot seen railed
 /* #707/#745: ticks that fired before the session's first shared scan had
  * completed, so no sample could be built. A DRY TICK — not a sample and not a
  * drop; see the emit-path comment.
@@ -1055,8 +1060,8 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                  * describes the current frame rather than the worst so far. */
                 gClipLiveMask = clipMask;
                 if (clipMask != 0u) {
-                    gClippedSamples++;
-                    gClipChannelMask |= clipMask;
+                    gStreamStats.clippedSamples++;
+                    gStreamStats.clippedChannelMask |= clipMask;
                 }
                 taskEXIT_CRITICAL();
                 Streaming_UpdateFlowWindow(false);
@@ -2008,10 +2013,8 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
-    /* #814: boot-time zeroing of both the cumulative counters and the live
-     * mask. Init runs single-threaded, like the gTimerISRCalls reset above. */
-    gClippedSamples = 0;
-    gClipChannelMask = 0;
+    /* #814: the cumulative pair is inside gStreamStats and is already zeroed
+     * by the memset above; only the live mask needs its own reset. */
     gClipLiveMask = 0;
     gDryTicks = 0;
     gPrimingPending = false;
@@ -2187,8 +2190,6 @@ void Streaming_GetStats(StreamingStats* out) {
                                                      : 0u;
     }
     out->scanStaleDropped = gScanStaleDropped;  // #557 (separate volatile, like timerISRCalls)
-    out->clippedSamples = gClippedSamples;          // #814
-    out->clippedChannelMask = gClipChannelMask;     // #814
     taskEXIT_CRITICAL();
 }
 
@@ -2237,10 +2238,6 @@ void Streaming_ClearStats(void) {
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
-    /* #814: the cumulative view, cleared with the rest of the session
-     * counters. */
-    gClippedSamples = 0;
-    gClipChannelMask = 0;
     /* #814: gClipLiveMask is deliberately NOT cleared here. This function also
      * serves SYST:STR:STATS:CLEar, which a client may issue MID-SESSION, and
      * the live mask is not a session statistic -- zeroing it there would report

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2008,9 +2008,8 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
-    /* #814: cleared with the rest of the session counters. gClipLiveMask is
-     * cleared too so a stopped stream never reports a stale rail -- it is
-     * live state, and there is no live frame once streaming ends. */
+    /* #814: boot-time zeroing of both the cumulative counters and the live
+     * mask. Init runs single-threaded, like the gTimerISRCalls reset above. */
     gClippedSamples = 0;
     gClipChannelMask = 0;
     gClipLiveMask = 0;
@@ -2238,12 +2237,17 @@ void Streaming_ClearStats(void) {
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
-    /* #814: cleared with the rest of the session counters. gClipLiveMask is
-     * cleared too so a stopped stream never reports a stale rail -- it is
-     * live state, and there is no live frame once streaming ends. */
+    /* #814: the cumulative view, cleared with the rest of the session
+     * counters. */
     gClippedSamples = 0;
     gClipChannelMask = 0;
-    gClipLiveMask = 0;
+    /* #814: gClipLiveMask is deliberately NOT cleared here. This function also
+     * serves SYST:STR:STATS:CLEar, which a client may issue MID-SESSION, and
+     * the live mask is not a session statistic -- zeroing it there would report
+     * 'not clipping' for a channel still sitting on a rail until the next
+     * delivered sample republished it. Streaming_Stop clears it (there is no
+     * live frame once the timer is off) and Streaming_Init clears it at boot,
+     * which between them cover every point where it must read zero. */
     gDryTicks = 0;
     gScanEosSeq = 1u;       // #557/#563: prime seq one ahead of "seen" so the
     gScanEosSeqSeen = 0u;   // first post-start tick (no scan completed yet) reads fresh

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1159,7 +1159,21 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                  * actually streamed. (The priming path deliberately publishes
                  * neither -- there the cache can hold a stale value that looks
                  * exactly like the bottom rail.) */
-                gClipLiveMask = clipMask;
+                /* Guarded on Running, inside a critical section, because
+                 * Streaming_Stop clears this mask from TASK context. Without
+                 * the guard a deferred iteration already in flight when STOP
+                 * ran could publish AFTER that clear and strand the bit set
+                 * for the whole idle period -- re-creating the stuck state
+                 * this PR exists to remove. Stop writes Running=false BEFORE
+                 * it clears the mask, and a critical section cannot be
+                 * preempted by another task, so the two orderings are the
+                 * only ones possible: publish-then-clear, or see-false-and-
+                 * skip. Both end with the mask correctly clear. */
+                taskENTER_CRITICAL();
+                if (gpRuntimeConfigStream->Running) {
+                    gClipLiveMask = clipMask;
+                }
+                taskEXIT_CRITICAL();
                 LOG_E_SESSION(LOG_SESSION_QUEUE_OVERFLOW, "Streaming: Sample queue overflow detected");
                 AInSampleList_FreeToPool(pPublicSampleList);  // Use pool!
                 Streaming_UpdateFlowWindow(true);
@@ -1168,8 +1182,15 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                 gStreamStats.totalSamplesStreamed++;
                 /* #814: publish the rail state for THIS delivered sample.
                  * Live mask is rewritten every delivery, set or clear, so it
-                 * describes the current frame rather than the worst so far. */
-                gClipLiveMask = clipMask;
+                 * describes the current frame rather than the worst so far.
+                 * Guarded on Running for the STOP race described on the
+                 * queue-overflow path above; the counters are NOT guarded,
+                 * because a sample that was genuinely delivered still counts
+                 * toward the session total even if STOP lands immediately
+                 * after. */
+                if (gpRuntimeConfigStream->Running) {
+                    gClipLiveMask = clipMask;
+                }
                 if (clipMask != 0u) {
                     gStreamStats.clippedSamples++;
                     gStreamStats.clippedChannelMask |= clipMask;

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -174,7 +174,19 @@ static volatile uint32_t gScanStaleDropped = 0;  // ticks scan armed but no new 
  * Only the LIVE mask needs to be separate -- it is read outside the stats
  * snapshot, by the protobuf encoder and SCPI_SyncQuesBits.
  *
- * Both are published ONLY for a sample that is actually delivered --
+ * EVERY exit from a tick must leave the live mask describing that tick, or it
+ * becomes the latch it is documented not to be. The full map, because three
+ * separate rounds of review found a path that had been missed:
+ *   - delivered sample      -> publish clipMask
+ *   - queue push failed     -> publish clipMask (the frame WAS built)
+ *   - pool exhausted        -> clear (no frame could be built at all)
+ *   - priming suppression   -> neither, and that is safe rather than an
+ *                              oversight: priming only happens at session
+ *                              start, where Streaming_Start has just cleared
+ *                              the mask, so there is nothing stale to strand
+ *   - Stop / Init           -> clear
+ *
+ * Both counters are published ONLY for a sample that is actually delivered --
  * see the publish block next to gStreamStats.totalSamplesStreamed++. A frame
  * suppressed by the priming gate or lost to a full queue describes nothing
  * the consumer ever sees, and the priming window in particular can present
@@ -788,6 +800,30 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                 if (pastGrace) {
                     gStreamStats.queueDroppedSamplesSteady++;
                 }
+                /* #814: no frame could be BUILT on this tick, so there is no
+                 * current rail state to report -- clear the live mask rather
+                 * than leave the last delivered frame's value standing.
+                 *
+                 * Neither answer is knowable here, and that is the point: the
+                 * bit is documented as live, 'a channel is at a rail RIGHT
+                 * NOW', explicitly not a latch. A value that survives an
+                 * indefinite pool-exhaustion stall IS a latch, and this stall
+                 * is the firmware's INTENDED back-pressure regime (see the
+                 * solo-USB comment further down), so it can last seconds.
+                 * Clearing can under-report a rail that is still physically
+                 * present; leaving it stranded QUES bit 0 and device_status
+                 * 0x100 at 'clipping now' after the rails had cleared, which
+                 * is the failure already fixed on the queue-overflow path.
+                 * The cost of clearing is bounded: no samples are reaching the
+                 * consumer during this window anyway, the loss itself is
+                 * reported loudly by QueueDropped/PoolExhausted and QUES bits
+                 * 4/8-13, and the true state is republished by the very next
+                 * delivered sample.
+                 *
+                 * Counters are untouched -- clipping counts stay
+                 * delivery-only, so a tick that produced nothing cannot
+                 * inflate a statistic about what was streamed. */
+                gClipLiveMask = 0;
                 taskEXIT_CRITICAL();
                 LOG_E_SESSION(LOG_SESSION_POOL_EXHAUST, "Streaming: Sample pool exhausted");
                 Streaming_UpdateFlowWindow(true);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -855,9 +855,17 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                 // defense alone is enough; keeping both means a future
                 // contributor can't accidentally re-introduce the bug
                 // by reverting one of the two.
+                /* #814: signedness describes the VALUE SITTING IN Values[j],
+                 * not merely the channel. A test pattern or PIPELINE run
+                 * writes a SYNTHETIC unsigned code in [0, adcMax] there --
+                 * Streaming_GenerateTestValue has no notion of AD7609's
+                 * two's-complement range -- so judging those as signed would
+                 * read a perfectly ordinary pattern value as a negative rail. */
+                const bool valueIsSynthetic =
+                        (gBenchmarkMode == BENCHMARK_PIPELINE) || (gTestPattern != 0);
                 if (pBoardConfig->AInChannels.Data[cfgIdx].Type == AIn_AD7609) {
                     adcMax = 262143u;  // 18-bit AD7609
-                    adcIsSigned = true;
+                    adcIsSigned = !valueIsSynthetic;
                 } else {
                     adcMax = 4095u;    // 12-bit MC12bADC
                     adcIsSigned = false;
@@ -1081,6 +1089,17 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                     gStreamStats.queueDroppedSamplesSteady++;
                 }
                 taskEXIT_CRITICAL();
+                /* #814: the rail state of this frame is real whether or not
+                 * the queue took it, and leaving the previous frame's mask in
+                 * place would strand device_status / QUES bit 0 reporting
+                 * 'clipping now' through a sustained overflow after the rails
+                 * had cleared. Published here as well as on the delivery path;
+                 * the COUNTERS stay delivery-only, so a dropped frame is
+                 * visible live without inflating a statistic about what was
+                 * actually streamed. (The priming path deliberately publishes
+                 * neither -- there the cache can hold a stale value that looks
+                 * exactly like the bottom rail.) */
+                gClipLiveMask = clipMask;
                 LOG_E_SESSION(LOG_SESSION_QUEUE_OVERFLOW, "Streaming: Sample queue overflow detected");
                 AInSampleList_FreeToPool(pPublicSampleList);  // Use pool!
                 Streaming_UpdateFlowWindow(true);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -167,12 +167,18 @@ static volatile uint32_t gScanStaleDropped = 0;  // ticks scan armed but no new 
  * consumer reading device_status sees the current frame's state rather than a
  * latch it must learn to clear. The other two accumulate for SYST:STR:STATS?.
  *
- * Single writer (the deferred streaming task), 32-bit aligned, so the plain
- * store of gClipLiveMask is atomic on PIC32MZ and needs no critical section;
- * the two accumulators are RMW but are only ever written by that same task.
- * Readers (NanoPB encoder, SCPI) get a coherent 32-bit load either way. */
+ * All three are published ONLY for a sample that is actually delivered --
+ * see the publish block next to gStreamStats.totalSamplesStreamed++. A frame
+ * suppressed by the priming gate or lost to a full queue describes nothing
+ * the consumer ever sees, and the priming window in particular can present
+ * a stale cache value that looks exactly like the bottom rail.
+ *
+ * They are updated inside the same taskENTER_CRITICAL as that counter, which
+ * the 64-bit gClippedSamples requires anyway (CLAUDE.md: 64-bit operations
+ * always need one) and which makes the two RMWs consistent with their
+ * neighbours rather than relying on a single-writer argument. */
 static volatile uint32_t gClipLiveMask = 0;      // channels at a rail THIS tick
-static volatile uint32_t gClippedSamples = 0;    // samples with >=1 railed channel
+static volatile uint64_t gClippedSamples = 0;    // samples with >=1 railed channel
 static volatile uint32_t gClipChannelMask = 0;   // OR of every slot seen railed
 /* #707/#745: ticks that fired before the session's first shared scan had
  * completed, so no sample could be built. A DRY TICK — not a sample and not a
@@ -960,14 +966,6 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                 }
             }
 
-            /* Publish LIVE state every tick, set or clear -- device_status
-             * must describe this frame, not the worst frame so far. The
-             * accumulators below are the cumulative view for STATS?. */
-            gClipLiveMask = clipMask;
-            if (clipMask != 0u) {
-                gClippedSamples++;
-                gClipChannelMask |= clipMask;
-            }
 
             // #717: every emitted packet already carries the deterministic
             // trigStamp (set before the channel loop, >=1) regardless of mode —
@@ -1052,6 +1050,14 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             } else {
                 taskENTER_CRITICAL();
                 gStreamStats.totalSamplesStreamed++;
+                /* #814: publish the rail state for THIS delivered sample.
+                 * Live mask is rewritten every delivery, set or clear, so it
+                 * describes the current frame rather than the worst so far. */
+                gClipLiveMask = clipMask;
+                if (clipMask != 0u) {
+                    gClippedSamples++;
+                    gClipChannelMask |= clipMask;
+                }
                 taskEXIT_CRITICAL();
                 Streaming_UpdateFlowWindow(false);
             }

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -822,7 +822,22 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                  *
                  * Counters are untouched -- clipping counts stay
                  * delivery-only, so a tick that produced nothing cannot
-                 * inflate a statistic about what was streamed. */
+                 * inflate a statistic about what was streamed.
+                 *
+                 * The obvious third option -- read the ADC here and publish a
+                 * TRUE answer instead of choosing between two falsehoods -- is
+                 * rejected deliberately. The T1 path reads ADCDATAx, and that
+                 * read CLEARS ARDY (#541 D-A), so sampling it on a drop tick
+                 * would consume the conversion the next successful tick is
+                 * meant to deliver. Harming the data path to service a status
+                 * bit is the wrong trade, and on an already-overloaded tick it
+                 * is also the worst moment to add work.
+                 *
+                 * A consumer can still tell 'not clipping' from 'not knowable'
+                 * without a third state: this window always coincides with
+                 * QueueDropped/PoolExhausted rising and QUES loss bits 4/8-13
+                 * being set. Bit 0 reading 0 while those are set means 'no
+                 * current measurement', not 'measured and clean'. */
                 gClipLiveMask = 0;
                 taskEXIT_CRITICAL();
                 LOG_E_SESSION(LOG_SESSION_POOL_EXHAUST, "Streaming: Sample pool exhausted");

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -162,6 +162,18 @@ static volatile uint64_t gTimerISRCalls = 0;
 static volatile uint32_t gScanEosSeq      = 1u;  // bumped per completed scan (EOS ISR); primed 1 ahead of "seen"
 static volatile uint32_t gScanEosSeqSeen  = 0u;  // last seq the timer ISR observed
 static volatile uint32_t gScanStaleDropped = 0;  // ticks scan armed but no new EOS
+
+/* #814: rail detection. `gClipLiveMask` is LIVE -- rewritten every tick, so a
+ * consumer reading device_status sees the current frame's state rather than a
+ * latch it must learn to clear. The other two accumulate for SYST:STR:STATS?.
+ *
+ * Single writer (the deferred streaming task), 32-bit aligned, so the plain
+ * store of gClipLiveMask is atomic on PIC32MZ and needs no critical section;
+ * the two accumulators are RMW but are only ever written by that same task.
+ * Readers (NanoPB encoder, SCPI) get a coherent 32-bit load either way. */
+static volatile uint32_t gClipLiveMask = 0;      // channels at a rail THIS tick
+static volatile uint32_t gClippedSamples = 0;    // samples with >=1 railed channel
+static volatile uint32_t gClipChannelMask = 0;   // OR of every slot seen railed
 /* #707/#745: ticks that fired before the session's first shared scan had
  * completed, so no sample could be built. A DRY TICK — not a sample and not a
  * drop; see the emit-path comment.
@@ -807,6 +819,7 @@ void _Streaming_Deferred_Interrupt_Task(void) {
             // the field on Timestamp==0), which retires the old post-loop net.
             pPublicSampleList->Timestamp = trigStamp;
 
+            uint32_t clipMask = 0;   /* #814: rails seen in THIS sample */
             for (uint8_t j = 0; j < mapping->count; j++) {
                 uint8_t cfgIdx = mapping->configIndices[j];
 
@@ -924,6 +937,36 @@ void _Streaming_Deferred_Interrupt_Task(void) {
                     }
                     // else: bit stays 0 in validMask (invalid)
                 }
+
+                /* #814: rail check, once per channel and after every branch
+                 * above, so it covers the ADC paths, the T1-direct path and
+                 * the test-pattern/PIPELINE paths alike. Only a channel whose
+                 * validMask bit is set is judged -- an invalid slot carries no
+                 * measurement to be at a rail.
+                 *
+                 * Both ends count: 0 is as much a rail as full scale. `>=`
+                 * rather than `==` on the top so a value that somehow exceeds
+                 * the module's range is caught rather than slipping past.
+                 *
+                 * Integer-only by construction -- this task is registered
+                 * pure-integer (no portTASK_USES_FLOATING_POINT), and adcMax
+                 * is the uint32_t constant chosen above precisely to keep the
+                 * FPU out of this loop (#368/#369). */
+                if (pPublicSampleList->validMask & (1U << j)) {
+                    const uint32_t v = pPublicSampleList->Values[j];
+                    if (v == 0u || v >= adcMax) {
+                        clipMask |= (1U << j);
+                    }
+                }
+            }
+
+            /* Publish LIVE state every tick, set or clear -- device_status
+             * must describe this frame, not the worst frame so far. The
+             * accumulators below are the cumulative view for STATS?. */
+            gClipLiveMask = clipMask;
+            if (clipMask != 0u) {
+                gClippedSamples++;
+                gClipChannelMask |= clipMask;
             }
 
             // #717: every emitted packet already carries the deterministic
@@ -1843,6 +1886,15 @@ static void Streaming_Stop(void) {
         MC12b_RestoreIdleScanList();
         gpRuntimeConfigStream->Running = false;
 
+        /* #814: clear the LIVE rail mask. It describes the current frame, and
+         * once the timer is stopped there is no current frame -- leaving it set
+         * would strand device_status bit 0x100 on until the next START, telling
+         * a status poller the device is clipping while it is idle. The
+         * cumulative counters are deliberately NOT cleared here: like the rest
+         * of the session stats they survive until the next Streaming_ClearStats
+         * so STATS? can still be read after STOP. */
+        gClipLiveMask = 0;
+
         // #533: drain BOTH sample queues at stop so nothing captured by
         // this session's final ticks can be encoded into the NEXT session.
         // The AIN queue was previously cleared only at start; the DIO list
@@ -1950,6 +2002,12 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
+    /* #814: cleared with the rest of the session counters. gClipLiveMask is
+     * cleared too so a stopped stream never reports a stale rail -- it is
+     * live state, and there is no live frame once streaming ends. */
+    gClippedSamples = 0;
+    gClipChannelMask = 0;
+    gClipLiveMask = 0;
     gDryTicks = 0;
     gPrimingPending = false;
     gScanEosSeq = 1u;       // #557/#563: prime seq one ahead of "seen" so the
@@ -2124,6 +2182,8 @@ void Streaming_GetStats(StreamingStats* out) {
                                                      : 0u;
     }
     out->scanStaleDropped = gScanStaleDropped;  // #557 (separate volatile, like timerISRCalls)
+    out->clippedSamples = gClippedSamples;          // #814
+    out->clippedChannelMask = gClipChannelMask;     // #814
     taskEXIT_CRITICAL();
 }
 
@@ -2172,6 +2232,12 @@ void Streaming_ClearStats(void) {
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
+    /* #814: cleared with the rest of the session counters. gClipLiveMask is
+     * cleared too so a stopped stream never reports a stale rail -- it is
+     * live state, and there is no live frame once streaming ends. */
+    gClippedSamples = 0;
+    gClipChannelMask = 0;
+    gClipLiveMask = 0;
     gDryTicks = 0;
     gScanEosSeq = 1u;       // #557/#563: prime seq one ahead of "seen" so the
     gScanEosSeqSeen = 0u;   // first post-start tick (no scan completed yet) reads fresh
@@ -2274,6 +2340,14 @@ static void Streaming_UpdateFlowWindow(bool dropped) {
         gQuesBits &= ~QUES_BIT_DATA_LOSS;
     }
     taskEXIT_CRITICAL();
+}
+
+bool Streaming_IsClipping(void)
+{
+    /* Plain 32-bit load -- atomic on PIC32MZ, single writer (the deferred
+     * streaming task). No critical section: taking one here would add ISR
+     * latency on a path the protobuf encoder hits once per frame. */
+    return (gClipLiveMask != 0u);
 }
 
 uint32_t Streaming_GetQuesBits(void) {

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -553,6 +553,16 @@ typedef struct {
     uint32_t dioDroppedSamplesSteady;
     uint32_t queueDroppedSamplesSteady;  // post-grace subset of queueDroppedSamples
     uint32_t eosOverruns;      // EOS notifications coalesced (>1 per wake) (#295)
+    /* #814: samples in which at least one enabled channel sat at a rail (raw
+     * code 0 or the module's full-scale code), and the OR of which channel
+     * slots did so. A railed sample is INDISTINGUISHABLE from a real reading
+     * once it leaves the device, which is the failure you cannot recover from
+     * after a long log. These are counters for diagnostics; the live signal
+     * rides the protobuf device_status word so a consumer can mark the span
+     * as it plots. NOT loss -- a clipped sample is delivered, it is just not
+     * trustworthy as a measurement, so it is never folded into any loss %. */
+    uint32_t clippedSamples;
+    uint32_t clippedChannelMask;
     uint32_t scanStaleDropped; // #557: scan armed but EOS not fired by next trigger
                                // (scan-busy/stale) — counted as a dropped sample
     // #541 D-A diagnostic: ticks where a T1 (dedicated-module) channel's
@@ -646,6 +656,21 @@ void Streaming_NoteEosFired(void);
  * Called by SCPI_SyncQuesBits() in SCPIInterface.c before register queries.
  * Bits are cleared automatically when streaming stops.
  */
+/**
+ * @brief True while at least one enabled channel is AT A RAIL right now.
+ *
+ * #814: live state, recomputed every streaming tick -- not a sticky latch and
+ * not a cumulative counter. The protobuf encoder ORs this into device_status
+ * as bit 0x100, so a consumer plotting the stream can mark the affected span
+ * as it happens rather than discovering a total afterwards. Returns false
+ * when not streaming.
+ *
+ * A railed value is delivered normally; the bit says only that it cannot be
+ * trusted as a measurement, because a genuine full-scale reading and a
+ * clamped one are the same number on the wire.
+ */
+bool Streaming_IsClipping(void);
+
 uint32_t Streaming_GetQuesBits(void);
 
 // #589: QUES condition bit 13 — shared SPI4 bus jammed (suspect SD card).

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -561,7 +561,10 @@ typedef struct {
      * rides the protobuf device_status word so a consumer can mark the span
      * as it plots. NOT loss -- a clipped sample is delivered, it is just not
      * trustworthy as a measurement, so it is never folded into any loss %. */
-    uint32_t clippedSamples;
+    /* 64-bit for the same reason totalSamplesStreamed is: a fully railed
+     * channel makes clippedSamples EQUAL to it, so it inherits the same
+     * range requirement and a uint32 would wrap inside a long log. */
+    uint64_t clippedSamples;
     uint32_t clippedChannelMask;
     uint32_t scanStaleDropped; // #557: scan armed but EOS not fired by next trigger
                                // (scan-busy/stale) — counted as a dropped sample
@@ -659,11 +662,14 @@ void Streaming_NoteEosFired(void);
 /**
  * @brief True while at least one enabled channel is AT A RAIL right now.
  *
- * #814: live state, recomputed every streaming tick -- not a sticky latch and
- * not a cumulative counter. The protobuf encoder ORs this into device_status
- * as bit 0x100, so a consumer plotting the stream can mark the affected span
- * as it happens rather than discovering a total afterwards. Returns false
- * when not streaming.
+ * #814: live state, republished for every DELIVERED sample -- not a sticky
+ * latch and not a cumulative counter. Returns false when not streaming.
+ *
+ * Where this is observable matters and is easy to get wrong: streaming
+ * protobuf frames do NOT carry device_status (the fast encoder emits only
+ * timestamp, analog, digital and port-dir), so the bit rides the INFO and
+ * DISCOVERY messages, not the stream. The live in-session surface is
+ * STAT:QUES:COND? bit 0, read over a link that is not carrying the stream.
  *
  * A railed value is delivered normally; the bit says only that it cannot be
  * trusted as a measurement, because a genuine full-scale reading and a


### PR DESCRIPTION
Closes #814.

## The problem

A sample at the end of its scale is **indistinguishable from a genuine reading** once it leaves the device — a full-scale ADC code and a clamped one are the same number on the wire. For a deployment logging for years that is the failure you cannot recover from afterwards, because the data looks fine. An on-device counter alone does not solve it either, since the consumer plotting the data never sees it.

## What changed

The deferred streaming task checks every valid channel against **both** rails (raw code `0` or the module's full-scale code) once per tick, placed after all the value branches so it covers the ADC paths, the #541 T1-direct path and the test-pattern/PIPELINE paths alike. Integer-only by construction — `adcMax` is already the `uint32_t` constant chosen to keep the FPU out of this pure-integer task (#368/#369).

Three surfaces, deliberately different in kind:

| surface | kind | notes |
|---|---|---|
| `SYST:STR:STATS?` → `ClippedSamples`, `ClippedChannelMask` | cumulative, per session | folded into the existing stats reply |
| protobuf `device_status` bit `0x100` | live | the convention the issue proposed, shared with the Gloor IAQ board |
| `STAT:QUES:COND?` bit 0 | live | the surface that works during a session — with one caveat, below |

**On the SCPI surface:** the issue proposed `SYST:STR:CLIPped?` / `:CLEar`. Per the standing "extend an existing command before adding one" rule those are not added — `SYST:STR:STATS?` is already the streaming-statistics reply and `STATS:CLEar` already resets it, so clipping rides both. No new SCPI commands.

## The QUES bit is beyond the issue, and here is why

The issue's premise is that the bit "rides on frames the consumer is already parsing". **That does not hold on the Nyquist**, for two independent reasons found while implementing it:

- the streaming protobuf fast encoder emits only `msg_time_stamp`, `analog_in_data`, `digital_data` and `digital_port_dir` — `device_status` is **absent from streaming frames by design**, to keep the hot path small. Adding it would cost ~3 B on a 10.9 B single-channel sample and would invalidate the fitted transport caps;
- **any** SCPI reply issued mid-stream over the link that is carrying the stream arrives buried in protobuf. Measured on the bench: a mid-stream `STAT:QUES:COND?` reply came back as **10,395 bytes of protobuf frames containing no CRLF-delimited integer anywhere**, and a mid-stream `SYSInfoPB?` parses `device_status` as `0` because the first length-delimited message in the reply is a streaming frame.

So `device_status` bit `0x100` alone would be correct and unobservable. `STAT:QUES:COND?` bit 0 is small, is already the register meaning *"this measurement is suspect"*, and IEEE 488.2 assigns bit 0 to **VOLTAGE** — exactly what a railed channel makes questionable. It is derived in `SCPI_SyncQuesBits` from `Streaming_IsClipping()` rather than latched in `gQuesBits` — the same treatment as `QUES_ANALOG_LIMIT` (#670), and what makes it clear itself when the channel comes off the rail.

**The honest caveat:** reading it live requires a link that is not itself carrying the stream — stream to SD or WiFi and query over USB, or stream to USB and query over TCP. That is a real constraint, not a workaround, and it applies to every mid-stream SCPI query on this device (it is why the project's quiescence rule exists). The companion test streams to the card for exactly this reason.

The QUES bit sits in its own commit and can be dropped independently if you'd rather not extend the QUES register.

## Deliberate choices

- **Never counted as loss.** The sample is delivered; it is just not trustworthy as a *measurement*. It stays out of every loss percentage, like `EosOverruns`.
- **The live mask is cleared in `Streaming_Stop`**, not only in `ClearStats` — it describes the current frame, and leaving it set would strand the bit on while the device sits idle. The cumulative counters deliberately survive stop, like the rest of the session stats.
- **`>=` on the top rail**, not `==`, so a value that somehow exceeds the module's range is caught rather than slipping past.
- **The mask is over session slots** (bit *j* = the *j*-th enabled channel, matching `validMask`), not board channel numbers.

## Verification

Both **NQ1 (`default`) and NQ3** build clean at `-O3 -Werror`, zero diagnostics.

Bench, Nq1 `7E2898F46200E8A7`, one T1 channel, protobuf, **streaming to SD with QUES read over USB**:

```
midscale : total=1922 clipped=0    mask=0 ques during=0 after=0
fullscale: total=1922 clipped=1922 mask=1 ques during=1 after=0
```

Clean separation on every axis, both arms exercised: counts 0 vs 100%, mask 0 vs 1, and the QUES bit set **only** while streaming fullscale and clearing on stop — which is what distinguishes a live bit from a latched or always-on one. midscale's `during=0` is a real zero rather than an unparsed reply, which is what makes that check discriminating.

> **Correction.** An earlier revision of this body quoted a USB-streamed run showing `ques during=1`. That number was not evidence — it came from a loose digit search matching protobuf payload in a mid-stream reply, which is the very hazard described above. The measurement was redone over a clean link; the values are unchanged but are now actually read. Details in [daqifi-python-test-suite#174](https://github.com/daqifi/daqifi-python-test-suite/pull/174).

Wiki updated (QUES bit row, both STATS fields, and a note on where `device_status` is and is not visible) — committed locally and **held until this merges**, since the wiki has no review step.

Companion regression test: [daqifi-python-test-suite#174](https://github.com/daqifi/daqifi-python-test-suite/pull/174).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
