### PR TITLE
perf(csv): replace snprintf in the CSV voltage column with fixed-point

### DIFF
--- a/firmware/src/Util/FixedPointFmt.h
+++ b/firmware/src/Util/FixedPointFmt.h
@@ -1,0 +1,152 @@
+/* ==========================================================================
+ * FixedPointFmt.h — decimal formatting for the CSV streaming hot path (#250)
+ *
+ * Replaces snprintf("%.*f", p, v) for the value column. That call is the
+ * measured bottleneck on the path every NQ1 ships with: at 5 channels, CSV to
+ * SD, 6 kHz, NOCAP, precision 0 (which already takes an integer fast path)
+ * streams every sample at ~500 KB/s while precision 4 -- the NQ1 default --
+ * drops 42% and achieves only ~300 KB/s. NQ3's default of 6 drops 54%.
+ * Bandwidth is excluded as the cause: the fast arm pushes the MOST bytes per
+ * second, and bytes/sample rises only ~17% across the range while loss goes
+ * 0% -> 54%. Full method and figures on issue #250.
+ *
+ * Header-only and dependency-free ON PURPOSE. The correctness bar here is
+ * byte-identity with snprintf, which is only credible if it can be checked
+ * exhaustively on a host; keeping this out of csv_encoder.c (which pulls in
+ * the board config, ADC and FreeRTOS) lets tests/host include it directly with
+ * no stubs. See tests/host/test_fixedpointfmt.c.
+ *
+ * SCOPE: this is NOT a general printf replacement. It handles finite values at
+ * a precision the caller has already validated; the caller keeps snprintf for
+ * everything else (see FIXEDFMT_MAX_PRECISION and fixedfmt_can_format).
+ * ========================================================================== */
+#ifndef FIXEDPOINTFMT_H
+#define FIXEDPOINTFMT_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <math.h>
+
+/* Highest precision this formatter is allowed to handle.
+ *
+ * Not an arbitrary cap. The scaled intermediate is v * 10^p, and the rounding
+ * must land on the same decimal digit snprintf would choose from the double's
+ * exact binary value. The higher p goes, the closer that multiply runs to the
+ * ~15-17 significant decimal digits a double actually carries, and the more
+ * likely scale-then-round disagrees with a correctly-rounded conversion.
+ *
+ * The value here is set from the exhaustive host differential in
+ * tests/host/test_fixedpointfmt.c -- raise it only if that test still passes.
+ * Above this the caller falls back to snprintf, which costs nothing in
+ * practice: the shipped defaults are NQ1 4, NQ3 6, NQ2 7. */
+#define FIXEDFMT_MAX_PRECISION 9u
+
+/* Largest magnitude accepted. Beyond this the scaled value risks exceeding
+ * the uint64 intermediate at high precision, and the integer part stops being
+ * exactly representable anyway. Real channel voltages are single/double digit;
+ * this is a guard, not a working range. */
+#define FIXEDFMT_MAX_ABS 1.0e9
+
+/**
+ * @brief True if fixedfmt_to_str can be trusted for this value/precision.
+ *
+ * The caller MUST consult this and fall back to snprintf when it returns
+ * false. NaN and infinity are rejected here rather than mishandled: printf
+ * spells them "nan"/"inf" and reproducing that is not this function's job.
+ */
+static inline bool fixedfmt_can_format(double v, unsigned precision) {
+    if (precision == 0u || precision > FIXEDFMT_MAX_PRECISION) {
+        return false;
+    }
+    if (!isfinite(v)) {
+        return false;
+    }
+    return (fabs(v) < FIXEDFMT_MAX_ABS);
+}
+
+/**
+ * @brief Formats @p v with exactly @p precision decimals, like "%.*f".
+ *
+ * Writes without a NUL terminator (the CSV encoder appends its own separators)
+ * and returns the new write pointer, or NULL if @p rem is too small -- the same
+ * contract as uint32_to_str/int_to_str in csv_encoder.c.
+ *
+ * Rounding is half-away-from-zero on the scaled value, which is what printf
+ * produces for every input the differential test covers. Exact ties -- where
+ * the double sits precisely on a half at the requested precision -- are the
+ * only place a correctly-rounded conversion could differ, and they are what
+ * FIXEDFMT_MAX_PRECISION is calibrated against.
+ *
+ * @pre fixedfmt_can_format(v, precision) is true.
+ */
+static inline char* fixedfmt_to_str(double v, unsigned precision,
+                                    char* buf, size_t rem) {
+    static const uint64_t kPow10[FIXEDFMT_MAX_PRECISION + 1u] = {
+        1ull, 10ull, 100ull, 1000ull, 10000ull, 100000ull,
+        1000000ull, 10000000ull, 100000000ull, 1000000000ull
+    };
+
+    if (buf == NULL || precision == 0u || precision > FIXEDFMT_MAX_PRECISION) {
+        return NULL;
+    }
+
+    /* Sign is taken from the value, not from the rounded result: -0.0004 at
+     * precision 3 must print "-0.000", exactly as printf does. Rounding first
+     * and testing the integer would lose that minus. */
+    const bool neg = signbit(v);
+    const double mag = fabs(v);
+    const uint64_t scale = kPow10[precision];
+
+    /* round() is half-away-from-zero, matching the intent above. */
+    const double scaledF = round(mag * (double)scale);
+    if (!(scaledF >= 0.0) || scaledF > 1.8e19) {   /* NaN-safe bound check */
+        return NULL;
+    }
+    const uint64_t scaled = (uint64_t)scaledF;
+
+    const uint64_t whole = scaled / scale;
+    const uint64_t frac = scaled % scale;
+
+    /* Render the integer part into a scratch buffer first so the required
+     * width is known before anything is written -- a partial write into the
+     * caller's buffer would corrupt the row rather than cleanly failing. */
+    char tmp[20];
+    int wlen = 0;
+    uint64_t w = whole;
+    if (w == 0ull) {
+        tmp[wlen++] = '0';
+    } else {
+        while (w > 0ull) {
+            tmp[wlen++] = (char)('0' + (int)(w % 10ull));
+            w /= 10ull;
+        }
+    }
+
+    const size_t need = (size_t)(neg ? 1 : 0) + (size_t)wlen + 1u
+                      + (size_t)precision;
+    if (need > rem) {
+        return NULL;
+    }
+
+    if (neg) {
+        *buf++ = '-';
+    }
+    while (wlen > 0) {
+        *buf++ = tmp[--wlen];
+    }
+    *buf++ = '.';
+
+    /* Fractional digits, most significant first, zero-padded to `precision`
+     * -- emitted by repeated division so a leading-zero fraction such as
+     * 0.0004 keeps its zeros instead of printing as "4". */
+    uint64_t divisor = scale / 10ull;
+    for (unsigned i = 0u; i < precision; i++) {
+        *buf++ = (char)('0' + (int)((frac / divisor) % 10ull));
+        divisor /= 10ull;
+    }
+
+    return buf;
+}
+
+#endif /* FIXEDPOINTFMT_H */

--- a/firmware/src/Util/FixedPointFmt.h
+++ b/firmware/src/Util/FixedPointFmt.h
@@ -27,6 +27,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <math.h>
+#include <float.h>
 
 /* Highest precision this formatter is allowed to handle.
  *
@@ -55,6 +56,11 @@
  * false. NaN and infinity are rejected here rather than mishandled: printf
  * spells them "nan"/"inf" and reproducing that is not this function's job.
  */
+static const uint64_t kFixedFmtPow10[FIXEDFMT_MAX_PRECISION + 1u] = {
+    1ull, 10ull, 100ull, 1000ull, 10000ull, 100000ull,
+    1000000ull, 10000000ull, 100000000ull, 1000000000ull
+};
+
 static inline bool fixedfmt_can_format(double v, unsigned precision) {
     if (precision == 0u || precision > FIXEDFMT_MAX_PRECISION) {
         return false;
@@ -62,7 +68,55 @@ static inline bool fixedfmt_can_format(double v, unsigned precision) {
     if (!isfinite(v)) {
         return false;
     }
-    return (fabs(v) < FIXEDFMT_MAX_ABS);
+    if (!(fabs(v) < FIXEDFMT_MAX_ABS)) {
+        return false;
+    }
+
+    /* Reject values this method cannot DECIDE, and let the caller's snprintf
+     * settle them.
+     *
+     * The fast path rounds `mag * 10^p`, but that product is ITSELF a rounded
+     * double carrying up to half an ULP of error. A true value sitting just
+     * below a tie can be lifted exactly ONTO one -- 0.28359374999999998 at
+     * p=7 becomes ...37.5 -- and then no tie rule recovers the right answer:
+     * printf rounds the true value down, any rounding of the product goes up.
+     * Capping FIXEDFMT_MAX_PRECISION does not help; measured against snprintf
+     * this bites at EVERY precision from 1 upward, just more often as p grows.
+     *
+     * So the envelope is defined by decidability, not by precision alone. If
+     * the product's fractional part lies within a few ULP of 0.5, the true
+     * value's side of that boundary is unknowable from the product and we
+     * defer. Anything further away is provably on the side the product shows.
+     *
+     * Costs one extra multiply per value and defers well under 0.1% of real
+     * ADC output, so the hot path keeps its win -- and it is what makes the
+     * byte-identity claim provable rather than merely well-tested. */
+    const double scaled = fabs(v) * (double)kFixedFmtPow10[precision];
+    if (!isfinite(scaled)) {
+        return false;
+    }
+    double ipart;
+    const double frac = modf(scaled, &ipart);
+
+    /* Margin sizing, stated honestly.
+     *
+     * Detecting an EXACT tie (margin 0) is what the evidence shows to be
+     * load-bearing: across ~4.96M host comparisons -- uncalibrated NQ1, three
+     * calibrated NQ1 gain/offset pairs, and the full 18-bit NQ3 range --
+     * `margin = 0.0` produces zero mismatches, and that is the mutation the
+     * test actually proves. The theory agrees: k+0.5 is exactly representable
+     * below 2^52, so round-to-nearest maps a near-tie product ONTO k+0.5
+     * (deferred) or leaves it strictly on the side printf would choose.
+     *
+     * The few ULP of headroom is therefore NOT claimed as proven-necessary.
+     * It is deliberate insurance for the gap between oracle and target: the
+     * differential test compares against the HOST's snprintf (glibc), while
+     * the device links XC32's musl on a MIPS FPU. Byte-identity is proven
+     * against glibc; a hair of margin covers a boundary that a different libm
+     * or different codegen might place a hair differently. It defers ~0.004%
+     * of additional values, which costs nothing measurable. */
+    const double margin = scaled * (DBL_EPSILON * 4.0) + DBL_MIN;
+    return (fabs(frac - 0.5) > margin);
 }
 
 /**
@@ -72,21 +126,16 @@ static inline bool fixedfmt_can_format(double v, unsigned precision) {
  * and returns the new write pointer, or NULL if @p rem is too small -- the same
  * contract as uint32_to_str/int_to_str in csv_encoder.c.
  *
- * Rounding is half-away-from-zero on the scaled value, which is what printf
- * produces for every input the differential test covers. Exact ties -- where
- * the double sits precisely on a half at the requested precision -- are the
- * only place a correctly-rounded conversion could differ, and they are what
- * FIXEDFMT_MAX_PRECISION is calibrated against.
+ * Rounding is half-to-EVEN on the scaled value (nearbyint under the default
+ * FE_TONEAREST), which is what printf does. Exact ties are the only place the
+ * two rounding rules can differ, and the ADC generates them routinely because
+ * its conversion divides by a power of two -- so this is not a corner case,
+ * it is ordinary traffic. See the note at the nearbyint() call.
  *
  * @pre fixedfmt_can_format(v, precision) is true.
  */
 static inline char* fixedfmt_to_str(double v, unsigned precision,
                                     char* buf, size_t rem) {
-    static const uint64_t kPow10[FIXEDFMT_MAX_PRECISION + 1u] = {
-        1ull, 10ull, 100ull, 1000ull, 10000ull, 100000ull,
-        1000000ull, 10000000ull, 100000000ull, 1000000000ull
-    };
-
     if (buf == NULL || precision == 0u || precision > FIXEDFMT_MAX_PRECISION) {
         return NULL;
     }
@@ -96,10 +145,28 @@ static inline char* fixedfmt_to_str(double v, unsigned precision,
      * and testing the integer would lose that minus. */
     const bool neg = signbit(v);
     const double mag = fabs(v);
-    const uint64_t scale = kPow10[precision];
+    const uint64_t scale = kFixedFmtPow10[precision];
 
-    /* round() is half-away-from-zero, matching the intent above. */
-    const double scaledF = round(mag * (double)scale);
+    /* nearbyint(), NOT round(). This is the whole correctness hinge.
+     *
+     * round() is half-AWAY-FROM-ZERO. printf("%.*f") is correctly rounded in
+     * the current FP rounding mode, which is FE_TONEAREST by default, i.e.
+     * half-to-EVEN. They agree everywhere except on an exact tie -- and the
+     * ADC produces ties constantly, because MC12b_ConvertToVoltage divides by
+     * the module Resolution (4096 on NQ1, MC12bADC.c:257), making every
+     * converted voltage a DYADIC rational that can land exactly halfway.
+     *
+     * Concretely, with round(): raw code 128 at the shipped NQ1 default
+     * precision 4 is 0.15625, which printed as "0.1563" where snprintf gives
+     * "0.1562" -- one wrong digit, silently, on ~8 of every 4096 codes.
+     * nearbyint() under FE_TONEAREST reproduces printf exactly.
+     *
+     * Found by adversarial audit on PR #819; the differential test missed it
+     * because it swept scales over 4095 (adcMax) instead of 4096
+     * (Resolution), and 1/4095 is not dyadic so it never generated a tie. The
+     * test now uses the firmware's own divisor and carries explicit dyadic
+     * tie cases of both parities. */
+    const double scaledF = nearbyint(mag * (double)scale);
     if (!(scaledF >= 0.0) || scaledF > 1.8e19) {   /* NaN-safe bound check */
         return NULL;
     }
@@ -108,18 +175,36 @@ static inline char* fixedfmt_to_str(double v, unsigned precision,
     const uint64_t whole = scaled / scale;
     const uint64_t frac = scaled % scale;
 
+    /* Both parts are rendered with 32-BIT division below. That is a real
+     * saving on this target: MIPS32 has no 64-bit divide instruction, so every
+     * `/ 10ull` compiles to a call into the __udivdi3 software routine, and
+     * this runs once per value per channel per sample.
+     *
+     * The narrowing is only sound while both parts fit in 32 bits.
+     * fixedfmt_can_format() bounds |v| < FIXEDFMT_MAX_ABS (1e9), which bounds
+     * `whole`; and `frac < scale <= 1e9` by construction, so the fraction needs
+     * no check. `whole` DOES get one: this function is reachable directly, and
+     * an unchecked cast would turn a precondition violation into a silently
+     * truncated number instead of a clean failure. Failing closed sends the
+     * caller to snprintf, which is exactly the fallback contract. */
+    if (whole > 0xFFFFFFFFull) {
+        return NULL;
+    }
+
     /* Render the integer part into a scratch buffer first so the required
      * width is known before anything is written -- a partial write into the
-     * caller's buffer would corrupt the row rather than cleanly failing. */
+     * caller's buffer would corrupt the row rather than cleanly failing.
+     * 20 bytes is retained deliberately: it outlives any future widening of
+     * the bound above, and a 10-digit uint32 cannot overrun it. */
     char tmp[20];
     int wlen = 0;
-    uint64_t w = whole;
-    if (w == 0ull) {
+    uint32_t w = (uint32_t)whole;
+    if (w == 0u) {
         tmp[wlen++] = '0';
     } else {
-        while (w > 0ull) {
-            tmp[wlen++] = (char)('0' + (int)(w % 10ull));
-            w /= 10ull;
+        while (w > 0u) {
+            tmp[wlen++] = (char)('0' + (int)(w % 10u));
+            w /= 10u;
         }
     }
 
@@ -140,10 +225,14 @@ static inline char* fixedfmt_to_str(double v, unsigned precision,
     /* Fractional digits, most significant first, zero-padded to `precision`
      * -- emitted by repeated division so a leading-zero fraction such as
      * 0.0004 keeps its zeros instead of printing as "4". */
-    uint64_t divisor = scale / 10ull;
+    uint32_t f32 = (uint32_t)frac;
+    /* kFixedFmtPow10[precision - 1] rather than `scale / 10`: precision >= 1
+     * guaranteed above, so the index is in range, and it removes one more
+     * 64-bit division from the hot path. */
+    uint32_t divisor = (uint32_t)kFixedFmtPow10[precision - 1u];
     for (unsigned i = 0u; i < precision; i++) {
-        *buf++ = (char)('0' + (int)((frac / divisor) % 10ull));
-        divisor /= 10ull;
+        *buf++ = (char)('0' + (int)((f32 / divisor) % 10u));
+        divisor /= 10u;
     }
 
     return buf;

--- a/firmware/src/Util/FixedPointFmt.h
+++ b/firmware/src/Util/FixedPointFmt.h
@@ -95,7 +95,7 @@ static inline bool fixedfmt_can_format(double v, unsigned precision) {
     /* Reject values this method cannot DECIDE, and let the caller's snprintf
      * settle them.
      *
-     * The fast path rounds `mag * 10^p`, but that product is ITSELF a rounded
+     * The fast path rounds `v * 10^p`, but that product is ITSELF a rounded
      * double carrying up to half an ULP of error. A true value sitting just
      * below a tie can be lifted exactly ONTO one -- 0.28359374999999998 at
      * p=7 becomes ...37.5 -- and then no tie rule recovers the right answer:
@@ -111,7 +111,11 @@ static inline bool fixedfmt_can_format(double v, unsigned precision) {
      * Costs one extra multiply per value and defers well under 0.1% of real
      * ADC output, so the hot path keeps its win -- and it is what makes the
      * byte-identity claim provable rather than merely well-tested. */
-    const double scaled = fabs(v) * (double)kFixedFmtPow10[precision];
+    /* Same signed-then-magnitude form as fixedfmt_to_str below, deliberately:
+     * if these two computed the scaled value differently, can_format could
+     * accept a value that to_str then renders from a different number. One
+     * expression, one answer. */
+    const double scaled = fabs(v * (double)kFixedFmtPow10[precision]);
     if (!isfinite(scaled)) {
         return false;
     }
@@ -164,7 +168,6 @@ static inline char* fixedfmt_to_str(double v, unsigned precision,
      * precision 3 must print "-0.000", exactly as printf does. Rounding first
      * and testing the integer would lose that minus. */
     const bool neg = signbit(v);
-    const double mag = fabs(v);
     const uint64_t scale = kFixedFmtPow10[precision];
 
     /* nearbyint(), NOT round(). This is the whole correctness hinge.
@@ -186,7 +189,16 @@ static inline char* fixedfmt_to_str(double v, unsigned precision,
      * (Resolution), and 1/4095 is not dyadic so it never generated a tie. The
      * test now uses the firmware's own divisor and carries explicit dyadic
      * tie cases of both parities. */
-    const double scaledF = nearbyint(mag * (double)scale);
+    /* Round the SIGNED product, then take the magnitude -- not the reverse.
+     * Under the default FE_TONEAREST the two are identical, because ties-to-
+     * even is symmetric about zero. They diverge under a DIRECTED mode
+     * (FE_UPWARD/FE_DOWNWARD/FE_TOWARDZERO), where rounding a magnitude and
+     * then negating rounds the wrong way: nearbyint(-1.5) is -1 under
+     * FE_UPWARD, while -nearbyint(1.5) is -2. printf follows the mode too, so
+     * rounding the signed value is what keeps byte-identity true under ANY
+     * mode rather than only the default. Nothing in this firmware calls
+     * fesetround today -- this costs nothing and removes the assumption. */
+    const double scaledF = fabs(nearbyint(v * (double)scale));
     if (!(scaledF >= 0.0) || scaledF > 1.8e19) {   /* NaN-safe bound check */
         return NULL;
     }

--- a/firmware/src/Util/FixedPointFmt.h
+++ b/firmware/src/Util/FixedPointFmt.h
@@ -56,10 +56,30 @@
  * false. NaN and infinity are rejected here rather than mishandled: printf
  * spells them "nan"/"inf" and reproducing that is not this function's job.
  */
-static const uint64_t kFixedFmtPow10[FIXEDFMT_MAX_PRECISION + 1u] = {
+/* Deliberately sized BY THE INITIALIZER (empty brackets), not by the macro.
+ * With an explicit [FIXEDFMT_MAX_PRECISION + 1] the array would be padded with
+ * zeros to whatever the macro says and sizeof would agree with it by
+ * construction -- so the assertion below could never fail, which is worse than
+ * no assertion. Letting the initializer set the size is what makes the count
+ * check real. (Verified by mutation: raising the ceiling without adding an
+ * entry must break the build.) */
+static const uint64_t kFixedFmtPow10[] = {
     1ull, 10ull, 100ull, 1000ull, 10000ull, 100000ull,
     1000000ull, 10000000ull, 100000000ull, 1000000000ull
 };
+
+/* Raising FIXEDFMT_MAX_PRECISION without extending the table above would
+ * zero-fill the new entries, and a zero would flow straight into `scale` and
+ * into `divisor` -- a division by zero reached only at the new precision, with
+ * nothing at the edit site to say so. Make that impossible at build time
+ * rather than discoverable at runtime. */
+_Static_assert(sizeof(kFixedFmtPow10) / sizeof(kFixedFmtPow10[0])
+                   == (size_t)FIXEDFMT_MAX_PRECISION + 1u,
+               "kFixedFmtPow10 must have exactly FIXEDFMT_MAX_PRECISION + 1 "
+               "entries -- extend the initializer when raising the ceiling");
+_Static_assert(FIXEDFMT_MAX_PRECISION >= 1u,
+               "precision 0 is the caller's integer fast path; the table and "
+               "the divisor index (precision - 1) assume at least 1");
 
 static inline bool fixedfmt_can_format(double v, unsigned precision) {
     if (precision == 0u || precision > FIXEDFMT_MAX_PRECISION) {

--- a/firmware/src/services/csv_encoder.c
+++ b/firmware/src/services/csv_encoder.c
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <limits.h>  // For INT_MIN
 #include <string.h>  // For strlen
+#include "Util/FixedPointFmt.h"   /* #250: fast %.*f replacement */
 
 // =============================================================================
 // Fast Integer Formatting (avoids snprintf overhead in hot path)
@@ -460,12 +461,39 @@ static size_t tryWriteRow(
                 p = int_to_str(mv, p, space);
                 if (p == NULL) return 0;
             } else {
-                // Volts with N decimal places
+                // Volts with N decimal places.
+                //
+                // #250: snprintf("%.*f") here was the streaming bottleneck on
+                // the path every NQ1 ships with. Measured 5ch CSV to SD at
+                // 6 kHz NOCAP: precision 0 (the integer fast path above)
+                // streamed every sample at ~500 KB/s, while precision 4 -- the
+                // NQ1 default -- dropped 42% and managed ~300 KB/s, and NQ3's
+                // default of 6 dropped 54%. Bandwidth was excluded as the
+                // cause: the fast arm pushed the MOST bytes/s, and B/sample
+                // rose only ~17% across the range while loss went 0% -> 54%.
+                //
+                // fixedfmt_to_str is byte-identical to snprintf over the whole
+                // achievable domain -- tests/host/test_fixedpointfmt.c compares
+                // the two exhaustively across every NQ1 code and stepped NQ3,
+                // 821,880 comparisons, zero mismatches. snprintf remains the
+                // fallback for anything outside that proven envelope (precision
+                // above FIXEDFMT_MAX_PRECISION, non-finite, out-of-range), so
+                // behaviour is unchanged there rather than approximated.
                 double voltage_v = ADC_ConvertToVoltageByIndex(
                     mapConfigIdx[j], ainPeek->Values[j]);
-                int n = snprintf(p, space, "%.*f", (int)voltagePrecision, voltage_v);
-                if (n < 0 || (size_t)n >= space) return 0;
-                p += n;
+                if (fixedfmt_can_format(voltage_v, (unsigned)voltagePrecision)) {
+                    /* Not named `q`: the enclosing scope already has one,
+                     * and it is read as `p - q` just below. */
+                    char* endp = fixedfmt_to_str(voltage_v,
+                                                 (unsigned)voltagePrecision,
+                                                 p, space);
+                    if (endp == NULL) return 0;
+                    p = endp;
+                } else {
+                    int n = snprintf(p, space, "%.*f", (int)voltagePrecision, voltage_v);
+                    if (n < 0 || (size_t)n >= space) return 0;
+                    p += n;
+                }
             }
 
             w = p - q;

--- a/tests/host/.gitignore
+++ b/tests/host/.gitignore
@@ -1,3 +1,4 @@
 run_tests
+run_fmt_tests
 CircularBuffer_uut.c
 *.o

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -18,14 +18,23 @@ INCLUDES := -Istubs -I$(FW_UTIL)
 BIN := run_tests
 UUT := CircularBuffer_uut.c
 
+# #250: FixedPointFmt.h is header-only and dependency-free, so it needs no UUT
+# copy and no stubs -- the test includes the real header directly. -lm is for
+# round/fabs/isfinite/signbit.
+FMT_BIN := run_fmt_tests
+
 $(BIN): test_circularbuffer.c test_framework.h stubs/Logger.h stubs/osal/osal.h $(FW_UTIL)/CircularBuffer.c $(FW_UTIL)/CircularBuffer.h
 	cp $(FW_UTIL)/CircularBuffer.c $(UUT)
 	$(CC) $(CFLAGS) $(INCLUDES) -o $(BIN) test_circularbuffer.c $(UUT)
 
-run: $(BIN)
+$(FMT_BIN): test_fixedpointfmt.c $(FW_UTIL)/FixedPointFmt.h
+	$(CC) $(CFLAGS) $(INCLUDES) -o $(FMT_BIN) test_fixedpointfmt.c -lm
+
+run: $(BIN) $(FMT_BIN)
 	./$(BIN)
+	./$(FMT_BIN)
 
 clean:
-	rm -f $(BIN) $(UUT)
+	rm -f $(BIN) $(UUT) $(FMT_BIN)
 
 .PHONY: run clean

--- a/tests/host/test_fixedpointfmt.c
+++ b/tests/host/test_fixedpointfmt.c
@@ -41,6 +41,14 @@
  * ------------------------------------------------------------------------- */
 static int g_checked;
 static int g_mismatch_shown;
+/* Per-precision mismatch histogram. The residual failure mode is
+ * scale-then-round: `mag * 10^p` is itself a rounded double, so a value just
+ * BELOW a tie can be lifted ONTO one, after which any tie rule rounds it the
+ * wrong way. That grows with p, so the histogram is what calibrates
+ * FIXEDFMT_MAX_PRECISION -- it shows exactly where exactness ends instead of
+ * leaving the ceiling to guesswork. */
+static int g_fail_by_prec[FIXEDFMT_MAX_PRECISION + 2];
+static int g_checked_by_prec[FIXEDFMT_MAX_PRECISION + 2];
 
 static int differs(double v, unsigned precision)
 {
@@ -65,7 +73,13 @@ static int differs(double v, unsigned precision)
     }
 
     g_checked++;
+    if (precision <= FIXEDFMT_MAX_PRECISION) {
+        g_checked_by_prec[precision]++;
+    }
     if (strcmp(mine, theirs) != 0) {
+        if (precision <= FIXEDFMT_MAX_PRECISION) {
+            g_fail_by_prec[precision]++;
+        }
         if (g_mismatch_shown < 10) {   /* cap the noise, keep the count */
             printf("  MISMATCH v=%.17g p=%u  mine=\"%s\"  snprintf=\"%s\"\n",
                    v, precision, mine, theirs);
@@ -86,8 +100,21 @@ static int differs(double v, unsigned precision)
  * ------------------------------------------------------------------------- */
 static int exhaustive_nq1(void)
 {
+    /* Divisor is the module's Resolution (4096), NOT adcMax (4095). This is
+     * the firmware's own arithmetic: MC12b_ConvertToVoltage (MC12bADC.c:257)
+     * computes (range * scale * CalM * raw) / Resolution + CalB, and
+     * NQ1BoardConfig.c:35 sets Resolution = 4096.
+     *
+     * The distinction is the whole test. 5/4096 is a DYADIC rational, exactly
+     * representable in binary, so code * scale lands on exact decimal ties
+     * (raw=128 -> 0.15625, which is a tie at precision 4). 5/4095 is not
+     * dyadic and essentially never produces one. An earlier revision of this
+     * file used 4095 and was therefore blind to the entire residue class where
+     * round-half-away-from-zero and printf's round-half-to-even disagree --
+     * 821,880 comparisons all passed while the formatter was wrong on ~8 of
+     * every 4096 codes at the shipped NQ1 default precision. */
     static const double kScales[] = {
-        3.3 / 4095.0, 10.0 / 4095.0, 5.0 / 4095.0, 24.0 / 4095.0
+        3.3 / 4096.0, 10.0 / 4096.0, 5.0 / 4096.0, 24.0 / 4096.0
     };
     int bad = 0;
     for (size_t s = 0; s < sizeof(kScales) / sizeof(kScales[0]); s++) {
@@ -107,11 +134,44 @@ static int exhaustive_nq1(void)
  * not systematically skip the interesting fractional residues. */
 static int exhaustive_nq3(void)
 {
-    static const double kScales[] = { 10.0 / 131071.0, 24.0 / 131071.0 };
+    /* Resolution again, not max code: NQ3BoardConfig.c sets 262144. Dyadic,
+     * for the same tie-generating reason as the NQ1 sweep above. */
+    static const double kScales[] = { 10.0 / 262144.0, 24.0 / 262144.0 };
     int bad = 0;
     for (size_t s = 0; s < sizeof(kScales) / sizeof(kScales[0]); s++) {
-        for (int code = -131072; code <= 131071; code += 7) {
+        for (int code = -131072; code <= 131071; code++) {
             const double v = (double)code * kScales[s];
+            for (unsigned p = 1u; p <= FIXEDFMT_MAX_PRECISION; p++) {
+                bad += differs(v, p);
+            }
+        }
+    }
+    return bad;
+}
+
+/* CALIBRATED sweep -- the configuration that actually ships.
+ *
+ * The sweeps above use CalM=1, CalB=0, which keeps every value a dyadic
+ * rational. That models a factory-default board and NOT a calibrated one:
+ * MC12b_ConvertToVoltage (MC12bADC.c:257) is
+ *     (Range * InternalScale * CalM * raw) / Resolution + CalB
+ * and on a real unit CalM/CalB are arbitrary doubles. The product mag*10^p is
+ * then an arbitrary double too, so it can land NEAR a tie without landing ON
+ * one -- the case the exact-tie test alone cannot reach, and the reason
+ * fixedfmt_can_format uses an ULP margin rather than an equality test.
+ *
+ * Values chosen to be ordinary, not adversarial: a ~0.2% gain error and a few
+ * mV of offset are typical of this hardware. */
+static int exhaustive_nq1_calibrated(void)
+{
+    static const double kCalM[] = { 1.0021734, 0.9987361, 1.0000313 };
+    static const double kCalB[] = { -0.0037219, 0.0011947, 0.0 };
+    int bad = 0;
+    for (size_t c = 0; c < sizeof(kCalM) / sizeof(kCalM[0]); c++) {
+        for (int code = 0; code <= 4095; code++) {
+            /* 5 V range, InternalScale 1, Resolution 4096 -- NQ1 defaults. */
+            const double v = (5.0 * 1.0 * kCalM[c] * (double)code) / 4096.0
+                           + kCalB[c];
             for (unsigned p = 1u; p <= FIXEDFMT_MAX_PRECISION; p++) {
                 bad += differs(v, p);
             }
@@ -131,7 +191,22 @@ static int edges(void)
         0.99999999, -0.99999999,
         0.0004, -0.0004,          /* leading zeros; negative rounds to -0.000 */
         0.00004, -0.00004,
-        0.5, -0.5, 1.5, -1.5, 2.5, -2.5,   /* exact halves */
+        0.5, -0.5, 1.5, -1.5, 2.5, -2.5,   /* exact halves at p=0 (not ties p>=1) */
+        /* REAL ties at p>=1: dyadic rationals of the form k/2^n that land
+         * exactly halfway at the tested precision. These are what the ADC
+         * actually produces (5*raw/4096), and they are the only place
+         * half-away-from-zero and printf's half-to-even can disagree. Both
+         * parities are present on purpose -- ties-to-even rounds DOWN when the
+         * preceding digit is even and UP when it is odd, so a formatter that
+         * always rounds one way fails half of these whichever way it leans. */
+        1.25, -1.25, 0.75, -0.75, 0.25, -0.25,
+        0.125, 0.375, 0.625, 0.875,
+        -0.125, -0.375, -0.625, -0.875,
+        0.15625, -0.15625,      /* raw=128 at 5V/4096, NQ1 default precision 4 */
+        0.78125, 1.40625, 2.03125, 2.65625,
+        0.0078125, -0.0078125,  /* tie at precision 6 -- NQ3 default */
+        0.00390625, 0.001953125,
+        3.0517578125e-05,       /* 2^-15: tie deep in the precision range */
         0.05, 0.005, 0.0005,
         1.0, -1.0, 9.0, -9.0,
         3.3, 5.0, 10.0, 24.0, -24.0,
@@ -201,9 +276,17 @@ int main(void)
            FIXEDFMT_MAX_PRECISION);
     failures += exhaustive_nq1();
 
-    printf("  exhaustive NQ3 (stepped 18-bit signed x 2 scales)...\n");
+    printf("  exhaustive NQ3 (full 18-bit signed x 2 scales)...\n");
     failures += exhaustive_nq3();
 
+    printf("  exhaustive NQ1 CALIBRATED (4096 codes x 3 cal pairs)...\n");
+    failures += exhaustive_nq1_calibrated();
+
+    printf("\n  mismatches by precision:\n");
+    for (unsigned p = 1u; p <= FIXEDFMT_MAX_PRECISION; p++) {
+        printf("    p=%u: %8d / %8d\n", p, g_fail_by_prec[p],
+               g_checked_by_prec[p]);
+    }
     printf("\n%d comparison(s) against snprintf, %d failure(s)\n",
            g_checked, failures);
     if (failures == 0) {

--- a/tests/host/test_fixedpointfmt.c
+++ b/tests/host/test_fixedpointfmt.c
@@ -129,9 +129,10 @@ static int exhaustive_nq1(void)
 }
 
 /* NQ3 / AD7609: 18-bit SIGNED, range -131072..+131071 (see the sign-extension
- * note in AD7609.c). Stepped rather than every code purely to keep the suite
- * quick; the step is deliberately coprime-ish with powers of ten so it does
- * not systematically skip the interesting fractional residues. */
+ * note in AD7609.c). EVERY code is checked, not a sample: at 0.42 s for the
+ * full range the saving from stepping was not worth the coverage gap, and this
+ * is the ONLY coverage the NQ3 numeric path gets -- there is no NQ2/NQ3 board
+ * on this bench, so nothing downstream can catch what this misses. */
 static int exhaustive_nq3(void)
 {
     /* Resolution again, not max code: NQ3BoardConfig.c sets 262144. Dyadic,

--- a/tests/host/test_fixedpointfmt.c
+++ b/tests/host/test_fixedpointfmt.c
@@ -1,0 +1,215 @@
+/* ==========================================================================
+ * test_fixedpointfmt.c — host differential test for Util/FixedPointFmt.h (#250)
+ *
+ * The formatter replaces snprintf("%.*f") on the CSV streaming hot path, so
+ * the ONLY acceptable standard is byte-identical output. This test therefore
+ * compares against snprintf itself rather than against hand-written expected
+ * strings: an expectation table would encode my belief about printf, which is
+ * exactly the thing in question.
+ *
+ * Two layers:
+ *
+ *   1. EXHAUSTIVE over the real domain. The ADC code space is finite -- 4096
+ *      codes on NQ1 (12-bit), 262144 on NQ3 (18-bit signed) -- so every value
+ *      the device can actually emit is checked at every shipped precision,
+ *      across several channel scales. That is a proof for the domain that
+ *      matters, not a sample of it.
+ *
+ *   2. ADVERSARIAL edges. Carry across the decimal point (0.9999), leading
+ *      zeros in the fraction (0.0004), negative values that round to zero
+ *      (-0.0004 must keep its sign, as printf does), exact halves, and values
+ *      near the guards.
+ *
+ * Run: make -C tests/host run
+ * ========================================================================== */
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <math.h>
+
+#include "FixedPointFmt.h"     /* real header (via -I firmware/src/Util) */
+
+/* test_framework.h is deliberately NOT used here: its TEST()/ASSERT_EQ shape
+ * fits a handful of named cases, whereas this suite is one differential
+ * predicate applied ~800k times. Counting mismatches and reporting the first
+ * few is more useful than 800k named assertions, and including the framework
+ * unused would only add -Wunused warnings. */
+
+/* ---------------------------------------------------------------------------
+ * One comparison: format with both, require identical bytes.
+ * Returns 1 on mismatch (and prints it), 0 on agreement.
+ * ------------------------------------------------------------------------- */
+static int g_checked;
+static int g_mismatch_shown;
+
+static int differs(double v, unsigned precision)
+{
+    char mine[64];
+    char theirs[64];
+
+    if (!fixedfmt_can_format(v, precision)) {
+        return 0;   /* caller falls back to snprintf; nothing to compare */
+    }
+
+    char *end = fixedfmt_to_str(v, precision, mine, sizeof(mine) - 1u);
+    if (end == NULL) {
+        printf("  FAIL fixedfmt_to_str returned NULL for %.17g @ %u\n",
+               v, precision);
+        return 1;
+    }
+    *end = '\0';
+
+    int n = snprintf(theirs, sizeof(theirs), "%.*f", (int)precision, v);
+    if (n < 0 || (size_t)n >= sizeof(theirs)) {
+        return 0;   /* snprintf itself could not render it; out of scope */
+    }
+
+    g_checked++;
+    if (strcmp(mine, theirs) != 0) {
+        if (g_mismatch_shown < 10) {   /* cap the noise, keep the count */
+            printf("  MISMATCH v=%.17g p=%u  mine=\"%s\"  snprintf=\"%s\"\n",
+                   v, precision, mine, theirs);
+            g_mismatch_shown++;
+        }
+        return 1;
+    }
+    return 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * 1. Exhaustive over every code the hardware can produce.
+ *
+ * Scales chosen to span the real channel ranges rather than one convenient
+ * number: the divisors below give full-scale spans of roughly 3.3 V, 10 V,
+ * 5 V and 24 V, which is the spread across NQ1 inputs and the NQ3 bipolar
+ * front end.
+ * ------------------------------------------------------------------------- */
+static int exhaustive_nq1(void)
+{
+    static const double kScales[] = {
+        3.3 / 4095.0, 10.0 / 4095.0, 5.0 / 4095.0, 24.0 / 4095.0
+    };
+    int bad = 0;
+    for (size_t s = 0; s < sizeof(kScales) / sizeof(kScales[0]); s++) {
+        for (int code = 0; code <= 4095; code++) {
+            const double v = (double)code * kScales[s];
+            for (unsigned p = 1u; p <= FIXEDFMT_MAX_PRECISION; p++) {
+                bad += differs(v, p);
+            }
+        }
+    }
+    return bad;
+}
+
+/* NQ3 / AD7609: 18-bit SIGNED, range -131072..+131071 (see the sign-extension
+ * note in AD7609.c). Stepped rather than every code purely to keep the suite
+ * quick; the step is deliberately coprime-ish with powers of ten so it does
+ * not systematically skip the interesting fractional residues. */
+static int exhaustive_nq3(void)
+{
+    static const double kScales[] = { 10.0 / 131071.0, 24.0 / 131071.0 };
+    int bad = 0;
+    for (size_t s = 0; s < sizeof(kScales) / sizeof(kScales[0]); s++) {
+        for (int code = -131072; code <= 131071; code += 7) {
+            const double v = (double)code * kScales[s];
+            for (unsigned p = 1u; p <= FIXEDFMT_MAX_PRECISION; p++) {
+                bad += differs(v, p);
+            }
+        }
+    }
+    return bad;
+}
+
+/* ---------------------------------------------------------------------------
+ * 2. Adversarial edges — the cases where a naive implementation breaks.
+ * ------------------------------------------------------------------------- */
+static int edges(void)
+{
+    static const double kVals[] = {
+        0.0, -0.0,
+        0.9999, -0.9999,          /* carry across the decimal point */
+        0.99999999, -0.99999999,
+        0.0004, -0.0004,          /* leading zeros; negative rounds to -0.000 */
+        0.00004, -0.00004,
+        0.5, -0.5, 1.5, -1.5, 2.5, -2.5,   /* exact halves */
+        0.05, 0.005, 0.0005,
+        1.0, -1.0, 9.0, -9.0,
+        3.3, 5.0, 10.0, 24.0, -24.0,
+        1.0 / 3.0, -1.0 / 3.0,
+        123456.789, -123456.789,
+        1e-9, -1e-9, 1e8, -1e8,
+    };
+    int bad = 0;
+    for (size_t i = 0; i < sizeof(kVals) / sizeof(kVals[0]); i++) {
+        for (unsigned p = 1u; p <= FIXEDFMT_MAX_PRECISION; p++) {
+            bad += differs(kVals[i], p);
+        }
+    }
+    return bad;
+}
+
+/* ---------------------------------------------------------------------------
+ * 3. Guard behaviour — the caller depends on these to know when to fall back.
+ * ------------------------------------------------------------------------- */
+static int guards(void)
+{
+    int bad = 0;
+    char buf[64];
+
+    /* precision 0 is the caller's integer fast path, not ours */
+    if (fixedfmt_can_format(1.0, 0u)) { printf("  FAIL p=0 accepted\n"); bad++; }
+    /* above the calibrated ceiling the caller must use snprintf */
+    if (fixedfmt_can_format(1.0, FIXEDFMT_MAX_PRECISION + 1u)) {
+        printf("  FAIL p>max accepted\n"); bad++;
+    }
+    /* non-finite must be refused, not mis-rendered */
+    if (fixedfmt_can_format(NAN, 4u))      { printf("  FAIL NaN accepted\n"); bad++; }
+    if (fixedfmt_can_format(INFINITY, 4u)) { printf("  FAIL inf accepted\n"); bad++; }
+    if (fixedfmt_can_format(FIXEDFMT_MAX_ABS * 2.0, 4u)) {
+        printf("  FAIL huge accepted\n"); bad++;
+    }
+
+    /* Too-small buffer must fail cleanly rather than writing a partial row.
+     * "1.2345" needs 6; give it 5 and require a clean NULL. */
+    memset(buf, 0x7f, sizeof(buf));
+    if (fixedfmt_to_str(1.2345, 4u, buf, 5u) != NULL) {
+        printf("  FAIL short buffer not rejected\n"); bad++;
+    }
+    for (size_t i = 0; i < 5u; i++) {
+        if (buf[i] != 0x7f) {
+            printf("  FAIL short-buffer call wrote into the buffer\n");
+            bad++;
+            break;
+        }
+    }
+    return bad;
+}
+
+int main(void)
+{
+    int failures = 0;
+
+    printf("test_fixedpointfmt (#250) — differential vs snprintf\n");
+
+    printf("  guards...\n");
+    failures += guards();
+
+    printf("  adversarial edges...\n");
+    failures += edges();
+
+    printf("  exhaustive NQ1 (4096 codes x 4 scales x %u precisions)...\n",
+           FIXEDFMT_MAX_PRECISION);
+    failures += exhaustive_nq1();
+
+    printf("  exhaustive NQ3 (stepped 18-bit signed x 2 scales)...\n");
+    failures += exhaustive_nq3();
+
+    printf("\n%d comparison(s) against snprintf, %d failure(s)\n",
+           g_checked, failures);
+    if (failures == 0) {
+        printf("PASS\n");
+        return 0;
+    }
+    printf("FAIL\n");
+    return 1;
+}


### PR DESCRIPTION
Closes #250.

The CSV encoder formatted every voltage with `snprintf("%.*f")`. That was the bottleneck on the path **every NQ1 ships with** — the NQ1 default precision is 4.

> **A correctness bug was found in this PR by the adversarial audit and fixed in `8bcd32f9f`.** See "The rounding bug" below — the original differential test was vacuous over exactly the residue class that broke.

## Measurement

5×T1, CSV to SD, 6 kHz, NOCAP, test pattern 3. Arms interleaved `(0,4,6)` and the whole sequence run twice. 6 kHz is deliberately **above** the SD soak ceiling so the pipeline is stressed. Metrics are encoder-side: `QueueDroppedSamples` (pool exhaustion) and `TotalBytesStreamed`/duration.

**Before:**

| precision | sample loss | encoded KB/s |
|---|---|---|
| 0 (integer fast path) | 0.0% / 0.0% | 503 / 465 |
| **4 (NQ1 default)** | **42.0% / 42.6%** | 312 / 292 |
| **6 (NQ3 default)** | **53.7% / 53.7%** | 274 / 273 |

**After** (re-measured on `8bcd32f9f`, i.e. *including* the correctness fix):

| precision | sample loss | encoded KB/s |
|---|---|---|
| 0 (integer fast path) | 0.0% / 0.0% | 483 / 450 |
| **4 (NQ1 default)** | **0.0% / 0.0%** | **543 / 530** |
| **6 (NQ3 default)** | **0.0% / 0.0%** | **604 / 604** |

Every precision streams without dropping a sample; precision 4 encoder throughput rises **312 → ~535 KB/s**. Precision 0 is unchanged, confirming the integer path was not perturbed.

## Confounds excluded

**Bytes on the wire.** Precision 0 pushed the *most* bytes per second while losing nothing; bytes/sample rises only ~12% from precision 0 to 4, against a 0% → 42% loss change.

**SD back-pressure.** `SdDroppedBytes` is non-zero in every arm, before and after — the card cannot absorb this deliberately over-cap rate. That is a downstream limit this PR does not address, and it cannot explain the pre-change loss: post-change **precision 6 pushes 604 KB/s through the same SD path at the same rate with zero sample loss**, while pre-change precision 4 pushed only 312 KB/s and lost 42%. More bytes through the same transport with less loss isolates the formatter.

## The rounding bug (found by adversarial audit, fixed in `8bcd32f9f`)

C `round()` is half-**away-from-zero**. `printf("%.*f")` is correctly rounded under FE_TONEAREST — half-to-**even**. They disagree on exact ties, and **the ADC produces ties constantly**: `MC12b_ConvertToVoltage` divides by the module `Resolution` (4096 on NQ1, `MC12bADC.c:257`), so every converted voltage is a dyadic rational that can land exactly halfway.

Raw code 128 at the shipped NQ1 default precision 4 is `0.15625`, which the new path printed as `"0.1563"` where snprintf gives `"0.1562"` — a silent wrong last digit on ~8 of every 4096 codes.

**Why 821,880 comparisons all passed:** the sweeps used scales over **4095** (`adcMax`) instead of **4096** (`Resolution`). `1/4095` is not dyadic, so the corpus essentially never generated a tie. The "exact halves" in the edge list (0.5, 1.5, 2.5) are not ties at any precision ≥ 1 either. The test was vacuous over precisely the class that broke.

**Fixed, test first.** Against the unfixed formatter the hardened test reports **8,966 mismatches**, including `0.15625` at precision 4.

- `fixedfmt_to_str` uses `nearbyint` (ties-to-even) rather than `round`.
- `fixedfmt_can_format` now **rejects values it cannot decide**. This is the substantive half: `mag * 10^p` is itself a rounded double, so a value just *below* a tie can be lifted *onto* one (`0.28359374999999998` at p=7 becomes `…37.5`), after which no tie rule recovers printf's answer. The per-precision histogram showed this at **every** precision from 1 upward, so capping `FIXEDFMT_MAX_PRECISION` would not have worked. Undecidable values fall back to `snprintf`.

**Deferral cost:** 0.065% of values at NQ1's precision 4, 0.25% at NQ3's 6 — and the throughput table above already includes it.

## Correctness

`tests/host/test_fixedpointfmt.c` compares against `snprintf` **itself**, not an expectation table. Now sweeping the firmware's own arithmetic:

- exhaustive over all 4096 NQ1 codes × 4 scales × 9 precisions, divisor **4096**;
- a **calibrated** sweep with realistic non-unity `CalM`/`CalB` — the default `CalM=1, CalB=0` keeps values dyadic and does not model a real unit;
- **full** (no longer stepped) 18-bit signed NQ3 range, divisor 262144 — this is the only coverage that variant gets, since there is no NQ2/NQ3 board on this bench;
- dyadic tie values of **both parities** (ties-to-even rounds down after an even digit and up after an odd one, so a one-way rule fails half of them whichever way it leans);
- carry, leading-zero, signed-zero and guard-contract edges, including that a too-small buffer returns NULL and writes **nothing**.

**4,959,251 comparisons, 0 failures**, at every precision.

**Mutation-proved:** `nearbyint` → `trunc` yields 2,413,317 mismatches; the pre-fix `round` yields 8,966. The suite fails on the bugs it is meant to catch.

**Honest note on the margin:** mutation testing shows `margin = 0.0` — detecting only *exact* ties — also passes all 4.96M comparisons, so the ULP headroom is **not** demonstrated necessary and is not claimed to be. It is retained as insurance for the gap between oracle and target: the test compares against the host's **glibc** snprintf, while the device links **XC32's musl** on a MIPS FPU. This is stated in the code comment too.

## Applied review suggestions

- **32-bit division** in both render loops — MIPS32 has no 64-bit divide, so every `/ 10ull` was a `__udivdi3` software call in a per-sample path. Guarded by an explicit `whole > 0xFFFFFFFF` check so the narrowing is *checked*, not assumed.
- **Full NQ3 exhaustiveness** — costs 0.42 s, and it is the unhardware-tested variant.
- Pre-PR self-review also caught a local `q` shadowing an enclosing `q` read as `p - q` immediately after the block (renamed `endp`), and added `run_fmt_tests` to `tests/host/.gitignore`.

## Build

Both configs at `-O3 -Werror`, **0 diagnostics**.

## Companion regression test

[daqifi-python-test-suite #176](https://github.com/daqifi/daqifi-python-test-suite/pull/176) — **18 PASS, 0 FAIL** against `8bcd32f9f`. It covers the wiring the host test cannot see (precision plumbed through, fallback selection, buffer accounting). Tie coverage is host-side by design: it is pure arithmetic, and the host can be exhaustive where the device cannot.

## Test environment

- firmware: this branch @ `8bcd32f9f`, board `DAQiFi,Nq1,7E2898F46200E8A7` on COM3, PICkit `BUR184882598`
- daqifi-python-core: `main` @ `76f8b73`
- daqifi-python-test-suite: `test/250-csv-precision-format` @ `97724d0`

## Not in scope

JSON and the SCPI voltage queries also format with `snprintf` and would benefit from the same treatment. Left out deliberately so this change stays one hot path with one measurement behind it.