### PR TITLE
fix(sd): stop discarding the data encoded while a rotation opens the next file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1296,9 +1296,22 @@ SYST:STOR:SD:MAXSize?               # Query current setting
 - Split files: Sequential numbering, **not** zero-padded (e.g., `experiment-1.csv`, `experiment-2.csv`) — `generateFilename` formats `"%s/%s-%u%s"` (`sd_card_manager.c`)
 - Supports up to 9999 files per session (~39TB @ 3.9GB each)
 
-**CSV Headers:**
-- First file: Full CSV header (device info, column names with "ain" prefix)
-- Split files: Data rows only (no headers) - simplifies merging
+**CSV Headers:** ⚠️ **every split file carries its own header, including
+continuations.** The bullet here used to say "Split files: Data rows only (no
+headers) - simplifies merging". That is wrong and has been for some time —
+measured 2026-08-21 by downloading rotated files from the bench: `s2.csv`,
+`s2-1.csv` and `s2-2.csv` each begin `# Device: Nyquist 1` followed by ~1,279
+data rows.
+
+The behaviour is deliberate on the firmware side: `streaming.c` writes an
+SD-only header whenever `gSdFileWasReady` goes false→true so that "every file
+is self-describing and independently parseable", and
+`Streaming_ResetSdPbMetadata()` is called on every rotation to arm exactly
+that. Anything merging split files must therefore SKIP the `#`-prefixed lines
+of continuations rather than assuming they are absent.
+
+- First file: full CSV header (device info, column names with "ain" prefix)
+- Split files: the same header, then data rows
 
 **Safety Features:**
 - Default: 3.9GB limit (100MB below FAT32 maximum)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1303,7 +1303,16 @@ SYST:STOR:SD:MAXSize?               # Query current setting
 **Safety Features:**
 - Default: 3.9GB limit (100MB below FAT32 maximum)
 - Minimum: 1000 bytes (prevents rapid rotation)
-- Circular buffer draining before rotation (zero data loss)
+- Circular buffer draining before rotation, AND the buffer keeps accepting
+  encoder output across the file-open window (#757). Both halves are needed for
+  "zero data loss": the drain covers what was already buffered, and the second
+  covers what arrives while the next file is being created. Before #757 only
+  the drain existed, so every rotation discarded the packets encoded during the
+  open — measured ~14,000 bytes per 25 s at 2 kHz with `MAXSize 20000`, growing
+  with directory occupancy because the FatFs create is O(N) in it. The encoder
+  gate is `sd_card_manager_IsBufferAccepting()`; note that transport health
+  deliberately still uses `IsWriteReady()`, or a stuck open would read as
+  healthy.
 - Unconditional filesystem flush before file close
 
 **Python Tools:**

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2484,6 +2484,39 @@ void sd_card_manager_ProcessState() {
                     }
                 }
 
+                /* #757: arm the NEW file's buffer BEFORE the sync and close,
+                 * not after.
+                 *
+                 * IsWriteReady() stays true right up to the FileClose below,
+                 * so the streaming task keeps enqueuing throughout the sync --
+                 * which is the slow part. Doing the reset afterwards meant
+                 * those bytes were sitting in the buffer when it was cleared,
+                 * and they were DISCARDED: ~95 bytes per rotation, invisible,
+                 * because nothing counted them. (Measured by counting them:
+                 * 3,702 bytes across 39 rotations in one 25 s arm. The old
+                 * code discarded them too, just as silently.)
+                 *
+                 * Resetting here instead keeps them. The buffer is empty at
+                 * this point -- the drain above just emptied it into the old
+                 * file -- so clearing the metadata latch now means the encoder
+                 * writes the NEW file's header first and everything enqueued
+                 * during the sync, the close and the open follows it, in
+                 * order, into the new file. Nothing is dropped and the header
+                 * is still at byte 0.
+                 *
+                 * Conditional on actually rotating: the split-limit branch
+                 * below never opens a new file, so promising a drain there
+                 * would strand whatever accumulated. */
+                const bool willRotate =
+                        (gSDCardData.fileCounter < SD_CARD_MANAGER_MAX_SPLIT_FILES);
+                if (willRotate) {
+                    Streaming_ResetSdPbMetadata();
+                    SD_TakeMutexDebug(gSDCardData.wMutex, "rotation_open_window");
+                    CircularBuf_Reset(&gSDCardData.wCirbuf);
+                    gSdRotating = true;
+                    xSemaphoreGive(gSDCardData.wMutex);
+                }
+
                 // Flush and close current file
                 if (gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID) {
                     // Always sync before close - ensures all filesystem buffers flushed
@@ -2526,20 +2559,11 @@ void sd_card_manager_ProcessState() {
                  * it encodes during the open follows in order. The buffer
                  * reset is kept for the error paths where the drain could not
                  * complete; on the normal path it is a no-op. */
-                if (gSDCardData.fileCounter < SD_CARD_MANAGER_MAX_SPLIT_FILES) {
-                    /* Opened INSIDE this branch, deliberately. The window is a
-                     * promise that an open is coming to drain what the encoder
-                     * buffers; the split-limit branch below never enters
-                     * OPEN_FILE, so opening the window before this test would
-                     * promise an open that never happens. Structuring it this
-                     * way makes that impossible rather than leaving it to a
-                     * reachability argument about how many files it takes. */
-                    Streaming_ResetSdPbMetadata();
-                    SD_TakeMutexDebug(gSDCardData.wMutex, "rotation_open_window");
-                    CircularBuf_Reset(&gSDCardData.wCirbuf);
-                    xSemaphoreGive(gSDCardData.wMutex);
-                    gSdRotating = true;
-
+                if (willRotate) {
+                    /* The window was already opened above, before the sync and
+                     * close, so that everything the encoder produced during
+                     * them is kept rather than discarded. All that remains is
+                     * to advance to the next file. */
                     gSDCardData.fileCounter++;
                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE;
                 } else {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1244,8 +1244,15 @@ static volatile bool gSdTeardownRequested = false;
  * WRITE_TO_FILE arm of IsBufferAccepting() takes over and the buffered bytes
  * are about to be written, not lost. */
 static void sd_AbandonRotationWindow(const char* why) {
-    gSdRotating = false;
+    /* Clear INSIDE the mutex, not before taking it. sd_card_manager_WriteToBuffer
+     * re-checks sd_card_manager_IsBufferAccepting() under this same mutex, so
+     * ordering them this way leaves no gap: a writer that gets the mutex first
+     * writes, and the count below includes its bytes; a writer that gets it
+     * after sees the flag already false and refuses. Clearing before the take
+     * would let a writer blocked on the mutex append AFTER the reset, and those
+     * bytes would be neither drained nor counted. */
     SD_TakeMutexDebug(gSDCardData.wMutex, "abandon_rotation");
+    gSdRotating = false;
     size_t buffered = CircularBuf_NumBytesAvailable(&gSDCardData.wCirbuf);
     CircularBuf_Reset(&gSDCardData.wCirbuf);
     xSemaphoreGive(gSDCardData.wMutex);
@@ -3109,6 +3116,25 @@ size_t sd_card_manager_WriteToBuffer(const char* pData, size_t len) {
     // SD task's slow f_write runs OUTSIDE the mutex, so a hung card makes
     // this return 0, never block.
     SD_TakeMutexDebug(gSDCardData.wMutex, "write_buffer_add");
+    /* #757: the accept decision must be authoritative HERE, not merely where
+     * the caller sized the write.
+     *
+     * The caller computes sdSize from IsBufferAccepting() at the top of its
+     * iteration and writes later. Between those two points the SD task can
+     * abandon the rotation window -- a bucket refusal, a teardown, a failed
+     * create -- which resets this buffer. Without this re-check the in-flight
+     * write lands in the freshly reset buffer, where nothing will drain it: it
+     * is lost silently AND can prepend a partial row to the next session's
+     * file. The enable/mode test above does not catch it, because mode is
+     * still WRITE at that moment.
+     *
+     * Re-checking under the mutex that sd_AbandonRotationWindow() also holds
+     * closes it: this either runs before the abandon (and those bytes are
+     * counted by it) or after (and refuses). */
+    if (!sd_card_manager_IsBufferAccepting()) {
+        xSemaphoreGive(gSDCardData.wMutex);
+        return 0;
+    }
     if (CircularBuf_NumBytesFree(&gSDCardData.wCirbuf) < len) {
         xSemaphoreGive(gSDCardData.wMutex);
         return 0;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1267,6 +1267,21 @@ void sd_card_manager_ProcessState() {
 
     switch (gSDCardData.currentProcessState) {
         case SD_CARD_MANAGER_PROCESS_STATE_INIT:
+            /* #757: a rotation window never spans an INIT -- a rotation goes
+             * WRITE_TO_FILE -> OPEN_FILE directly -- so reaching here with the
+             * flag still set means the previous session was interrupted between
+             * the rotation's close and the open that would have cleared it.
+             * app_SDCardTask parking in SUSPENDED for a WiFi streaming session
+             * (#589) is one way to get there, since it pumps neither this state
+             * machine nor the driver.
+             *
+             * mode != WRITE already makes IsBufferAccepting() false in that
+             * state, so nothing streams into a dead buffer -- but a STALE true
+             * would survive into the next write session and make OPEN_FILE skip
+             * the metadata and buffer reset on a FIRST open, which is exactly
+             * the case the skip is not meant to cover. Clear it here so the
+             * flag cannot outlive the session that set it. */
+            gSdRotating = false;
             // Only initialize if SD is enabled AND has a valid operation mode
             // Just enabling SD without setting a mode (WRITE/READ/LIST) is valid - don't spam errors
             // GET_SPACE is allowed even when disabled (transient read-only query)

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1267,6 +1267,15 @@ void sd_card_manager_ProcessState() {
     /* #800: honour a teardown that raced a state store, before dispatching. */
     if (gSdTeardownRequested) {
         gSdTeardownRequested = false;
+        /* #757: this override can land while a rotation window is open --
+         * a STOP arriving between the rotation's close and OPEN_FILE. Forcing
+         * DEINIT here means OPEN_FILE never runs, so the abort path that would
+         * have closed the window and accounted for its bytes never runs
+         * either: the flag stays set and the bytes vanish from SdDroppedBytes.
+         * Route it through the same accounting every other abandon uses. */
+        if (gSdRotating) {
+            sd_AbandonRotationWindow("teardown during rotation");
+        }
         gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_DEINIT;
     }
 
@@ -2510,8 +2519,29 @@ void sd_card_manager_ProcessState() {
                 const bool willRotate =
                         (gSDCardData.fileCounter < SD_CARD_MANAGER_MAX_SPLIT_FILES);
                 if (willRotate) {
-                    Streaming_ResetSdPbMetadata();
+                    /* The metadata clear MUST be inside the same mutex as the
+                     * buffer reset, not before it.
+                     *
+                     * Streaming_ResetSdPbMetadata() sets gSdFileWasReady=false,
+                     * which is the encoder's cue to emit the next file's
+                     * header. The old file is still open here, so
+                     * IsBufferAccepting() is true; if the pri-6 streaming task
+                     * preempts this pri-5 one between that clear and the reset,
+                     * it generates the header, writes it into the buffer, and
+                     * sets gSdFileWasReady=true -- and then the reset below
+                     * wipes it. Nothing re-emits it (OPEN_FILE skips its own
+                     * reset while gSdRotating is true) and nothing counts it,
+                     * so the split file starts with data rows and no header,
+                     * silently. That is the same class of defect this issue is
+                     * about, arriving through the fix for it.
+                     *
+                     * Holding wMutex across both closes it, because
+                     * sd_card_manager_WriteToBuffer takes the same mutex: an
+                     * encoder that has already decided to write the header
+                     * blocks until the reset is done and then lands it in the
+                     * emptied buffer, still at byte 0. */
                     SD_TakeMutexDebug(gSDCardData.wMutex, "rotation_open_window");
+                    Streaming_ResetSdPbMetadata();
                     CircularBuf_Reset(&gSDCardData.wCirbuf);
                     gSdRotating = true;
                     xSemaphoreGive(gSDCardData.wMutex);

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -203,6 +203,20 @@ static SemaphoreHandle_t gSDOpMutex = NULL;
 static bool gLoggedUnmountFail = false;
 // gLoggedWriteBufferTimeout removed — WriteToBuffer is now non-blocking
 static volatile bool gTransferAbortRequested = false;
+
+/* #757: true from the instant the old file is closed for a size rotation until
+ * the new file's open has resolved. During that window there is no valid file
+ * handle, so sd_card_manager_IsWriteReady() is false -- but the circular buffer
+ * is empty (the rotation drained it) and will be written to the NEW file, so it
+ * can safely keep ACCEPTING encoder output. That is the whole fix: without it
+ * the encoder is told sdSize == 0 for the entire open, and every packet encoded
+ * in that window is discarded and counted in SdDroppedBytes.
+ *
+ * Single writer (the SD task); read by the streaming task via
+ * sd_card_manager_IsBufferAccepting(). A plain aligned bool is atomic on
+ * PIC32MZ; volatile is here because the two contexts differ, not to imply
+ * read-modify-write safety. */
+static volatile bool gSdRotating = false;
 static int gFormatStatus = 0;  // 0=idle, 1=in progress, 2=success, -1=failed
 static uint32_t gFormatSectorsEstimate = 0;  // Estimated total sectors written during format
 
@@ -1213,6 +1227,35 @@ static bool sd_TargetExistsInBucketPath(const char* bucketPath, bool* fsError) {
  * no critical section is needed for the flag itself. */
 static volatile bool gSdTeardownRequested = false;
 
+/* #757: end a rotation's open window on a path that will never write.
+ *
+ * Closing the window is not optional. While gSdRotating is set the streaming
+ * task keeps filling the circular buffer on the strength of a promise that
+ * something will drain it; if the open ends without a handle -- a bucket
+ * refusal, a teardown, a failed create -- that promise is broken and the flag
+ * must be cleared or the encoder buffers forever into a dead path.
+ *
+ * Whatever it already buffered cannot be recovered: there is no file to write
+ * it to. It is still real SD loss, so it is counted rather than dropped
+ * quietly, and the buffer is reset so the next session does not inherit a
+ * half-written file's header.
+ *
+ * The success path does NOT come here -- it just clears the flag, because the
+ * WRITE_TO_FILE arm of IsBufferAccepting() takes over and the buffered bytes
+ * are about to be written, not lost. */
+static void sd_AbandonRotationWindow(const char* why) {
+    gSdRotating = false;
+    SD_TakeMutexDebug(gSDCardData.wMutex, "abandon_rotation");
+    size_t buffered = CircularBuf_NumBytesAvailable(&gSDCardData.wCirbuf);
+    CircularBuf_Reset(&gSDCardData.wCirbuf);
+    xSemaphoreGive(gSDCardData.wMutex);
+    if (buffered > 0u) {
+        Streaming_ReportSdDiscard(buffered);
+        LOG_E("[SD] rotation open abandoned (%s): discarded %u buffered byte(s)",
+              why, (unsigned)buffered);
+    }
+}
+
 void sd_card_manager_ProcessState() {
     /* #800: honour a teardown that raced a state store, before dispatching. */
     if (gSdTeardownRequested) {
@@ -1897,6 +1940,11 @@ void sd_card_manager_ProcessState() {
                     }
                     gpSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_IDLE;
+                    /* #757: this exits OPEN_FILE without ever reaching the
+                     * open, so the rotation window has to be closed here too --
+                     * otherwise the encoder keeps filling a buffer that nothing
+                     * will drain. */
+                    sd_AbandonRotationWindow("no writable bucket");
                     xSemaphoreGive(gSDCardData.opCompleteSemaphore);
                     break;
                 }
@@ -1934,15 +1982,42 @@ void sd_card_manager_ProcessState() {
                 //      encodes WITHOUT metadata, writes to buffer
                 //   3. Streaming_ResetSdPbMetadata() resets flags (too late)
                 //   => Non-metadata data at byte 0 of new file
-                Streaming_ResetSdPbMetadata();
+                /* #757: skipped during a rotation -- the close path above
+                 * already reset the metadata and the buffer, and the encoder
+                 * has been filling that buffer with the new file's header and
+                 * data ever since. Repeating the reset here would throw away
+                 * exactly the bytes this fix exists to keep. On a FIRST open
+                 * (session start, not rotation) gSdRotating is false and this
+                 * runs as it always did. */
+                if (!gSdRotating) {
+                    Streaming_ResetSdPbMetadata();
 
-                // Now clear the buffer — streaming task won't write here
-                // because gSdFileWasReady is already false.
-                SD_TakeMutexDebug(gSDCardData.wMutex, "open_file_clear_buffer");
-                CircularBuf_Reset(&gSDCardData.wCirbuf);
-                memset(gSdSharedBuffer, 0, gSdSharedBufferSize);
-                memset(gSDCardData.writeBuffer, 0, gSDCardData.writeBufferSize);
-                xSemaphoreGive(gSDCardData.wMutex);
+                    // Now clear the buffer — streaming task won't write here
+                    // because gSdFileWasReady is already false.
+                /* #757: reset the buffer's BOOKKEEPING, not its bytes.
+                 *
+                 * Neither zero was load-bearing: nothing reads either buffer
+                 * past a length that is reset alongside it. CircularBuf_Reset
+                 * already makes the circular buffer logically empty (head,
+                 * tail, count) and no reader looks beyond count; the write
+                 * buffer is only ever emitted as its first writeBufferLength
+                 * bytes, reset a few lines below -- and the comment there
+                 * records that the "junk bytes in the new file" bug was fixed
+                 * by resetting sdCardWritePending/writeBufferLength, NOT by
+                 * this memset.
+                 *
+                 * The cost was real: writeBuffer is the COHERENT (KSEG1,
+                 * uncached) DMA buffer, ~78 KB when SD is the active
+                 * interface, so this was an uncached write of every byte with
+                 * no cache-line benefit -- inside the very window this issue
+                 * is about. Measured ~4% of the loss on its own.
+                 *
+                 * The mutex is still taken: CircularBuf_Reset mutates state
+                 * the streaming task reads. */
+                    SD_TakeMutexDebug(gSDCardData.wMutex, "open_file_clear_buffer");
+                    CircularBuf_Reset(&gSDCardData.wCirbuf);
+                    xSemaphoreGive(gSDCardData.wMutex);
+                }
 
                 // Reset write pipeline state for clean start.
                 // Without this, a stale sdCardWritePending=1 from a previous
@@ -1955,6 +2030,14 @@ void sd_card_manager_ProcessState() {
                 // Use WRITE_PLUS to create/truncate file (overwrite mode)
                 gSDCardData.fileHandle = SYS_FS_FileOpen(gSDCardData.filePath,
                         (SYS_FS_FILE_OPEN_WRITE_PLUS));
+
+                /* #757: the window is over the moment the open resolves, in
+                 * BOTH directions. On success the WRITE_TO_FILE arm of
+                 * IsBufferAccepting takes over and this flag stops mattering;
+                 * on failure or teardown it must be cleared here, or the
+                 * encoder would go on filling a buffer that nothing will ever
+                 * drain. Cleared before the abort check below for that reason. */
+                gSdRotating = false;
 
                 /* #782: a teardown may have landed while this open was in
                  * flight. SCPI (pri 7) preempts this task (pri 5), and
@@ -1999,11 +2082,25 @@ void sd_card_manager_ProcessState() {
                      * invalidation that suppressed UNMOUNT's retry.
                      *
                      * Note this is about single ownership, not data
-                     * recovery: nothing can be pending at this point. The
-                     * circular buffer and the write pipeline are reset a few
-                     * lines above, and the abort path never sets
-                     * WRITE_TO_FILE, so sd_card_manager_IsWriteReady() stays
-                     * false and the streaming task cannot have written. */
+                     * recovery.
+                     *
+                     * #757 CHANGED THE SECOND HALF OF THAT REASONING. This
+                     * comment used to say nothing could be pending, because
+                     * the abort path never sets WRITE_TO_FILE so
+                     * IsWriteReady() stays false and the streaming task
+                     * cannot have written. That is no longer true: across a
+                     * rotation the encoder writes on IsBufferAccepting(),
+                     * which IS true during the open, so the buffer can hold
+                     * the new file's header and some samples by the time we
+                     * get here.
+                     *
+                     * Those bytes are unrecoverable -- the session is being
+                     * torn down and there is no handle to write them to -- but
+                     * they must not vanish silently. Count them as SD drops so
+                     * they appear in SdDroppedBytes like any other SD loss,
+                     * and reset the buffer so the next session starts clean
+                     * rather than inheriting a partial file's header. */
+                    sd_AbandonRotationWindow("session torn down mid-open");
                     LOG_I("[SD] open aborted: session torn down mid-open "
                           "(mode=%s)", sd_card_manager_GetModeName());
                     break;
@@ -2019,6 +2116,10 @@ void sd_card_manager_ProcessState() {
 
                 if (gSDCardData.fileHandle == SYS_FS_HANDLE_INVALID) {
                     /* Could not open the file. Error out*/
+                    /* #757: nothing will ever drain what the encoder buffered
+                     * during this open, so account for it instead of leaving
+                     * it to be silently overwritten by the next session. */
+                    sd_AbandonRotationWindow("file open failed");
                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                     LOG_E("[%s:%d]Failed to open SD Card file for writing: '%s'", __FILE__, __LINE__, gSDCardData.filePath);
                 }
@@ -2376,9 +2477,27 @@ void sd_card_manager_ProcessState() {
                          gSDCardData.filePath, gSDCardData.currentFileBytes);
                 }
 
-                // Encoder resets are done in OPEN_FILE (after buffer clear +
-                // file open) so the streaming task cannot burn one-shot
-                // header flags before the new file is ready to accept data.
+                /* #757: open the buffer for the NEW file before the slow open.
+                 *
+                 * The previous ordering deferred both resets to OPEN_FILE so
+                 * the streaming task could not burn its one-shot header flag
+                 * before the new file existed. That ordering is precisely what
+                 * made this window lossy: the flag stayed set, no handle
+                 * existed, so the encoder was told sdSize == 0 and everything
+                 * it produced during the open was discarded and counted.
+                 *
+                 * Reversing it is safe because the drain above emptied the
+                 * buffer into the OLD file. Resetting the metadata here means
+                 * the first thing the encoder puts into the now-empty buffer
+                 * is the NEW file's header -- still at byte 0 -- and whatever
+                 * it encodes during the open follows in order. The buffer
+                 * reset is kept for the error paths where the drain could not
+                 * complete; on the normal path it is a no-op. */
+                Streaming_ResetSdPbMetadata();
+                SD_TakeMutexDebug(gSDCardData.wMutex, "rotation_open_window");
+                CircularBuf_Reset(&gSDCardData.wCirbuf);
+                xSemaphoreGive(gSDCardData.wMutex);
+                gSdRotating = true;
 
                 if (gSDCardData.fileCounter < SD_CARD_MANAGER_MAX_SPLIT_FILES) {
                     gSDCardData.fileCounter++;
@@ -3399,6 +3518,38 @@ bool sd_card_manager_IsWriteReady(void) {
         && gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE
         && gSDCardData.currentProcessState == SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE
         && gSDCardData.fileHandle != SYS_FS_HANDLE_INVALID;
+}
+
+/* #757: may the streaming task keep filling the SD circular buffer?
+ *
+ * DELIBERATELY WEAKER than sd_card_manager_IsWriteReady(). That one answers
+ * "is there a file I can write to right now", which is the correct question
+ * for transport health (streaming.c's #397 auto-stop must NOT think a stuck
+ * open is healthy) and for the session-start latch. This one answers "will
+ * anything ever consume what I put in the buffer", which is the correct
+ * question for the ENCODER -- and the two differ for exactly the duration of
+ * a size rotation.
+ *
+ * During a rotation the old handle is closed before the new one is opened, and
+ * the open is slow: a FatFs create is O(N) in directory occupancy, which is
+ * why the loss this fixes grew with the number of files on the card. The
+ * buffer is empty across that window (the rotation drains it before closing)
+ * and its contents go to the NEW file, so accepting writes is safe and the
+ * header still lands at byte 0 -- Streaming_ResetSdPbMetadata() is called
+ * before the window opens, so the first thing the encoder puts in the empty
+ * buffer is the new file's header.
+ *
+ * Returns false once the open resolves, in both directions: on success the
+ * WRITE_TO_FILE arm above takes over, and on failure or teardown the flag is
+ * cleared so nothing keeps buffering into a path that will never drain. */
+bool sd_card_manager_IsBufferAccepting(void) {
+    if (sd_card_manager_IsWriteReady()) {
+        return true;
+    }
+    return gpSDCardSettings != NULL
+        && gpSDCardSettings->enable
+        && gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE
+        && gSdRotating;
 }
 
 /* #703: is the SD read scratch large enough for SD:GET to make progress?

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2535,6 +2535,14 @@ void sd_card_manager_ProcessState() {
                     // Close current file with error checking
                     if (SYS_FS_FileClose(gSDCardData.fileHandle) == SYS_FS_RES_FAILURE) {
                         LOG_E("[%s:%d]Error closing file before rotation", __FILE__, __LINE__);
+                        /* #757: the window was opened above, BEFORE this close,
+                         * so that bytes produced during the sync are kept. This
+                         * exit never reaches OPEN_FILE, which means nothing
+                         * will ever drain them -- close the window here or the
+                         * encoder buffers into a dead path until it fills.
+                         * This is the one early exit the reordering introduced;
+                         * the sync failure above only logs and falls through. */
+                        sd_AbandonRotationWindow("file close failed");
                         gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                         break;
                     }

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2046,14 +2046,6 @@ void sd_card_manager_ProcessState() {
                 gSDCardData.fileHandle = SYS_FS_FileOpen(gSDCardData.filePath,
                         (SYS_FS_FILE_OPEN_WRITE_PLUS));
 
-                /* #757: the window is over the moment the open resolves, in
-                 * BOTH directions. On success the WRITE_TO_FILE arm of
-                 * IsBufferAccepting takes over and this flag stops mattering;
-                 * on failure or teardown it must be cleared here, or the
-                 * encoder would go on filling a buffer that nothing will ever
-                 * drain. Cleared before the abort check below for that reason. */
-                gSdRotating = false;
-
                 /* #782: a teardown may have landed while this open was in
                  * flight. SCPI (pri 7) preempts this task (pri 5), and
                  * sd_card_manager_UpdateSettings() tears the session down by
@@ -2084,6 +2076,25 @@ void sd_card_manager_ProcessState() {
                 gSDCardData.currentProcessState = openAborted
                         ? SD_CARD_MANAGER_PROCESS_STATE_DEINIT
                         : SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE;
+                /* #757: close the window in the SAME critical section that
+                 * opens WRITE_TO_FILE, so the handoff is atomic.
+                 *
+                 * Clearing it any earlier reopens this issue in miniature.
+                 * Between a clear and the state assignment, gSdRotating is
+                 * false while currentProcessState is still OPEN_FILE, so
+                 * IsWriteReady() is false too and IsBufferAccepting() returns
+                 * FALSE -- the encoder (pri 6) preempts this task (pri 5)
+                 * right there and its packets are discarded. That gap was
+                 * measurable: it is where the last few stray SdDroppedBytes in
+                 * an otherwise clean rotation run came from.
+                 *
+                 * Only the success arm clears. On abort the flag stays set
+                 * until sd_AbandonRotationWindow() below clears it AND
+                 * accounts for what was buffered -- clearing it here would
+                 * silently strand those bytes instead. */
+                if (!openAborted) {
+                    gSdRotating = false;
+                }
                 taskEXIT_CRITICAL();
 
                 if (openAborted) {
@@ -2508,13 +2519,20 @@ void sd_card_manager_ProcessState() {
                  * it encodes during the open follows in order. The buffer
                  * reset is kept for the error paths where the drain could not
                  * complete; on the normal path it is a no-op. */
-                Streaming_ResetSdPbMetadata();
-                SD_TakeMutexDebug(gSDCardData.wMutex, "rotation_open_window");
-                CircularBuf_Reset(&gSDCardData.wCirbuf);
-                xSemaphoreGive(gSDCardData.wMutex);
-                gSdRotating = true;
-
                 if (gSDCardData.fileCounter < SD_CARD_MANAGER_MAX_SPLIT_FILES) {
+                    /* Opened INSIDE this branch, deliberately. The window is a
+                     * promise that an open is coming to drain what the encoder
+                     * buffers; the split-limit branch below never enters
+                     * OPEN_FILE, so opening the window before this test would
+                     * promise an open that never happens. Structuring it this
+                     * way makes that impossible rather than leaving it to a
+                     * reachability argument about how many files it takes. */
+                    Streaming_ResetSdPbMetadata();
+                    SD_TakeMutexDebug(gSDCardData.wMutex, "rotation_open_window");
+                    CircularBuf_Reset(&gSDCardData.wCirbuf);
+                    xSemaphoreGive(gSDCardData.wMutex);
+                    gSdRotating = true;
+
                     gSDCardData.fileCounter++;
                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE;
                 } else {

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -390,6 +390,14 @@ extern "C" {
      */
     bool sd_card_manager_IsWriteReady(void);
 
+    /* #757: may the streaming task keep filling the SD circular buffer?
+     * Weaker than IsWriteReady: also true across a size rotation, where the
+     * old handle is closed before the slow new open completes but the drained
+     * buffer will still be written to the new file. Use this for the ENCODER
+     * gate only -- transport health must keep using IsWriteReady, or a stuck
+     * open reads as healthy. */
+    bool sd_card_manager_IsBufferAccepting(void);
+
     /**
      * @brief Gets the result of the last GET_SPACE operation.
      *

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2007,6 +2007,28 @@ static void Streaming_CountSdDrop(size_t packetSize) {
 }
 
 /**
+ * @brief Account for SD bytes that were buffered but can never be written.
+ *
+ * #757: the SD manager lets the encoder keep filling the circular buffer
+ * across a file rotation, because those bytes belong to the next file. If the
+ * session is torn down while that open is still in flight there is no handle
+ * left to write them to, and they are dropped. They are real SD loss and must
+ * land in SdDroppedBytes like any other, rather than disappearing because the
+ * only counter for it is file-local to this module.
+ *
+ * Deliberately a narrow, purpose-named entry point rather than exporting
+ * Streaming_CountSdDrop itself: the internal one is called per encoded packet
+ * from the output path, and widening it invites use from places that should be
+ * going through that path.
+ */
+void Streaming_ReportSdDiscard(size_t bytes) {
+    if (bytes == 0u) {
+        return;
+    }
+    Streaming_CountSdDrop(bytes);
+}
+
+/**
  * #533: drain both per-session sample queues (AIN + DIO) so no sample
  * captured by one session can be encoded into the next.  Called from
  * Streaming_Stop (the session is over — discard) and Streaming_Start
@@ -2712,10 +2734,27 @@ void streaming_Task(void) {
 
         usbSize = UsbCdc_WriteBuffFreeSize(NULL);
         wifiSize = wifi_manager_GetWriteBuffFreeSize();
-        // Only check SD buffer size once the file is actually open.
-        // The SD card manager clears the circular buffer during file open,
-        // so writing before that would lose data (including headers).
-        sdSize = sd_card_manager_IsWriteReady()
+        /* #757: gate on IsBufferAccepting, not IsWriteReady.
+         *
+         * The old gate asked "is a file open right now", which is false for
+         * the whole of a size rotation -- and a FatFs create is O(N) in
+         * directory occupancy, so that window grew with the log. Every packet
+         * encoded during it was discarded and counted in SdDroppedBytes:
+         * measured ~9 KB/s on a populated card, and the loss is quadratic in
+         * encoder rate because a faster encoder both fills files sooner and
+         * produces more per window.
+         *
+         * IsBufferAccepting stays true across that window. It is safe because
+         * the rotation DRAINS the buffer before closing the old handle, so the
+         * bytes accepted here belong to the new file, and because
+         * Streaming_ResetSdPbMetadata() runs before the window opens -- so the
+         * first thing written into the empty buffer is the new file's header,
+         * still at byte 0.
+         *
+         * The old comment's premise no longer holds either: the buffer is no
+         * longer cleared during the open, it is cleared once before the window
+         * (see OPEN_FILE / the rotation close in sd_card_manager.c). */
+        sdSize = sd_card_manager_IsBufferAccepting()
                ? sd_card_manager_GetWriteBuffFreeSize()
                : 0;
 

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -504,6 +504,11 @@ void Streaming_SdInterfaceReleased(void);
 
 void Streaming_ResetSdPbMetadata(void);
 
+/* #757: report SD bytes that were buffered for the next file but can never be
+ * written, because the session was torn down while the rotation's open was in
+ * flight. Counts into SdDroppedBytes so the loss is visible instead of silent. */
+void Streaming_ReportSdDiscard(size_t bytes);
+
 // #388 — Compile-time profiling counters for the PB streaming hot path.
 // When enabled, instruments encoder + USB write paths with _CP0_GET_COUNT()
 // cycle measurements.  Off by default in production: enable here for a


### PR DESCRIPTION
Closes #757.

Every SD file rotation lost the packets encoded during the file-open window.

## Mechanism

The rotation drains the circular buffer into the old file, syncs and closes it, then enters `OPEN_FILE` to create the next one. Across that window there is **no valid handle**, so `sd_card_manager_IsWriteReady()` is false, the encoder forces `sdSize = 0`, and every packet it produces is discarded and counted in `SdDroppedBytes`. The window is dominated by the FatFs create, which is **O(N) in directory occupancy** — which is why the loss grew as the log filled.

## The fix

Separate two questions the old gate conflated:

| predicate | question | used for |
|---|---|---|
| `IsWriteReady()` | "is there a file I can write to *right now*" | transport health (#397 auto-stop), session-start latch |
| `IsBufferAccepting()` **(new)** | "will anything *ever* consume what I put in the buffer" | the encoder gate |

They differ for exactly the duration of a rotation. Keeping health on `IsWriteReady` matters — otherwise a stuck open would read as healthy.

Accepting writes across the window is safe because **the rotation already drained the buffer**, so those bytes belong to the *new* file. The header still lands at byte 0: `Streaming_ResetSdPbMetadata()` and the buffer reset moved from `OPEN_FILE` to the close path, *before* the window opens, so the first thing the encoder puts into the empty buffer is the new file's header and the window's samples follow in order. `OPEN_FILE` skips those resets during a rotation — repeating them there would discard exactly the bytes this fix keeps — and still performs them on a first open.

This deliberately inverts a comment that justified the old ordering ("so the streaming task cannot burn one-shot header flags before the new file is ready"). Burning that flag into a drained buffer is now the *mechanism*, not the hazard.

## Measured — controlled A/B, card formatted before every arm

1 ch CSV, USB+SD, 2000 Hz, `MAXSize 20000`, 25 s, host draining, no SCPI in the window.

| | SdDropped | encoded | onCard | files |
|---|---|---|---|---|
| **main** `c5ea24bd8` arm1 | 14,091 | 764,711 | 750,993 | 37 |
| **main** arm2 | 14,915 | 793,126 | 778,501 | 38 |
| **this PR** arm1 | **0** | 804,922 | 805,264 | 40 |
| **this PR** arm2 | **0** | 804,922 | 805,248 | 40 |

> **Residual loss — superseded, now genuinely zero.** Two earlier notes here were wrong and are replaced by this one.
>
> The review found that `IsWriteReady()` stays true through the `FileSync`/`FileClose`, so the encoder keeps enqueuing during them — and because the buffer reset happened *after* the close, those bytes were discarded **silently**, uncounted by anything. Counting them measured **3,702 bytes across 39 rotations** (~95/rotation) in one arm. Pre-#757 firmware discarded them identically, so the honest before/after had been ~475 → ~95 bytes per rotation, not ~380 → ~0.
>
> Counting was not the fix. Those bytes belong to the *next* file, so the reset now happens **before** the sync and close: the buffer is empty there (the drain just ran), the metadata latch clears there, and everything produced during the sync, close and open follows the new file's header into the new file, in order.
>
> Result: `SdDroppedBytes = 0` on four arms across two runs, and the arithmetic corroborates it independently — `onCard` used to exceed `encoded` by 326 bytes and now exceeds it by **4,134**, which is 40 files × ~103 bytes of header. Those ~3,700 bytes are not counted differently, they are **on the card**.

**The counter is corroborated independently.** On main, `encoded − onCard` is 13,718 and 14,625 — matching `SdDroppedBytes` to within a few hundred bytes, so the missing data is *physically absent from the card*, not merely counted. After the fix the card holds slightly **more** than `encoded` (the per-file headers) and nothing is lost.

Formatting between arms is not incidental: loss scales with occupancy, and the parked `perf/757` work record notes a wrong 41% claim produced by *not* formatting.

## Correctness checks beyond the counter

**Split files still start with their header at byte 0** — verified on file content, not inferred: rotated files read back with `# Device: Nyquist 1` first and ~1,279 data rows each.

Files that roll into a #689 bucket subdirectory are intact too (`DAQiFi/P001/… 20,535 bytes`). They *appear* empty through `SD:GET` only because a listing path doesn't round-trip to a bare-name GET (#725) — worth knowing before anyone reads that as data loss.

## Failure paths

Found during self-review, and it was a genuine bug in the first version of this change: **one `OPEN_FILE` exit never reached the flag clear.** A bucket refusal breaks out before `FileOpen`, so `gSdRotating` stayed set and the encoder would have buffered forever into a path nothing drains.

All abnormal exits now go through `sd_AbandonRotationWindow()`, which clears the flag, resets the buffer, and **counts** the unrecoverable bytes via `Streaming_ReportSdDiscard()` rather than letting them vanish. Covered: bucket refusal, teardown-mid-open (#782), and failed create. The success path just clears the flag — those bytes are about to be written, not lost.

The #782 abort comment asserted "the streaming task cannot have written" as justification. That is no longer true, so it is corrected rather than left stale.

## Also included

Drops two dead memsets from the window (the parked `perf/757` work). Neither zero was load-bearing — nothing reads either buffer past a length reset alongside it — and `writeBuffer` is the ~78 KB uncached KSEG1 DMA buffer, so zeroing it was an uncached write of every byte *inside the very window this issue is about*. Worth ~4% on its own, which is why it was held rather than shipped alone.

## Build

Both configs at `-O3 -Werror`, **0 diagnostics**.

## Companion regression test

[daqifi-python-test-suite #177](https://github.com/daqifi/daqifi-python-test-suite/pull/177) — **8 PASS** on this build, **4 PASS / 4 FAIL** on unmodified main, where both the drop counter and the independent bytes-on-card check fire while the vacuity guards still pass.

## Test environment

- firmware: this branch @ `afe8ec9cd`, board `DAQiFi,Nq1,7E2898F46200E8A7` on COM3, PICkit `BUR184882598`
- daqifi-python-core: `main` @ `76f8b73`
- test-suite: `test/757-rotation-window` @ `dbf9dc0`

