### PR TITLE
fix(sd): bound the rotation drain so file splitting survives high throughput

### DIFF
--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2436,8 +2436,31 @@ void sd_card_manager_ProcessState() {
 
                 if (bufferBytes > 0) {
                     LOG_D("[SD] Draining %zu bytes from circular buffer before rotation\r\n", bufferBytes);
-                    // Process all remaining data in circular buffer
-                    while (CircularBuf_NumBytesAvailable(&gSDCardData.wCirbuf) > 0) {
+                    /* #822: drain the SNAPSHOT, not the live level.
+                     *
+                     * This loop used to run `while NumBytesAvailable() > 0`,
+                     * i.e. until the buffer was empty. The streaming task keeps
+                     * FILLING that buffer throughout, so above roughly
+                     * 340 KB/s the drain never catches up: the loop keeps
+                     * writing into the file it is trying to retire, and the
+                     * rotation never completes. Measured on 11 channels at
+                     * 2 kHz, one file grew to 8.7 MB against a 20,000 byte
+                     * limit and only a single "size limit reached" ever
+                     * appeared. Below that rate it merely overshoots -- 1.5x at
+                     * 170 KB/s, 53x at 266 KB/s -- which is the same defect
+                     * losing the race by less.
+                     *
+                     * Bytes that arrive after this point belong to the NEXT
+                     * file, which is exactly the model #757 established when
+                     * the rotation window began accepting encoder output for
+                     * the new file. Draining the snapshot makes rotation
+                     * bounded and its timing independent of throughput.
+                     *
+                     * `drained` counts what CircularBuf_ProcessBytes actually
+                     * extracted, so a partial write cannot spin the loop. */
+                    size_t drained = 0;
+                    while (drained < bufferBytes
+                           && CircularBuf_NumBytesAvailable(&gSDCardData.wCirbuf) > 0) {
                         int writeLen = -2;
                         SD_TakeMutexDebug(gSDCardData.wMutex, "drain_loop");
                         if (gSDCardData.sdCardWritePending != 1) {
@@ -2447,6 +2470,13 @@ void sd_card_manager_ProcessState() {
                             CircularBuf_ProcessBytes(&gSDCardData.wCirbuf, NULL,
                                 gSDCardData.writeBufferSize, &writeLen);
                             gSDCardData.totalBytesFlushPending += gSDCardData.writeBufferLength;
+                            /* #822: advance the bound by what was actually
+                             * EXTRACTED from the circular buffer, not by what
+                             * the write below reports -- a partial write is
+                             * retried against the same extracted chunk, and
+                             * counting it there would let the loop run past
+                             * the snapshot. */
+                            drained += gSDCardData.writeBufferLength;
                             xSemaphoreGive(gSDCardData.wMutex);
 
                             // Write immediately, loop for partial writes

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2467,15 +2467,33 @@ void sd_card_manager_ProcessState() {
                             gSDCardData.sdCardWritePending = 1;
                             /* #738: runtime size, not the compile-time
                              * ceiling — see the WRITE_TO_FILE extract. */
+                            /* #822: cap the EXTRACTION at the snapshot too,
+                             * not just the loop condition.
+                             *
+                             * Testing `drained < bufferBytes` before each
+                             * iteration bounds how many times we extract, but
+                             * not how much: ProcessBytes would take up to
+                             * writeBufferSize, which is auto-balanced to ~78 KB
+                             * (USB+SD) or ~124 KB (SD only). Against a snapshot
+                             * of a few tens of KB a single extraction therefore
+                             * swallowed the whole buffer INCLUDING bytes the
+                             * producer added after the snapshot -- so the drain
+                             * was still effectively unbounded in one pass, and
+                             * that is where the residual file-size overshoot
+                             * came from. */
+                            size_t remaining = bufferBytes - drained;
+                            uint32_t extractLen =
+                                (remaining < (size_t)gSDCardData.writeBufferSize)
+                                    ? (uint32_t)remaining
+                                    : gSDCardData.writeBufferSize;
                             CircularBuf_ProcessBytes(&gSDCardData.wCirbuf, NULL,
-                                gSDCardData.writeBufferSize, &writeLen);
+                                extractLen, &writeLen);
                             gSDCardData.totalBytesFlushPending += gSDCardData.writeBufferLength;
-                            /* #822: advance the bound by what was actually
-                             * EXTRACTED from the circular buffer, not by what
-                             * the write below reports -- a partial write is
+                            /* Advance by what was actually EXTRACTED, not by
+                             * what the write below reports -- a partial write is
                              * retried against the same extracted chunk, and
-                             * counting it there would let the loop run past
-                             * the snapshot. */
+                             * counting it there would let the loop run past the
+                             * snapshot. */
                             drained += gSDCardData.writeBufferLength;
                             xSemaphoreGive(gSDCardData.wMutex);
 
@@ -2572,9 +2590,33 @@ void sd_card_manager_ProcessState() {
                      * emptied buffer, still at byte 0. */
                     SD_TakeMutexDebug(gSDCardData.wMutex, "rotation_open_window");
                     Streaming_ResetSdPbMetadata();
+                    /* #822: whatever the producer appended DURING the drain is
+                     * still here, and this reset is about to destroy it.
+                     *
+                     * It cannot be saved. It is newer than everything drained,
+                     * so it cannot go into the old file without reopening the
+                     * unbounded-drain livelock that #822 is; and it cannot be
+                     * carried into the new one, because ResetSdPbMetadata()
+                     * above has just armed the next header and these bytes
+                     * would land AHEAD of it.
+                     *
+                     * So it is dropped -- but it is COUNTED. The bounded drain
+                     * traded #822's visible overshoot for a discard, and an
+                     * uncounted discard would be the worse of the two: the
+                     * bytes were ACCEPTED by WriteToBuffer, so without this
+                     * they appear in neither file nor in SdDroppedBytes, and
+                     * the gap is invisible. Same reasoning, same accounting, as
+                     * sd_AbandonRotationWindow(). */
+                    size_t stranded =
+                            CircularBuf_NumBytesAvailable(&gSDCardData.wCirbuf);
                     CircularBuf_Reset(&gSDCardData.wCirbuf);
                     gSdRotating = true;
                     xSemaphoreGive(gSDCardData.wMutex);
+                    if (stranded > 0u) {
+                        Streaming_ReportSdDiscard(stranded);
+                        LOG_D("[SD] rotation dropped %u byte(s) buffered during drain\r\n",
+                              (unsigned)stranded);
+                    }
                 }
 
                 // Flush and close current file


### PR DESCRIPTION
## What breaks

SD file splitting silently stops above ~340 KB/s. The device keeps
streaming and keeps writing, but it stops rotating: an 11-channel CSV
stream at 2 kHz for 25 s produced **one file of 8,745,722 bytes**
against a `MAXSize` of 20,000.

The device log names it exactly:

```
File size limit reached (24064 >= 20000)
Closed file (wrote 2165082 bytes)
```

The limit is detected on time. The close writes 2 MB anyway.

## Root cause

The pre-close drain looped on the **live** circular-buffer level:

```c
while (CircularBuf_NumBytesAvailable(&gSDCardData.wCirbuf) > 0) { ... }
```

The streaming task refills that buffer as fast as the SD task drains
it, so above ~340 KB/s the condition never goes false and the drain
keeps writing into the file it is supposed to be retiring. It is a
livelock against the producer, not a slow drain.

**Not a regression from #757** — the same bisect on `c5ea24bd8`
reproduces identically.

## The fix

Drain the **snapshot** the code already takes for its log line, rather
than the live level, and cap the extraction at that snapshot too. The
loop bound alone was not enough: it bounded how many times the drain
extracts but not how much, and `CircularBuf_ProcessBytes` would take up
to `writeBufferSize` — auto-balanced to ~78 KB (USB+SD) or ~124 KB
(SD-only) — so against a snapshot of a few tens of KB a single
extraction still swallowed everything present, including bytes the
producer appended after the snapshot.

`drained` advances by what `ProcessBytes` **extracted**, not by what the
write reports: a partial write is retried against the same extracted
chunk, and counting it there would let the loop run past the snapshot.

## The discard, and why it is counted

Bounding the drain means bytes the producer appends **during** the drain
are still in `wCirbuf` when the rotation window resets it. They cannot
be saved. They are newer than everything drained, so writing them to the
old file reopens the livelock this issue is about; and they cannot be
carried into the new file, because `Streaming_ResetSdPbMetadata()` has
just armed the next header and they would land ahead of it.

So they are dropped — but through `Streaming_ReportSdDiscard()`, the same
accounting `sd_AbandonRotationWindow()` already uses. Uncounted, they
appeared in neither file nor `SdDroppedBytes`, which would have traded
#822's visible overshoot for a silent gap: the worse of the two
directions, and the defect class #757 exists to eliminate.

Measured on the bench, 16ch CSV @2 kHz, `MAXSize=20000`, 6 s, with the
counting hunk neutered as the only difference between builds:

| build | onCard | SdDropped | accounted | vs `TotalBytesStreamed` |
|---|---:|---:|---:|---:|
| counting **off** | 2,839,484 | 62,976 | 2,902,460 | 0.922 |
| counting **on** | 2,836,924 | 340,224 | 3,177,148 | **1.009** |

On-card is unchanged, so **the loss was always there** — 277,248 bytes
of it (~3.6 KB across each of 76 rotations) were simply invisible. The
1.009 excess over unity is the 76 per-file CSV headers, which land on
the card without counting as streamed; the same corroboration that
validated #757.

The discard scales with rotation **frequency**, not with rate: at the
default 3.9 GB `MAXSize` it is a few KB per multi-GB file. Eliminating
it entirely requires writing the header at file open rather than through
the ring buffer — a redesign, out of scope here.

## Known, unchanged: files still overshoot MAXSize

~20.5 KB at 1ch to ~76 KB at 16ch against a 20,000 limit — the pre-close
drain writing the buffered backlog into the old file. Bounded now, and
harmless at the default `MAXSize`. #822 does not claim to fix it.

I tried clamping per-chunk extraction to the remaining split budget
(distinct from the snapshot cap above), measured **no improvement**, and
reverted it — the overshoot comes from the drain, not the extraction
(5ch even got worse: 39,940 vs 20,980).

## Result

| config | before | after |
|---|---:|---:|
| 1ch @2 kHz | 9 files | 9 files |
| 5ch | 41 | 41 |
| 8ch | 40 | 59 |
| 11ch | **1** | 61 |
| 16ch | **1** | 49 |

11ch @2 kHz, 25 s: 1 file / 8,745,722 bytes → **295 files / 55,018
largest**.

## Test

`daqifi/daqifi-python-test-suite#179` — `test_822_splitting_at_rate.py`.
Bench, COM3 / `7E2898F46200E8A7`:

| firmware | result |
|---|---|
| unmodified main `5be04ca99` | **16 PASS / 4 FAIL** — 11ch+16ch, checks 1–2, `files=1` |
| discard uncounted (mutant) | **18 PASS / 2 FAIL** — 11ch+16ch, check 5 |
| this PR `0c84e2d87` | **20 PASS / 0 FAIL** |

The middle row is the mutation proof that the accounting check earns its
place rather than passing by construction.

Both configs (`default`, `Nq3`) build `-O3 -Werror` clean.

Fixes #822
