### PR TITLE
fix(sd): SD:LISt? lists a directory without moving the working directory (#799 part 3)

### DIFF
--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -709,9 +709,13 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
     SCPI_ParamCharacters(context, &pBuff, &fileLen, false);
 
     if (fileLen > 0) {
-        if (fileLen >= sizeof(pSDCardRuntimeConfig->directory)) {
+        /* #799: bound against the field actually written (opDirectory), not
+         * its sibling. They are the same size today, so this is not a live
+         * overflow -- but checking one buffer and filling another is how a
+         * later divergence becomes one silently. */
+        if (fileLen >= sizeof(pSDCardRuntimeConfig->opDirectory)) {
             LOG_E("SD:LIST? - Directory path too long: %d bytes, max: %d\r\n", 
-                  fileLen, sizeof(pSDCardRuntimeConfig->directory) - 1);
+                  fileLen, sizeof(pSDCardRuntimeConfig->opDirectory) - 1);
             result = SCPI_RES_ERR;
             goto __exit_point;
         }

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -737,11 +737,23 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
          * sd_list_files(dir) is a standalone listing that nothing chains into a
          * GET.
          *
-         * Critical section retained, for the reason part 1-2 introduced it: the
-         * two-step write (copy, then terminator) is read by the SD task, and a
-         * reader landing between the steps would see new-prefix + old-suffix
-         * ended by the old terminator -- a well-formed path naming a directory
-         * nobody asked for. */
+         * On the critical section: it is NOT doing what the same guard does for
+         * `directory`, and the rationale copied from parts 1-2 would be wrong
+         * here. That field has a getter (SD:DIRectory?) reachable from the
+         * OTHER SCPI transport, so an unguarded two-step write really can be
+         * observed torn. `opDirectory` has no getter -- nothing outside the SD
+         * manager reads it -- and a writer-only critical section cannot make a
+         * reader's read coherent anyway; it only makes the WRITE indivisible
+         * with respect to task switches.
+         *
+         * What actually keeps the SD task from reading this mid-update is the
+         * IsBusy() interlock above: a second listing is refused while one is in
+         * flight, so the field is not rewritten under a running LIST_DIRECTORY.
+         *
+         * The guard is kept regardless -- it costs a few instructions and keeps
+         * all three sites that touch these path fields symmetric, so the next
+         * person to add one inherits the safe shape rather than having to
+         * work out which fields have external readers. */
         taskENTER_CRITICAL();
         memcpy(pSDCardRuntimeConfig->opDirectory, pBuff, fileLen);
         pSDCardRuntimeConfig->opDirectory[fileLen] = '\0';

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -720,27 +720,41 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
-        /* #799: same critical section as SCPI_StorageSDDirectorySet, for the
-         * same reason. This is a two-step write (copy, then terminator) to a
-         * field the new SD:DIRectory? getter reads from the OTHER SCPI
-         * transport -- USB is priority 7, WiFi TCP is 2, and there is no
-         * shared dispatch mutex between them. A reader landing between the
-         * steps sees new-prefix + old-suffix, ended by the old terminator: a
-         * well-formed path naming a directory nobody asked for.
+        /* #799 part 3: the operand goes to the TRANSIENT field, not to the
+         * persistent working directory. A query must not change the device.
          *
-         * Guarding the reader alone cannot fix this -- it only guarantees the
-         * reader sees a STABLE buffer, not a coherent one. All three sites
-         * that touch this field are now symmetric.
+         * This used to memcpy into pSDCardRuntimeConfig->directory and leave it
+         * there, which made SD:LISt? the only way to move the working
+         * directory -- and it moved it as a SIDE EFFECT. One browse, or a typo,
+         * silently redirected SD:GET, SD:DELete, SD:CRC and the next logging
+         * session. The DELete case was the sharp one: the caller named a file,
+         * the device deleted a same-named file somewhere else, and replied
+         * success. Callers that want to MOVE the working directory now use
+         * SD:DIRectory (part 2, already shipped).
          *
-         * NOTE this does not change WHETHER SD:LISt? writes the field, which
-         * is #799 part 3 and needs a client survey. Only that the write other
-         * tasks observe is indivisible -- invisible to clients. */
+         * The client survey the issue asked for came back clean: daqifi-core
+         * only ever sends the no-operand form, and python-core's
+         * sd_list_files(dir) is a standalone listing that nothing chains into a
+         * GET.
+         *
+         * Critical section retained, for the reason part 1-2 introduced it: the
+         * two-step write (copy, then terminator) is read by the SD task, and a
+         * reader landing between the steps would see new-prefix + old-suffix
+         * ended by the old terminator -- a well-formed path naming a directory
+         * nobody asked for. */
         taskENTER_CRITICAL();
-        memcpy(pSDCardRuntimeConfig->directory, pBuff, fileLen);
-        pSDCardRuntimeConfig->directory[fileLen] = '\0';
+        memcpy(pSDCardRuntimeConfig->opDirectory, pBuff, fileLen);
+        pSDCardRuntimeConfig->opDirectory[fileLen] = '\0';
+        taskEXIT_CRITICAL();
+    } else {
+        /* No operand: list the working directory. Clearing is what makes the
+         * operand transient -- otherwise the PREVIOUS listing's operand would
+         * silently serve this one, which is the same defect wearing a
+         * different hat. */
+        taskENTER_CRITICAL();
+        pSDCardRuntimeConfig->opDirectory[0] = '\0';
         taskEXIT_CRITICAL();
     }
-    // If no directory specified, the sd_card_manager will use the default from settings
     
     // Set mode to LIST_DIRECTORY and let sd_card_manager handle it
     const bool listOverTcp = wifi_tcp_server_ContextIsTcp(context);   /* #598 */

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -1243,6 +1243,26 @@ static volatile bool gSdTeardownRequested = false;
  * The success path does NOT come here -- it just clears the flag, because the
  * WRITE_TO_FILE arm of IsBufferAccepting() takes over and the buffered bytes
  * are about to be written, not lost. */
+/* #799: which directory an operation should act on.
+
+ * Only SD:LISt? sets `opDirectory`, and only for the duration of that one
+ * listing -- it is cleared when the command is armed without an operand. Every
+ * other operation (GET / DELete / CRC / logging) reads `directory`, the
+ * persistent working directory, which now changes ONLY through SD:DIRectory.
+ *
+ * Before this, the listing copied its operand into `directory` and left it
+ * there, so a query silently repositioned all of those. */
+static const char* sd_ListDirTarget(const sd_card_manager_settings_t* cfg) {
+    if (cfg == NULL) {
+        return "";
+    }
+    if (cfg->mode == SD_CARD_MANAGER_MODE_LIST_DIRECTORY
+            && cfg->opDirectory[0] != '\0') {
+        return cfg->opDirectory;
+    }
+    return cfg->directory;
+}
+
 static void sd_AbandonRotationWindow(const char* why) {
     /* Clear INSIDE the mutex, not before taking it. sd_card_manager_WriteToBuffer
      * re-checks sd_card_manager_IsBufferAccepting() under this same mutex, so
@@ -1313,8 +1333,13 @@ void sd_card_manager_ProcessState() {
                          gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_DELETE_FILE);
                 const char* opName = isTransientOp ? gpSDCardSettings->opFile
                                                    : gpSDCardSettings->file;
-                bool dirValid = strlen(gpSDCardSettings->directory) > 0 &&
-                               strlen(gpSDCardSettings->directory) <= SD_CARD_MANAGER_CONF_DIR_NAME_LEN_MAX;
+                /* #799: validate the directory this op will actually use. For
+                 * LIST that is the transient operand when present, so a listing
+                 * of a valid directory is not refused because the persistent
+                 * one happens to be empty (and vice versa). */
+                const char* dirName = sd_ListDirTarget(gpSDCardSettings);
+                bool dirValid = strlen(dirName) > 0 &&
+                               strlen(dirName) <= SD_CARD_MANAGER_CONF_DIR_NAME_LEN_MAX;
                 bool fileValid = strlen(opName) > 0 &&
                                 strlen(opName) <= SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX;
 
@@ -1342,7 +1367,7 @@ void sd_card_manager_ProcessState() {
                     if (!errorLogged) {
                         LOG_E("[%s:%d]Invalid SD Card Directory or file name (dir='%s', file='%s')",
                               __FILE__, __LINE__,
-                              gpSDCardSettings->directory,
+                              dirName,
                               opName);
                         errorLogged = true;
                     }
@@ -2946,11 +2971,15 @@ void sd_card_manager_ProcessState() {
                 SD_TakeMutexDebug(gSDOpMutex, "list_operation");
             }
 
-            LOG_D("[SD] Listing directory: '%s'\r\n", gpSDCardSettings->directory);
+            /* #799: the operand directory when one was given, else the working
+             * directory. The operand is NOT copied into the working directory
+             * -- see sd_ListDirTarget(). */
+            const char* listTarget = sd_ListDirTarget(gpSDCardSettings);
+            LOG_D("[SD] Listing directory: '%s'\r\n", listTarget);
 
             // List files in chunks using static callback
             ListDirResult listResult = ListFilesInDirectoryChunked(
-                    gpSDCardSettings->directory,
+                    listTarget,
                     gSDCardData.messageBuffer,
                     SD_CARD_MANAGER_CONF_RBUFFER_SIZE,
                     sd_listdir_send_chunk);

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -68,6 +68,16 @@ extern "C" {
          * (and left 0) when replyTarget == SD_CARD_REPLY_USB. */
         uint32_t replyGeneration;
         char directory[SD_CARD_MANAGER_CONF_DIR_NAME_LEN_MAX + 1];
+        /* #799 part 3: transient operand directory for SD:LISt?, kept SEPARATE
+         * from `directory` (the persistent working directory) for the same
+         * reason #724 split opFile out of `file`: a QUERY must not change the
+         * device. Listing a directory used to copy the operand into
+         * `directory`, silently redirecting SD:GET / SD:DELete / SD:CRC and the
+         * next logging session -- a browse or a typo repointed all of them, and
+         * SD:DELete would then delete a same-named file somewhere else and
+         * report success. Empty means "list the working directory". Callers
+         * that want to MOVE the working directory use SD:DIRectory (part 2). */
+        char opDirectory[SD_CARD_MANAGER_CONF_DIR_NAME_LEN_MAX + 1];
         char file[SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX + 1];
         /* #724: transient operand filename for the READ (SD:GET) / COMPUTE_CRC /
          * DELETE ops. Kept SEPARATE from `file` (the persistent logging target set


### PR DESCRIPTION
## The bug

`SYST:STOR:SD:LISt? "<dir>"` copied its operand into `pSDCardRuntimeConfig->directory` and left it there. That field is the SD **working directory**: `SD:GET`, `SD:DELete` and `SD:CRC` resolve their operands against it, and logging writes into it.

So a **query** — the one command class that should have no effect — was the only way to change it, and it changed it as a *side effect*. One listing (a browse, a typo, a stale path from an earlier session) silently redirected reads, deletes, checksums and the next capture.

The `SD:DELete` case is the sharp one: the caller names a file, the device deletes a same-named file somewhere else, and replies success.

## The fix

The operand now goes to a transient `opDirectory`, read only by the `LIST_DIRECTORY` op and cleared when a listing arrives without one. This is the same split **#724** made between `opFile` and `file`, for the same reason — there, `GET`/`DELete`/`CRC` were clobbering the logging target. The persistent `directory` now changes only through `SD:DIRectory`, which parts 1–2 already shipped.

Clearing on the no-operand path matters: otherwise the *previous* listing's operand would silently serve this one, which is the same defect wearing a different hat.

Not NVM-persisted (`BoardRunTimeConfig` only), so the added field changes no stored layout.

## Client compatibility — surveyed, as the issue asked

| client | what it sends | relies on the side effect? |
|---|---|---|
| **daqifi-core** (.NET) | `SYSTem:STORage:SD:LIST?`, **no operand** | No — never sets a directory at all |
| **daqifi-python-core** | both forms; `get_sd_file_list_for_directory(dir)` called only from `sd_list_files()` | No — a standalone listing; nothing chains it into a `GET` |
| **daqifi-desktop** | no direct usage — goes through daqifi-core | No |

## ⚠️ Behaviour change worth knowing about

A path printed by a listing of a **non-default** directory no longer round-trips into `SD:GET` on its own. `SD_StripConfiguredDir` strips the *working* directory from a GET operand (the #749 fix), so this used to work only because the listing had quietly set `directory=X`:

```
SD:LISt? "X"          → prints X/f.csv   (and silently set directory=X)
SD:GET  "X/f.csv"     → stripped, read   ✅  (by accident)
```

The supported sequence is now explicit, using the part-2 setter:

```
SD:DIRectory "X"
SD:LISt?
SD:GET "X/f.csv"      ✅
```

This interacts with #725 (the silent half of the round-trip problem), which stays open.

## Test

`daqifi/daqifi-python-test-suite#180` — `test_799_list_must_not_move_directory.py`. Bench, COM3 / `7E2898F46200E8A7`:

| firmware | result |
|---|---|
| unmodified main `ff803fb14` | **2 PASS / 3 FAIL** |
| this PR `a917ec30e` | **5 PASS / 0 FAIL** |

The baseline failure states the bug exactly — *"was 'DAQiFi', now 'T799DIR' — the query moved it"* — and the cascade is the defect in miniature: checks 4 and 5 also fail because the bare listing then reads the directory the previous listing silently switched to, returning identical contents for two listings that named different targets.

Both configs (`default`, `Nq3`) build `-O3 -Werror` clean.

Closes #799