### PR TITLE
fix(sd): claim the SD manager atomically, not check-then-set

### DIFF
--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -180,12 +180,11 @@ static bool SD_ArmOrRefuse(scpi_t *context, const char *cmd,
  * a TORN write, not this race: it makes each write atomic without deciding
  * which caller's value survives.
  */
-static bool SD_ClaimOrRefuse(scpi_t *context, const char *cmd,
-                             sd_card_manager_settings_t *cfg,
-                             sd_card_manager_mode_t mode)
+static bool SD_ClaimOrRefuse(scpi_t *context, const char *cmd)
 {
-    (void)cfg;    /* mode is written by the caller, AFTER its operands */
-    (void)mode;
+    /* Takes no cfg/mode: the claim is a flag inside the manager, and `mode`
+     * is written by the CALLER after its operands (see sd_card_manager.h).
+     * Passing them here would suggest this function arms something. */
     bool busy = !sd_card_manager_TryClaim();
     if (busy) {
         /* LOG_SD_BUSY() concatenates a string LITERAL ("SD:" cmd " - ..."), so
@@ -563,8 +562,7 @@ scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
      * reads the SCPI context, so it stays ahead of the claim -- which also
      * preserves the #610 behaviour that a MALFORMED request is rejected
      * without disturbing a cached CRC. */
-    if (!SD_ClaimOrRefuse(context, "CRC", pSDCardRuntimeConfig,
-                          SD_CARD_MANAGER_MODE_COMPUTE_CRC)) {
+    if (!SD_ClaimOrRefuse(context, "CRC")) {
         return SCPI_RES_ERR;
     }
     /* #724: transient operand, not the logging target `file`. */
@@ -689,8 +687,7 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
      * decides which interface this file is delivered to, so a lost race here
      * sends a client's file to the OTHER transport. The two validation paths
      * inside the block release the claim before bailing. */
-    if (!SD_ClaimOrRefuse(context, "GET", pSDCardRuntimeConfig,
-                          SD_CARD_MANAGER_MODE_READ)) {
+    if (!SD_ClaimOrRefuse(context, "GET")) {
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -785,8 +782,7 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
      * above only reads the SCPI context, so it is safe ahead of the claim;
      * everything from here down is owner-only, and the two validation failures
      * inside the block release the claim before bailing. */
-    if (!SD_ClaimOrRefuse(context, "LISt", pSDCardRuntimeConfig,
-                          SD_CARD_MANAGER_MODE_LIST_DIRECTORY)) {
+    if (!SD_ClaimOrRefuse(context, "LISt")) {
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -1396,8 +1392,7 @@ scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
     /* #829: claim before writing the shared operand -- otherwise a second
      * caller could overwrite opFile between this write and the mode
      * assignment, and the winner would delete the LOSER's filename. */
-    if (!SD_ClaimOrRefuse(context, "DELete", pSDCardRuntimeConfig,
-                          SD_CARD_MANAGER_MODE_DELETE_FILE)) {
+    if (!SD_ClaimOrRefuse(context, "DELete")) {
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -1482,8 +1477,7 @@ scpi_result_t SCPI_StorageSDFormat(scpi_t * context) {
      * progress" to FORmat? queries, so a caller that then loses the claim
      * would have advertised a format nobody is going to run. Claiming first
      * means only the owner ever publishes. */
-    if (!SD_ClaimOrRefuse(context, "FORmat", pSDCardRuntimeConfig,
-                          SD_CARD_MANAGER_MODE_FORMAT)) {
+    if (!SD_ClaimOrRefuse(context, "FORmat")) {
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -1806,8 +1800,7 @@ scpi_result_t SCPI_StorageSDSpaceGet(scpi_t * context) {
     // Set mode to GET_SPACE and let sd_card_manager handle mount/query/unmount
     /* #829: atomic claim -- the plain assignment could race a second caller
      * that had already passed the IsBusy() fast path above. */
-    if (!SD_ClaimOrRefuse(context, "SPACe", pSDCardRuntimeConfig,
-                          SD_CARD_MANAGER_MODE_GET_SPACE)) {
+    if (!SD_ClaimOrRefuse(context, "SPACe")) {
         result = SCPI_RES_ERR;
         goto __exit_point;
     }

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -151,6 +151,52 @@ static bool SD_ArmOrRefuse(scpi_t *context, const char *cmd,
 }
 
 
+/* #829: ATOMIC claim of the SD manager, modelled on the #736 BENCH interlock.
+ *
+ * Every SD entry point checked sd_card_manager_IsBusy() and then wrote `mode`
+ * as two separate steps. USB SCPI (pri 7) preempts WiFi SCPI (pri 2) with no
+ * shared dispatch mutex, so both callers could pass the check and both write
+ * the shared operand fields -- including `replyTarget`/`replyGeneration`,
+ * which decide WHICH INTERFACE the reply is written to. #598/#599 guard the
+ * delivery of an async reply; they do not guard this window.
+ *
+ * IsBusy() is true whenever `mode != MODE_NONE`, so writing `mode` IS the
+ * claim. Doing both under one critical section makes exactly one caller the
+ * owner; the loser refuses instead of overwriting the winner.
+ *
+ * Ordering matters as much as atomicity -- the #736 comment learned that the
+ * hard way. Callers must claim BEFORE touching any shared field. Parsing and
+ * validation may precede it (they only read the SCPI context), but every write
+ * to opDirectory/opFile/replyTarget/replyGeneration must follow it, and any
+ * failure path after a successful claim must release with MODE_NONE.
+ *
+ * Note the pre-existing taskENTER_CRITICAL around those operand writes guards
+ * a TORN write, not this race: it makes each write atomic without deciding
+ * which caller's value survives.
+ */
+static bool SD_ClaimOrRefuse(scpi_t *context, const char *cmd,
+                             sd_card_manager_settings_t *cfg,
+                             sd_card_manager_mode_t mode)
+{
+    bool busy;
+    taskENTER_CRITICAL();
+    busy = sd_card_manager_IsBusy();
+    if (!busy) {
+        cfg->mode = mode;
+    }
+    taskEXIT_CRITICAL();
+    if (busy) {
+        /* LOG_SD_BUSY() concatenates a string LITERAL ("SD:" cmd " - ..."), so
+         * it cannot take this const char* -- format the name instead. */
+        LOG_E("SD:%s - SD card busy, state=%s mode=%s\r\n", cmd,
+              sd_card_manager_GetStateName(),
+              sd_card_manager_GetModeName());
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return false;
+    }
+    return true;
+}
+
 static bool SD_RefuseIfSuspended(scpi_t *context, const char *cmd)
 {
     /* The LIVE condition, not SpiBusHealth_IsSdSuspended(): the SD task runs
@@ -414,6 +460,7 @@ scpi_result_t SCPI_StorageSDLoggingSet(scpi_t * context) {
             goto __exit_point;
         }
         if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
+            pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
             SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
             result = SCPI_RES_ERR;
             goto __exit_point;
@@ -511,6 +558,14 @@ scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         return SCPI_RES_ERR;
     }
+    /* #829: claim before writing the shared operand. Validation above only
+     * reads the SCPI context, so it stays ahead of the claim -- which also
+     * preserves the #610 behaviour that a MALFORMED request is rejected
+     * without disturbing a cached CRC. */
+    if (!SD_ClaimOrRefuse(context, "CRC", pSDCardRuntimeConfig,
+                          SD_CARD_MANAGER_MODE_COMPUTE_CRC)) {
+        return SCPI_RES_ERR;
+    }
     /* #724: transient operand, not the logging target `file`. */
     memcpy(pSDCardRuntimeConfig->opFile, pBuff, fileLen);
     pSDCardRuntimeConfig->opFile[fileLen] = '\0';
@@ -528,6 +583,7 @@ scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
      * answer to the request just refused (bench-confirmed before the fix). */
     if (SD_RefuseIfSuspended(context, "CRC")) {
         sd_card_manager_InvalidateCrcResult();
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
         return SCPI_RES_ERR;
     }
 
@@ -541,8 +597,9 @@ scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
-    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_COMPUTE_CRC;
+    /* mode already claimed above (#829) */
     if (!SD_ArmOrRefuse(context, "CRC", pSDCardRuntimeConfig)) {
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
         return SCPI_RES_ERR;
     }
     return SCPI_RES_OK;
@@ -625,12 +682,24 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
      * prefix the device itself emitted. */
     pBuff = SD_StripConfiguredDir(pBuff, &fileLen, pSDCardRuntimeConfig->directory);
 
+    /* #829: claim before the operand and replyTarget writes below. replyTarget
+     * decides which interface this file is delivered to, so a lost race here
+     * sends a client's file to the OTHER transport. The two validation paths
+     * inside the block release the claim before bailing. */
+    if (!SD_ClaimOrRefuse(context, "GET", pSDCardRuntimeConfig,
+                          SD_CARD_MANAGER_MODE_READ)) {
+        result = SCPI_RES_ERR;
+        goto __exit_point;
+    }
+
     if (fileLen > 0) {
         if (fileLen > SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX) {
+            pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
         if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
+            pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
             SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
             result = SCPI_RES_ERR;
             goto __exit_point;
@@ -653,8 +722,9 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
             ? SD_CARD_REPLY_WIFI_TCP : SD_CARD_REPLY_USB;
     pSDCardRuntimeConfig->replyGeneration =
             getOverTcp ? wifi_tcp_server_GetConnGeneration() : 0u;
-    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_READ;
+    /* mode already claimed above (#829) */
     if (!SD_ArmOrRefuse(context, "GET", pSDCardRuntimeConfig)) {
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -708,6 +778,16 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
     // Get optional directory parameter
     SCPI_ParamCharacters(context, &pBuff, &fileLen, false);
 
+    /* #829: claim BEFORE the operand and replyTarget writes below. Parsing
+     * above only reads the SCPI context, so it is safe ahead of the claim;
+     * everything from here down is owner-only, and the two validation failures
+     * inside the block release the claim before bailing. */
+    if (!SD_ClaimOrRefuse(context, "LISt", pSDCardRuntimeConfig,
+                          SD_CARD_MANAGER_MODE_LIST_DIRECTORY)) {
+        result = SCPI_RES_ERR;
+        goto __exit_point;
+    }
+
     if (fileLen > 0) {
         /* #799: bound against the field actually written (opDirectory), not
          * its sibling. They are the same size today, so this is not a live
@@ -716,6 +796,7 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
         if (fileLen >= sizeof(pSDCardRuntimeConfig->opDirectory)) {
             LOG_E("SD:LIST? - Directory path too long: %d bytes, max: %d\r\n", 
                   fileLen, sizeof(pSDCardRuntimeConfig->opDirectory) - 1);
+            pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
@@ -778,8 +859,9 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
             ? SD_CARD_REPLY_WIFI_TCP : SD_CARD_REPLY_USB;
     pSDCardRuntimeConfig->replyGeneration =
             listOverTcp ? wifi_tcp_server_GetConnGeneration() : 0u;   /* #599 */
-    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_LIST_DIRECTORY;
+    /* mode already claimed above (#829) */
     if (!SD_ArmOrRefuse(context, "LISt", pSDCardRuntimeConfig)) {
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -1307,14 +1389,23 @@ scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
         goto __exit_point;
     }
+    /* #829: claim before writing the shared operand -- otherwise a second
+     * caller could overwrite opFile between this write and the mode
+     * assignment, and the winner would delete the LOSER's filename. */
+    if (!SD_ClaimOrRefuse(context, "DELete", pSDCardRuntimeConfig,
+                          SD_CARD_MANAGER_MODE_DELETE_FILE)) {
+        result = SCPI_RES_ERR;
+        goto __exit_point;
+    }
     /* #724: delete the transient operand, not the logging target `file`. */
     memcpy(pSDCardRuntimeConfig->opFile, pBuff, fileLen);
     pSDCardRuntimeConfig->opFile[fileLen] = '\0';
     LOG_D("SD:DELete - Deleting file '%s'\r\n", pSDCardRuntimeConfig->opFile);
 
     // Set mode to DELETE and trigger the operation
-    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_DELETE_FILE;
+    /* mode already claimed above (#829) */
     if (!SD_ArmOrRefuse(context, "DELete", pSDCardRuntimeConfig)) {
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -1382,8 +1473,16 @@ scpi_result_t SCPI_StorageSDFormat(scpi_t * context) {
 
     // Set mode to FORMAT and trigger the operation (non-blocking)
     // Poll SYST:STOR:SD:FORmat? for status and progress percentage
+    /* #829: claim BEFORE SetFormatPending(). That call publishes "format in
+     * progress" to FORmat? queries, so a caller that then loses the claim
+     * would have advertised a format nobody is going to run. Claiming first
+     * means only the owner ever publishes. */
+    if (!SD_ClaimOrRefuse(context, "FORmat", pSDCardRuntimeConfig,
+                          SD_CARD_MANAGER_MODE_FORMAT)) {
+        result = SCPI_RES_ERR;
+        goto __exit_point;
+    }
     sd_card_manager_SetFormatPending();  // Immediately visible to FORmat? queries
-    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_FORMAT;
     /* This one reported SUCCESS on a refused arm -- it returns OK without
      * waiting, so the client believed a format had started when nothing had
      * been queued at all. That is the worst of the three shapes. */
@@ -1393,6 +1492,7 @@ scpi_result_t SCPI_StorageSDFormat(scpi_t * context) {
          * so clear it -- otherwise FORmat? reports a format in flight
          * forever and a client polling for completion never stops. */
         sd_card_manager_ClearFormatStatus();
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -1697,8 +1797,15 @@ scpi_result_t SCPI_StorageSDSpaceGet(scpi_t * context) {
     }
 
     // Set mode to GET_SPACE and let sd_card_manager handle mount/query/unmount
-    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_GET_SPACE;
+    /* #829: atomic claim -- the plain assignment could race a second caller
+     * that had already passed the IsBusy() fast path above. */
+    if (!SD_ClaimOrRefuse(context, "SPACe", pSDCardRuntimeConfig,
+                          SD_CARD_MANAGER_MODE_GET_SPACE)) {
+        result = SCPI_RES_ERR;
+        goto __exit_point;
+    }
     if (!SD_ArmOrRefuse(context, "SPACe", pSDCardRuntimeConfig)) {
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -140,9 +140,15 @@ const char *SD_SuspendReasonText(void)
 static bool SD_ArmOrRefuse(scpi_t *context, const char *cmd,
                            sd_card_manager_settings_t *cfg)
 {
+    /* #829: the arm is where ownership hands over from the SCPI claim flag to
+     * `mode`. Release on BOTH paths and there is no gap: on success `mode !=
+     * MODE_NONE` already keeps IsBusy() true, and on failure the caller clears
+     * `mode` too. Centralised here so no entry point can leak the flag. */
     if (sd_card_manager_UpdateSettings(cfg)) {
+        sd_card_manager_ReleaseClaim();
         return true;
     }
+    sd_card_manager_ReleaseClaim();
     const char *why = SD_SuspendReasonText();
     LOG_E("SD:%s - could not arm the operation: %s\r\n", cmd,
           why ? why : "the SD task is not accepting work");
@@ -178,13 +184,9 @@ static bool SD_ClaimOrRefuse(scpi_t *context, const char *cmd,
                              sd_card_manager_settings_t *cfg,
                              sd_card_manager_mode_t mode)
 {
-    bool busy;
-    taskENTER_CRITICAL();
-    busy = sd_card_manager_IsBusy();
-    if (!busy) {
-        cfg->mode = mode;
-    }
-    taskEXIT_CRITICAL();
+    (void)cfg;    /* mode is written by the caller, AFTER its operands */
+    (void)mode;
+    bool busy = !sd_card_manager_TryClaim();
     if (busy) {
         /* LOG_SD_BUSY() concatenates a string LITERAL ("SD:" cmd " - ..."), so
          * it cannot take this const char* -- format the name instead. */
@@ -460,7 +462,6 @@ scpi_result_t SCPI_StorageSDLoggingSet(scpi_t * context) {
             goto __exit_point;
         }
         if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
-            pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
             SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
             result = SCPI_RES_ERR;
             goto __exit_point;
@@ -583,7 +584,7 @@ scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
      * answer to the request just refused (bench-confirmed before the fix). */
     if (SD_RefuseIfSuspended(context, "CRC")) {
         sd_card_manager_InvalidateCrcResult();
-        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+        sd_card_manager_ReleaseClaim();  /* #829 release */
         return SCPI_RES_ERR;
     }
 
@@ -594,13 +595,14 @@ scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
      * sitting in the slot. "SD suspended" is both true and actionable; the
      * stale probe is neither. */
     if (!SCPI_CheckSDCardPresent(context)) {
-        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+        sd_card_manager_ReleaseClaim();  /* #829 release */
         return SCPI_RES_ERR;
     }
 
-    /* mode already claimed above (#829) */
+    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_COMPUTE_CRC;  /* #829: LAST write */
     if (!SD_ArmOrRefuse(context, "CRC", pSDCardRuntimeConfig)) {
-        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
+        /* #829: SD_ArmOrRefuse already released the claim */
         return SCPI_RES_ERR;
     }
     return SCPI_RES_OK;
@@ -695,12 +697,12 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
 
     if (fileLen > 0) {
         if (fileLen > SD_CARD_MANAGER_CONF_FILE_NAME_LEN_MAX) {
-            pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+            sd_card_manager_ReleaseClaim();  /* #829 release */
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
         if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
-            pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+            sd_card_manager_ReleaseClaim();  /* #829 release */
             SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
             result = SCPI_RES_ERR;
             goto __exit_point;
@@ -723,9 +725,10 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
             ? SD_CARD_REPLY_WIFI_TCP : SD_CARD_REPLY_USB;
     pSDCardRuntimeConfig->replyGeneration =
             getOverTcp ? wifi_tcp_server_GetConnGeneration() : 0u;
-    /* mode already claimed above (#829) */
+    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_READ;  /* #829: LAST write */
     if (!SD_ArmOrRefuse(context, "GET", pSDCardRuntimeConfig)) {
-        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
+        /* #829: SD_ArmOrRefuse already released the claim */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -797,12 +800,12 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
         if (fileLen >= sizeof(pSDCardRuntimeConfig->opDirectory)) {
             LOG_E("SD:LIST? - Directory path too long: %d bytes, max: %d\r\n", 
                   fileLen, sizeof(pSDCardRuntimeConfig->opDirectory) - 1);
-            pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+            sd_card_manager_ReleaseClaim();  /* #829 release */
             result = SCPI_RES_ERR;
             goto __exit_point;
         }
         if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
-            pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+            sd_card_manager_ReleaseClaim();  /* #829 release */
             SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
             result = SCPI_RES_ERR;
             goto __exit_point;
@@ -861,9 +864,10 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
             ? SD_CARD_REPLY_WIFI_TCP : SD_CARD_REPLY_USB;
     pSDCardRuntimeConfig->replyGeneration =
             listOverTcp ? wifi_tcp_server_GetConnGeneration() : 0u;   /* #599 */
-    /* mode already claimed above (#829) */
+    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_LIST_DIRECTORY;  /* #829: LAST write */
     if (!SD_ArmOrRefuse(context, "LISt", pSDCardRuntimeConfig)) {
-        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
+        /* #829: SD_ArmOrRefuse already released the claim */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -1405,9 +1409,10 @@ scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
     LOG_D("SD:DELete - Deleting file '%s'\r\n", pSDCardRuntimeConfig->opFile);
 
     // Set mode to DELETE and trigger the operation
-    /* mode already claimed above (#829) */
+    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_DELETE_FILE;  /* #829: LAST write */
     if (!SD_ArmOrRefuse(context, "DELete", pSDCardRuntimeConfig)) {
-        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
+        /* #829: SD_ArmOrRefuse already released the claim */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -1485,6 +1490,7 @@ scpi_result_t SCPI_StorageSDFormat(scpi_t * context) {
         goto __exit_point;
     }
     sd_card_manager_SetFormatPending();  // Immediately visible to FORmat? queries
+    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_FORMAT;  /* #829: LAST write */
     /* This one reported SUCCESS on a refused arm -- it returns OK without
      * waiting, so the client believed a format had started when nothing had
      * been queued at all. That is the worst of the three shapes. */
@@ -1494,7 +1500,7 @@ scpi_result_t SCPI_StorageSDFormat(scpi_t * context) {
          * so clear it -- otherwise FORmat? reports a format in flight
          * forever and a client polling for completion never stops. */
         sd_card_manager_ClearFormatStatus();
-        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+        /* #829: SD_ArmOrRefuse already released the claim */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -1806,8 +1812,9 @@ scpi_result_t SCPI_StorageSDSpaceGet(scpi_t * context) {
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
+    pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_GET_SPACE;  /* #829: LAST write */
     if (!SD_ArmOrRefuse(context, "SPACe", pSDCardRuntimeConfig)) {
-        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
+        /* #829: SD_ArmOrRefuse already released the claim */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -1412,6 +1412,7 @@ scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
         pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
         /* #829: SD_ArmOrRefuse already released the claim */  /* mode must still be cleared */
         result = SCPI_RES_ERR;
+        goto __exit_point;
     }
 
     // Wait for sd_card_manager to complete deletion (up to 5 seconds)

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -602,7 +602,7 @@ scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_COMPUTE_CRC;  /* #829: LAST write */
     if (!SD_ArmOrRefuse(context, "CRC", pSDCardRuntimeConfig)) {
         pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
-        /* #829: SD_ArmOrRefuse already released the claim */
+        /* #829: SD_ArmOrRefuse already released the claim */  /* mode must still be cleared */
         return SCPI_RES_ERR;
     }
     return SCPI_RES_OK;
@@ -728,7 +728,6 @@ scpi_result_t SCPI_StorageSDGetData(scpi_t * context) {
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_READ;  /* #829: LAST write */
     if (!SD_ArmOrRefuse(context, "GET", pSDCardRuntimeConfig)) {
         pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
-        /* #829: SD_ArmOrRefuse already released the claim */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -867,8 +866,7 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_LIST_DIRECTORY;  /* #829: LAST write */
     if (!SD_ArmOrRefuse(context, "LISt", pSDCardRuntimeConfig)) {
         pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
-        /* #829: SD_ArmOrRefuse already released the claim */
-        result = SCPI_RES_ERR;
+        /* #829: SD_ArmOrRefuse already released the claim */  /* mode must still be cleared */
         goto __exit_point;
     }
 
@@ -1412,9 +1410,8 @@ scpi_result_t SCPI_StorageSDDelete(scpi_t * context) {
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_DELETE_FILE;  /* #829: LAST write */
     if (!SD_ArmOrRefuse(context, "DELete", pSDCardRuntimeConfig)) {
         pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
-        /* #829: SD_ArmOrRefuse already released the claim */
+        /* #829: SD_ArmOrRefuse already released the claim */  /* mode must still be cleared */
         result = SCPI_RES_ERR;
-        goto __exit_point;
     }
 
     // Wait for sd_card_manager to complete deletion (up to 5 seconds)
@@ -1500,7 +1497,8 @@ scpi_result_t SCPI_StorageSDFormat(scpi_t * context) {
          * so clear it -- otherwise FORmat? reports a format in flight
          * forever and a client polling for completion never stops. */
         sd_card_manager_ClearFormatStatus();
-        /* #829: SD_ArmOrRefuse already released the claim */
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
+        /* #829: SD_ArmOrRefuse already released the claim */  /* mode must still be cleared */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -1814,7 +1812,8 @@ scpi_result_t SCPI_StorageSDSpaceGet(scpi_t * context) {
     }
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_GET_SPACE;  /* #829: LAST write */
     if (!SD_ArmOrRefuse(context, "SPACe", pSDCardRuntimeConfig)) {
-        /* #829: SD_ArmOrRefuse already released the claim */
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
+        /* #829: SD_ArmOrRefuse already released the claim */  /* mode must still be cleared */
         result = SCPI_RES_ERR;
         goto __exit_point;
     }

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -594,6 +594,7 @@ scpi_result_t SCPI_StorageSDCrcStart(scpi_t * context) {
      * sitting in the slot. "SD suspended" is both true and actionable; the
      * stale probe is neither. */
     if (!SCPI_CheckSDCardPresent(context)) {
+        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
         return SCPI_RES_ERR;
     }
 
@@ -801,6 +802,7 @@ scpi_result_t SCPI_StorageSDListDir(scpi_t * context){
             goto __exit_point;
         }
         if (!SD_ValidatePathParam(pBuff, fileLen)) {   /* #612 */
+            pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;  /* #829 release */
             SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
             result = SCPI_RES_ERR;
             goto __exit_point;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -3704,7 +3704,53 @@ bool sd_card_manager_GetSpaceInfo(uint64_t *freeBytes, uint64_t *totalBytes) {
     return true;
 }
 
+/* #829: the busy predicate without the claim flag, so TryClaim can consult it
+ * from inside its own critical section. */
+static bool sd_card_manager_IsBusyLocked(void);
+
+/* #829: SCPI-side exclusive claim, separate from `mode`.
+ *
+ * `mode` cannot be used as the claim. gpSDCardSettings ALIASES the runtime
+ * config the SCPI handlers write (sd_card_manager_Init takes
+ * &gpBoardRuntimeConfig->sdCardConfig, and UpdateSettings' memcpy is a
+ * self-copy), and PROCESS_STATE_INIT starts work as soon as
+ * `mode != MODE_NONE`. So writing mode early to reserve the manager also
+ * makes the operation startable -- and app_SDCardTask (pri 5) preempts
+ * app_WifiTask (pri 2), so a TCP command could have its operation begin on
+ * STALE opFile/opDirectory/replyTarget before the handler filled them.
+ *
+ * This flag reserves the manager without arming anything. Handlers claim it,
+ * fill the operands, write `mode` LAST as before, arm, and then release the
+ * flag -- by which point `mode != MODE_NONE` keeps IsBusy() true, so there is
+ * no gap. Error paths release it with mode still MODE_NONE.
+ */
+static volatile bool gSdScpiClaim = false;
+
+bool sd_card_manager_TryClaim(void) {
+    bool got;
+    taskENTER_CRITICAL();
+    got = !gSdScpiClaim && !sd_card_manager_IsBusyLocked();
+    if (got) {
+        gSdScpiClaim = true;
+    }
+    taskEXIT_CRITICAL();
+    return got;
+}
+
+void sd_card_manager_ReleaseClaim(void) {
+    taskENTER_CRITICAL();
+    gSdScpiClaim = false;
+    taskEXIT_CRITICAL();
+}
+
 bool sd_card_manager_IsBusy(void) {
+    if (gSdScpiClaim) {
+        return true;          /* #829: reserved by a SCPI handler, not yet armed */
+    }
+    return sd_card_manager_IsBusyLocked();
+}
+
+static bool sd_card_manager_IsBusyLocked(void) {
     // If SD manager hasn't been initialized yet, treat as busy/unavailable.
     // Intentionally true: prevents WiFi FW update or other SPI consumers from
     // starting before SD init completes during early boot.

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -344,6 +344,17 @@ extern "C" {
      */
     bool sd_card_manager_IsBusy(void);
 
+/* #829: reserve the SD manager for a SCPI handler WITHOUT arming an
+ * operation. `mode` cannot serve as the claim -- PROCESS_STATE_INIT starts
+ * work as soon as mode != MODE_NONE, and gpSDCardSettings aliases the struct
+ * the handlers write, so an early mode write would let app_SDCardTask (pri 5)
+ * begin on stale operands ahead of app_WifiTask (pri 2).
+ *
+ * Handlers: TryClaim -> fill operands -> write mode -> arm -> ReleaseClaim.
+ * Any failure after a successful claim must ReleaseClaim with mode unchanged. */
+bool sd_card_manager_TryClaim(void);
+void sd_card_manager_ReleaseClaim(void);
+
     /**
      * @brief #703: is the SD read scratch buffer large enough for SD:GET?
      *


### PR DESCRIPTION
## What

Every SD SCPI entry point checked `sd_card_manager_IsBusy()` and then wrote `mode` as **two separate steps**. USB SCPI (pri 7) preempts WiFi SCPI (pri 2) with no shared dispatch mutex, so both callers could pass the check and both write the shared operand fields — including `replyTarget`/`replyGeneration`, which decide *which interface* a reply is delivered to.

`IsBusy()` is true whenever `mode != MODE_NONE`, so writing `mode` **is** the claim. New `SD_ClaimOrRefuse()` does both under one critical section: exactly one caller becomes the owner, the loser refuses.

## This is the #736 BENCH interlock generalised

`SCPI_StorageSDBenchmark` already carried this exact fix, and its comment already named this exact mechanism:

> *"USB SCPI (pri 7) preempts WiFi SCPI (pri 2) with no shared dispatch mutex, so two BENCH invocations could both pass that check and both enter."*

So the race was acknowledged in-tree and one of seven entry points was already protected. This applies the proven pattern to the other six — no new design.

## Ordering matters as much as atomicity

The claim goes before **any** shared write, not merely before the `mode` assignment. My first attempt placed it just ahead of `mode`, which protects `replyTarget` but still allows: A writes `opDirectory=X`, B writes `opDirectory=Y`, A claims, B refused — **A then lists B's directory**.

Parsing and validation stay ahead of the claim (they only read the SCPI context). Everything downstream is owner-only, with **11 release points** across the 6 sites.

| site | claim placed before | consequence of losing the race |
|---|---|---|
| `LISt?` | `opDirectory`, `replyTarget` | listing delivered to the wrong transport |
| `GET` | `opFile`, `replyTarget` | **a client's file sent to the other transport** |
| `CRC` | `opFile` | CRC computed over the wrong file |
| `DELete` | `opFile` | **the winner deletes the loser's file** |
| `FORMat` | `SetFormatPending()` | a format advertised that nobody runs |
| `SPACe?` | `mode` | — (no operand) |

## Two findings the issue does not list

**`FORMat` published before it claimed.** `sd_card_manager_SetFormatPending()` makes `FORmat?` report "in progress", and it ran *ahead* of the mode write — so a caller that then lost the race had already told clients a format had started. Claiming first means only the owner publishes.

**`DELete` is the sharpest case.** Its operand is a filename, so a clobbered write means the surviving caller deletes the *other* client's file. That is data loss, not a misrouted reply.

Also worth recording: the pre-existing `taskENTER_CRITICAL` around those operand writes guards a **torn** write, not this race — it makes each write atomic without deciding whose value survives. The `LISt` comment asserting *"a second listing is refused while one is in flight"* was the assumption this issue disputes. It is now true rather than assumed.

## Test status — deliberately test-exempt

Agreed with the maintainer before implementing. The race window is the **microseconds** between check and arm; host command inter-arrival jitter over USB/TCP is **milliseconds**. Five bench attempts could not create contention at all (all documented on #829, including two that were themselves invalid). Any host-side regression test would pass identically on old and new firmware — theatre, not evidence. The #736 BENCH interlock shipped on the same basis.

**What is verified on hardware** — bench Nq1 `7E2898F46200E8A7`, this build flashed and confirmed `Program Succeeded`:

```
test_799_list_must_not_move_directory   5 PASS 0 FAIL   LISt / FORMat / SPACe
test_724_sd_opfile_clobber              1 PASS 0 FAIL   GET
CRC + DELete smoke                      1 PASS 0 FAIL   CRC / DELete
```

All six restructured entry points behave correctly in normal single-transport use and release their claims on every exercised path. The smoke deliberately ends with `SPACe?` *after* CRC and DELete, to catch the likeliest defect in this change — a claim taken and not released, leaving the card busy until reboot. It answers normally.

**These do not demonstrate the race is fixed.** That rests on the code-correctness argument and the #736 precedent. `test_724` in particular is named for opFile clobbering but exercises no concurrency — it confirms I did not break an existing single-transport guarantee while inserting the claim ahead of it.

## Gates

- Build: clean, `-O3`, `default`.
- cppcheck: 0 findings, baseline unchanged.
- Flash verified (`Program Succeeded`) before any test was trusted — the first two attempts silently failed on a relative hex path and would have tested the *old* firmware.

Closes #829



## Scope correction — the invariant is file-local, not global

The adversarial audit caught an over-broad claim in this description. "Every writer of `mode` claims first, writes `mode` last, arms, releases" holds **inside `SCPIStorageSD.c`**. It is not global.

`SYST:STR:START`'s SD-logging arm in `SCPIInterface.c` still uses the old check-then-set shape — busy check at 3655, unclaimed `mode = MODE_WRITE` at 3692, and again on the re-open retry at 3824. `git grep TryClaim -- SCPIInterface.c` returns nothing.

Verified independently before accepting. Tracked as **#836**, deliberately not fixed here:

- The gap is **pre-existing**; this PR is scoped to `SCPIStorageSD.c` / `sd_card_manager.c`/`.h` and does not touch that file.
- This PR makes it **strictly better, never worse**: the new `IsBusy()` also reports `gSdScpiClaim`, so a SCPI handler holding the claim now blocks a later `STR:START`. Only the reverse direction remains open.
