### PR TITLE
fix(scpi): claim the SD manager before arming SD logging on stream start

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3652,7 +3652,18 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         }
         // Check if SD card is busy with another operation (DELETE, FORMAT, etc.).
         // SD is a single consumer — don't start a logging file while any SD op runs.
-        if (sd_card_manager_IsBusy()) {
+        /* #836: CLAIM rather than check-then-set. This used to be a bare
+         * IsBusy() test ~37 lines above the `mode = WRITE` write below, and USB
+         * SCPI (pri 7) preempts WiFi SCPI (pri 2) with no shared dispatch mutex
+         * -- so a SCPI SD:GET could take the claim, arm MODE_READ and return OK
+         * in that gap, and this arm would then silently overwrite it. The GET
+         * caller waits forever for data that is never coming.
+         *
+         * Same interlock as #829/PR #835, which converted the six entry points
+         * in SCPIStorageSD.c. The claim reserves the manager WITHOUT arming
+         * anything; `mode` is still written last, and the claim is released
+         * once UpdateSettings has handed ownership to `mode`. */
+        if (!sd_card_manager_TryClaim()) {
             LOG_E("Cannot start SD logging - SD card busy with another operation");
             SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
             return SCPI_RES_ERR;
@@ -3691,6 +3702,9 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
 
         pSDCardSettings->mode = SD_CARD_MANAGER_MODE_WRITE;
         sd_card_manager_UpdateSettings(pSDCardSettings);
+        /* #836: ownership is now carried by `mode != MODE_NONE`, which keeps
+         * IsBusy() true, so releasing here leaves no gap. */
+        sd_card_manager_ReleaseClaim();
 
         // Wait for SD file to be open before starting streaming.
         // Without this, early samples are dropped while SD mounts/opens.
@@ -3819,10 +3833,24 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
              * total data loss on an SD-only session. Mirror the first block: clear
              * the flags, early-exit the poll, and FAIL START with the precise cause
              * so SD-logging is never falsely asserted. */
+            /* #836: the first arm released its claim before the poll above, so
+             * an SCPI SD command can own the manager by the time we re-open
+             * here. Claim again rather than overwriting whatever it armed. A
+             * refusal fails START with a precise cause, matching the
+             * dir-full / disk-full handling immediately below -- silently
+             * asserting SD logging with no file open is the failure #690
+             * already fixed once on this path. */
+            if (!sd_card_manager_TryClaim()) {
+                LOG_E("STR:START refused: SD busy with another operation at "
+                      "post-repartition re-open\r\n");
+                SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+                return SCPI_RES_ERR;
+            }
             sd_card_manager_ClearStartupDirFull();
             sd_card_manager_ClearStartupDiskFull();
             pSDCardSettings->mode = SD_CARD_MANAGER_MODE_WRITE;
             sd_card_manager_UpdateSettings(pSDCardSettings);
+            sd_card_manager_ReleaseClaim();   /* #836: mode now holds it */
             int readyWait = 0;
             while (!sd_card_manager_IsWriteReady() && readyWait < 500) {
                 if (sd_card_manager_StartupDirFull() || sd_card_manager_StartupDiskFull()) {


### PR DESCRIPTION
## What

#829 (PR #835) converted the six SD SCPI entry points in `SCPIStorageSD.c` to an atomic claim. `SYST:STR:START`'s SD-logging arms in `SCPIInterface.c` were left on the old check-then-set shape — an `IsBusy()` test **~37 lines above** an unguarded `mode = MODE_WRITE`, plus a second arm on the re-open retry with **no busy check at all**.

Found by the adversarial audit on #835, deferred there as out-of-scope, verified independently before implementing.

## The race — same mechanism, one file over

USB SCPI (pri 7) preempts WiFi SCPI (pri 2) with no shared dispatch mutex:

1. WiFi `STR:START` passes the busy check while the manager is idle, then is preempted.
2. USB `SD:GET "a.csv"` takes the claim, fills operands, arms `MODE_READ`, releases, and **returns SCPI OK**.
3. WiFi resumes and overwrites `mode = WRITE` — no recheck, no claim.

`UpdateSettings` has no ownership check, and `gpSDCardSettings` aliases the live struct, so the overwrite lands on the armed READ. **Failure toward silence**: the GET caller already has its OK and waits forever for data that never arrives.

## The second arm needed judgement, not just the same edit

It runs *after* the first arm released its claim, so an SCPI command can legitimately own the manager by then. A refusal there must **fail START** rather than fall through — silently asserting SD logging with no file open is precisely the failure #690 already fixed once on this path.

Its refusal now matches the dir-full / disk-full handling immediately below it.

## Method — #829's lesson applied from the start

#835 took **seven defects** to learn that this file's call sites look uniform and are not. So here:

- Hand-written edits, with `assert count == 1` on every anchor before replacing.
- Structural audit run **before** the compiler:

```
[ok] arm@3703  claim@3666  release@3707  unreleased-exits-between=0
[ok] arm@3851  claim@3843  release@3853  unreleased-exits-between=0
```

## Verified

Bench Nq1 `7E2898F46200E8A7`, flash confirmed `Program Succeeded`:

```
test_829_sd_claim_release  11 PASS 0 FAIL   (incl. the new #836 step)
test_799                    5 PASS 0 FAIL
```

Gates: build 0 errors, cppcheck 0 findings (baseline unchanged).

## Companion test

Extended the existing guard rather than adding a near-duplicate — same contract, same probe, one place to look when a seventh claim site appears. See daqifi/daqifi-python-test-suite#191.

The race itself is **not host-reproducible**, for the same reason as #829: microsecond check-to-arm window against millisecond host jitter, with five documented failed contention attempts on that issue. What the test covers is the **release obligation** these two arms add — which is where every mistake in #835 actually landed.

Closes #836
