### PR TITLE
fix(sd): a failed rotation-drain write must be counted, and must not report success

### DIFF
--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2743,7 +2743,21 @@ void sd_card_manager_ProcessState() {
                         }
                         gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
                     }
-                    gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_IDLE;
+                    /* #825: do not clobber an ERROR the drain above set. This branch is
+                     * the twin of the rotation tail: it too transitioned unconditionally,
+                     * so a stop that failed to write its backlog reported as a clean one.
+                     * Leaving ERROR standing routes the session through UNMOUNT_DISK with
+                     * lastOperationSuccess = false.
+                     *
+                     * No sd_AbandonRotationWindow() here, unlike the rotation tail: the
+                     * #757 window is armed only under `willRotate`, and this is the branch
+                     * where that is false, so there is no open window to close. */
+                    if (gSDCardData.currentProcessState
+                        != SD_CARD_MANAGER_PROCESS_STATE_ERROR) {
+                        gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_IDLE;
+                    }
+                    /* Signal either way -- the operation IS over, and skipping the give
+                     * would hang the waiter, which is what this give exists to prevent. */
                     xSemaphoreGive(gSDCardData.opCompleteSemaphore);
                 }
                 break;  // Exit to reopen with new filename or error

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2427,6 +2427,13 @@ void sd_card_manager_ProcessState() {
                         LOG_E("[SD] Error flushing pending write before rotation");
                         gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                         gSDCardData.sdCardWritePending = 0;
+                        /* #825: same obligation as the drain loop below. This chunk was
+                         * extracted from wCirbuf by the chunk loop (which exits with
+                         * sdCardWritePending=1 on its 4th chunk -- see the comment above),
+                         * so the bytes are already gone from the buffer. Nothing else can
+                         * see them: the drain loop counts its OWN writeBufferLength, and
+                         * the strand/abandon paths only count what is still in wCirbuf. */
+                        Streaming_ReportSdDiscard(gSDCardData.writeBufferLength);
                         gSDCardData.writeBufferLength = 0;
                         gSDCardData.sdCardWriteBufferOffset = 0;
                         break;
@@ -2448,6 +2455,13 @@ void sd_card_manager_ProcessState() {
                         LOG_E("[SD] Zero-byte write during rotation flush");
                         gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                         gSDCardData.sdCardWritePending = 0;
+                        /* #825: same obligation as the drain loop below. This chunk was
+                         * extracted from wCirbuf by the chunk loop (which exits with
+                         * sdCardWritePending=1 on its 4th chunk -- see the comment above),
+                         * so the bytes are already gone from the buffer. Nothing else can
+                         * see them: the drain loop counts its OWN writeBufferLength, and
+                         * the strand/abandon paths only count what is still in wCirbuf. */
+                        Streaming_ReportSdDiscard(gSDCardData.writeBufferLength);
                         gSDCardData.writeBufferLength = 0;
                         gSDCardData.sdCardWriteBufferOffset = 0;
                         break;

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2743,6 +2743,23 @@ void sd_card_manager_ProcessState() {
                         }
                         gSDCardData.fileHandle = SYS_FS_HANDLE_INVALID;
                     }
+                    /* #825: the split limit means no further file will EVER be opened, so
+                     * anything still in the circular buffer is unwritable -- and routing
+                     * ERROR onward does not save it either: UNMOUNT_DISK guards its whole
+                     * drain on `fileHandle != SYS_FS_HANDLE_INVALID` and the handle was
+                     * just closed above. Count it here rather than let the next reset
+                     * discard it silently, which is the same obligation the drain has.
+                     * A clean stop already drained the buffer, so this is a no-op then.
+                     * Mirrors the #823 stranded-remainder accounting in the rotation path. */
+                    SD_TakeMutexDebug(gSDCardData.wMutex, "split_limit_strand");
+                    size_t splitStranded = CircularBuf_NumBytesAvailable(&gSDCardData.wCirbuf);
+                    CircularBuf_Reset(&gSDCardData.wCirbuf);
+                    xSemaphoreGive(gSDCardData.wMutex);
+                    if (splitStranded > 0u) {
+                        Streaming_ReportSdDiscard(splitStranded);
+                        LOG_E("[SD] split limit reached: discarded %u unwritable buffered byte(s)",
+                              (unsigned)splitStranded);
+                    }
                     /* #825: do not clobber an ERROR the drain above set. This branch is
                      * the twin of the rotation tail: it too transitioned unconditionally,
                      * so a stop that failed to write its backlog reported as a clean one.

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2485,6 +2485,8 @@ void sd_card_manager_ProcessState() {
                      * extracted, so a partial write cannot spin the loop. */
                     size_t drained = 0;
                     while (drained < bufferBytes
+                           && gSDCardData.currentProcessState
+                              != SD_CARD_MANAGER_PROCESS_STATE_ERROR
                            && CircularBuf_NumBytesAvailable(&gSDCardData.wCirbuf) > 0) {
                         int writeLen = -2;
                         SD_TakeMutexDebug(gSDCardData.wMutex, "drain_loop");
@@ -2532,6 +2534,11 @@ void sd_card_manager_ProcessState() {
                                     }
                                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                                     gSDCardData.sdCardWritePending = 0;
+                                    /* #825: this chunk already left wCirbuf via CircularBuf_ProcessBytes,
+                                     * so these bytes are gone whether or not they reached the card.
+                                     * Count them BEFORE the length is cleared, or the loss is silent --
+                                     * the same class #823 closed for the stranded remainder. */
+                                    Streaming_ReportSdDiscard(gSDCardData.writeBufferLength);
                                     gSDCardData.writeBufferLength = 0;
                                     gSDCardData.sdCardWriteBufferOffset = 0;
                                     break;
@@ -2554,6 +2561,11 @@ void sd_card_manager_ProcessState() {
                                     }
                                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                                     gSDCardData.sdCardWritePending = 0;
+                                    /* #825: this chunk already left wCirbuf via CircularBuf_ProcessBytes,
+                                     * so these bytes are gone whether or not they reached the card.
+                                     * Count them BEFORE the length is cleared, or the loss is silent --
+                                     * the same class #823 closed for the stranded remainder. */
+                                    Streaming_ReportSdDiscard(gSDCardData.writeBufferLength);
                                     gSDCardData.writeBufferLength = 0;
                                     gSDCardData.sdCardWriteBufferOffset = 0;
                                     break;
@@ -2699,8 +2711,22 @@ void sd_card_manager_ProcessState() {
                      * close, so that everything the encoder produced during
                      * them is kept rather than discarded. All that remains is
                      * to advance to the next file. */
-                    gSDCardData.fileCounter++;
-                    gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE;
+                    if (gSDCardData.currentProcessState
+                        == SD_CARD_MANAGER_PROCESS_STATE_ERROR) {
+                        /* #825: the drain above could not write its backlog and set
+                         * ERROR. Advancing to OPEN_FILE would overwrite that state and
+                         * report a failed rotation as a successful one -- the ERROR is
+                         * what routes the session through UNMOUNT_DISK with
+                         * lastOperationSuccess = false. Leave it standing.
+                         *
+                         * The #757 window was opened above, before the sync and close,
+                         * and skipping OPEN_FILE means nothing will ever drain it, so
+                         * close it here exactly as the file-close failure does. */
+                        sd_AbandonRotationWindow("drain write failed");
+                    } else {
+                        gSDCardData.fileCounter++;
+                        gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_OPEN_FILE;
+                    }
                 } else {
                     LOG_E("[%s:%d]File counter limit reached (%d files). Stopping streaming.",
                           __FILE__, __LINE__, SD_CARD_MANAGER_MAX_SPLIT_FILES);


### PR DESCRIPTION
Fixes #825.

Defects on one path in the SD rotation drain (`sd_card_manager.c`), all **pre-existing** — found by adversarial audit during #823 and deferred out of it rather than fixed there.

## 1. A failed write discarded its chunk uncounted

On `SDCardWrite() < 0` or `== 0` the branch set `ERROR` and zeroed `writeBufferLength` — but the chunk had **already left `wCirbuf`** via `CircularBuf_ProcessBytes`, so those bytes were gone and nothing routed them to `Streaming_ReportSdDiscard()`. They never appeared in `SdDroppedBytes`. Same silent-loss class #823 closed for the *stranded* remainder; the write-failure path simply was not part of that fix.

The outer loop did not test `currentProcessState` either, so after the first failure it kept extracting and discarding further chunks the same way, with `rotationDrainErrorLogged` suppressing all but the first `LOG_E`.

**Fix:** report the unwritten remainder before the clear, and stop the outer loop on `ERROR`.

## 1b. So did the pending-flush loop, one loop earlier

Found by the adversarial audit. The chunk loop exits with `sdCardWritePending = 1` when it hits its 4th chunk — the in-tree comment says so outright (*"The loop can exit with sdCardWritePending=1 (4th chunk read but not yet written)"*). The rotation **pending-flush** loop that writes it had the same hole: both failure branches zeroed `writeBufferLength` with no `Streaming_ReportSdDiscard()`. Those bytes had already left `wCirbuf`, and nothing else can see them — the drain loop counts its *own* `writeBufferLength`, and the strand/abandon paths only count what is still in `wCirbuf`.

Pre-existing (identical on base `0e98749a`) and narrow to trigger — file splitting, a small `MAXSize`, exactly the 4th-of-4 chunk boundary, *and* a write failure at that moment — but it fails in the **silent** direction, which is the direction #825 is about, and leaving it open would have made this PR's headline claim false.

## 2. The ERROR never reached the caller — in *both* exits

The rotation tail unconditionally did `fileCounter++` / `currentProcessState = OPEN_FILE`, overwriting the `ERROR` the drain had just set. That `ERROR` is what routes the session through `UNMOUNT_DISK` with `lastOperationSuccess = false`, so the overwrite suppressed a genuine session abort: **a rotation that failed to write its backlog reported as a rotation that succeeded.** Only a `FileClose` failure escaped with `ERROR` intact.

Qodo then caught that I had fixed one branch and left its twin: the `willRotate == false` exit — the split-file-limit stop — did exactly the same thing (`IDLE` + `xSemaphoreGive`, unconditionally), so a *stop* that failed to write its backlog also reported clean. Both are now guarded.

**Fix:** skip the transition when the drain errored.
- Rotation tail: skipping `OPEN_FILE` means nothing will ever drain the #757 window opened before the sync and close, so close it via `sd_AbandonRotationWindow()` exactly as the file-close failure does — which also counts whatever it still holds.
- Split-limit exit: deliberately **no** abandon call. The #757 window is armed only under `willRotate` (the arming site says so outright), and this is the branch where that is false, so there is no open window to close. The semaphore give stays unconditional — the operation is over either way, and skipping it would hang the waiter.

## Bench evidence (E)

Nq1 `7E2898F46200E8A7`, 2026-08-22. A real drain-write failure needs an actual media fault, so both defects were exercised with a **temporary source injection** forcing every drain write to fail (`if (++s825Drains_ > 4) writeLen = -1;`) — **never committed**; the branch was `git checkout --`'d before push and carries no injection.

| firmware | `SdDroppedBytes` | files | onCard vs encoded | session |
|---|--:|--:|---|---|
| **pre-fix** + injection | **0** | 39–40 | card holds MORE | ran to completion, reported success |
| **post-fix** + injection | **25,564** / 31,336 | 5 / 1 | 101,327 vs 775,043 | **aborted** |

The pre-fix row is the bug in one line: rotations completed and reported success while every drain write was failing, and the counter said zero. The companion test's new check fails on that row and passes on healthy firmware — see below.

**Unregressed on the final build** (`efa5fe265`): `test_757_rotation_window.py` **10 PASS 0 FAIL** — arm1 `SdDropped=0` / 772,430 encoded / 776,352 on card / 38 files; arm2 `SdDropped=0` / 787,125 / 791,153 / 39 files. The card holds ~4 KB *more* than encoded on both arms (per-file headers), so #757's rotation window and #822's file counts are untouched.

**Every extracted-but-unwritten byte on this path is now accounted for** (`Streaming_ReportSdDiscard` call sites 5 → 7):

| where the bytes are | counted by |
|---|---|
| pending-flush chunk (4th-of-4 boundary) | both branches — **1b** |
| drain-loop chunk | both branches — **1** |
| still in `wCirbuf`, rotating | `sd_AbandonRotationWindow()` |
| still in `wCirbuf`, split limit | `split_limit_strand` — **3** |

Build: 0 errors. cppcheck: 0 findings (matches the empty baseline).

## Note for review

`totalBytesFlushPending` is deliberately **not** adjusted on the discard path. It is only a boolean "is there anything to sync" gate and is zeroed wholesale after a successful sync (`sd_card_manager.c:1545`, `:2670`); it is not a loss counter, so leaving it inflated costs at worst one extra `FileSync`.

The post-abort shortfall in the post-fix row (648 KB) is **not** new loss: with SD torn down, streaming continues until the #397 transport-down watchdog fires, whose grace is 60 s (`TRANSPORT_GRACE_DEFAULT_SEC`, `streaming.c:317`) against a 25 s test stream. Documented behaviour.

## Companion test

daqifi/daqifi-python-test-suite#192 — adds check 6 to `test_757_rotation_window.py`: *if the device logged a failed rotation drain, `SdDroppedBytes` must be non-zero.* Keyed on the device's own error log rather than byte arithmetic, so it is independent of the existing checks and **fails exactly where they pass** — on the pre-fix mutant it is the only failure while checks 1–5 all pass and everything looks healthy.
