### PR TITLE
feat(scpi): report a build fingerprint, not just a release string (#833)

### DIFF
--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -34,10 +34,19 @@
 // *****************************************************************************
 // *****************************************************************************
 
+#include "services/SCPI/SCPIInterface.h"
+
 int main ( void )
 {
     /* Initialize all modules */
     SYS_Initialize ( NULL );
+
+    /* #833: fold the program image into its CRC fingerprint here, before
+     * SYS_Tasks() starts the scheduler. It is ~120 ms of straight-line work,
+     * which is nothing against a multi-second boot but would be a poor thing
+     * to do inside a SCPI query -- and doing it with no task running means
+     * the value is published before anything can read it. */
+    SCPI_PrecomputeFirmwareImageCrc32();
 
     while ( true )
     {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5235,16 +5235,40 @@ static void EmitDioChannelJson(scpi_t* context,
  * straight-line because the watchdog is disabled (FWDTEN = OFF,
  * initialization.c). Erased flash reads as a stable 0xFF, so the unused tail
  * contributes a constant rather than making the value non-deterministic. */
+/* Both operands are compile-time constants, so the relationship is settled
+ * at build time rather than guarded at runtime: if the reserved settings
+ * region ever grew to meet or exceed program flash, the length below would
+ * underflow and the CRC would read far past the end of flash. Fail the
+ * BUILD instead. */
+_Static_assert(RESERVED_SETTINGS_SPACE < __KSEG0_PROGRAM_MEM_LENGTH,
+               "#833: the reserved settings region must be smaller than"
+               " program flash, or the image-CRC length underflows");
+
 static uint32_t SCPI_FirmwareImageCrc32(void)
 {
-    static uint32_t sCrc;
-    static bool sComputed = false;
+    /* volatile + a compiler barrier, NOT for atomicity -- a 32-bit aligned
+     * access is already atomic on PIC32MZ, which is why the project declines
+     * volatile-for-atomicity suggestions. The hazard here is ORDERING of two
+     * DIFFERENT objects: USB SCPI (pri 7) and WiFi SCPI (pri 2) can both
+     * reach this, and nothing stops the compiler publishing sComputed before
+     * sCrc, which would let the other task read a zero CRC and report
+     * 00000000 as a build fingerprint.
+     *
+     * No critical section: this runs for tens of ms, and disabling
+     * interrupts for that long would wreck streaming. It does not need one
+     * -- the function is PURE, so the worst a race can do is compute the
+     * same value twice and store it twice, which is wasted work and not a
+     * wrong answer. */
+    static volatile uint32_t sCrc;
+    static volatile bool sComputed = false;
 
     if (!sComputed) {
         const uint8_t *image = (const uint8_t *)__KSEG0_PROGRAM_MEM_BASE;
         const size_t len = (size_t)(__KSEG0_PROGRAM_MEM_LENGTH
                                     - RESERVED_SETTINGS_SPACE);
-        sCrc = CRC32_Compute(image, len);
+        uint32_t crc = CRC32_Compute(image, len);
+        sCrc = crc;
+        __asm__ __volatile__ ("" ::: "memory");   /* value before flag */
         sComputed = true;
     }
     return sCrc;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -27,6 +27,7 @@
 #include "state/data/BoardData.h"
 #include "state/board/BoardConfig.h"
 #include "services/daqifi_settings.h"
+#include "Util/CRC32.h"
 #include "state/runtime/BoardRuntimeConfig.h"
 #include "state/board/AInConfig.h"  // For MAX_AIN_PUBLIC_CHANNELS
 #include "peripheral/gpio/plib_gpio.h"
@@ -5213,6 +5214,42 @@ static void EmitDioChannelJson(scpi_t* context,
  * revision scheme introduces such characters, add a small JSON
  * string escaper before embedding these fields.
  */
+/* #833: a fingerprint of the program image, so measurement data can tell two
+ * builds of the SAME release apart.
+ *
+ * identity.firmware_rev is a release string ("3.7.2"), so every build between
+ * two releases reports the same value -- two benchmark runs can carry an
+ * identical repeatability triplet and have executed different firmware.
+ *
+ * CRC32 of program flash EXCLUDING the reserved settings region: the last
+ * RESERVED_SETTINGS_SPACE bytes hold the NVM pages, so including them would
+ * change the fingerprint every time a setting is saved.
+ *
+ * The length comes from the two SIZE macros, not from
+ * (RESERVED_SETTINGS_ADDR - __KSEG0_PROGRAM_MEM_BASE). That subtraction is
+ * correct today only because every term in the unparenthesised
+ * daqifi_settings.h address macros is + or -; it would break the moment one
+ * gained a parenthesis-sensitive operator. This form does not care.
+ *
+ * Lazy and cached: ~1.9 MB costs tens of ms -- fine once, not per query. Safe
+ * straight-line because the watchdog is disabled (FWDTEN = OFF,
+ * initialization.c). Erased flash reads as a stable 0xFF, so the unused tail
+ * contributes a constant rather than making the value non-deterministic. */
+static uint32_t SCPI_FirmwareImageCrc32(void)
+{
+    static uint32_t sCrc;
+    static bool sComputed = false;
+
+    if (!sComputed) {
+        const uint8_t *image = (const uint8_t *)__KSEG0_PROGRAM_MEM_BASE;
+        const size_t len = (size_t)(__KSEG0_PROGRAM_MEM_LENGTH
+                                    - RESERVED_SETTINGS_SPACE);
+        sCrc = CRC32_Compute(image, len);
+        sComputed = true;
+    }
+    return sCrc;
+}
+
 static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
     const tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
     const tBoardRuntimeConfig* rt =
@@ -5280,6 +5317,10 @@ static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
         "\"identity\":{\"vendor\":\"DAQiFi\",\"model\":\"Nyquist\","
         "\"variant\":\"%s\",",
         variantName);
+
+    scpi_printf(context,
+        "\"firmware_crc32\":\"%08lX\",",
+        (unsigned long)SCPI_FirmwareImageCrc32());
 
     scpi_printf(context,
         "\"serial\":\"%llX\","

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5274,6 +5274,11 @@ static uint32_t SCPI_FirmwareImageCrc32(void)
     return sCrc;
 }
 
+void SCPI_PrecomputeFirmwareImageCrc32(void)
+{
+    (void)SCPI_FirmwareImageCrc32();
+}
+
 static scpi_result_t SCPI_CapabilitiesJsonGet(scpi_t * context) {
     const tBoardConfig* cfg = BoardConfig_Get(BOARDCONFIG_ALL_CONFIG, 0);
     const tBoardRuntimeConfig* rt =

--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -39,6 +39,16 @@ extern "C" {
      */
     void SCPI_InitIdentification(void);
 
+    /* #833: compute the program-image CRC that CONF:CAP:JSON? reports as
+     * identity.firmware_crc32. Call ONCE from main(), BEFORE the scheduler
+     * starts: it takes ~120 ms (measured on the bench -- a cold
+     * CONF:CAP:JSON? was 128 ms against 5-12 ms warm), which is invisible in
+     * a multi-second boot but far too long to spend inside a SCPI query, and
+     * doing it here means the cache is written by a single caller with no
+     * task running -- so the USB/WiFi SCPI concurrency question never
+     * arises. Safe to call more than once; the second call is a no-op. */
+    void SCPI_PrecomputeFirmwareImageCrc32(void);
+
     /**
      * Creates a new SCPI context object.
      * This allows us to have multiple independent consoles.


### PR DESCRIPTION
Fixes #833.

`identity.firmware_rev` is a **release** string (`"3.7.2"`), so every build between two releases reports the same value. Two benchmark runs can therefore carry an identical repeatability triplet — `*IDN?` + firmware version + test-suite SHA — and have executed different firmware. That is precisely the question committed measurement data exists to answer, and today it cannot.

Adds `identity.firmware_crc32`: a CRC32 of the program image.

## The issue's stated mechanism does not exist — verified before building

The issue opens with *"Benchmark artifacts record `firmware_version` from `SYST:VERSion?`, which returns `FIRMWARE_REVISION`."* Neither half holds, and it changes where the fix belongs:

- **`SYST:VERSion?` is not ours.** The pattern binds to libscpi's built-in `SCPI_SystemVersionQ` (`libraries/scpi/libscpi/src/minimal.c:71`), which returns the **SCPI standard** revision — `SCPI_STD_VERSION_REVISION "1999.0"` (`constants.h:50`). Appending a build stamp there would have stamped the spec version.
- **The suite does not read it.** `collect_run_metadata()` takes the authoritative rev from `CONF:CAP:JSON?` → `identity.firmware_rev`.

So the surface here is the **`identity` block of `CONF:CAP:JSON?`** — an extension of an existing query (no new SCPI pattern, per the standing "keep the command list lean" rule), already the suite's identity source, and it leaves the `VERSion?` reply shape untouched, which is exactly the client-parsing risk the issue correctly flagged.

## Why an image CRC rather than a build-time git SHA

The issue suggested a git SHA. That needs a pre-build step in `configurations.xml` for **both** configurations — a CI-guarded file that a config switch is known to prune — and degrades to `unknown` for a build without git. The CRC needs no build tooling, stays in sync across configurations for free, and cannot go stale the way a `__DATE__` stamp does when its translation unit is not recompiled.

It answers *"same build or different?"*, which is what the repeatability key needs. It does **not** answer *"which commit?"*, so a SHA remains a complement rather than a rival — worth adding later if the build-step risk is ever accepted.

## Implementation notes

- **The settings region is excluded.** The last `RESERVED_SETTINGS_SPACE` (128 KB) of program flash holds the NVM pages; including them would change the fingerprint every time a setting is saved.
- **The length comes from the two SIZE macros**, not from `RESERVED_SETTINGS_ADDR - __KSEG0_PROGRAM_MEM_BASE`. That subtraction is correct today only because every term in the unparenthesised `daqifi_settings.h` address macros happens to be `+` or `-`.
- **Lazy and cached** — ~1.9 MB costs tens of ms, fine once and not per query. Safe straight-line because `FWDTEN = OFF` (`initialization.c`).
- Erased flash reads as a stable `0xFF`, so the unused tail contributes a constant rather than making the value non-deterministic.

## Bench evidence (E)

Nq1 `7E2898F46200E8A7`, 2026-08-22. Two builds **both reporting `firmware_rev "3.7.2"`**, differing only by one string constant:

| build | `firmware_rev` | `firmware_crc32` |
|---|---|---|
| variant A | `3.7.2` | **`60A250F0`** |
| variant B (one string changed) | `3.7.2` | **`0B1C6FFA`** |

Stable across repeated queries and across a reboot. The clean rebuild after reverting the probe reproduced variant A's hex **byte for byte** (md5 `1e475844…`), so the build is deterministic and the difference above is the code change, not build noise.

A first attempt at this A/B was invalid and is worth recording: an unreferenced `static const char … __attribute__((used))` never reached the image at all, because `used` stops *compiler* elision but not `--gc-sections`. The CRC was right and the instrument was wrong — caught by checking `strings` on the ELF rather than trusting the identical CRC.

Build: 0 errors. cppcheck: 0 findings.

## Wiki

`03-Capabilities-JSON-Schema.md` identity table updated and **pushed** (`bd6bbf0`) — the schema page is where clients read this contract.

## Companion test

daqifi/daqifi-python-test-suite#193 — asserts the field is present, well formed, non-degenerate, stable across queries **and across a reboot** (the check that proves it is a property of the flashed image rather than of RAM or session state), and that `collect_run_metadata()` records it so every future sidecar carries the build identity. 8 PASS / 0 FAIL.
