### PR TITLE
refactor(streaming): drop a write-only SD flag and name the function honestly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1332,7 +1332,7 @@ data rows.
 The behaviour is deliberate on the firmware side: `streaming.c` writes an
 SD-only header whenever `gSdFileWasReady` goes false→true so that "every file
 is self-describing and independently parseable", and
-`Streaming_ResetSdPbMetadata()` is called on every rotation to arm exactly
+`Streaming_ResetSdFileHeader()` is called on every rotation to arm exactly
 that. Anything merging split files must therefore SKIP the `#`-prefixed lines
 of continuations rather than assuming they are absent.
 
@@ -1359,7 +1359,7 @@ of continuations rather than assuming they are absent.
   8.7 MB file against a 20 KB `MAXSize`). Bytes the encoder appends *during*
   that drain are therefore still buffered when the rotation resets the buffer,
   and they cannot be saved: writing them to the old file is the livelock, and
-  they cannot go to the new one because `Streaming_ResetSdPbMetadata()` has
+  they cannot go to the new one because `Streaming_ResetSdFileHeader()` has
   already armed the next header and they would land ahead of it. They are
   dropped and **counted** via `Streaming_ReportSdDiscard()`, so they show up in
   `SdDroppedBytes`. Measured ~3.6 KB per rotation (16ch CSV @2 kHz,

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3992,7 +3992,7 @@ static scpi_result_t SCPI_StopStreaming(scpi_t * context) {
     // Reset encoder state so next session gets fresh headers
     csv_ResetEncoder();
     json_ResetEncoder();
-    Streaming_ResetSdPbMetadata();
+    Streaming_ResetSdFileHeader();
 
     // Clear STATus:OPERation condition register
     SCPI_ClearOperBits(OPER_MEASURING | OPER_SD_LOGGING);

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -10,7 +10,7 @@
 #include "sd_card_manager.h"
 #include "services/UsbCdc/UsbCdc.h"
 #include "Util/CRC32.h"   /* #306 */
-#include "services/streaming.h"  // For Streaming_ResetSdPbMetadata on file rotation
+#include "services/streaming.h"  // For Streaming_ResetSdFileHeader on file rotation
 #include <stddef.h>
 #include "ff.h"   /* #810: FILINFO, for the layout assert below */
 
@@ -2036,7 +2036,7 @@ void sd_card_manager_ProcessState() {
                 //   1. CircularBuf_Reset() clears buffer (space available)
                 //   2. Streaming task sees gSdFileWasReady=true (stale),
                 //      encodes WITHOUT metadata, writes to buffer
-                //   3. Streaming_ResetSdPbMetadata() resets flags (too late)
+                //   3. Streaming_ResetSdFileHeader() resets flags (too late)
                 //   => Non-metadata data at byte 0 of new file
                 /* #757: skipped during a rotation -- the close path above
                  * already reset the metadata and the buffer, and the encoder
@@ -2046,7 +2046,7 @@ void sd_card_manager_ProcessState() {
                  * (session start, not rotation) gSdRotating is false and this
                  * runs as it always did. */
                 if (!gSdRotating) {
-                    Streaming_ResetSdPbMetadata();
+                    Streaming_ResetSdFileHeader();
 
                     // Now clear the buffer — streaming task won't write here
                     // because gSdFileWasReady is already false.
@@ -2621,7 +2621,7 @@ void sd_card_manager_ProcessState() {
                     /* The metadata clear MUST be inside the same mutex as the
                      * buffer reset, not before it.
                      *
-                     * Streaming_ResetSdPbMetadata() sets gSdFileWasReady=false,
+                     * Streaming_ResetSdFileHeader() sets gSdFileWasReady=false,
                      * which is the encoder's cue to emit the next file's
                      * header. The old file is still open here, so
                      * IsBufferAccepting() is true; if the pri-6 streaming task
@@ -2640,7 +2640,7 @@ void sd_card_manager_ProcessState() {
                      * blocks until the reset is done and then lands it in the
                      * emptied buffer, still at byte 0. */
                     SD_TakeMutexDebug(gSDCardData.wMutex, "rotation_open_window");
-                    Streaming_ResetSdPbMetadata();
+                    Streaming_ResetSdFileHeader();
                     /* #822: whatever the producer appended DURING the drain is
                      * still here, and this reset is about to destroy it.
                      *
@@ -3874,7 +3874,7 @@ bool sd_card_manager_IsWriteReady(void) {
  * why the loss this fixes grew with the number of files on the card. The
  * buffer is empty across that window (the rotation drains it before closing)
  * and its contents go to the NEW file, so accepting writes is safe and the
- * header still lands at byte 0 -- Streaming_ResetSdPbMetadata() is called
+ * header still lands at byte 0 -- Streaming_ResetSdFileHeader() is called
  * before the window opens, so the first thing the encoder puts in the empty
  * buffer is the new file's header.
  *

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2825,8 +2825,6 @@ void streaming_Task(void) {
                     BoardData_Get(BOARDDATA_ALL_DATA, true);
                 sdHdrLen = Nanopb_Encode(pBoardData,
                     &fields_sd_metadata, (uint8_t*)buffer, bufferSize);
-                if (sdHdrLen > 0) {
-                }
             }
             if (sdHdrLen > 0) {
                 size_t written = sd_card_manager_WriteToBuffer(

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -110,11 +110,6 @@ static volatile uint32_t gBenchmarkMode = BENCHMARK_OFF;
 // task.
 static volatile bool gNeedSharedScan = false;
 
-// SD protobuf metadata: emitted as first message in each SD log file.
-// volatile: written by SD card task (via Streaming_ResetSdPbMetadata),
-// read by streaming task — compiler must not cache in registers.
-static volatile bool gSdPbMetadataSent = false;
-
 // Tracks whether the SD file has become ready during this streaming session.
 // Used to reset encoder header flags when SD transitions to ready, since
 // encoding may have already fired (and burned headers) before the file opened.
@@ -1779,7 +1774,6 @@ static void Streaming_Start(void) {
         // Clear encoding buffer once to prevent stale data artifacts in SD files
         if (buffer != NULL) memset(buffer, 0, bufferSize);
 
-        gSdPbMetadataSent = false;
         // If SD file is already open and ready (SCPI_StartStreaming waited
         // for it), start with true to avoid dropping packets while the
         // encoder waits for the first sdSize > 0 detection.
@@ -2214,7 +2208,6 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
      * the very thing the flag exists to suppress (#733 audit). */
     gStreamRateConfigured = 0u;
     gBenchmarkMode = BENCHMARK_OFF;
-    gSdPbMetadataSent = false;
     gSdFileWasReady = false;
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
@@ -2371,8 +2364,16 @@ void Streaming_SdInterfaceReleased(void) {
     }
 }
 
-void Streaming_ResetSdPbMetadata(void) {
-    gSdPbMetadataSent = false;
+/* Re-arm the SD header for a new file. The SD task calls this at rotation;
+ * the streaming task then sees gSdFileWasReady false and emits a header so
+ * every split file is self-describing.
+ *
+ * Was Streaming_ResetSdPbMetadata(), which also cleared a gSdPbMetadataSent
+ * flag. That flag was assigned in five places and READ in none -- five
+ * volatile stores nobody looked at, and a name promising protobuf-metadata
+ * bookkeeping this function never did. Both removed; the header latch below
+ * is the whole of what it ever meant. */
+void Streaming_ResetSdFileHeader(void) {
     gSdFileWasReady = false;
 }
 
@@ -2784,7 +2785,7 @@ void streaming_Task(void) {
          * IsBufferAccepting stays true across that window. It is safe because
          * the rotation DRAINS the buffer before closing the old handle, so the
          * bytes accepted here belong to the new file, and because
-         * Streaming_ResetSdPbMetadata() runs before the window opens -- so the
+         * Streaming_ResetSdFileHeader() runs before the window opens -- so the
          * first thing written into the empty buffer is the new file's header,
          * still at byte 0.
          *
@@ -2800,7 +2801,6 @@ void streaming_Task(void) {
         // without injecting duplicate headers into the USB/WiFi stream.
         if (sdSize > 0 && !gSdFileWasReady) {
             gSdFileWasReady = true;
-            gSdPbMetadataSent = false;
 
             // Write SD-only header/metadata for each new file so every
             // file is self-describing and independently parseable.
@@ -2826,7 +2826,6 @@ void streaming_Task(void) {
                 sdHdrLen = Nanopb_Encode(pBoardData,
                     &fields_sd_metadata, (uint8_t*)buffer, bufferSize);
                 if (sdHdrLen > 0) {
-                    gSdPbMetadataSent = true;
                 }
             }
             if (sdHdrLen > 0) {

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -553,7 +553,7 @@ void TimestampTimer_Init( void );
  * interface is SD or USB+SD. */
 void Streaming_SdInterfaceReleased(void);
 
-void Streaming_ResetSdPbMetadata(void);
+void Streaming_ResetSdFileHeader(void);
 
 /* #757: report SD bytes that were buffered for the next file but can never be
  * written, because the session was torn down while the rotation's open was in


### PR DESCRIPTION
Groundwork for #824, and a standalone cleanup on its own merits.

## `gSdPbMetadataSent` was write-only

Assigned in five places, read in **none** — a recursive grep over `firmware/src` finds no branch, no getter, no macro that reads it:

```
streaming.c:116    static volatile bool gSdPbMetadataSent = false;   /* decl */
streaming.c:1782   gSdPbMetadataSent = false;
streaming.c:2217   gSdPbMetadataSent = false;
streaming.c:2375   gSdPbMetadataSent = false;      /* Streaming_ResetSdPbMetadata */
streaming.c:2803   gSdPbMetadataSent = false;
streaming.c:2829   gSdPbMetadataSent = true;
```

It is `volatile`, so the compiler faithfully emitted five stores nobody looked at.

## The name was the more expensive part

`Streaming_ResetSdPbMetadata()` reads as if it manages protobuf metadata state. Its only load-bearing effect is clearing `gSdFileWasReady` — the latch that re-arms the SD header for a new file.

That matters because this is the rotation path, which has been read and re-read a great deal lately (#757, #822, #823, #825). Anyone reasoning about it has to first work out that the PB half is inert before they can discount it. I spent that time today while scoping #824, which is what surfaced this.

## What changed

- flag removed;
- `Streaming_ResetSdPbMetadata()` → **`Streaming_ResetSdFileHeader()`**, with a doc comment stating what it does and why it was renamed;
- the orphaned comment block that described the removed flag is deleted, rather than left describing a variable that no longer exists.

Three call sites (`SCPIInterface.c`, `sd_card_manager.c` ×2) plus the header declaration renamed mechanically. **Zero references to either old name remain.**

## No behaviour change — and the companion-test exemption

The standing rule exempts pure refactors with no behaviour change. This is one: a write-only variable and a rename. The existing rotation coverage is what guards it, and it was run against this build:

```
===== 757_rotation_window: 10 PASS, 0 FAIL =====
```

with the header evidence visible in its own numbers — arm2 encoded **804,922** bytes against **809,056** on the card, a **+4,134** surplus across 40 files, i.e. the per-file headers are still being written. That surplus is the check that would catch a header regression, which is why it is worth quoting rather than just the verdict.

Build: 0 errors. cppcheck: 0 findings.

## Relation to #824

This shrinks that refactor rather than performing it. #824's remaining work — writing the header at file open instead of injecting it through the ring buffer — now has **one** piece of state to preserve rather than two. The sizing question (444 B worst case), the FPU question (all three generators are integer/string only), and the task-ownership question (the SD task already calls into streaming at exactly the right moment) are all answered on that issue.
