### PR TITLE
fix(sd): write each split file's header at open, so rotation keeps its bytes (#824)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,7 +533,7 @@ SYSTem:STReam:STATS:CLEar  # Reset all counters
 | `QueueDroppedSamples` | uint32 | Samples lost due to pool exhaustion or full sample queue (pool defaults 1100, re-partitioned per session) |
 | `UsbDroppedBytes` | uint32 | Data lost due to USB circular buffer full (16KB default; auto-balance raises it to 64KB whenever USB is active — `hasUsb` covers **USB+SD** too, which is why the auto-balance table shows 65,536 in that column as well) |
 | `WifiDroppedBytes` | uint32 | Data lost due to WiFi circular buffer full (14KB default; auto-balance raises it to 96KB when WiFi is the only active interface — `STREAMING_WIFI_WIFI_ONLY`, #497) |
-| `SdDroppedBytes` | uint32 | Data the SD path could not take. **There is no fixed retry count** — an earlier revision of this row said "3 retries", which matches nothing on this path (the SD manager's only retry constants are `SD_MOUNT_MAX_RETRIES` 10 and `SD_UNMOUNT_MAX_RETRIES` 40, neither governing writes; other subsystems have their own — `SCPI_WRITE_MAX_RETRIES`, `SPI_RETRY_COUNT` — none of them 3). The two real paths differ: **multi-output** (USB+SD) counts a short write **immediately, with no retry at all** (`streaming.c` — `LOG_E_SESSION "SD buffer overflow (multi-output no-retry)"`), which is deliberate so a stalled SD cannot block USB (#534/#536); **SD-only** goes through `Streaming_WriteWithRetry`, which spins, then backs off on `vTaskDelay(1)` up to `STREAM_WRITE_TIMEOUT_MS` (10 s) before counting. Also carries the bytes a split-file rotation strands in the circular buffer (#823 — see "SD Card File Splitting"). **Not** counted: bytes lost to a *failed* write mid-rotation-drain, still discarded silently (#825). |
+| `SdDroppedBytes` | uint32 | Data the SD path could not take. **There is no fixed retry count** — an earlier revision of this row said "3 retries", which matches nothing on this path (the SD manager's only retry constants are `SD_MOUNT_MAX_RETRIES` 10 and `SD_UNMOUNT_MAX_RETRIES` 40, neither governing writes; other subsystems have their own — `SCPI_WRITE_MAX_RETRIES`, `SPI_RETRY_COUNT` — none of them 3). The two real paths differ: **multi-output** (USB+SD) counts a short write **immediately, with no retry at all** (`streaming.c` — `LOG_E_SESSION "SD buffer overflow (multi-output no-retry)"`), which is deliberate so a stalled SD cannot block USB (#534/#536); **SD-only** goes through `Streaming_WriteWithRetry`, which spins, then backs off on `vTaskDelay(1)` up to `STREAM_WRITE_TIMEOUT_MS` (10 s) before counting. It no longer carries a split-file rotation strand: #823 made that visible here and **#824 eliminated it** by writing each file's header at open instead of through the ring (see "SD Card File Splitting"). **Not** counted: bytes lost to a *failed* write mid-rotation-drain, still discarded silently (#825). |
 | `EncoderFailures` | uint32 | Encoding attempts that returned 0 bytes with data available |
 | `TimerISRCalls` | uint64 | Actual streaming timer ISR entry count this session (#265). Invariant: `TimerISRCalls == TotalSamplesStreamed + QueueDroppedSamples`. |
 | `EosOverruns` | uint32 | EOS notifications coalesced (>1 per wake) (#295). Task-behind-but-fresh — NOT a loss (excluded from loss total). |
@@ -1329,15 +1329,23 @@ measured 2026-08-21 by downloading rotated files from the bench: `s2.csv`,
 `s2-1.csv` and `s2-2.csv` each begin `# Device: Nyquist 1` followed by ~1,279
 data rows.
 
-The behaviour is deliberate on the firmware side: `streaming.c` writes an
-SD-only header whenever `gSdFileWasReady` goes false→true so that "every file
-is self-describing and independently parseable", and
-`Streaming_ResetSdFileHeader()` is called on every rotation to arm exactly
-that. Anything merging split files must therefore SKIP the `#`-prefixed lines
-of continuations rather than assuming they are absent.
+The behaviour is deliberate on the firmware side, though **which task writes
+the header changed in #824**. It is now rendered once per session by the
+streaming task (`Streaming_BuildSdFileHeader`, into a 512 B static) and written
+by the **SD task** straight into each newly opened file with `SYS_FS_FileWrite`
+(`Streaming_GetSdFileHeader`, called from `OPEN_FILE`). Before #824 it was
+pushed through the SD circular buffer whenever a `gSdFileWasReady` latch went
+false→true, which is what forced the rotation to reset that buffer and made
+rotation lossy — see the ⚠️ under Safety Features. Anything merging split files
+must SKIP the `#`-prefixed lines of continuations rather than assuming they are
+absent.
 
-- First file: full CSV header (device info, column names with "ain" prefix)
-- Split files: the same header, then data rows
+- First file: full CSV header (device info, column names with "ain" prefix),
+  written **inline by the encoder** — the file is open before the encoder runs,
+  so the SD task has nothing to write yet, which is also why a **protobuf**
+  session's first file carries no `sd_metadata` (files 2..N do; pre-existing
+  #196 gap)
+- Split files: the same header, written at file open, then data rows
 
 **Safety Features:**
 - Default: 3.9GB limit (100MB below FAT32 maximum)
@@ -1352,21 +1360,24 @@ of continuations rather than assuming they are absent.
   `sd_card_manager_IsBufferAccepting()`; note that transport health
   deliberately still uses `IsWriteReady()`, or a stuck open would read as
   healthy.
-- ⚠️ **Rotation is not zero-loss, and an earlier revision of this file claimed
-  it was.** The pre-close drain is bounded to a *snapshot* of the circular
-  buffer (#822/#823) — draining the live level livelocks against the producer
-  above ~340 KB/s, which stopped rotation outright (11ch @2 kHz produced one
-  8.7 MB file against a 20 KB `MAXSize`). Bytes the encoder appends *during*
-  that drain are therefore still buffered when the rotation resets the buffer,
-  and they cannot be saved: writing them to the old file is the livelock, and
-  they cannot go to the new one because `Streaming_ResetSdFileHeader()` has
-  already armed the next header and they would land ahead of it. They are
-  dropped and **counted** via `Streaming_ReportSdDiscard()`, so they show up in
-  `SdDroppedBytes`. Measured ~3.6 KB per rotation (16ch CSV @2 kHz,
-  `MAXSize=20000`: 277,248 bytes across 76 rotations). It scales with rotation
-  *frequency*, not with rate — at the default 3.9 GB `MAXSize` it is a few KB
-  per multi-GB file. #824 tracks eliminating it by writing the header at file
-  open rather than through the ring buffer.
+- ⚠️ **Rotation used to discard ~3.6 KB per split; #824 removed that.** The
+  pre-close drain is still bounded to a *snapshot* of the circular buffer
+  (#822/#823) — draining the live level livelocks against the producer above
+  ~340 KB/s, which stopped rotation outright (11ch @2 kHz produced one 8.7 MB
+  file against a 20 KB `MAXSize`) — so bytes the encoder appends *during* that
+  drain are still buffered when the old file closes. What changed is where they
+  can go. They used to be unsaveable: not the old file (that is the livelock),
+  and not the new one either, because the next header was about to travel
+  through the same ring and they would have landed ahead of it. So the rotation
+  reset the buffer and `Streaming_ReportSdDiscard()` counted the loss into
+  `SdDroppedBytes` — measured 277,248 bytes across 76 rotations at 16ch CSV
+  @2 kHz with `MAXSize=20000`. #824 writes the header directly into the new
+  file at open instead, so byte 0 is guaranteed by call order, the reset is
+  gone, and those bytes simply become the new file's first data rows. Rotation
+  now contributes nothing to `SdDroppedBytes`; what remains there is genuine
+  buffer-full loss. (`test_824_rotation_no_discard.py` measures this as an A/B
+  — same config with and without rotation — because the counter aggregates both
+  and a bare `== 0` would fail at any saturating shape.)
 - Unconditional filesystem flush before file close
 
 **Python Tools:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1087,7 +1087,7 @@ The `StreamingInterface` enum exposes four combinations: `USB`, `WiFi`, `SD`, an
 | SD DMA write (coherent) | 512 | 512 | 124,368 | 77,922 |
 | USB DMA write (coherent) | 124,368 | 512 | 512 | 46,958 |
 | WiFi SPI staging (coherent) | 2,048 | 125,904 | 2,048 | 2,048 |
-| Sample pool CAPACITY (slots @16ch)¹ | 1,593 | 1,141 | 1,953 | 1,095 |
+| Sample pool CAPACITY (slots @16ch)¹ | 1,593 | 1,141 | 1,952 | 1,095 |
 
 ¹ **Capacity, not the depth in use.** These are how many slots the leftover pool space holds — what `StreamingBufferPool_Partition` computes and logs as `samples=<n>x<elementBytes>`. Note the log's second number is the **element** size (72 at 16ch), not the per-sample cost — the free-list entry is counted separately, which is why the divisor below is 74 while the log shows 72. Reconciling `1600 x 72` against a `/ 74` formula otherwise looks like an inconsistency; it is not. The depth actually available is min(that, whatever the FreeRTOS sample queue could be grown to), which on the bench came out at **1100** because the queue resize was skipped for want of ~1 KB of heap (#828). That is **not** an invariant: `AInSampleList_InitializeExternal` only clamps when it tries to GROW the queue and the heap will not stretch, so a device with more free heap grows it — and once grown it stays grown for later sessions. Read the number, do not assume it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -941,7 +941,7 @@ All items verified against the actual errata document. Only issues affecting fea
 
 The firmware uses four distinct memory regions, each with different properties:
 
-1. **Streaming Buffer Pool** (**197,632 B** static BSS — `STATIC_POOL_SIZE` is `(194 * 1024) - 1024`, so "194KB" is 1 KB high; `firmware/src/Util/StreamingBufferPool.c`)
+1. **Streaming Buffer Pool** (**197,120 B** static BSS — `STATIC_POOL_SIZE` is `(194 * 1024) - 1024 - 512`, so the "194KB" label is 1.5 KB high; `firmware/src/Util/StreamingBufferPool.c`. Was 197,632 until #824 trimmed a further 512 B to pay for `streaming.c`'s `gSdHeaderBytes`, the per-session SD file header — net BSS unchanged, the bytes just moved.)
    - Single `static uint8_t gPoolStorage[]` array, partitioned at each stream start
    - Contains: USB circular buffer + WiFi circular buffer + encoder buffer + SD circular buffer + sample pool + free-list
    - Layout: `[USB circ | WiFi circ | encoder | SD circ | <align> | samplePool[] | nextFree[]]`
@@ -971,7 +971,7 @@ The firmware uses four distinct memory regions, each with different properties:
 
 | Region | Bytes | Source |
 |--------|------:|--------|
-| Streaming Buffer Pool | 197,632 | Static BSS (`STATIC_POOL_SIZE` = 194KB - 1KB) |
+| Streaming Buffer Pool | 197,120 | Static BSS (`STATIC_POOL_SIZE` = 194KB - 1KB - 512B) |
 | FreeRTOS Heap | 74,000 | Static BSS |
 | Coherent Pool | 126,976 | Static coherent (KSEG1) |
 | USB coherent struct | ~2,000 | Static coherent |
@@ -1033,7 +1033,7 @@ SYSTem:MEMory:FREE?                   # Full memory diagnostics
 SYSTem:MEMory:AUTO                    # Auto-balance for enabled interfaces
 ```
 
-All USB, WiFi, **SD**, encoder, and sample pool memory comes from the unified Streaming Buffer Pool (197,632 B static BSS) — the SD *circular* buffer is in this pool; the separate SD *DMA write* buffer is not, it comes from the coherent pool. Setting any value carves it from the pool; remaining space goes to the sample pool. Setting any field to a non-zero value disables auto-balance for all fields.
+All USB, WiFi, **SD**, encoder, and sample pool memory comes from the unified Streaming Buffer Pool (197,120 B static BSS) — the SD *circular* buffer is in this pool; the separate SD *DMA write* buffer is not, it comes from the coherent pool. Setting any value carves it from the pool; remaining space goes to the sample pool. Setting any field to a non-zero value disables auto-balance for all fields.
 
 **Setter Bounds:**
 
@@ -1087,11 +1087,11 @@ The `StreamingInterface` enum exposes four combinations: `USB`, `WiFi`, `SD`, an
 | SD DMA write (coherent) | 512 | 512 | 124,368 | 77,922 |
 | USB DMA write (coherent) | 124,368 | 512 | 512 | 46,958 |
 | WiFi SPI staging (coherent) | 2,048 | 125,904 | 2,048 | 2,048 |
-| Sample pool CAPACITY (slots @16ch)¹ | 1,600 | 1,148 | 1,959 | 1,101 |
+| Sample pool CAPACITY (slots @16ch)¹ | 1,593 | 1,141 | 1,953 | 1,095 |
 
 ¹ **Capacity, not the depth in use.** These are how many slots the leftover pool space holds — what `StreamingBufferPool_Partition` computes and logs as `samples=<n>x<elementBytes>`. Note the log's second number is the **element** size (72 at 16ch), not the per-sample cost — the free-list entry is counted separately, which is why the divisor below is 74 while the log shows 72. Reconciling `1600 x 72` against a `/ 74` formula otherwise looks like an inconsistency; it is not. The depth actually available is min(that, whatever the FreeRTOS sample queue could be grown to), which on the bench came out at **1100** because the queue resize was skipped for want of ~1 KB of heap (#828). That is **not** an invariant: `AInSampleList_InitializeExternal` only clamps when it tries to GROW the queue and the heap will not stretch, so a device with more free heap grows it — and once grown it stays grown for later sessions. Read the number, do not assume it.
 
-  All four are now derived from this table's own buffer values: `(197,632 - (USB + WiFi + SD + encoder circular)) / 74`, the 74 being the 16-channel element (72 B) plus its free-list entry. Only the stream-pool rows enter the sum — the three coherent-pool DMA rows come from a different 124 KB region. The formula is **confirmed against the device**: for USB-only it gives 1,600, and the firmware logged `samples=1600x72 (of 1600 max, 197632 pool)` on the bench 2026-08-21, alongside `SamplePoolCount=1100` for the queue-limited depth. The earlier figures (~1,618 / ~1,178 / ~1,921 / ~1,086) were computed with the old, wrong 512-byte SD-circular value.
+  All four are derived from this table's own buffer values: `(197,120 - (USB + WiFi + SD + encoder circular)) / 74`, the 74 being the 16-channel element (72 B) plus its free-list entry. Only the stream-pool rows enter the sum — the three coherent-pool DMA rows come from a different 124 KB region. The formula was **confirmed against the device** at the pre-#824 pool size: with 197,632 it gives 1,600 for USB-only, and the firmware logged `samples=1600x72 (of 1600 max, 197632 pool)` on the bench 2026-08-21 alongside `SamplePoolCount=1100` for the queue-limited depth. #824 trimmed the pool by 512 B, so each column drops by ~7 slots — off a *partitioned* capacity that already exceeds the usable depth by ~500, which is why the change costs nothing in practice. The figures above are the recomputed ones and have **not** been re-confirmed on the bench; expect `samples=1593x72 (of 1593 max, 197120 pool)` in that log line. Earlier figures still in circulation (~1,618 / ~1,178 / ~1,921 / ~1,086) were computed with the old, wrong 512-byte SD-circular value and are wrong twice over.
 
 
 **Implementation:** `firmware/src/Util/StreamingBufferPool.c` (unified pool), `firmware/src/Util/CoherentPool.c` (DMA pool), `firmware/src/services/streaming.c` (`ComputeAutoBuffers`), `firmware/src/state/data/AInSample.c` (`InitializeExternal`), `firmware/src/services/SCPI/SCPIInterface.c` (SCPI callbacks), `firmware/src/state/runtime/StreamingRuntimeConfig.h` (MemoryConfig struct), `firmware/src/config/default/driver/winc/dev/spi/wdrv_winc_spi.c` (WiFi SPI staging)

--- a/firmware/src/Util/StreamingBufferPool.c
+++ b/firmware/src/Util/StreamingBufferPool.c
@@ -12,8 +12,16 @@
  * Trimmed 1KB from 194KB (#665) to make room for the DIO-peripheral epic's
  * static footprint (SPI1 mutex + DIO ownership registry) — the device was at
  * the RAM edge and the extra statics overflowed the main stack region. 1KB is
- * ~13 samples off the stream-time partition; negligible to throughput. */
-#define STATIC_POOL_SIZE ((194U * 1024U) - 1024U)
+ * ~13 samples off the stream-time partition; negligible to throughput.
+ *
+ * Trimmed a further 512 B (#824) to pay for streaming.c's gSdHeaderBytes, the
+ * per-session SD file header that rotation now writes straight into each new
+ * file. Same reason as #665 — without it the link fails with "Not enough
+ * memory for stack (8208 bytes needed, 7816 available)" — and the cost is
+ * nil in practice, not merely small: at 16 channels this is ~7 slots off a
+ * PARTITIONED depth that already exceeds the usable one by ~500, because the
+ * FreeRTOS sample queue is what clamps it (#828). */
+#define STATIC_POOL_SIZE ((194U * 1024U) - 1024U - 512U)
 static uint8_t gPoolStorage[STATIC_POOL_SIZE];
 
 /* The overcommit fallback below carves these four minimums and expects the

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2201,11 +2201,6 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
     if (periodCycles < 2) periodCycles = 2;
     pStreamCfg->ClockPeriod = periodCycles - 1;
     StreamFreq_Set(pStreamCfg, freq);
-    /* #824: every path that starts a session must open an SD-header epoch, or
-     * this session's first SD file inherits the PREVIOUS session's header.
-     * This one saves and restores the SD mode rather than forcing it off, so
-     * it can run with SD logging armed. */
-    Streaming_BeginSdHeaderEpoch();
     pStreamCfg->IsEnabled = true;
     Streaming_UpdateState();
 
@@ -2371,9 +2366,6 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
     Streaming_ClearStats();
     cfg->ClockPeriod = periodCycles - 1;
     StreamFreq_Set(cfg, freq);
-    /* #824: same invariant as the other two start sites -- each finder step is
-     * its own session, so each opens its own epoch. */
-    Streaming_BeginSdHeaderEpoch();
     cfg->IsEnabled = true;
     Streaming_UpdateState();
     if (!cfg->Running) {
@@ -3610,15 +3602,6 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
             return SCPI_RES_ERR;
         }
     }
-
-    /* #824: open this session's SD-header epoch HERE, before anything below
-     * arms SD logging. Everything after this point may cause the SD task to
-     * open a log file, and the invariant is that the session's FIRST file
-     * finds no valid cached header -- which is what the pre-#824
-     * gSdFileWasReady latch produced, and what keeps the previous session's
-     * protobuf sd_metadata off this session's file 1. Invalidating at STOP
-     * instead raced an in-flight rotation open (audit round 2). */
-    Streaming_BeginSdHeaderEpoch();
 
     /* Interface_All is USB+SD (WiFi excluded by SPI bus conflict). Any
      * interface other than WiFi-only can drive SD logging when the SD

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3701,6 +3701,10 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         sd_card_manager_ClearStartupDiskFull();
         sd_card_manager_ClearStartupDirFull();   /* #689 */
 
+        /* #824: this WRITE is a streaming log, so its rotated split files must
+         * carry the session header. Declared per-arm because the SD manager
+         * defaults to "not a streaming log" -- see the header's comment. */
+        sd_card_manager_DeclareWriteIsStreamingLog();
         pSDCardSettings->mode = SD_CARD_MANAGER_MODE_WRITE;
         sd_card_manager_UpdateSettings(pSDCardSettings);
         /* #836: ownership is now carried by `mode != MODE_NONE`, which keeps
@@ -3849,6 +3853,11 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
             }
             sd_card_manager_ClearStartupDirFull();
             sd_card_manager_ClearStartupDiskFull();
+            /* #824: re-declare. The token is consumed by the FIRST arm's
+             * UpdateSettings above, and PrepareStreamingBuffers tore that
+             * session down (WRITE -> NONE) in between, so this re-open is a
+             * fresh arm and must state its own case. */
+            sd_card_manager_DeclareWriteIsStreamingLog();
             pSDCardSettings->mode = SD_CARD_MANAGER_MODE_WRITE;
             sd_card_manager_UpdateSettings(pSDCardSettings);
             sd_card_manager_ReleaseClaim();   /* #836: mode now holds it */

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2201,6 +2201,11 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
     if (periodCycles < 2) periodCycles = 2;
     pStreamCfg->ClockPeriod = periodCycles - 1;
     StreamFreq_Set(pStreamCfg, freq);
+    /* #824: every path that starts a session must open an SD-header epoch, or
+     * this session's first SD file inherits the PREVIOUS session's header.
+     * This one saves and restores the SD mode rather than forcing it off, so
+     * it can run with SD logging armed. */
+    Streaming_BeginSdHeaderEpoch();
     pStreamCfg->IsEnabled = true;
     Streaming_UpdateState();
 
@@ -2366,6 +2371,9 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
     Streaming_ClearStats();
     cfg->ClockPeriod = periodCycles - 1;
     StreamFreq_Set(cfg, freq);
+    /* #824: same invariant as the other two start sites -- each finder step is
+     * its own session, so each opens its own epoch. */
+    Streaming_BeginSdHeaderEpoch();
     cfg->IsEnabled = true;
     Streaming_UpdateState();
     if (!cfg->Running) {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3603,6 +3603,15 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         }
     }
 
+    /* #824: open this session's SD-header epoch HERE, before anything below
+     * arms SD logging. Everything after this point may cause the SD task to
+     * open a log file, and the invariant is that the session's FIRST file
+     * finds no valid cached header -- which is what the pre-#824
+     * gSdFileWasReady latch produced, and what keeps the previous session's
+     * protobuf sd_metadata off this session's file 1. Invalidating at STOP
+     * instead raced an in-flight rotation open (audit round 2). */
+    Streaming_BeginSdHeaderEpoch();
+
     /* Interface_All is USB+SD (WiFi excluded by SPI bus conflict). Any
      * interface other than WiFi-only can drive SD logging when the SD
      * card is enabled and a filename is set. */

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3702,11 +3702,11 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         sd_card_manager_ClearStartupDirFull();   /* #689 */
 
         /* #824: this WRITE is a streaming log, so its rotated split files must
-         * carry the session header. Declared per-arm because the SD manager
-         * defaults to "not a streaming log" -- see the header's comment. */
-        sd_card_manager_DeclareWriteIsStreamingLog();
+         * carry the session header. Stated as an ARGUMENT of the arm, not a
+         * flag set beforehand -- a flag was stealable by a concurrent
+         * benchmark arm (audit round 8; see the header's comment). */
         pSDCardSettings->mode = SD_CARD_MANAGER_MODE_WRITE;
-        sd_card_manager_UpdateSettings(pSDCardSettings);
+        sd_card_manager_UpdateSettingsForStreamingLog(pSDCardSettings);
         /* #836: ownership is now carried by `mode != MODE_NONE`, which keeps
          * IsBusy() true, so releasing here leaves no gap. */
         sd_card_manager_ReleaseClaim();
@@ -3853,13 +3853,11 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
             }
             sd_card_manager_ClearStartupDirFull();
             sd_card_manager_ClearStartupDiskFull();
-            /* #824: re-declare. The token is consumed by the FIRST arm's
-             * UpdateSettings above, and PrepareStreamingBuffers tore that
-             * session down (WRITE -> NONE) in between, so this re-open is a
-             * fresh arm and must state its own case. */
-            sd_card_manager_DeclareWriteIsStreamingLog();
+            /* #824: PrepareStreamingBuffers tore the first arm's session down
+             * (WRITE -> NONE) in between, so this re-open is a fresh arm and
+             * must state its own case. */
             pSDCardSettings->mode = SD_CARD_MANAGER_MODE_WRITE;
-            sd_card_manager_UpdateSettings(pSDCardSettings);
+            sd_card_manager_UpdateSettingsForStreamingLog(pSDCardSettings);
             sd_card_manager_ReleaseClaim();   /* #836: mode now holds it */
             int readyWait = 0;
             while (!sd_card_manager_IsWriteReady() && readyWait < 500) {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3989,10 +3989,14 @@ static scpi_result_t SCPI_StopStreaming(scpi_t * context) {
         }
     }
 
-    // Reset encoder state so next session gets fresh headers
+    /* Reset encoder state so the next session gets fresh headers.
+     *
+     * #824: the SD per-file header used to need clearing here too. It no
+     * longer does -- Streaming_Stop(), which Streaming_UpdateState() below
+     * runs, invalidates it, and the next session's encoder loop rebuilds it.
+     * Clearing it here as well would only re-state that in a second place. */
     csv_ResetEncoder();
     json_ResetEncoder();
-    Streaming_ResetSdFileHeader();
 
     // Clear STATus:OPERation condition register
     SCPI_ClearOperBits(OPER_MEASURING | OPER_SD_LOGGING);

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -1071,7 +1071,12 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
      * (mirrors SCPI_StartStreaming / the #503 disk-full pattern). */
     sd_card_manager_ClearStartupDirFull();
     pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_WRITE;
-    sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
+    /* #824: the benchmark ARMS a write session and it is NOT a streaming log,
+     * so it says so. Staying silent here is what let a benchmark inherit a
+     * live log's header cache and prepend that stream's protobuf sd_metadata
+     * to a rotated benchmark_*.dat part (audit rounds 5, 6, 9) -- output that
+     * no longer matches the requested pattern. */
+    sd_card_manager_UpdateSettingsForPlainWrite(pSDCardRuntimeConfig);
 
     // Wait for file to be open and ready before writing
     {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -243,24 +243,33 @@ static volatile bool gSdRotating = false;
  * start's declaration and its own UpdateSettings() consumed the declaration
  * and latched ITSELF as a streaming log. A parameter cannot be taken by
  * another caller; there is nothing global left to race for. A declaring arm
- * SETS the latch, a session teardown (mode NONE) CLEARS it, and nothing else
- * touches it. See the decision block
- * in sd_card_manager_UpdateSettings() for why that last clause is not
- * "re-latch on every WRITE" -- a config setter called during a live session
- * carries mode==WRITE without declaring anything, and re-latching there
- * silently stopped a running log from writing its rotation headers.
+ * SETS the latch, an arm that declares itself PLAIN clears it, a teardown
+ * (mode NONE) clears it, and nothing else touches it. That last clause is
+ * why it is not "re-latch on every WRITE": a config setter called during a
+ * live session carries mode==WRITE without arming anything, and re-latching
+ * there silently stopped a running log from writing its rotation headers.
  *
- * A non-streaming WRITE arm therefore needs no call and cannot get this wrong
- * by omission: an undeclared arm that finds the manager outside WRITE_TO_FILE
- * is starting a new session and clears the latch. Do NOT weaken that to "the
- * teardown clears it" -- this file sets mode NONE directly in sixteen places
- * that never reach UpdateSettings, so a session can end with the latch still
- * set. At boot it is false by the #409 scrub in sd_card_manager_Init().
+ * A non-streaming WRITE arm says so too, by calling
+ * sd_card_manager_UpdateSettingsForPlainWrite() -- SYST:STOR:SD:BENCHmark is
+ * the one in the tree. Do NOT replace that with "the teardown clears it":
+ * this file sets mode NONE directly in sixteen places that never reach
+ * UpdateSettings, so a session can end with the latch still set. At boot it
+ * is false by the #409 scrub in sd_card_manager_Init().
  *
- * Single writer per field in practice (SCPI task arms; the SD task only reads
- * the latch), both plain aligned bools -- atomic on PIC32MZ. volatile because
- * the arming task and the SD task are different contexts. */
+ * Single writer in practice (SCPI task arms; the SD task only reads it), a
+ * plain aligned bool -- atomic on PIC32MZ. volatile because the arming task
+ * and the SD task are different contexts. */
 static volatile bool gWriteSessionIsStreamingLog = false; /* latched at arm */
+
+/* #824: what a sd_UpdateSettingsImpl() caller is doing. See the three public
+ * wrappers in sd_card_manager.h for why this is a parameter and not something
+ * inferred from the manager's state. */
+typedef enum {
+    SD_WRITE_ARM_NONE = 0,   /* not arming a write session (config update,
+                              * teardown, or a non-WRITE operation) */
+    SD_WRITE_ARM_STREAMING,  /* arming a WRITE that IS a streaming log */
+    SD_WRITE_ARM_PLAIN,      /* arming a WRITE that is NOT one */
+} SdWriteArmKind;
 static int gFormatStatus = 0;  // 0=idle, 1=in progress, 2=success, -1=failed
 static uint32_t gFormatSectorsEstimate = 0;  // Estimated total sectors written during format
 
@@ -3484,12 +3493,12 @@ bool sd_card_manager_Deinit() {
     return true;
 }
 
-/* #824: the real entry point. `declaredStreaming` says whether the caller is
- * arming a STREAMING LOG, and it is a PARAMETER rather than a global precisely
- * so that no other caller can consume or clobber it (audit round 8). The two
- * public wrappers below are the whole API. */
+/* #824: the real entry point. `arm` says what the CALLER is doing, and it is a
+ * PARAMETER rather than a global precisely so that no other caller can consume
+ * or clobber it (audit round 8). The three public wrappers below are the whole
+ * API. */
 static bool sd_UpdateSettingsImpl(sd_card_manager_settings_t *pSettings,
-                                  bool declaredStreaming) {
+                                  SdWriteArmKind arm) {
     /* #589 P1: SD activity expected - restore the fast detect-poll cadence.
        (extern kept per the app_freertos.c pattern; prototype now also lives
        in drv_sdspi.h so signatures are checkable.) */
@@ -3554,52 +3563,32 @@ static bool sd_UpdateSettingsImpl(sd_card_manager_settings_t *pSettings,
 
     /* #824: decide the "is this WRITE session a streaming log?" latch.
      *
-     * Three rules, and each one is a review round:
+     * Only an ARM answers it, and it answers by which wrapper it called. A
+     * teardown (mode NONE) clears it. Everything else -- notably a config
+     * setter like SYST:STOR:SD:MAXSize, which reaches here with `mode`
+     * already WRITE and no intention of arming anything -- leaves it alone.
      *
-     *  1. A DECLARING arm sets it. Only whoever armed the write knows.
-     *  2. A NON-declaring arm clears it -- UNLESS the manager is already in
-     *     WRITE_TO_FILE, i.e. this call is a CONFIG UPDATE to a session
-     *     already in flight rather than a new session. An earlier revision
-     *     had no exception and re-latched on every mode==WRITE call, and
-     *     several setters call this with the mode unchanged:
-     *     SYST:STOR:SD:MAXSize during a live SD log re-latched "not a
-     *     streaming log", and every rotation after it lost its header.
-     *  3. mode NONE clears it.
+     * THIS USED TO BE INFERRED FROM THE MANAGER'S STATE, and every version of
+     * that inference was wrong in a different window. Recorded so nobody
+     * reintroduces one:
      *
-     * RULE 2 CANNOT BE REPLACED BY RULE 3 ALONE, which an earlier revision of
-     * this comment claimed by asserting that every WRITE session ends through
-     * mode NONE. It does not: this file makes SIXTEEN direct
-     * `gpSDCardSettings->mode = MODE_NONE` assignments that never pass through
-     * here. The OPEN_FILE no-writable-bucket path is the concrete one -- it
-     * closes the handle, sets mode NONE and goes IDLE in place, so a protobuf
-     * log that died there left the latch set, SCPI_StopStreaming then saw mode
-     * already NONE and skipped its teardown call, and the next
-     * SYST:STOR:SD:BENCHmark inherited a true latch and prepended stale
-     * sd_metadata to its rotated part. The state test closes that: whatever
-     * route the session took to end, the manager is no longer in
-     * WRITE_TO_FILE when the benchmark arms.
+     *   - "re-latch on every mode==WRITE call": SYST:STOR:SD:MAXSize during a
+     *     live log re-latched "not a streaming log" and every rotation after
+     *     it lost its header.
+     *   - "clear on mode NONE, else leave alone": this file sets
+     *     gpSDCardSettings->mode = MODE_NONE DIRECTLY in sixteen places that
+     *     never reach here -- the OPEN_FILE no-writable-bucket path among
+     *     them -- so a session could end with the latch still set, and the
+     *     next benchmark inherited it (audit round 6).
+     *   - "...unless currentProcessState == WRITE_TO_FILE": during a ROTATION
+     *     the manager sits in OPEN_FILE, so a config update landing there was
+     *     read as a new session (round 7).
+     *   - "...or gSdRotating": that then let a benchmark ARMED during a
+     *     rotation be read as a config update and inherit the latch (round 9).
      *
-     * RESIDUALS, stated rather than hidden. Note the asymmetry first: every
-     * path below that gets the latch WRONG in the "false" direction merely
-     * leaves a split file without its "# Device:" header. Only (b) can put a
-     * header where none belongs, and only through a path that has already
-     * destroyed the session.
-     *
-     * (a) A config update landing in the FIRST file's open -- before any
-     * rotation has occurred, so gSdRotating is still false and the state is
-     * OPEN_FILE -- is covered by neither half of the in-flight test and clears
-     * the latch. That window is one file-open wide and SCPI_StartStreaming is
-     * blocked on IsWriteReady() throughout it, so the setter would have to
-     * arrive on the OTHER SCPI transport.
-     *
-     * (b) A benchmark issued while a log is genuinely still in WRITE_TO_FILE
-     * is indistinguishable here from a config update, so it would inherit the
-     * latch. That is reachable only because SYST:STOR:SD:BENCHmark has no
-     * IsBusy guard by design (#736 -- a running benchmark OWNS the logging
-     * target), and on that path it has already clobbered the logging target
-     * out from under the live session (#728). A wrong header is the least of
-     * what is wrong there, and adding the guard is a behaviour change on the
-     * #736 claim machinery.
+     * Each of the last three put a stale protobuf sd_metadata into a
+     * benchmark output file, or took a header off a live log's split files.
+     * The caller knows what it is doing; the state does not say.
      *
      * Placed AFTER the #589 refusal gate on purpose: that gate clears the
      * requested mode and returns, so a refused STR:START must not leave the
@@ -3607,28 +3596,10 @@ static bool sd_UpdateSettingsImpl(sd_card_manager_settings_t *pSettings,
      * the #409 scrub in sd_card_manager_Init(). */
     if (pSettings != NULL) {
         taskENTER_CRITICAL();
-        if (pSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
-            if (declaredStreaming) {
-                gWriteSessionIsStreamingLog = true;
-            } else if (gSDCardData.currentProcessState
-                           != SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE
-                       && !gSdRotating) {
-                /* An undeclared arm that is NOT a config update to a session
-                 * already in flight is a NEW write session, and it did not
-                 * claim to be a streaming log -- so it is not one.
-                 *
-                 * `!gSdRotating` is the second half of "in flight" and it is
-                 * not optional (audit round 7): DURING a rotation the manager
-                 * sits in OPEN_FILE, not WRITE_TO_FILE, so the state test
-                 * alone read a config update landing in that window as a new
-                 * session and cleared the latch -- costing the split file
-                 * being opened right then, and every rotation after it, its
-                 * header. gSdRotating is true for exactly that window (set
-                 * while the old handle is still open, cleared in the critical
-                 * block that opens WRITE_TO_FILE), so the two together cover
-                 * the whole steady-state life of a rotating write session. */
-                gWriteSessionIsStreamingLog = false;
-            }
+        if (arm == SD_WRITE_ARM_STREAMING) {
+            gWriteSessionIsStreamingLog = true;
+        } else if (arm == SD_WRITE_ARM_PLAIN) {
+            gWriteSessionIsStreamingLog = false;
         } else if (pSettings->mode == SD_CARD_MANAGER_MODE_NONE) {
             gWriteSessionIsStreamingLog = false;
         }
@@ -3680,12 +3651,17 @@ static bool sd_UpdateSettingsImpl(sd_card_manager_settings_t *pSettings,
 }
 
 bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
-    return sd_UpdateSettingsImpl(pSettings, false);
+    return sd_UpdateSettingsImpl(pSettings, SD_WRITE_ARM_NONE);
 }
 
 bool sd_card_manager_UpdateSettingsForStreamingLog(
         sd_card_manager_settings_t *pSettings) {
-    return sd_UpdateSettingsImpl(pSettings, true);
+    return sd_UpdateSettingsImpl(pSettings, SD_WRITE_ARM_STREAMING);
+}
+
+bool sd_card_manager_UpdateSettingsForPlainWrite(
+        sd_card_manager_settings_t *pSettings) {
+    return sd_UpdateSettingsImpl(pSettings, SD_WRITE_ARM_PLAIN);
 }
 
 bool sd_card_manager_IsIdle() {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -3580,14 +3580,27 @@ bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
      * route the session took to end, the manager is no longer in
      * WRITE_TO_FILE when the benchmark arms.
      *
-     * RESIDUAL, stated rather than hidden: a benchmark issued while a log is
-     * genuinely still in WRITE_TO_FILE is indistinguishable here from a config
-     * update, so it would inherit the latch. That is reachable only because
-     * SYST:STOR:SD:BENCHmark has no IsBusy guard by design (#736 -- a running
-     * benchmark OWNS the logging target), and on that path it has already
-     * clobbered the logging target out from under the live session (#728). A
-     * wrong header is the least of what is wrong there, and adding the guard
-     * is a behaviour change on the #736 claim machinery.
+     * RESIDUALS, stated rather than hidden. Note the asymmetry first: every
+     * path below that gets the latch WRONG in the "false" direction merely
+     * leaves a split file without its "# Device:" header. Only (b) can put a
+     * header where none belongs, and only through a path that has already
+     * destroyed the session.
+     *
+     * (a) A config update landing in the FIRST file's open -- before any
+     * rotation has occurred, so gSdRotating is still false and the state is
+     * OPEN_FILE -- is covered by neither half of the in-flight test and clears
+     * the latch. That window is one file-open wide and SCPI_StartStreaming is
+     * blocked on IsWriteReady() throughout it, so the setter would have to
+     * arrive on the OTHER SCPI transport.
+     *
+     * (b) A benchmark issued while a log is genuinely still in WRITE_TO_FILE
+     * is indistinguishable here from a config update, so it would inherit the
+     * latch. That is reachable only because SYST:STOR:SD:BENCHmark has no
+     * IsBusy guard by design (#736 -- a running benchmark OWNS the logging
+     * target), and on that path it has already clobbered the logging target
+     * out from under the live session (#728). A wrong header is the least of
+     * what is wrong there, and adding the guard is a behaviour change on the
+     * #736 claim machinery.
      *
      * Placed AFTER the #589 refusal gate on purpose: that gate clears the
      * requested mode and returns, so a refused STR:START must not leave the
@@ -3600,10 +3613,22 @@ bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
             if (declaredStreaming) {
                 gWriteSessionIsStreamingLog = true;
             } else if (gSDCardData.currentProcessState
-                       != SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE) {
+                           != SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE
+                       && !gSdRotating) {
                 /* An undeclared arm that is NOT a config update to a session
                  * already in flight is a NEW write session, and it did not
-                 * claim to be a streaming log -- so it is not one. */
+                 * claim to be a streaming log -- so it is not one.
+                 *
+                 * `!gSdRotating` is the second half of "in flight" and it is
+                 * not optional (audit round 7): DURING a rotation the manager
+                 * sits in OPEN_FILE, not WRITE_TO_FILE, so the state test
+                 * alone read a config update landing in that window as a new
+                 * session and cleared the latch -- costing the split file
+                 * being opened right then, and every rotation after it, its
+                 * header. gSdRotating is true for exactly that window (set
+                 * while the old handle is still open, cleared in the critical
+                 * block that opens WRITE_TO_FILE), so the two together cover
+                 * the whole steady-state life of a rotating write session. */
                 gWriteSessionIsStreamingLog = false;
             }
         } else if (pSettings->mode == SD_CARD_MANAGER_MODE_NONE) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -2125,6 +2125,10 @@ void sd_card_manager_ProcessState() {
                  * until sd_AbandonRotationWindow() below clears it AND
                  * accounts for what was buffered -- clearing it here would
                  * silently strand those bytes instead. */
+                /* #824: latch whether THIS open is a rotation, in the same
+                 * critical section that clears the flag -- the header write
+                 * below needs the answer and the flag is gone by then. */
+                bool openWasRotation = gSdRotating;
                 if (!openAborted) {
                     gSdRotating = false;
                 }
@@ -2196,18 +2200,26 @@ void sd_card_manager_ProcessState() {
                      * left alone and its contents become this file's first
                      * data rows.
                      *
-                     * Returns 0 for the session's FIRST file, in every
-                     * encoding, because this open happens before the encoder
-                     * has run and so before the header exists. That is what
-                     * the old code did too, for the same reason in different
-                     * clothes: gSdFileWasReady was initialised from
-                     * IsWriteReady(), which SCPI_StartStreaming has already
-                     * waited for, so the SD-only header block never fired for
-                     * file 1 either. For CSV/JSON that is correct -- the
-                     * encoder's own inline header lands there instead. For
-                     * protobuf it means file 1 carries no sd_metadata, a
-                     * pre-existing #196 gap left deliberately untouched here
-                     * (files 2..N do carry it, as they always did).
+                     * ONLY FOR A ROTATION, and that narrowness is doing
+                     * three jobs at once (#824 audit rounds 2-3):
+                     *   - the session's FIRST file is excluded, which is what
+                     *     the old gSdFileWasReady latch produced: it was
+                     *     initialised from IsWriteReady(), already true
+                     *     because SCPI_StartStreaming waits for it, so the
+                     *     SD-only header block never fired for file 1. Under
+                     *     CSV/JSON the encoder's inline header lands there
+                     *     instead; under protobuf file 1 carries no
+                     *     sd_metadata, a pre-existing #196 gap left untouched.
+                     *   - a NON-STREAMING write open is excluded, which
+                     *     matters because this state also serves
+                     *     SYST:STOR:SD:BENCHmark. That arms WRITE mode
+                     *     directly, and an unconditional fetch here prepended
+                     *     the last protobuf stream's sd_metadata to the
+                     *     benchmark's output file.
+                     *   - and it is why the cache can be cleared at session
+                     *     START rather than at stop: a rotation cannot happen
+                     *     before the encoder has run, so the live session has
+                     *     always rebuilt it in time.
                      *
                      * A short or failed write is logged, not retried, and
                      * the session continues. FatFs returns short only on a
@@ -2219,7 +2231,8 @@ void sd_card_manager_ProcessState() {
                      * currentFileBytes takes what actually landed, so the
                      * split threshold stays honest either way. */
                     const uint8_t* hdr = NULL;
-                    size_t hdrLen = Streaming_GetSdFileHeader(&hdr);
+                    size_t hdrLen = openWasRotation
+                                  ? Streaming_GetSdFileHeader(&hdr) : 0u;
                     if (hdrLen > 0u && hdr != NULL) {
                         TickType_t hdrStart = xTaskGetTickCount();
                         int hdrWritten = (int)SYS_FS_FileWrite(

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -234,9 +234,17 @@ static volatile bool gSdRotating = false;
  * is a session latch that stays true after the stream ends. Each reopens the
  * rotation race those earlier rounds closed.
  *
- * The answer is only known at ARM time, by whoever armed the write, so that is
- * where it is recorded: a declaring arm SETS the latch, a session teardown
- * (mode NONE) CLEARS it, and nothing else touches it. See the decision block
+ * The answer is only known at ARM time, by whoever armed the write, so the arm
+ * states it AS AN ARGUMENT: sd_card_manager_UpdateSettingsForStreamingLog()
+ * instead of sd_card_manager_UpdateSettings(). An earlier revision used a
+ * global one-shot token set just before the arm, and audit round 8 showed it
+ * was STEALABLE -- SYST:STOR:SD:BENCHmark takes no claim (#736), so a
+ * benchmark arming from USB SCPI in the window between a WiFi-SCPI stream
+ * start's declaration and its own UpdateSettings() consumed the declaration
+ * and latched ITSELF as a streaming log. A parameter cannot be taken by
+ * another caller; there is nothing global left to race for. A declaring arm
+ * SETS the latch, a session teardown (mode NONE) CLEARS it, and nothing else
+ * touches it. See the decision block
  * in sd_card_manager_UpdateSettings() for why that last clause is not
  * "re-latch on every WRITE" -- a config setter called during a live session
  * carries mode==WRITE without declaring anything, and re-latching there
@@ -252,7 +260,6 @@ static volatile bool gSdRotating = false;
  * Single writer per field in practice (SCPI task arms; the SD task only reads
  * the latch), both plain aligned bools -- atomic on PIC32MZ. volatile because
  * the arming task and the SD task are different contexts. */
-static volatile bool gWriteArmDeclaredStreaming = false;  /* one-shot token */
 static volatile bool gWriteSessionIsStreamingLog = false; /* latched at arm */
 static int gFormatStatus = 0;  // 0=idle, 1=in progress, 2=success, -1=failed
 static uint32_t gFormatSectorsEstimate = 0;  // Estimated total sectors written during format
@@ -947,7 +954,7 @@ bool sd_card_manager_Init(sd_card_manager_settings_t *pSettings) {
      * places OUTSIDE [_bss_begin,_bss_end] -- so the compile-time `= false`
      * initializers below are NOT honoured across MCLR or an IPE flash.
      *
-     * These three are the ones that decide a FILE'S CONTENT since #824, which
+     * These two are the ones that decide a FILE'S CONTENT since #824, which
      * is why they are scrubbed and the file's other statics (pre-existing, and
      * only affecting behaviour after they are written) are left alone: a
      * stale gSdRotating plus a stale gWriteSessionIsStreamingLog would put a
@@ -958,7 +965,6 @@ bool sd_card_manager_Init(sd_card_manager_settings_t *pSettings) {
      * static too, so a scrub placed under it is skipped in exactly the case
      * it exists for. Runs pre-scheduler with interrupts off; no critical
      * section needed. */
-    gWriteArmDeclaredStreaming = false;
     gWriteSessionIsStreamingLog = false;
     gSdRotating = false;
 
@@ -3478,19 +3484,12 @@ bool sd_card_manager_Deinit() {
     return true;
 }
 
-bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
-    /* #824: consume the one-shot streaming declaration HERE, ahead of every
-     * early return below, so it can never survive into a later arm that did
-     * not make it. The latch it feeds is decided further down, after the #589
-     * refusal gate -- a refused arm must not leave the latch set. */
-    bool declaredStreaming = false;
-    if (pSettings != NULL) {
-        taskENTER_CRITICAL();
-        declaredStreaming = gWriteArmDeclaredStreaming;
-        gWriteArmDeclaredStreaming = false;
-        taskEXIT_CRITICAL();
-    }
-
+/* #824: the real entry point. `declaredStreaming` says whether the caller is
+ * arming a STREAMING LOG, and it is a PARAMETER rather than a global precisely
+ * so that no other caller can consume or clobber it (audit round 8). The two
+ * public wrappers below are the whole API. */
+static bool sd_UpdateSettingsImpl(sd_card_manager_settings_t *pSettings,
+                                  bool declaredStreaming) {
     /* #589 P1: SD activity expected - restore the fast detect-poll cadence.
        (extern kept per the app_freertos.c pattern; prototype now also lives
        in drv_sdspi.h so signatures are checkable.) */
@@ -3604,9 +3603,8 @@ bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
      *
      * Placed AFTER the #589 refusal gate on purpose: that gate clears the
      * requested mode and returns, so a refused STR:START must not leave the
-     * latch set for whatever arms WRITE next. The token itself was consumed at
-     * the top either way, so it cannot leak forward. At boot the latch is
-     * false by the #409 scrub in sd_card_manager_Init(). */
+     * latch set for whatever arms WRITE next. At boot the latch is false by
+     * the #409 scrub in sd_card_manager_Init(). */
     if (pSettings != NULL) {
         taskENTER_CRITICAL();
         if (pSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
@@ -3679,6 +3677,15 @@ bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
     }
     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_DEINIT;
     return true;
+}
+
+bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
+    return sd_UpdateSettingsImpl(pSettings, false);
+}
+
+bool sd_card_manager_UpdateSettingsForStreamingLog(
+        sd_card_manager_settings_t *pSettings) {
+    return sd_UpdateSettingsImpl(pSettings, true);
 }
 
 bool sd_card_manager_IsIdle() {
@@ -3999,10 +4006,6 @@ void sd_card_manager_ReleaseClaim(void) {
     taskENTER_CRITICAL();
     gSdScpiClaim = false;
     taskEXIT_CRITICAL();
-}
-
-void sd_card_manager_DeclareWriteIsStreamingLog(void) {
-    gWriteArmDeclaredStreaming = true;
 }
 
 bool sd_card_manager_IsBusy(void) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -3469,19 +3469,15 @@ bool sd_card_manager_Deinit() {
 }
 
 bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
-    /* #824: consume the one-shot streaming declaration, ahead of every early
-     * return below so it can never survive into a later arm that did not make
-     * it. Only a WRITE arm updates the latch: a NONE teardown or a READ/LIST
-     * op must not strip the header from a WRITE session it is not replacing.
-     * An arm that made no declaration latches FALSE -- that is the default-deny
-     * this rests on. */
+    /* #824: consume the one-shot streaming declaration HERE, ahead of every
+     * early return below, so it can never survive into a later arm that did
+     * not make it. The latch it feeds is decided further down, after the #589
+     * refusal gate -- a refused arm must not leave the latch set. */
+    bool declaredStreaming = false;
     if (pSettings != NULL) {
         taskENTER_CRITICAL();
-        bool declaredStreaming = gWriteArmDeclaredStreaming;
+        declaredStreaming = gWriteArmDeclaredStreaming;
         gWriteArmDeclaredStreaming = false;
-        if (pSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
-            gWriteSessionIsStreamingLog = declaredStreaming;
-        }
         taskEXIT_CRITICAL();
     }
 
@@ -3545,6 +3541,40 @@ bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
         }
         pSettings->mode = SD_CARD_MANAGER_MODE_NONE;
         return false;
+    }
+
+    /* #824: decide the "is this WRITE session a streaming log?" latch.
+     *
+     * SET on a declaring arm, CLEARED when a session is torn down, and
+     * OTHERWISE LEFT ALONE. That last clause is the part that took a review
+     * round to get right: an earlier revision re-decided the latch on ANY call
+     * carrying mode==WRITE, and several setters call this with the mode
+     * unchanged -- SYST:STOR:SD:MAXSize is the plain one. Issued during a live
+     * SD logging session it re-latched "not a streaming log", and every
+     * rotation after it lost its header. A config update to a session in
+     * flight must not re-answer a question only the ARM can answer.
+     *
+     * Default-deny survives that relaxation because every WRITE session ends
+     * through mode NONE -- SCPI_StopStreaming closes an enabled WRITE that
+     * way, SYST:STOR:SD:BENCHmark ends its own the same way, and
+     * app_SDCard_GracefulShutdown too -- so the latch is already false by the
+     * time a non-declaring arm (the benchmark, or RestoreSdMode after
+     * SYST:STR:THRoughput) opens one. At boot it is false by the #409 scrub in
+     * sd_card_manager_Init().
+     *
+     * Placed AFTER the #589 refusal gate on purpose: that gate clears the
+     * requested mode and returns, so a refused STR:START must not leave the
+     * latch set for whatever arms WRITE next. The token itself was consumed at
+     * the top either way, so it cannot leak forward. */
+    if (pSettings != NULL) {
+        taskENTER_CRITICAL();
+        if (declaredStreaming
+            && pSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
+            gWriteSessionIsStreamingLog = true;
+        } else if (pSettings->mode == SD_CARD_MANAGER_MODE_NONE) {
+            gWriteSessionIsStreamingLog = false;
+        }
+        taskEXIT_CRITICAL();
     }
 
     if (pSettings != NULL && gpSDCardSettings != NULL) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -235,9 +235,19 @@ static volatile bool gSdRotating = false;
  * rotation race those earlier rounds closed.
  *
  * The answer is only known at ARM time, by whoever armed the write, so that is
- * where it is recorded. DEFAULT-DENY: the arm declares itself streaming or it
- * is not one. A new non-streaming WRITE arm added later therefore gets the
- * safe answer without having to know this exists.
+ * where it is recorded: a declaring arm SETS the latch, a session teardown
+ * (mode NONE) CLEARS it, and nothing else touches it. See the decision block
+ * in sd_card_manager_UpdateSettings() for why that last clause is not
+ * "re-latch on every WRITE" -- a config setter called during a live session
+ * carries mode==WRITE without declaring anything, and re-latching there
+ * silently stopped a running log from writing its rotation headers.
+ *
+ * A non-streaming WRITE arm therefore needs no call and cannot get this wrong
+ * by omission, but the reason is the teardown, not the arm: every WRITE
+ * session ends through mode NONE (SCPI_StopStreaming for an enabled WRITE,
+ * SYST:STOR:SD:BENCHmark for its own, app_SDCard_GracefulShutdown), so the
+ * latch is already false when the next non-declaring arm opens one. At boot it
+ * is false by the #409 scrub in sd_card_manager_Init().
  *
  * Single writer per field in practice (SCPI task arms; the SD task only reads
  * the latch), both plain aligned bools -- atomic on PIC32MZ. volatile because

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -217,6 +217,33 @@ static volatile bool gTransferAbortRequested = false;
  * PIC32MZ; volatile is here because the two contexts differ, not to imply
  * read-modify-write safety. */
 static volatile bool gSdRotating = false;
+
+/* #824: is the CURRENT write session a streaming log?
+ *
+ * The header write in OPEN_FILE below needs "is this file part of a streaming
+ * log?", and gSdRotating alone does not answer it. WRITE mode also serves
+ * SYST:STOR:SD:BENCHmark, which uses the same split-file rotation path -- so a
+ * benchmark that rotates has gSdRotating set, and an unconditional fetch there
+ * prepends the last protobuf stream's still-valid sd_metadata to the rotated
+ * benchmark part (#824 audit round 5). Gating on gSdRotating excludes only the
+ * benchmark's FIRST open, not its rotations.
+ *
+ * Nothing on the streaming side can answer it either, and every candidate was
+ * tried: IsEnabled is cleared by SCPI_StopStreaming BEFORE Streaming_UpdateState
+ * runs, Running is cleared inside Streaming_Stop(), and gSdExpectedThisSession
+ * is a session latch that stays true after the stream ends. Each reopens the
+ * rotation race those earlier rounds closed.
+ *
+ * The answer is only known at ARM time, by whoever armed the write, so that is
+ * where it is recorded. DEFAULT-DENY: the arm declares itself streaming or it
+ * is not one. A new non-streaming WRITE arm added later therefore gets the
+ * safe answer without having to know this exists.
+ *
+ * Single writer per field in practice (SCPI task arms; the SD task only reads
+ * the latch), both plain aligned bools -- atomic on PIC32MZ. volatile because
+ * the arming task and the SD task are different contexts. */
+static volatile bool gWriteArmDeclaredStreaming = false;  /* one-shot token */
+static volatile bool gWriteSessionIsStreamingLog = false; /* latched at arm */
 static int gFormatStatus = 0;  // 0=idle, 1=in progress, 2=success, -1=failed
 static uint32_t gFormatSectorsEstimate = 0;  // Estimated total sectors written during format
 
@@ -2125,10 +2152,15 @@ void sd_card_manager_ProcessState() {
                  * until sd_AbandonRotationWindow() below clears it AND
                  * accounts for what was buffered -- clearing it here would
                  * silently strand those bytes instead. */
-                /* #824: latch whether THIS open is a rotation, in the same
-                 * critical section that clears the flag -- the header write
-                 * below needs the answer and the flag is gone by then. */
-                bool openWasRotation = gSdRotating;
+                /* #824: latch whether THIS open must carry the streaming
+                 * header, in the same critical section that clears the
+                 * rotation flag -- the header write below needs the answer and
+                 * the flag is gone by then. Both halves are load-bearing:
+                 * gSdRotating excludes the session's first file, and
+                 * gWriteSessionIsStreamingLog excludes a NON-streaming write
+                 * session entirely, rotations included (see its definition). */
+                bool openNeedsStreamHeader = gSdRotating
+                                          && gWriteSessionIsStreamingLog;
                 if (!openAborted) {
                     gSdRotating = false;
                 }
@@ -2200,8 +2232,9 @@ void sd_card_manager_ProcessState() {
                      * left alone and its contents become this file's first
                      * data rows.
                      *
-                     * ONLY FOR A ROTATION, and that narrowness is doing
-                     * three jobs at once (#824 audit rounds 2-3):
+                     * ONLY FOR A ROTATION OF A STREAMING LOG, and that
+                     * narrowness is doing three jobs at once (#824 audit
+                     * rounds 2-3 and 5):
                      *   - the session's FIRST file is excluded, which is what
                      *     the old gSdFileWasReady latch produced: it was
                      *     initialised from IsWriteReady(), already true
@@ -2210,12 +2243,15 @@ void sd_card_manager_ProcessState() {
                      *     CSV/JSON the encoder's inline header lands there
                      *     instead; under protobuf file 1 carries no
                      *     sd_metadata, a pre-existing #196 gap left untouched.
-                     *   - a NON-STREAMING write open is excluded, which
-                     *     matters because this state also serves
-                     *     SYST:STOR:SD:BENCHmark. That arms WRITE mode
-                     *     directly, and an unconditional fetch here prepended
-                     *     the last protobuf stream's sd_metadata to the
-                     *     benchmark's output file.
+                     *   - and a NON-STREAMING write session is excluded by
+                     *     the second half of the predicate, because this state
+                     *     also serves SYST:STOR:SD:BENCHmark. An unconditional
+                     *     fetch here prepended the last protobuf stream's
+                     *     still-valid sd_metadata to the benchmark's output
+                     *     file. The rotation test alone does NOT cover that
+                     *     case -- it excludes the benchmark's first open and
+                     *     nothing else, and the benchmark rotates through this
+                     *     same path (#824 audit round 5).
                      *   - and it is why the cache can be cleared at session
                      *     START rather than at stop: a rotation cannot happen
                      *     before the encoder has run, so the live session has
@@ -2231,7 +2267,7 @@ void sd_card_manager_ProcessState() {
                      * currentFileBytes takes what actually landed, so the
                      * split threshold stays honest either way. */
                     const uint8_t* hdr = NULL;
-                    size_t hdrLen = openWasRotation
+                    size_t hdrLen = openNeedsStreamHeader
                                   ? Streaming_GetSdFileHeader(&hdr) : 0u;
                     if (hdrLen > 0u && hdr != NULL) {
                         TickType_t hdrStart = xTaskGetTickCount();
@@ -3412,6 +3448,22 @@ bool sd_card_manager_Deinit() {
 }
 
 bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
+    /* #824: consume the one-shot streaming declaration, ahead of every early
+     * return below so it can never survive into a later arm that did not make
+     * it. Only a WRITE arm updates the latch: a NONE teardown or a READ/LIST
+     * op must not strip the header from a WRITE session it is not replacing.
+     * An arm that made no declaration latches FALSE -- that is the default-deny
+     * this rests on. */
+    if (pSettings != NULL) {
+        taskENTER_CRITICAL();
+        bool declaredStreaming = gWriteArmDeclaredStreaming;
+        gWriteArmDeclaredStreaming = false;
+        if (pSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
+            gWriteSessionIsStreamingLog = declaredStreaming;
+        }
+        taskEXIT_CRITICAL();
+    }
+
     /* #589 P1: SD activity expected - restore the fast detect-poll cadence.
        (extern kept per the app_freertos.c pattern; prototype now also lives
        in drv_sdspi.h so signatures are checkable.) */
@@ -3836,6 +3888,10 @@ void sd_card_manager_ReleaseClaim(void) {
     taskENTER_CRITICAL();
     gSdScpiClaim = false;
     taskEXIT_CRITICAL();
+}
+
+void sd_card_manager_DeclareWriteIsStreamingLog(void) {
+    gWriteArmDeclaredStreaming = true;
 }
 
 bool sd_card_manager_IsBusy(void) {

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -10,7 +10,7 @@
 #include "sd_card_manager.h"
 #include "services/UsbCdc/UsbCdc.h"
 #include "Util/CRC32.h"   /* #306 */
-#include "services/streaming.h"  // For Streaming_ResetSdFileHeader on file rotation
+#include "services/streaming.h"  // Streaming_GetSdFileHeader / Streaming_ReportSdDiscard
 #include <stddef.h>
 #include "ff.h"   /* #810: FILINFO, for the layout assert below */
 
@@ -2026,50 +2026,42 @@ void sd_card_manager_ProcessState() {
                      gSDCardData.filePath, gSDCardData.fileCounter,
                      gSDCardData.fileSplittingEnabled ? "enabled" : "disabled");
 
-                // Reset SD metadata flags FIRST, before clearing the buffer.
-                // This sets gSdFileWasReady = false, which causes the
-                // streaming task's SD write guard (hasSD && gSdFileWasReady)
-                // to fail — preventing non-metadata data from being written
-                // to the freshly-cleared buffer before the new file is ready.
-                //
-                // Race condition without this ordering:
-                //   1. CircularBuf_Reset() clears buffer (space available)
-                //   2. Streaming task sees gSdFileWasReady=true (stale),
-                //      encodes WITHOUT metadata, writes to buffer
-                //   3. Streaming_ResetSdFileHeader() resets flags (too late)
-                //   => Non-metadata data at byte 0 of new file
-                /* #757: skipped during a rotation -- the close path above
-                 * already reset the metadata and the buffer, and the encoder
-                 * has been filling that buffer with the new file's header and
-                 * data ever since. Repeating the reset here would throw away
-                 * exactly the bytes this fix exists to keep. On a FIRST open
-                 * (session start, not rotation) gSdRotating is false and this
-                 * runs as it always did. */
+                /* Discard anything a previous session left in the buffer, so
+                 * the first file of this one does not start with its tail.
+                 *
+                 * #757: skipped during a rotation -- the encoder has been
+                 * filling this buffer for the NEW file ever since the rotation
+                 * window opened, and clearing it here would throw away exactly
+                 * the bytes that fix exists to keep. On a FIRST open (session
+                 * start, not rotation) gSdRotating is false and this runs as it
+                 * always did.
+                 *
+                 * #824: the header latch that used to be cleared alongside it
+                 * is gone -- the header is written straight into the file
+                 * below, so there is no ordering to arrange through the
+                 * buffer and nothing to reset. */
                 if (!gSdRotating) {
-                    Streaming_ResetSdFileHeader();
-
-                    // Now clear the buffer — streaming task won't write here
-                    // because gSdFileWasReady is already false.
-                /* #757: reset the buffer's BOOKKEEPING, not its bytes.
-                 *
-                 * Neither zero was load-bearing: nothing reads either buffer
-                 * past a length that is reset alongside it. CircularBuf_Reset
-                 * already makes the circular buffer logically empty (head,
-                 * tail, count) and no reader looks beyond count; the write
-                 * buffer is only ever emitted as its first writeBufferLength
-                 * bytes, reset a few lines below -- and the comment there
-                 * records that the "junk bytes in the new file" bug was fixed
-                 * by resetting sdCardWritePending/writeBufferLength, NOT by
-                 * this memset.
-                 *
-                 * The cost was real: writeBuffer is the COHERENT (KSEG1,
-                 * uncached) DMA buffer, ~78 KB when SD is the active
-                 * interface, so this was an uncached write of every byte with
-                 * no cache-line benefit -- inside the very window this issue
-                 * is about. Measured ~4% of the loss on its own.
-                 *
-                 * The mutex is still taken: CircularBuf_Reset mutates state
-                 * the streaming task reads. */
+                    /* #757: reset the buffer's BOOKKEEPING, not its bytes.
+                     *
+                     * Neither zero was load-bearing: nothing reads either
+                     * buffer past a length that is reset alongside it.
+                     * CircularBuf_Reset already makes the circular buffer
+                     * logically empty (head, tail, count) and no reader looks
+                     * beyond count; the write buffer is only ever emitted as
+                     * its first writeBufferLength bytes, reset a few lines
+                     * below -- and the comment there records that the "junk
+                     * bytes in the new file" bug was fixed by resetting
+                     * sdCardWritePending/writeBufferLength, NOT by a memset.
+                     *
+                     * The cost was real: writeBuffer is the COHERENT (KSEG1,
+                     * uncached) DMA buffer, ~78 KB when SD is the active
+                     * interface, so this was an uncached write of every byte
+                     * with no cache-line benefit -- inside the very window
+                     * this issue is about. Measured ~4% of the loss on its
+                     * own.
+                     *
+                     * The mutex is still taken: CircularBuf_Reset mutates
+                     * state the streaming task reads. */
                     SD_TakeMutexDebug(gSDCardData.wMutex, "open_file_clear_buffer");
                     CircularBuf_Reset(&gSDCardData.wCirbuf);
                     xSemaphoreGive(gSDCardData.wMutex);
@@ -2173,10 +2165,10 @@ void sd_card_manager_ProcessState() {
                     break;
                 }
 
-                /* State is already WRITE_TO_FILE from the block above --
-                 * IsWriteReady() becomes true at that point, and the
-                 * streaming task detects the transition and writes SD-only
-                 * headers at byte 0. */
+                /* State is already WRITE_TO_FILE from the block above, so
+                 * IsWriteReady() is true from here on. Nothing else writes
+                 * this handle: WRITE_TO_FILE runs on THIS task, so the header
+                 * written below is guaranteed to be the file's first bytes. */
                 gSDCardData.totalBytesFlushPending = 0;
                 gSDCardData.currentFileBytes = 0;  // Reset byte counter for new file
                 gSDCardData.lastFlushMillis = pdTICKS_TO_MS(xTaskGetTickCount());
@@ -2189,6 +2181,61 @@ void sd_card_manager_ProcessState() {
                     sd_AbandonRotationWindow("file open failed");
                     gSDCardData.currentProcessState = SD_CARD_MANAGER_PROCESS_STATE_ERROR;
                     LOG_E("[%s:%d]Failed to open SD Card file for writing: '%s'", __FILE__, __LINE__, gSDCardData.filePath);
+                } else {
+                    /* #824: write this file's self-describing header HERE,
+                     * straight into the handle, instead of pushing it through
+                     * the circular buffer from the streaming task.
+                     *
+                     * That indirection is what made rotation lossy. The header
+                     * had to be at byte 0, so the rotation had to hand the
+                     * encoder an EMPTY buffer -- and emptying it destroyed the
+                     * ~3.6 KB the encoder had appended during the bounded
+                     * pre-close drain (#822/#823). Writing it from the owning
+                     * task removes the constraint rather than working around
+                     * it: byte 0 is guaranteed by call order, so the buffer is
+                     * left alone and its contents become this file's first
+                     * data rows.
+                     *
+                     * Returns 0 for the session's FIRST file, in every
+                     * encoding, because this open happens before the encoder
+                     * has run and so before the header exists. That is what
+                     * the old code did too, for the same reason in different
+                     * clothes: gSdFileWasReady was initialised from
+                     * IsWriteReady(), which SCPI_StartStreaming has already
+                     * waited for, so the SD-only header block never fired for
+                     * file 1 either. For CSV/JSON that is correct -- the
+                     * encoder's own inline header lands there instead. For
+                     * protobuf it means file 1 carries no sd_metadata, a
+                     * pre-existing #196 gap left deliberately untouched here
+                     * (files 2..N do carry it, as they always did).
+                     *
+                     * A short or failed write is logged, not retried, and
+                     * the session continues. FatFs returns short only on a
+                     * disk error or a full volume, neither of which another
+                     * immediate attempt fixes, and a retry loop here would
+                     * block the SD task inside the rotation window that #757
+                     * exists to keep short. The consequence is a file with an
+                     * incomplete header rather than a dead session -- and
+                     * currentFileBytes takes what actually landed, so the
+                     * split threshold stays honest either way. */
+                    const uint8_t* hdr = NULL;
+                    size_t hdrLen = Streaming_GetSdFileHeader(&hdr);
+                    if (hdrLen > 0u && hdr != NULL) {
+                        TickType_t hdrStart = xTaskGetTickCount();
+                        int hdrWritten = (int)SYS_FS_FileWrite(
+                                gSDCardData.fileHandle, (const void*)hdr,
+                                hdrLen);
+                        SD_CheckFsOpDuration(hdrStart, "FileWrite(header)",
+                                             hdrWritten);
+                        if (hdrWritten < 0 || (size_t)hdrWritten != hdrLen) {
+                            LOG_E("[SD] header write short: expected=%u "
+                                  "written=%d ('%s')", (unsigned)hdrLen,
+                                  hdrWritten, gSDCardData.filePath);
+                        }
+                        if (hdrWritten > 0) {
+                            gSDCardData.currentFileBytes += (uint32_t)hdrWritten;
+                        }
+                    }
                 }
             } else if (gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_READ ||
                        gpSDCardSettings->mode == SD_CARD_MANAGER_MODE_COMPUTE_CRC) {
@@ -2592,82 +2639,46 @@ void sd_card_manager_ProcessState() {
                     }
                 }
 
-                /* #757: arm the NEW file's buffer BEFORE the sync and close,
-                 * not after.
+                /* #757: open the rotation window BEFORE the sync and close,
+                 * so the encoder keeps enqueuing throughout the slow part
+                 * instead of having its packets refused and counted as loss.
                  *
-                 * IsWriteReady() stays true right up to the FileClose below,
-                 * so the streaming task keeps enqueuing throughout the sync --
-                 * which is the slow part. Doing the reset afterwards meant
-                 * those bytes were sitting in the buffer when it was cleared,
-                 * and they were DISCARDED: ~95 bytes per rotation, invisible,
-                 * because nothing counted them. (Measured by counting them:
-                 * 3,702 bytes across 39 rotations in one 25 s arm. The old
-                 * code discarded them too, just as silently.)
+                 * #824 REMOVED THE BUFFER RESET THAT USED TO LIVE HERE, and
+                 * with it the last of the rotation's data loss.
                  *
-                 * Resetting here instead keeps them. The buffer is empty at
-                 * this point -- the drain above just emptied it into the old
-                 * file -- so clearing the metadata latch now means the encoder
-                 * writes the NEW file's header first and everything enqueued
-                 * during the sync, the close and the open follows it, in
-                 * order, into the new file. Nothing is dropped and the header
-                 * is still at byte 0.
+                 * The drain above is bounded to a snapshot (#822 -- draining
+                 * the live level livelocks against the producer above about
+                 * 340 KB/s and stops rotation outright), so whatever the
+                 * encoder appended DURING the drain is still in the buffer at
+                 * this point. It used to be destroyed here and counted into
+                 * SdDroppedBytes (#823): ~3.6 KB per rotation, unsaveable
+                 * because it was newer than everything drained -- so it could
+                 * not go into the old file -- and because the next file's
+                 * header was about to be pushed through this same buffer, so
+                 * it could not go into the new one either without landing
+                 * ahead of that header.
+                 *
+                 * The header is no longer pushed through the buffer. The SD
+                 * task writes it into the new file directly at open (see
+                 * OPEN_FILE above), which happens on this task before any
+                 * buffered byte can reach the new handle. The byte-0 ordering
+                 * therefore holds by construction, the reset has nothing left
+                 * to protect, and these bytes simply become the new file's
+                 * first data rows.
                  *
                  * Conditional on actually rotating: the split-limit branch
                  * below never opens a new file, so promising a drain there
-                 * would strand whatever accumulated. */
+                 * would strand whatever accumulated.
+                 *
+                 * A plain store, no mutex: nothing here mutates buffer state
+                 * any more, and gSdRotating is a bool -- an atomic store on
+                 * PIC32MZ. It cannot open a gap either, because the flag is
+                 * set while the old handle is still open, i.e. while
+                 * IsBufferAccepting() is already true through IsWriteReady(). */
                 const bool willRotate =
                         (gSDCardData.fileCounter < SD_CARD_MANAGER_MAX_SPLIT_FILES);
                 if (willRotate) {
-                    /* The metadata clear MUST be inside the same mutex as the
-                     * buffer reset, not before it.
-                     *
-                     * Streaming_ResetSdFileHeader() sets gSdFileWasReady=false,
-                     * which is the encoder's cue to emit the next file's
-                     * header. The old file is still open here, so
-                     * IsBufferAccepting() is true; if the pri-6 streaming task
-                     * preempts this pri-5 one between that clear and the reset,
-                     * it generates the header, writes it into the buffer, and
-                     * sets gSdFileWasReady=true -- and then the reset below
-                     * wipes it. Nothing re-emits it (OPEN_FILE skips its own
-                     * reset while gSdRotating is true) and nothing counts it,
-                     * so the split file starts with data rows and no header,
-                     * silently. That is the same class of defect this issue is
-                     * about, arriving through the fix for it.
-                     *
-                     * Holding wMutex across both closes it, because
-                     * sd_card_manager_WriteToBuffer takes the same mutex: an
-                     * encoder that has already decided to write the header
-                     * blocks until the reset is done and then lands it in the
-                     * emptied buffer, still at byte 0. */
-                    SD_TakeMutexDebug(gSDCardData.wMutex, "rotation_open_window");
-                    Streaming_ResetSdFileHeader();
-                    /* #822: whatever the producer appended DURING the drain is
-                     * still here, and this reset is about to destroy it.
-                     *
-                     * It cannot be saved. It is newer than everything drained,
-                     * so it cannot go into the old file without reopening the
-                     * unbounded-drain livelock that #822 is; and it cannot be
-                     * carried into the new one, because ResetSdPbMetadata()
-                     * above has just armed the next header and these bytes
-                     * would land AHEAD of it.
-                     *
-                     * So it is dropped -- but it is COUNTED. The bounded drain
-                     * traded #822's visible overshoot for a discard, and an
-                     * uncounted discard would be the worse of the two: the
-                     * bytes were ACCEPTED by WriteToBuffer, so without this
-                     * they appear in neither file nor in SdDroppedBytes, and
-                     * the gap is invisible. Same reasoning, same accounting, as
-                     * sd_AbandonRotationWindow(). */
-                    size_t stranded =
-                            CircularBuf_NumBytesAvailable(&gSDCardData.wCirbuf);
-                    CircularBuf_Reset(&gSDCardData.wCirbuf);
                     gSdRotating = true;
-                    xSemaphoreGive(gSDCardData.wMutex);
-                    if (stranded > 0u) {
-                        Streaming_ReportSdDiscard(stranded);
-                        LOG_D("[SD] rotation dropped %u byte(s) buffered during drain\r\n",
-                              (unsigned)stranded);
-                    }
                 }
 
                 // Flush and close current file
@@ -3871,12 +3882,14 @@ bool sd_card_manager_IsWriteReady(void) {
  *
  * During a rotation the old handle is closed before the new one is opened, and
  * the open is slow: a FatFs create is O(N) in directory occupancy, which is
- * why the loss this fixes grew with the number of files on the card. The
- * buffer is empty across that window (the rotation drains it before closing)
- * and its contents go to the NEW file, so accepting writes is safe and the
- * header still lands at byte 0 -- Streaming_ResetSdFileHeader() is called
- * before the window opens, so the first thing the encoder puts in the empty
- * buffer is the new file's header.
+ * why the loss this fixes grew with the number of files on the card. Whatever
+ * is in the buffer across that window belongs to the NEW file, so accepting
+ * writes is safe.
+ *
+ * #824: the buffer is no longer emptied at the rotation, and it no longer has
+ * to be. The header is written into the new file by OPEN_FILE on this task
+ * before any buffered byte can reach it, so byte 0 is guaranteed by call
+ * order rather than by handing the encoder an empty buffer.
  *
  * Returns false once the open resolves, in both directions: on success the
  * WRITE_TO_FILE arm above takes over, and on failure or teardown the flag is

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -931,6 +931,27 @@ done:
 }
 
 bool sd_card_manager_Init(sd_card_manager_settings_t *pSettings) {
+    /* Defensive zero-init for retained-RAM safety (#409), same idiom and same
+     * reason as Streaming_Init(): with -fdata-sections each file-static lands
+     * in its own .bss.<name> section, which the best-fit allocator often
+     * places OUTSIDE [_bss_begin,_bss_end] -- so the compile-time `= false`
+     * initializers below are NOT honoured across MCLR or an IPE flash.
+     *
+     * These three are the ones that decide a FILE'S CONTENT since #824, which
+     * is why they are scrubbed and the file's other statics (pre-existing, and
+     * only affecting behaviour after they are written) are left alone: a
+     * stale gSdRotating plus a stale gWriteSessionIsStreamingLog would put a
+     * header at the front of the first file of the first session after a
+     * flash, which no rotation had asked for.
+     *
+     * OUTSIDE the isInitDone guard deliberately -- that flag is a retained
+     * static too, so a scrub placed under it is skipped in exactly the case
+     * it exists for. Runs pre-scheduler with interrupts off; no critical
+     * section needed. */
+    gWriteArmDeclaredStreaming = false;
+    gWriteSessionIsStreamingLog = false;
+    gSdRotating = false;
+
     static bool isInitDone = false;
     if (!isInitDone) {
         // Get SD circular buffer from streaming pool (CPU-only, no DMA needed)

--- a/firmware/src/services/sd_card_services/sd_card_manager.c
+++ b/firmware/src/services/sd_card_services/sd_card_manager.c
@@ -243,11 +243,11 @@ static volatile bool gSdRotating = false;
  * silently stopped a running log from writing its rotation headers.
  *
  * A non-streaming WRITE arm therefore needs no call and cannot get this wrong
- * by omission, but the reason is the teardown, not the arm: every WRITE
- * session ends through mode NONE (SCPI_StopStreaming for an enabled WRITE,
- * SYST:STOR:SD:BENCHmark for its own, app_SDCard_GracefulShutdown), so the
- * latch is already false when the next non-declaring arm opens one. At boot it
- * is false by the #409 scrub in sd_card_manager_Init().
+ * by omission: an undeclared arm that finds the manager outside WRITE_TO_FILE
+ * is starting a new session and clears the latch. Do NOT weaken that to "the
+ * teardown clears it" -- this file sets mode NONE directly in sixteen places
+ * that never reach UpdateSettings, so a session can end with the latch still
+ * set. At boot it is false by the #409 scrub in sd_card_manager_Init().
  *
  * Single writer per field in practice (SCPI task arms; the SD task only reads
  * the latch), both plain aligned bools -- atomic on PIC32MZ. volatile because
@@ -3555,32 +3555,57 @@ bool sd_card_manager_UpdateSettings(sd_card_manager_settings_t *pSettings) {
 
     /* #824: decide the "is this WRITE session a streaming log?" latch.
      *
-     * SET on a declaring arm, CLEARED when a session is torn down, and
-     * OTHERWISE LEFT ALONE. That last clause is the part that took a review
-     * round to get right: an earlier revision re-decided the latch on ANY call
-     * carrying mode==WRITE, and several setters call this with the mode
-     * unchanged -- SYST:STOR:SD:MAXSize is the plain one. Issued during a live
-     * SD logging session it re-latched "not a streaming log", and every
-     * rotation after it lost its header. A config update to a session in
-     * flight must not re-answer a question only the ARM can answer.
+     * Three rules, and each one is a review round:
      *
-     * Default-deny survives that relaxation because every WRITE session ends
-     * through mode NONE -- SCPI_StopStreaming closes an enabled WRITE that
-     * way, SYST:STOR:SD:BENCHmark ends its own the same way, and
-     * app_SDCard_GracefulShutdown too -- so the latch is already false by the
-     * time a non-declaring arm (the benchmark, or RestoreSdMode after
-     * SYST:STR:THRoughput) opens one. At boot it is false by the #409 scrub in
-     * sd_card_manager_Init().
+     *  1. A DECLARING arm sets it. Only whoever armed the write knows.
+     *  2. A NON-declaring arm clears it -- UNLESS the manager is already in
+     *     WRITE_TO_FILE, i.e. this call is a CONFIG UPDATE to a session
+     *     already in flight rather than a new session. An earlier revision
+     *     had no exception and re-latched on every mode==WRITE call, and
+     *     several setters call this with the mode unchanged:
+     *     SYST:STOR:SD:MAXSize during a live SD log re-latched "not a
+     *     streaming log", and every rotation after it lost its header.
+     *  3. mode NONE clears it.
+     *
+     * RULE 2 CANNOT BE REPLACED BY RULE 3 ALONE, which an earlier revision of
+     * this comment claimed by asserting that every WRITE session ends through
+     * mode NONE. It does not: this file makes SIXTEEN direct
+     * `gpSDCardSettings->mode = MODE_NONE` assignments that never pass through
+     * here. The OPEN_FILE no-writable-bucket path is the concrete one -- it
+     * closes the handle, sets mode NONE and goes IDLE in place, so a protobuf
+     * log that died there left the latch set, SCPI_StopStreaming then saw mode
+     * already NONE and skipped its teardown call, and the next
+     * SYST:STOR:SD:BENCHmark inherited a true latch and prepended stale
+     * sd_metadata to its rotated part. The state test closes that: whatever
+     * route the session took to end, the manager is no longer in
+     * WRITE_TO_FILE when the benchmark arms.
+     *
+     * RESIDUAL, stated rather than hidden: a benchmark issued while a log is
+     * genuinely still in WRITE_TO_FILE is indistinguishable here from a config
+     * update, so it would inherit the latch. That is reachable only because
+     * SYST:STOR:SD:BENCHmark has no IsBusy guard by design (#736 -- a running
+     * benchmark OWNS the logging target), and on that path it has already
+     * clobbered the logging target out from under the live session (#728). A
+     * wrong header is the least of what is wrong there, and adding the guard
+     * is a behaviour change on the #736 claim machinery.
      *
      * Placed AFTER the #589 refusal gate on purpose: that gate clears the
      * requested mode and returns, so a refused STR:START must not leave the
      * latch set for whatever arms WRITE next. The token itself was consumed at
-     * the top either way, so it cannot leak forward. */
+     * the top either way, so it cannot leak forward. At boot the latch is
+     * false by the #409 scrub in sd_card_manager_Init(). */
     if (pSettings != NULL) {
         taskENTER_CRITICAL();
-        if (declaredStreaming
-            && pSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
-            gWriteSessionIsStreamingLog = true;
+        if (pSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
+            if (declaredStreaming) {
+                gWriteSessionIsStreamingLog = true;
+            } else if (gSDCardData.currentProcessState
+                       != SD_CARD_MANAGER_PROCESS_STATE_WRITE_TO_FILE) {
+                /* An undeclared arm that is NOT a config update to a session
+                 * already in flight is a NEW write session, and it did not
+                 * claim to be a streaming log -- so it is not one. */
+                gWriteSessionIsStreamingLog = false;
+            }
         } else if (pSettings->mode == SD_CARD_MANAGER_MODE_NONE) {
             gWriteSessionIsStreamingLog = false;
         }

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -355,22 +355,22 @@ extern "C" {
 bool sd_card_manager_TryClaim(void);
 void sd_card_manager_ReleaseClaim(void);
 
-/* #824: declare that the WRITE session about to be armed is a STREAMING log,
- * so its rotated split files get this session's self-describing header.
+/* #824: arm a WRITE that IS a streaming log, so its rotated split files get
+ * this session's self-describing header. Use it in place of
+ * sd_card_manager_UpdateSettings() at a stream-start arm; everything else
+ * keeps using the plain form.
  *
- * Call it immediately before the `mode = MODE_WRITE` + UpdateSettings() pair.
- * It is a ONE-SHOT token: the next UpdateSettings() consumes it and sets the
- * session latch. Nothing else sets that latch -- a session teardown (mode
- * NONE) clears it, and every other call leaves it alone, which is what keeps a
- * mid-session config setter such as SYST:STOR:SD:MAXSize from silently
- * stopping a running log's rotation headers.
+ * It is a separate ENTRY POINT rather than a flag set beforehand because the
+ * flag was stealable: SYST:STOR:SD:BENCHmark takes no claim (#736), so a
+ * benchmark arming from USB SCPI could land between a WiFi-SCPI stream
+ * start's flag write and its own UpdateSettings(), consume the declaration,
+ * and latch itself as a streaming log — putting the previous stream's
+ * protobuf sd_metadata into a rotated benchmark part (#824 audit round 8).
  *
- * A non-streaming WRITE arm needs no call: SYST:STOR:SD:BENCHmark arms WRITE
- * through the same split-file rotation path, and inheriting the header there
- * corrupts its output file (#824 audit round 5) -- but the teardown of the
- * previous session has already cleared the latch by then, so omission is
- * safe. */
-void sd_card_manager_DeclareWriteIsStreamingLog(void);
+ * A non-streaming WRITE arm needs no call and cannot get this wrong by
+ * omission: the plain wrapper declares false. */
+bool sd_card_manager_UpdateSettingsForStreamingLog(
+        sd_card_manager_settings_t *pSettings);
 
     /**
      * @brief #703: is the SD read scratch buffer large enough for SD:GET?

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -359,12 +359,17 @@ void sd_card_manager_ReleaseClaim(void);
  * so its rotated split files get this session's self-describing header.
  *
  * Call it immediately before the `mode = MODE_WRITE` + UpdateSettings() pair.
- * It is a ONE-SHOT token: the next UpdateSettings() consumes it, and an arm
- * that did not set it latches "not a streaming log". That default-deny is the
- * point -- SYST:STOR:SD:BENCHmark arms WRITE through the same split-file
- * rotation path, and inheriting the header there corrupts its output file
- * (#824 audit round 5). A non-streaming WRITE arm needs no call and cannot get
- * it wrong by omission. */
+ * It is a ONE-SHOT token: the next UpdateSettings() consumes it and sets the
+ * session latch. Nothing else sets that latch -- a session teardown (mode
+ * NONE) clears it, and every other call leaves it alone, which is what keeps a
+ * mid-session config setter such as SYST:STOR:SD:MAXSize from silently
+ * stopping a running log's rotation headers.
+ *
+ * A non-streaming WRITE arm needs no call: SYST:STOR:SD:BENCHmark arms WRITE
+ * through the same split-file rotation path, and inheriting the header there
+ * corrupts its output file (#824 audit round 5) -- but the teardown of the
+ * previous session has already cleared the latch by then, so omission is
+ * safe. */
 void sd_card_manager_DeclareWriteIsStreamingLog(void);
 
     /**

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -355,6 +355,18 @@ extern "C" {
 bool sd_card_manager_TryClaim(void);
 void sd_card_manager_ReleaseClaim(void);
 
+/* #824: declare that the WRITE session about to be armed is a STREAMING log,
+ * so its rotated split files get this session's self-describing header.
+ *
+ * Call it immediately before the `mode = MODE_WRITE` + UpdateSettings() pair.
+ * It is a ONE-SHOT token: the next UpdateSettings() consumes it, and an arm
+ * that did not set it latches "not a streaming log". That default-deny is the
+ * point -- SYST:STOR:SD:BENCHmark arms WRITE through the same split-file
+ * rotation path, and inheriting the header there corrupts its output file
+ * (#824 audit round 5). A non-streaming WRITE arm needs no call and cannot get
+ * it wrong by omission. */
+void sd_card_manager_DeclareWriteIsStreamingLog(void);
+
     /**
      * @brief #703: is the SD read scratch buffer large enough for SD:GET?
      *

--- a/firmware/src/services/sd_card_services/sd_card_manager.h
+++ b/firmware/src/services/sd_card_services/sd_card_manager.h
@@ -355,21 +355,34 @@ extern "C" {
 bool sd_card_manager_TryClaim(void);
 void sd_card_manager_ReleaseClaim(void);
 
-/* #824: arm a WRITE that IS a streaming log, so its rotated split files get
- * this session's self-describing header. Use it in place of
- * sd_card_manager_UpdateSettings() at a stream-start arm; everything else
- * keeps using the plain form.
+/* #824: WHAT IS THIS CALL DOING? Three entry points, and the choice decides
+ * whether the rotated split files of the resulting WRITE session carry this
+ * session's self-describing header.
  *
- * It is a separate ENTRY POINT rather than a flag set beforehand because the
- * flag was stealable: SYST:STOR:SD:BENCHmark takes no claim (#736), so a
- * benchmark arming from USB SCPI could land between a WiFi-SCPI stream
- * start's flag write and its own UpdateSettings(), consume the declaration,
- * and latch itself as a streaming log — putting the previous stream's
- * protobuf sd_metadata into a rotated benchmark part (#824 audit round 8).
+ *   ...ForStreamingLog()  arming a WRITE that IS a streaming log  -> header
+ *   ...ForPlainWrite()    arming a WRITE that is NOT one          -> no header
+ *   ...UpdateSettings()   not arming a write session at all       -> unchanged
  *
- * A non-streaming WRITE arm needs no call and cannot get this wrong by
- * omission: the plain wrapper declares false. */
+ * The third case is the one worth spelling out: a CONFIG SETTER such as
+ * SYST:STOR:SD:MAXSize calls UpdateSettings() with `mode` already WRITE,
+ * without arming anything. It must not re-answer a question only an arm can
+ * answer -- doing so cost a running log its rotation headers. So "leave it
+ * alone" is the default, and the two arming forms are the only things that
+ * change the latch (a teardown to mode NONE also clears it).
+ *
+ * WHY THE KIND IS A PARAMETER, and not state inspected here: every attempt to
+ * INFER it from the manager's own state was wrong in a different window.
+ * A global one-shot flag set just before the arm was stealable, because
+ * SYST:STOR:SD:BENCHmark takes no claim by design (#736) and could consume
+ * another transport's declaration (audit round 8). Testing
+ * currentProcessState missed the rotation window, where the manager sits in
+ * OPEN_FILE rather than WRITE_TO_FILE (round 7), and adding gSdRotating to
+ * that test then let a benchmark armed DURING a rotation inherit the latch
+ * (round 9). Each of those put a stale protobuf sd_metadata into a benchmark
+ * output file. The caller knows; nothing else reliably does. */
 bool sd_card_manager_UpdateSettingsForStreamingLog(
+        sd_card_manager_settings_t *pSettings);
+bool sd_card_manager_UpdateSettingsForPlainWrite(
         sd_card_manager_settings_t *pSettings);
 
     /**

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2473,7 +2473,22 @@ static void Streaming_BuildSdFileHeader(StreamingEncoding encoding) {
  *     predicate; every protobuf file from the first ROTATION onward carries
  *     its sd_metadata. */
 size_t Streaming_GetSdFileHeader(const uint8_t** ppHeader) {
-    if (ppHeader == NULL || !gSdHeaderBuilt || gSdHeaderLen == 0u) {
+    if (ppHeader == NULL || !gSdHeaderBuilt) {
+        return 0;
+    }
+
+    /* ONE read of the length, in publish order (gSdHeaderBuilt is stored
+     * last, so testing it first cannot see a half-published cache).
+     *
+     * A SCPI stop on the USB task (pri 7) can preempt this one (pri 5) at
+     * any point and zero the cache. Reading the length twice -- once to
+     * test, once to return -- would let the second read see that zero and
+     * hand the caller a length of 0 with *ppHeader already assigned. That
+     * is harmless today because the caller re-tests the length, but it is
+     * the kind of two-read gap that stops being harmless when someone
+     * later trusts the pointer instead. */
+    uint32_t len = gSdHeaderLen;
+    if (len == 0u) {
         return 0;
     }
 
@@ -2489,7 +2504,7 @@ size_t Streaming_GetSdFileHeader(const uint8_t** ppHeader) {
     }
 
     *ppHeader = gSdHeaderBytes;
-    return (size_t)gSdHeaderLen;
+    return (size_t)len;
 }
 
 void Streaming_GetStats(StreamingStats* out) {

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2523,15 +2523,24 @@ size_t Streaming_GetSdFileHeader(const uint8_t** ppHeader) {
     }
 
     /* ONE read of the length, in publish order (gSdHeaderValid is stored
-     * last, so testing it first cannot see a half-published cache).
+     * last by the builder, so testing it first cannot see a half-published
+     * cache).
      *
-     * A SCPI stop on the USB task (pri 7) can preempt this one (pri 5) at
-     * any point and zero the cache. Reading the length twice -- once to
-     * test, once to return -- would let the second read see that zero and
-     * hand the caller a length of 0 with *ppHeader already assigned. That
-     * is harmless today because the caller re-tests the length, but it is
-     * the kind of two-read gap that stops being harmless when someone
-     * later trusts the pointer instead. */
+     * An earlier revision of this comment justified the single read by
+     * "a SCPI stop can zero the cache". That is no longer true and had
+     * become misdocumentation of the concurrency model: nothing at stop
+     * touches the cache -- only a STARTING session clears it, and that
+     * cannot overlap a rotation open belonging to a live one.
+     *
+     * The single read is still the right shape. The writer runs on the
+     * streaming task (pri 6) and this runs on the SD task (pri 5), so a
+     * preemption between two reads of gSdHeaderLen is possible in
+     * principle; reading it twice -- once to test, once to return -- would
+     * let the second read disagree with the first and hand the caller a
+     * length of 0 with *ppHeader already assigned. Harmless against
+     * today's caller, which re-tests the length, and exactly the kind of
+     * two-read gap that stops being harmless when someone later trusts the
+     * pointer instead. */
     uint32_t len = gSdHeaderLen;
     if (len == 0u) {
         return 0;

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -133,28 +133,33 @@ static uint8_t gSdHeaderBytes[STREAMING_SD_HEADER_MAX];
 static volatile uint32_t gSdHeaderLen = 0;
 static volatile uint8_t gSdHeaderEnc = 0;     // StreamingEncoding it was built for
 
-/* Validity is an EPOCH match, not a boolean, and that is the fix for a race
- * the boolean had (#824 audit round 2).
+/* Cleared at Streaming_START, set by the builder, and never touched at stop.
  *
- * The cache used to be cleared in Streaming_Stop(). SCPI runs at priority 7
- * (USB) against the SD task's 5, so a SYST:STR:STOP could land between the SD
- * task opening a rotation's new file and its Streaming_GetSdFileHeader() call
- * -- clearing the cache in that gap, while the SD manager was still in WRITE
- * mode, so the open completed and the file then received the rotation
- * window's buffered DATA with no header in front of it. That was a REGRESSION
- * against the pre-#824 design, where the header was already sitting in the
- * circular buffer ahead of the data and a late stop could not remove it.
+ * The stop/start asymmetry is deliberate and was arrived at the hard way
+ * (#824 audit rounds 2-3). Clearing at STOP is a race: SCPI runs at priority
+ * 7 against the SD task's 5, so a SYST:STR:STOP can land between the SD task
+ * opening a rotation's new file and its Streaming_GetSdFileHeader() call --
+ * the open completes while the manager is still in WRITE mode, the fetch
+ * returns 0, and the file takes the rotation window's DATA with no header in
+ * front of it. Pre-#824 that could not happen, because the header was already
+ * queued in the circular buffer ahead of the data.
  *
- * An epoch removes the gap instead of narrowing it. Stop clears nothing, so a
- * teardown cannot invalidate a header for a file that is already being
- * opened; the epoch is bumped at session START (Streaming_BeginSdHeaderEpoch,
- * called from SCPI_StartStreaming BEFORE the SD file is armed), which is what
- * keeps the NEXT session's first file from being handed the previous
- * session's bytes -- the hazard that put the clear in Stop to begin with.
- * Protobuf needs that: its sd_metadata has no encoder-side "already sent"
- * predicate to fall back on. */
-static volatile uint32_t gSdHeaderEpoch = 0;       // bumped once per session
-static volatile uint32_t gSdHeaderBuiltEpoch = 0;  // epoch the cache was built in
+ * Clearing at START is safe here ONLY because the SD task writes this header
+ * for ROTATIONS and nothing else (see OPEN_FILE). A rotation cannot occur
+ * before the encoder has run -- it takes MAXSize bytes to trigger one -- so
+ * the cache is always rebuilt for the live session well before any file that
+ * consumes it. The session's FIRST file needs no header from here: under
+ * CSV/JSON the encoder's own inline header lands at its byte 0, and under
+ * protobuf it has never had one (a pre-existing #196 gap).
+ *
+ * An intermediate revision used a session EPOCH bumped before the SD arm.
+ * That worked for the race but made the gate global, and the audit found two
+ * ways to lose: SYST:STOR:SD:BENCHmark arms WRITE with no epoch of its own
+ * and would have had the previous stream's sd_metadata prepended to its
+ * output file, and a REFUSED SYST:STR:START bumped the epoch before failing
+ * its claim, invalidating a running session's cache mid-rotation. Gating on
+ * the rotation itself removes the need for the epoch entirely. */
+static volatile bool gSdHeaderValid = false;
 
 // Per-session streaming statistics.
 // Written by: deferred ISR task (queueDroppedSamples, poolExhaustedSamples,
@@ -1814,6 +1819,11 @@ static void Streaming_Start(void) {
         // Clear encoding buffer once to prevent stale data artifacts in SD files
         if (buffer != NULL) memset(buffer, 0, bufferSize);
 
+        /* #824: this session gets its own header. Safe to clear HERE rather
+         * than at stop precisely because only a rotation consumes it, and a
+         * rotation needs MAXSize bytes of encoder output first. */
+        gSdHeaderValid = false;
+
         TimerApi_Initialize(gpStreamingConfig->TimerIndex);
         TimerApi_PeriodSet(gpStreamingConfig->TimerIndex, gpRuntimeConfigStream->ClockPeriod);
         TimerApi_CallbackRegister(gpStreamingConfig->TimerIndex, Streaming_TimerHandler, 0);
@@ -2119,10 +2129,8 @@ static void Streaming_DrainSessionSampleQueues(void) {
 }
 
 static void Streaming_Stop(void) {
-    /* #824: deliberately does NOT touch the SD header cache. An earlier
-     * revision cleared it here and that was a race -- see the epoch comment
-     * at gSdHeaderEpoch. Invalidation is Streaming_BeginSdHeaderEpoch()'s
-     * job, at session start, before the SD file is armed. */
+    /* #824: deliberately does NOT touch the SD header cache -- clearing it
+     * here races an in-flight rotation open. See gSdHeaderValid. */
     if (gpRuntimeConfigStream->Running) {
         TimerApi_Stop(gpStreamingConfig->TimerIndex);
         TimerApi_InterruptDisable(gpStreamingConfig->TimerIndex);
@@ -2248,8 +2256,7 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
     gStreamRateConfigured = 0u;
     gBenchmarkMode = BENCHMARK_OFF;
     gSdHeaderLen = 0;
-    gSdHeaderEpoch = 0;
-    gSdHeaderBuiltEpoch = 0;
+    gSdHeaderValid = false;
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
@@ -2450,7 +2457,7 @@ static void Streaming_BuildSdFileHeader(StreamingEncoding encoding) {
         len = 0;
     }
 
-    /* Publish. gSdHeaderBuiltEpoch is stored LAST and gates the two scalars above,
+    /* Publish. gSdHeaderValid is stored LAST and gates the two scalars above,
      * which in turn gate the byte array.
      *
      * The barrier makes that ordering explicit rather than incidental (Qodo
@@ -2469,18 +2476,7 @@ static void Streaming_BuildSdFileHeader(StreamingEncoding encoding) {
     gSdHeaderEnc = (uint8_t)encoding;
     gSdHeaderLen = (uint32_t)len;
     __asm__ volatile ("" ::: "memory");
-    gSdHeaderBuiltEpoch = gSdHeaderEpoch;
-}
-
-/* #824: open a new SD-header epoch, invalidating any cache from the previous
- * session. Called from SCPI_StartStreaming BEFORE SD logging is armed, which
- * is the ordering the whole scheme rests on: the session's first OPEN_FILE
- * then finds no valid header and writes none -- matching the pre-#824
- * behaviour, where SCPI_StartStreaming's IsWriteReady() wait had already made
- * the gSdFileWasReady latch true before the SD-only header block could fire
- * for file 1. */
-void Streaming_BeginSdHeaderEpoch(void) {
-    gSdHeaderEpoch++;
+    gSdHeaderValid = true;
 }
 
 /* #824: hand the SD task the bytes to write at the head of a newly opened
@@ -2506,11 +2502,11 @@ void Streaming_BeginSdHeaderEpoch(void) {
  *     predicate; every protobuf file from the first ROTATION onward carries
  *     its sd_metadata. */
 size_t Streaming_GetSdFileHeader(const uint8_t** ppHeader) {
-    if (ppHeader == NULL || gSdHeaderBuiltEpoch != gSdHeaderEpoch) {
+    if (ppHeader == NULL || !gSdHeaderValid) {
         return 0;
     }
 
-    /* ONE read of the length, in publish order (gSdHeaderBuiltEpoch is stored
+    /* ONE read of the length, in publish order (gSdHeaderValid is stored
      * last, so testing it first cannot see a half-published cache).
      *
      * A SCPI stop on the USB task (pri 7) can preempt this one (pri 5) at
@@ -2991,7 +2987,7 @@ void streaming_Task(void) {
          * header lands there instead); for protobuf it means file 1 carries
          * no sd_metadata, which is a pre-existing #196 gap this change
          * deliberately does not alter. */
-        if (gSdHeaderBuiltEpoch != gSdHeaderEpoch && gSdExpectedThisSession) {
+        if (!gSdHeaderValid && gSdExpectedThisSession) {
             Streaming_BuildSdFileHeader(pRunTimeStreamConf->Encoding);
         }
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -132,7 +132,29 @@ static volatile bool gNeedSharedScan = false;
 static uint8_t gSdHeaderBytes[STREAMING_SD_HEADER_MAX];
 static volatile uint32_t gSdHeaderLen = 0;
 static volatile uint8_t gSdHeaderEnc = 0;     // StreamingEncoding it was built for
-static volatile bool gSdHeaderBuilt = false;
+
+/* Validity is an EPOCH match, not a boolean, and that is the fix for a race
+ * the boolean had (#824 audit round 2).
+ *
+ * The cache used to be cleared in Streaming_Stop(). SCPI runs at priority 7
+ * (USB) against the SD task's 5, so a SYST:STR:STOP could land between the SD
+ * task opening a rotation's new file and its Streaming_GetSdFileHeader() call
+ * -- clearing the cache in that gap, while the SD manager was still in WRITE
+ * mode, so the open completed and the file then received the rotation
+ * window's buffered DATA with no header in front of it. That was a REGRESSION
+ * against the pre-#824 design, where the header was already sitting in the
+ * circular buffer ahead of the data and a late stop could not remove it.
+ *
+ * An epoch removes the gap instead of narrowing it. Stop clears nothing, so a
+ * teardown cannot invalidate a header for a file that is already being
+ * opened; the epoch is bumped at session START (Streaming_BeginSdHeaderEpoch,
+ * called from SCPI_StartStreaming BEFORE the SD file is armed), which is what
+ * keeps the NEXT session's first file from being handed the previous
+ * session's bytes -- the hazard that put the clear in Stop to begin with.
+ * Protobuf needs that: its sd_metadata has no encoder-side "already sent"
+ * predicate to fall back on. */
+static volatile uint32_t gSdHeaderEpoch = 0;       // bumped once per session
+static volatile uint32_t gSdHeaderBuiltEpoch = 0;  // epoch the cache was built in
 
 // Per-session streaming statistics.
 // Written by: deferred ISR task (queueDroppedSamples, poolExhaustedSamples,
@@ -2097,28 +2119,10 @@ static void Streaming_DrainSessionSampleQueues(void) {
 }
 
 static void Streaming_Stop(void) {
-    /* #824: invalidate this session's cached SD file header.
-     *
-     * HERE and not in Streaming_Start(), which would be too late to be safe.
-     * SCPI_StartStreaming arms SD logging and waits for the file to open
-     * BEFORE it calls Streaming_UpdateState(), so the next session's FIRST
-     * OPEN_FILE runs while Streaming_Start() still has not. A cache left
-     * valid across that boundary would be handed to that open -- and for
-     * protobuf, whose header has no encoder-side "already sent" predicate to
-     * fall back on, the new file would begin with the PREVIOUS session's
-     * sd_metadata, describing a channel set that may since have changed.
-     * (CSV/JSON happen to be covered anyway: SCPI_StopStreaming's
-     * csv_ResetEncoder()/json_ResetEncoder() make their predicate false.)
-     *
-     * Clearing at stop closes it, because every start path reaches here first
-     * -- Streaming_UpdateState() is Stop-then-Start, and a session that ended
-     * normally already ran a Stop of its own.
-     *
-     * Outside the Running guard on purpose: the flag must end up false
-     * whether or not this call had a live session to tear down. */
-    gSdHeaderBuilt = false;
-    gSdHeaderLen = 0;
-
+    /* #824: deliberately does NOT touch the SD header cache. An earlier
+     * revision cleared it here and that was a race -- see the epoch comment
+     * at gSdHeaderEpoch. Invalidation is Streaming_BeginSdHeaderEpoch()'s
+     * job, at session start, before the SD file is armed. */
     if (gpRuntimeConfigStream->Running) {
         TimerApi_Stop(gpStreamingConfig->TimerIndex);
         TimerApi_InterruptDisable(gpStreamingConfig->TimerIndex);
@@ -2243,8 +2247,9 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
      * the very thing the flag exists to suppress (#733 audit). */
     gStreamRateConfigured = 0u;
     gBenchmarkMode = BENCHMARK_OFF;
-    gSdHeaderBuilt = false;
     gSdHeaderLen = 0;
+    gSdHeaderEpoch = 0;
+    gSdHeaderBuiltEpoch = 0;
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
@@ -2445,7 +2450,7 @@ static void Streaming_BuildSdFileHeader(StreamingEncoding encoding) {
         len = 0;
     }
 
-    /* Publish. gSdHeaderBuilt is stored LAST and gates the two scalars above,
+    /* Publish. gSdHeaderBuiltEpoch is stored LAST and gates the two scalars above,
      * which in turn gate the byte array.
      *
      * The barrier makes that ordering explicit rather than incidental (Qodo
@@ -2464,7 +2469,18 @@ static void Streaming_BuildSdFileHeader(StreamingEncoding encoding) {
     gSdHeaderEnc = (uint8_t)encoding;
     gSdHeaderLen = (uint32_t)len;
     __asm__ volatile ("" ::: "memory");
-    gSdHeaderBuilt = true;
+    gSdHeaderBuiltEpoch = gSdHeaderEpoch;
+}
+
+/* #824: open a new SD-header epoch, invalidating any cache from the previous
+ * session. Called from SCPI_StartStreaming BEFORE SD logging is armed, which
+ * is the ordering the whole scheme rests on: the session's first OPEN_FILE
+ * then finds no valid header and writes none -- matching the pre-#824
+ * behaviour, where SCPI_StartStreaming's IsWriteReady() wait had already made
+ * the gSdFileWasReady latch true before the SD-only header block could fire
+ * for file 1. */
+void Streaming_BeginSdHeaderEpoch(void) {
+    gSdHeaderEpoch++;
 }
 
 /* #824: hand the SD task the bytes to write at the head of a newly opened
@@ -2490,11 +2506,11 @@ static void Streaming_BuildSdFileHeader(StreamingEncoding encoding) {
  *     predicate; every protobuf file from the first ROTATION onward carries
  *     its sd_metadata. */
 size_t Streaming_GetSdFileHeader(const uint8_t** ppHeader) {
-    if (ppHeader == NULL || !gSdHeaderBuilt) {
+    if (ppHeader == NULL || gSdHeaderBuiltEpoch != gSdHeaderEpoch) {
         return 0;
     }
 
-    /* ONE read of the length, in publish order (gSdHeaderBuilt is stored
+    /* ONE read of the length, in publish order (gSdHeaderBuiltEpoch is stored
      * last, so testing it first cannot see a half-published cache).
      *
      * A SCPI stop on the USB task (pri 7) can preempt this one (pri 5) at
@@ -2975,7 +2991,7 @@ void streaming_Task(void) {
          * header lands there instead); for protobuf it means file 1 carries
          * no sd_metadata, which is a pre-existing #196 gap this change
          * deliberately does not alter. */
-        if (!gSdHeaderBuilt && gSdExpectedThisSession) {
+        if (gSdHeaderBuiltEpoch != gSdHeaderEpoch && gSdExpectedThisSession) {
             Streaming_BuildSdFileHeader(pRunTimeStreamConf->Encoding);
         }
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -1819,10 +1819,26 @@ static void Streaming_Start(void) {
         // Clear encoding buffer once to prevent stale data artifacts in SD files
         if (buffer != NULL) memset(buffer, 0, bufferSize);
 
-        /* #824: this session gets its own header. Safe to clear HERE rather
-         * than at stop precisely because only a rotation consumes it, and a
-         * rotation needs MAXSize bytes of encoder output first. */
-        gSdHeaderValid = false;
+        /* #824: a STARTING session gets its own header.
+         *
+         * The IsEnabled guard is the whole point and was missing (audit round
+         * 4). Streaming_UpdateState() is Stop-then-Start UNCONDITIONALLY, so
+         * Streaming_Start() also runs on the STOP path -- and an unguarded
+         * clear here is therefore still a clear at stop, reached one call
+         * deeper. That put back the exact race rounds 2-3 were spent removing:
+         * a SYST:STR:STOP landing between a rotation's SYS_FS_FileOpen and its
+         * Streaming_GetSdFileHeader() call, leaving that split file with data
+         * and no header.
+         *
+         * Guarded, a stop-path Start leaves the cache alone -- so an in-flight
+         * rotation open still finds its header -- and the next real session
+         * clears it here before its encoder rebuilds. Safe because only a
+         * ROTATION consumes the cache and a rotation needs MAXSize bytes of
+         * encoder output first, so the live session has always rebuilt it in
+         * time. */
+        if (gpRuntimeConfigStream->IsEnabled) {
+            gSdHeaderValid = false;
+        }
 
         TimerApi_Initialize(gpStreamingConfig->TimerIndex);
         TimerApi_PeriodSet(gpStreamingConfig->TimerIndex, gpRuntimeConfigStream->ClockPeriod);

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -110,11 +110,29 @@ static volatile uint32_t gBenchmarkMode = BENCHMARK_OFF;
 // task.
 static volatile bool gNeedSharedScan = false;
 
-// Tracks whether the SD file has become ready during this streaming session.
-// Used to reset encoder header flags when SD transitions to ready, since
-// encoding may have already fired (and burned headers) before the file opened.
-// volatile: written by SD card task, read by streaming task.
-static volatile bool gSdFileWasReady = false;
+/* #824: the per-file SD header, built ONCE per streaming session by the
+ * streaming task and written into every new SD file by the SD task at open.
+ *
+ * It replaces gSdFileWasReady, which existed only to notice a new file and
+ * push a header through the SD circular buffer. That is what forced the
+ * rotation to reset the buffer -- the header had to land at byte 0 -- and the
+ * reset is what discarded the bytes encoded during the pre-close drain.
+ *
+ * 512 bytes bounds every encoding with margin. Measured on the bench
+ * 2026-08-22 with all 16 analog channels enabled and DIO on: CSV 444 B,
+ * CsvCompact 304 B, JSON 244 B. The protobuf sd_metadata message is 69 B,
+ * derived rather than sampled from its six bounded fields (#824).
+ *
+ * volatile on the scalars, not on the bytes: the scalars cross the streaming
+ * task -> SD task boundary, and the bytes are read only after gSdHeaderLen
+ * has been published non-zero. Each is an aligned scalar of 32 bits or less,
+ * so its store is atomic on PIC32MZ and a single-writer publish needs no
+ * critical section (CLAUDE.md atomicity rules). */
+#define STREAMING_SD_HEADER_MAX  512u
+static uint8_t gSdHeaderBytes[STREAMING_SD_HEADER_MAX];
+static volatile uint32_t gSdHeaderLen = 0;
+static volatile uint8_t gSdHeaderEnc = 0;     // StreamingEncoding it was built for
+static volatile bool gSdHeaderBuilt = false;
 
 // Per-session streaming statistics.
 // Written by: deferred ISR task (queueDroppedSamples, poolExhaustedSamples,
@@ -1774,11 +1792,6 @@ static void Streaming_Start(void) {
         // Clear encoding buffer once to prevent stale data artifacts in SD files
         if (buffer != NULL) memset(buffer, 0, bufferSize);
 
-        // If SD file is already open and ready (SCPI_StartStreaming waited
-        // for it), start with true to avoid dropping packets while the
-        // encoder waits for the first sdSize > 0 detection.
-        gSdFileWasReady = sd_card_manager_IsWriteReady();
-
         TimerApi_Initialize(gpStreamingConfig->TimerIndex);
         TimerApi_PeriodSet(gpStreamingConfig->TimerIndex, gpRuntimeConfigStream->ClockPeriod);
         TimerApi_CallbackRegister(gpStreamingConfig->TimerIndex, Streaming_TimerHandler, 0);
@@ -2084,6 +2097,28 @@ static void Streaming_DrainSessionSampleQueues(void) {
 }
 
 static void Streaming_Stop(void) {
+    /* #824: invalidate this session's cached SD file header.
+     *
+     * HERE and not in Streaming_Start(), which would be too late to be safe.
+     * SCPI_StartStreaming arms SD logging and waits for the file to open
+     * BEFORE it calls Streaming_UpdateState(), so the next session's FIRST
+     * OPEN_FILE runs while Streaming_Start() still has not. A cache left
+     * valid across that boundary would be handed to that open -- and for
+     * protobuf, whose header has no encoder-side "already sent" predicate to
+     * fall back on, the new file would begin with the PREVIOUS session's
+     * sd_metadata, describing a channel set that may since have changed.
+     * (CSV/JSON happen to be covered anyway: SCPI_StopStreaming's
+     * csv_ResetEncoder()/json_ResetEncoder() make their predicate false.)
+     *
+     * Clearing at stop closes it, because every start path reaches here first
+     * -- Streaming_UpdateState() is Stop-then-Start, and a session that ended
+     * normally already ran a Stop of its own.
+     *
+     * Outside the Running guard on purpose: the flag must end up false
+     * whether or not this call had a live session to tear down. */
+    gSdHeaderBuilt = false;
+    gSdHeaderLen = 0;
+
     if (gpRuntimeConfigStream->Running) {
         TimerApi_Stop(gpStreamingConfig->TimerIndex);
         TimerApi_InterruptDisable(gpStreamingConfig->TimerIndex);
@@ -2208,7 +2243,8 @@ void Streaming_Init(tStreamingConfig* pStreamingConfigInit,
      * the very thing the flag exists to suppress (#733 audit). */
     gStreamRateConfigured = 0u;
     gBenchmarkMode = BENCHMARK_OFF;
-    gSdFileWasReady = false;
+    gSdHeaderBuilt = false;
+    gSdHeaderLen = 0;
     memset((void*)&gStreamStats, 0, sizeof(gStreamStats));
     gTimerISRCalls = 0;
     gScanStaleDropped = 0;
@@ -2364,17 +2400,96 @@ void Streaming_SdInterfaceReleased(void) {
     }
 }
 
-/* Re-arm the SD header for a new file. The SD task calls this at rotation;
- * the streaming task then sees gSdFileWasReady false and emits a header so
- * every split file is self-describing.
+/* #824: build this session's per-file SD header into gSdHeaderBytes.
  *
- * Was Streaming_ResetSdPbMetadata(), which also cleared a gSdPbMetadataSent
- * flag. That flag was assigned in five places and READ in none -- five
- * volatile stores nobody looked at, and a name promising protobuf-metadata
- * bookkeeping this function never did. Both removed; the header latch below
- * is the whole of what it ever meant. */
-void Streaming_ResetSdFileHeader(void) {
-    gSdFileWasReady = false;
+ * Called from the encoder loop on the streaming task, once per session -- see
+ * the call site for why that placement, and not an earlier one, is the correct
+ * one. It must NOT move to the SD task: Nanopb_Encode's stack frame is 1,744
+ * bytes and app_SDCardTask has 4,096 with 1,872 peak-used, and the
+ * DaqifiOutMessage it builds has float members while that task is on
+ * CLAUDE.md's pure-integer list -- the #369 corruption pattern.
+ *
+ * Building once is correct rather than merely cheap: everything the header
+ * reports is frozen for the session. SYST:STR:FORmat is rejected while
+ * streaming (#619) and CONF:ADC:CHANnel / OBDiag / SAMC are too (#116/#541),
+ * so no split file can legitimately disagree with the first. */
+static void Streaming_BuildSdFileHeader(StreamingEncoding encoding) {
+    size_t len = 0;
+
+    if (Streaming_EncodingIsCsv(encoding)) {
+        len = csv_GenerateHeaderToBuffer((char*)gSdHeaderBytes,
+                                         sizeof(gSdHeaderBytes));
+    } else if (encoding == Streaming_Json) {
+        len = json_GenerateHeaderToBuffer((char*)gSdHeaderBytes,
+                                          sizeof(gSdHeaderBytes));
+    } else {
+        tBoardData* pBoardData = BoardData_Get(BOARDDATA_ALL_DATA, true);
+        len = Nanopb_Encode(pBoardData, &fields_sd_metadata,
+                            gSdHeaderBytes, sizeof(gSdHeaderBytes));
+    }
+
+    /* Reject a header that filled the buffer to the brim rather than ship it
+     * truncated. csv_GenerateHeaderToBuffer hands generateHeader (size - 1),
+     * and generateHeader's fast_strcpy_bounded stops at the bound WITHOUT
+     * reporting it -- so a header that did not fit comes back as exactly
+     * size - 1 bytes of valid-looking prefix. A file with no header is
+     * recoverable by a client that knows the configuration; a file whose
+     * column list is silently cut in half is not.
+     *
+     * Rejecting a genuine 511-byte header is the accepted false positive:
+     * the worst real case measured is 444 B (16ch CSV, DIO on). */
+    if (len >= sizeof(gSdHeaderBytes) - 1u) {
+        LOG_E("SD: per-file header did not fit %u bytes (got %u) - split "
+              "files will have no header", (unsigned)sizeof(gSdHeaderBytes),
+              (unsigned)len);
+        len = 0;
+    }
+
+    gSdHeaderEnc = (uint8_t)encoding;
+    gSdHeaderLen = (uint32_t)len;
+    gSdHeaderBuilt = true;   // published LAST: gates the two stores above
+}
+
+/* #824: hand the SD task the bytes to write at the head of a newly opened
+ * log file, or 0 when this file should not carry one.
+ *
+ * Runs on app_SDCardTask. Everything it touches is integer: the cached bytes,
+ * two scalars, and the encoders' header-sent getters. Those getters return a
+ * file-static bool that only ever transitions false -> true, once, early in
+ * the session -- a byte-wide load that cannot tear, reached through an
+ * ordinary cross-translation-unit call, which is why it does not need to be
+ * volatile at -O3 with no LTO on XC32 (the SET_ONCE_POINTER_AUDIT reasoning).
+ *
+ * Two things make it return 0, and together they reproduce exactly what the
+ * old streaming-task block wrote:
+ *
+ *   - no header BUILT yet. The session's first file is opened before the
+ *     encoder has run, so it gets none -- matching the old gSdFileWasReady
+ *     latch, which SCPI_StartStreaming's readiness wait had already made true
+ *     by the time the SD-only header block could have fired for file 1.
+ *   - CSV/JSON with the encoder's inline header not yet emitted. That inline
+ *     header is itself what lands at byte 0 of such a file, so writing here as
+ *     well would duplicate it. Protobuf has no inline header and so no such
+ *     predicate; every protobuf file from the first ROTATION onward carries
+ *     its sd_metadata. */
+size_t Streaming_GetSdFileHeader(const uint8_t** ppHeader) {
+    if (ppHeader == NULL || !gSdHeaderBuilt || gSdHeaderLen == 0u) {
+        return 0;
+    }
+
+    StreamingEncoding enc = (StreamingEncoding)gSdHeaderEnc;
+    if (Streaming_EncodingIsCsv(enc)) {
+        if (!csv_IsHeaderSent()) {
+            return 0;
+        }
+    } else if (enc == Streaming_Json) {
+        if (!json_IsHeaderSent()) {
+            return 0;
+        }
+    }
+
+    *ppHeader = gSdHeaderBytes;
+    return (size_t)gSdHeaderLen;
 }
 
 void Streaming_GetStats(StreamingStats* out) {
@@ -2783,58 +2898,53 @@ void streaming_Task(void) {
          * produces more per window.
          *
          * IsBufferAccepting stays true across that window. It is safe because
-         * the rotation DRAINS the buffer before closing the old handle, so the
-         * bytes accepted here belong to the new file, and because
-         * Streaming_ResetSdFileHeader() runs before the window opens -- so the
-         * first thing written into the empty buffer is the new file's header,
-         * still at byte 0.
+         * the rotation drains the buffer (to a snapshot, #822) before closing
+         * the old handle, so the bytes accepted here belong to the new file.
          *
-         * The old comment's premise no longer holds either: the buffer is no
-         * longer cleared during the open, it is cleared once before the window
-         * (see OPEN_FILE / the rotation close in sd_card_manager.c). */
+         * #824 removed the byte-0 constraint that used to come with that: the
+         * header is now written into the new file directly by the SD task at
+         * open, not pushed through this buffer, so the rotation no longer
+         * resets the buffer at all and whatever is still in it simply becomes
+         * the new file's first data. */
         sdSize = sd_card_manager_IsBufferAccepting()
                ? sd_card_manager_GetWriteBuffFreeSize()
                : 0;
 
-        // When SD file first becomes ready (new file or rotation), write
-        // an SD-only header/metadata so each file is self-describing
-        // without injecting duplicate headers into the USB/WiFi stream.
-        if (sdSize > 0 && !gSdFileWasReady) {
-            gSdFileWasReady = true;
-
-            // Write SD-only header/metadata for each new file so every
-            // file is self-describing and independently parseable.
-            size_t sdHdrLen = 0;
-            if (Streaming_EncodingIsCsv(pRunTimeStreamConf->Encoding)) {
-                // On rotation (header already sent to USB), generate
-                // SD-only header.  First file: encoder flag is false,
-                // so the encoder naturally includes the header for ALL
-                // interfaces — no special handling needed.
-                if (csv_IsHeaderSent()) {
-                    sdHdrLen = csv_GenerateHeaderToBuffer(
-                            (char*)buffer, bufferSize);
-                }
-            } else if (pRunTimeStreamConf->Encoding == Streaming_Json) {
-                if (json_IsHeaderSent()) {
-                    sdHdrLen = json_GenerateHeaderToBuffer(
-                            (char*)buffer, bufferSize);
-                }
-            } else {
-                // Protobuf: encode a standalone metadata message for SD
-                tBoardData* pBoardData =
-                    BoardData_Get(BOARDDATA_ALL_DATA, true);
-                sdHdrLen = Nanopb_Encode(pBoardData,
-                    &fields_sd_metadata, (uint8_t*)buffer, bufferSize);
-            }
-            if (sdHdrLen > 0) {
-                size_t written = sd_card_manager_WriteToBuffer(
-                        (const char*)buffer, sdHdrLen);
-                if (written != sdHdrLen) {
-                    LOG_E("SD: header write failed, expected=%u written=%u",
-                          (unsigned)sdHdrLen, (unsigned)written);
-                }
-                memset(buffer, 0, sdHdrLen);
-            }
+        /* #824: the per-file SD header no longer travels through the SD
+         * circular buffer. The SD task now writes it straight into each new
+         * file at open (sd_card_manager.c OPEN_FILE), which is what lets a
+         * rotation KEEP the bytes the encoder appended during the pre-close
+         * drain instead of resetting the buffer so the header lands at byte 0.
+         *
+         * All this task still owns is BUILDING the header, once per session.
+         * The content is fixed for the session anyway: SYST:STR:FORmat and
+         * CONF:ADC:CHANnel are both rejected while streaming (#619 / #116),
+         * so there is nothing to re-read per file.
+         *
+         * HERE rather than in Streaming_Start(), and that placement is
+         * load-bearing in two ways.
+         *
+         * It keeps generation off app_SDCardTask, which cannot afford it:
+         * Nanopb_Encode's frame measures 1,744 bytes (xc32-objdump: `addiu
+         * sp,sp,-1744`) against that task's 4,096-byte stack with 1,872 already
+         * peak-used, and the DaqifiOutMessage it builds there carries float
+         * members while the task is on CLAUDE.md's pure-integer list -- the
+         * #369 pattern. The SCPI task calling Streaming_Start() could afford
+         * it (SCPI_SysInfoGet already pays the same frame), so this is about
+         * the reader, not the writer.
+         *
+         * And it preserves what the session's FIRST file gets. That file is
+         * opened by SCPI_StartStreaming BEFORE Streaming_Start() runs -- it
+         * waits on sd_card_manager_IsWriteReady() -- so building the header
+         * any earlier would hand OPEN_FILE a header for file 1, which never
+         * had a separately-written one: the old gSdFileWasReady latch was
+         * initialised from IsWriteReady() precisely so the SD-only header
+         * block skipped it. For CSV/JSON that is right (the encoder's inline
+         * header lands there instead); for protobuf it means file 1 carries
+         * no sd_metadata, which is a pre-existing #196 gap this change
+         * deliberately does not alter. */
+        if (!gSdHeaderBuilt && gSdExpectedThisSession) {
+            Streaming_BuildSdFileHeader(pRunTimeStreamConf->Encoding);
         }
 
         // Compute hasSD for the SD write block below.  ActiveInterface
@@ -3120,7 +3230,7 @@ void streaming_Task(void) {
                 // else: wifiWr == packetSize (success) or
                 //       STREAM_WRITE_RETURN_STOPPED (stop-abort, no bookkeeping).
             }
-            if (hasSD && gSdFileWasReady) {
+            if (hasSD) {
                 if (pRunTimeStreamConf->ActiveInterface != StreamingInterface_SD) {
                     /* #534: multi-output — a stalled SD must never block the
                      * (healthy) USB path through this shared encoder loop.
@@ -3185,7 +3295,7 @@ void streaming_Task(void) {
                     pRunTimeStreamConf->ActiveInterface == StreamingInterface_UsbAndSd ||
                     (gSdExpectedThisSession &&
                      pRunTimeStreamConf->ActiveInterface != StreamingInterface_WiFi));
-                bool sdWritten = hasSD && gSdFileWasReady;
+                bool sdWritten = hasSD;
 
                 if (sdExpected && !sdWritten) {
                     // Gate on IsEnabled, mirroring the #484 encoder-failure

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -2445,9 +2445,26 @@ static void Streaming_BuildSdFileHeader(StreamingEncoding encoding) {
         len = 0;
     }
 
+    /* Publish. gSdHeaderBuilt is stored LAST and gates the two scalars above,
+     * which in turn gate the byte array.
+     *
+     * The barrier makes that ordering explicit rather than incidental (Qodo
+     * pass 1). It is not load-bearing on this part -- PIC32MZ is a
+     * single-core, in-order M-class core, so a preempting task cannot observe
+     * a store order different from program order, and the byte writes happen
+     * inside csv_GenerateHeaderToBuffer / Nanopb_Encode, opaque cross-TU calls
+     * that XC32 (no LTO) cannot sink stores across. But both of those are
+     * properties of the current build, not of the source, and the cost here is
+     * exactly zero instructions.
+     *
+     * `volatile` on gSdHeaderBytes was the suggested alternative and does not
+     * work: csv_GenerateHeaderToBuffer takes a plain `char *`, so the
+     * qualifier would be cast away at the call and buy nothing while
+     * pessimising every byte access that survived. */
     gSdHeaderEnc = (uint8_t)encoding;
     gSdHeaderLen = (uint32_t)len;
-    gSdHeaderBuilt = true;   // published LAST: gates the two stores above
+    __asm__ volatile ("" ::: "memory");
+    gSdHeaderBuilt = true;
 }
 
 /* #824: hand the SD task the bytes to write at the head of a newly opened

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -560,6 +560,13 @@ void Streaming_SdInterfaceReleased(void);
  * streaming task and are valid until streaming stops. */
 size_t Streaming_GetSdFileHeader(const uint8_t** ppHeader);
 
+/* #824: open a new SD-header epoch, invalidating any cache from the previous
+ * session. MUST be called by a start path BEFORE SD logging is armed --
+ * that ordering is what keeps the previous session's header off the new
+ * session's first file, and it is deliberately NOT done at stop, where it
+ * would race an in-flight rotation open (audit round 2). */
+void Streaming_BeginSdHeaderEpoch(void);
+
 /* #757: report SD bytes that were buffered for the next file but can never be
  * written, because the session was torn down while the rotation's open was in
  * flight. Counts into SdDroppedBytes so the loss is visible instead of silent. */

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -564,7 +564,13 @@ size_t Streaming_GetSdFileHeader(const uint8_t** ppHeader);
  * session. MUST be called by a start path BEFORE SD logging is armed --
  * that ordering is what keeps the previous session's header off the new
  * session's first file, and it is deliberately NOT done at stop, where it
- * would race an in-flight rotation open (audit round 2). */
+ * would race an in-flight rotation open (audit round 2).
+ *
+ * INVARIANT: every site that sets StreamingRuntimeConfig.IsEnabled = true
+ * calls this first. There are three, all in SCPIInterface.c -- the
+ * SYST:STR:START path, SYST:STR:THRoughput, and the WiFi rate finder's
+ * per-step start. A FOURTH start path must call it too, or its first SD file
+ * inherits the previous session's header; grep `IsEnabled = true` to check. */
 void Streaming_BeginSdHeaderEpoch(void);
 
 /* #757: report SD bytes that were buffered for the next file but can never be

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -544,16 +544,21 @@ void Streaming_Tasks(   StreamingRuntimeConfig* pStreamConfig, tBoardData* board
  */
 void TimestampTimer_Init( void );
 
-/**
- * Resets the SD protobuf metadata flag so the next SD log file
- * gets a self-describing metadata header as its first message.
- */
 /* #759: release a streaming selection that points at the SD card once the card
  * is no longer available. Safe to call from any task; no-op unless the active
  * interface is SD or USB+SD. */
 void Streaming_SdInterfaceReleased(void);
 
-void Streaming_ResetSdFileHeader(void);
+/* #824: the bytes to write at the head of a newly opened SD log file, so every
+ * split file is self-describing. Returns 0 -- and leaves *ppHeader untouched --
+ * when this file should not carry one: the session's FIRST file in any
+ * encoding (it is opened before the header exists, and under CSV/JSON the
+ * encoder's own inline header lands at its byte 0 instead).
+ *
+ * Called by the SD task from OPEN_FILE, before anything from the circular
+ * buffer reaches the new handle. The bytes are built once per session by the
+ * streaming task and are valid until streaming stops. */
+size_t Streaming_GetSdFileHeader(const uint8_t** ppHeader);
 
 /* #757: report SD bytes that were buffered for the next file but can never be
  * written, because the session was torn down while the rotation's open was in

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -560,19 +560,6 @@ void Streaming_SdInterfaceReleased(void);
  * streaming task and are valid until streaming stops. */
 size_t Streaming_GetSdFileHeader(const uint8_t** ppHeader);
 
-/* #824: open a new SD-header epoch, invalidating any cache from the previous
- * session. MUST be called by a start path BEFORE SD logging is armed --
- * that ordering is what keeps the previous session's header off the new
- * session's first file, and it is deliberately NOT done at stop, where it
- * would race an in-flight rotation open (audit round 2).
- *
- * INVARIANT: every site that sets StreamingRuntimeConfig.IsEnabled = true
- * calls this first. There are three, all in SCPIInterface.c -- the
- * SYST:STR:START path, SYST:STR:THRoughput, and the WiFi rate finder's
- * per-step start. A FOURTH start path must call it too, or its first SD file
- * inherits the previous session's header; grep `IsEnabled = true` to check. */
-void Streaming_BeginSdHeaderEpoch(void);
-
 /* #757: report SD bytes that were buffered for the next file but can never be
  * written, because the session was torn down while the rotation's open was in
  * flight. Counts into SdDroppedBytes so the loss is visible instead of silent. */


### PR DESCRIPTION
## What

Split-file rotation discarded ~3.6 KB of already-accepted data every time it fired. [#823](https://github.com/daqifi/daqifi-nyquist-firmware/issues/823) made that loss *visible* — it is counted through `Streaming_ReportSdDiscard` and lands in `SdDroppedBytes` — but could not eliminate it. This eliminates it.

## Why the loss existed

The per-file header was generated on the **streaming task** and pushed through the **same circular buffer** that carries sample data. That forced it to be at byte 0 of the buffer, so a rotation had to hand the encoder an **empty** one.

The pre-close drain, meanwhile, is bounded to a *snapshot* ([#822](https://github.com/daqifi/daqifi-nyquist-firmware/issues/822) — draining the live level livelocks against the producer above ~340 KB/s and stops rotation outright: 11ch @2 kHz produced one 8.7 MB file against a 20 KB `MAXSize`). So the bytes the encoder appended *during* the drain were still buffered when the rotation reset it, and they were unsaveable:

- not into the **old** file — that is the unbounded drain #822 is;
- not into the **new** one — the next header was about to travel through the same ring and they would have landed *ahead* of it.

## The change

**Invert who writes the header.** `Streaming_BuildSdFileHeader` renders it once per session into a 512 B static; the **SD task** writes it into each newly opened file with `SYS_FS_FileWrite` in `OPEN_FILE`, before anything from the buffer can reach the handle.

Byte 0 is then guaranteed by *call order* rather than by an empty buffer, so `CircularBuf_Reset` and its discard both disappear from the rotation path and the leftover bytes simply become the new file's first data rows.

### Placement of the build is load-bearing, twice

| not here | why |
|---|---|
| the **SD task** | `Nanopb_Encode`'s frame measures **1,744 bytes** (`xc32-objdump`: `addiu sp,sp,-1744`) against `app_SDCardTask`'s 4,096 with 1,872 peak-used — and the `DaqifiOutMessage` it builds carries `float` members while that task is on CLAUDE.md's pure-integer list, which is the [#369](https://github.com/daqifi/daqifi-nyquist-firmware/pull/369) corruption pattern |
| `Streaming_Start()` | `SCPI_StartStreaming` opens the SD file and **waits on `IsWriteReady()` before** calling it, so a header built there would reach file 1 — which never had a separately-written one |

The old `gSdFileWasReady` latch was initialised from `IsWriteReady()` for exactly that second reason, so **behaviour is preserved**, including the pre-existing [#196](https://github.com/daqifi/daqifi-nyquist-firmware/pull/196) gap where a protobuf session's *first* file carries no `sd_metadata` (files 2..N do, as they always did). Deliberately not changed here — it would alter byte 0 of file 1 for existing PB clients.

### A defect this PR found in its own first draft

Invalidating the cache in `Streaming_Start()` is **not** safe, for the same ordering reason: `Start` runs *after* the next session's first `OPEN_FILE`, so a cache left valid across the session boundary would hand that open the **previous** session's protobuf metadata, describing a channel set that may since have changed. (CSV/JSON happen to be covered anyway — `csv_ResetEncoder`/`json_ResetEncoder` make their predicate false.) The invalidation lives in `Streaming_Stop()`, which every start path reaches first.

### Incidental removals

- **`gSdFileWasReady` is gone.** It gated SD writes as `hasSD && gSdFileWasReady`, but it was set true in the same iteration that first observed `sdSize > 0` — which is the precondition of `hasSD`. The gate was already equivalent to `hasSD` alone.
- **`Streaming_ResetSdFileHeader()` is gone**, along with its three call sites.

### RAM

`STATIC_POOL_SIZE` drops 512 B to pay for the header buffer — the same trade [#665](https://github.com/daqifi/daqifi-nyquist-firmware/issues/665) made. Without it the link fails with `Not enough memory for stack (8208 bytes needed, 7816 available)`. The cost is **nil**, not merely small: at 16 channels this is ~7 slots off a *partitioned* depth that already exceeds the *usable* one by ~500, because the FreeRTOS sample queue is what clamps it ([#828](https://github.com/daqifi/daqifi-nyquist-firmware/issues/828)).

## Truncation guard

`generateHeader`'s `fast_strcpy_bounded` stops at its bound **without reporting it**, so a header that did not fit comes back as exactly `size - 1` bytes of valid-looking prefix. The builder rejects that length rather than shipping a silently halved column list. Worst real case measured on the bench 2026-08-22 at 16 channels with DIO on: CSV **444 B**, CsvCompact 304 B, JSON 244 B, protobuf `sd_metadata` 69 B (derived from its six bounded fields).

## Test plan

Companion: **daqifi/daqifi-python-test-suite** branch `test/824-header-at-file-open` — [`test_824_rotation_no_discard.py`](https://github.com/daqifi/daqifi-python-test-suite/blob/test/824-header-at-file-open/test_824_rotation_no_discard.py).

It measures rotation cost as an **A/B**, not as `SdDroppedBytes == 0`. That counter aggregates every SD refusal and rotation discard was only one of them — #823's own measurement read **62,976** before it taught the counter to include the rotation strand, because 16ch CSV @2 kHz drives ~505 KB/s at a path that tops out near 500. An `== 0` assertion at a saturating shape **fails on fixed firmware**, for a reason unrelated to this issue.

So the run stays clear of saturation (5 channels, SD-only, ~158 KB/s) and measures the same configuration twice — arm A with `MAXSize 0` (nothing rotates), arm B with `MAXSize 20000` (rotates continuously). `dropB - dropA` over the rotation count is what rotation costs; the gate is **512 B/rotation** against a pre-fix strand of kilobytes.

The arrangement is asserted, not assumed: arm B must have rotated, arm A must **not** have (which also catches a device that ignored `MAXSize 0`), both arms must have streamed at rate, and arm A must be unsaturated or the subtraction compares noise. A run with no rotations scores the claim as *infinite* rather than passing vacuously. A **continuation** file — not file 1, whose header comes from the encoder either way — must still start with its header, which is the risk this change itself introduces.

### Status: built and statically validated; **bench run queued**

| check | result |
|---|---|
| `default` (NQ1) build, -O3, `-Werror` | clean |
| `Nq3` build, -O3, `-Werror` | clean |
| cppcheck gate | 0 findings, baseline unchanged |
| harness-policy lint (test suite) | 0 violations |
| **rotation soak on hardware** | **not yet run — COM3 is occupied by the #832 above-cap escalation** |

The bench was continuously busy with another agent's characterization run for the whole of this work, so no flash was performed (a flash also wipes NVM). Per the standing rule the test is committed and referenced; the run is queued.

## Epistemics

- **V** — `diskio.c:281` `memcpy`s the caller's buffer into its own aligned buffer before `SYS_FS_MEDIA_MANAGER_SectorWrite`, so the cached `gSdHeaderBytes` never reaches a DMA engine; no coherent allocation is needed.
- **V** — `Nanopb_Encode` frame size 1,744 B, read from `xc32-objdump -d` on the built ELF.
- **V** — `SCPI_StartStreaming` waits on `sd_card_manager_IsWriteReady()` before `Streaming_UpdateState()`; that is what makes file 1's behaviour unchanged.
- **E** — header sizes (444/304/244 B) are the bench measurement recorded on #824, 2026-08-22.
- **I** — that rotation now contributes *nothing* to `SdDroppedBytes` follows from there being no discard site left in the path; the companion test is what turns it into E, and it has not run yet.

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)
