### PR TITLE
fix(streaming): re-fit the pure-T1 single-channel CSV cap, at precision 4 (#832)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -864,7 +864,21 @@ The PBxDIV /3 writes live in `SystemInit`/`initialization.c` (Harmony's `CLK_Ini
 
 **SPI4 (SD + WINC) is clocked from PBCLK2, not REFCLK1** — `MCLKSEL=0` in `plib_spi4_master.c`, and no `REFO1CON` configuration exists anywhere in the tree (the pre-#487 revision of this table claiming "REFCLK1 passthrough, MCLKSEL=1" was stale: the measured 16.67 MHz SPI4 clock matched PBCLK2=100/BRG=2 exactly, not REFCLK1=200). SPI4 BRG formula: `SPI_CLK = 84MHz / (2 × (BRG + 1))` — SDSPI's 20 MHz request now rounds to 21 MHz (BRG=1); at the old 100 MHz PBCLK2 it rounded to 16.67 MHz (BRG=2).
 
-> **⚠️ The descriptive throughput TABLES below (Session-24 soaks, fit basis) pre-date #487 — measured at 200 MHz/100 MHz.** They are historical characterization, not the enforced caps. **The ENFORCED caps HAVE been re-fit for 252 MHz** (contrary to older revisions of this note): PB transport + additive were raised (**#595/#600** — USB PB single 15000→22000 curve 120000/(1+n), SD PB single 9000→13000 curve 99000/(4+n), ISR_MAX 16000→22000); USB CSV transport was raised (**#712**); and the pure-T1 PB additive was **lowered** (**#715/#714** — the 252 MHz PB refit had over-capped pure-T1 PB, silently dropping data at cap: USB PB 1×T1 19340→15799, SD PB 1×T1 9852→7900). **Still on the 200 MHz-era fit (real remaining headroom):** the CSV *additive* grid, JSON (`CSV×0.5` placeholder, **#529**), the WiFi PB curve, and all NQ2/NQ3 caps (legacy 200 MHz envelope by design). The authoritative, current cap dataset is `daqifi-python-test-suite/benchmarks/` (e.g. `atcap_20260723_*.csv`), not the tables in this file; the enforced values live in `firmware/src/services/streaming.h` (`Streaming_AdcAdditiveCap_NQ1` / `Streaming_SdAdditiveCap_NQ1` / `Streaming_TransportMaxFreq`). Cross-check those + the `#595/#600/#712/#715` PRs before running any 252 MHz cap work.
+> **⚠️ The descriptive throughput TABLES below (Session-24 soaks, fit basis) pre-date #487 — measured at 200 MHz/100 MHz.** They are historical characterization, not the enforced caps. **The ENFORCED caps HAVE been re-fit for 252 MHz** (contrary to older revisions of this note): PB transport + additive were raised (**#595/#600** — USB PB single 15000→22000 curve 120000/(1+n), SD PB single 9000→13000 curve 99000/(4+n), ISR_MAX 16000→22000); USB CSV transport was raised (**#712**); and the pure-T1 PB additive was **lowered** (**#715/#714** — the 252 MHz PB refit had over-capped pure-T1 PB, silently dropping data at cap: USB PB 1×T1 19340→15799, SD PB 1×T1 9852→7900). **Still on the 200 MHz-era fit (real remaining headroom):** the CSV *additive* grid for **nT1 >= 2** (its **single-channel** case was re-fitted by **#832**, 10589 -> 15263), JSON (`CSV×0.5` placeholder except USB/NQ1, **#529**), the WiFi PB curve, and all NQ2/NQ3 caps (legacy 200 MHz envelope by design). The authoritative, current cap dataset is `daqifi-python-test-suite/benchmarks/` (e.g. `atcap_20260723_*.csv`), not the tables in this file; the enforced values live in `firmware/src/services/streaming.h` (`Streaming_AdcAdditiveCap_NQ1` / `Streaming_SdAdditiveCap_NQ1` / `Streaming_TransportMaxFreq`). Cross-check those + the `#595/#600/#712/#715` PRs before running any 252 MHz cap work.
+>
+> **⚠️ CAP WORK MUST PIN `CONFigure:VOLTage:PRECision` (#832 / test-suite #233).**
+> `csv_encoder` takes an integer fast path (`int_to_str`) at precision **0** and
+> formats a float per channel per sample at **4**, which is what NQ1 **ships**.
+> That is a first-order cost, not a rounding detail: an A/B at one rate measured
+> precision 0 clean against precision **4 losing 10.8 %**, at byte rates within
+> 1 % of each other — encoder CPU, not bandwidth. Precision is NVM-backed, so a
+> board that some earlier test pinned and never restored silently changes what
+> every subsequent ceiling means. A #832 CSV refit fitted to unpinned
+> (precision-0) ceilings dropped **21,286 samples at its own new cap** when
+> flashed. `test_overnight_characterization.py --precision <0-10|device>` pins it
+> and records the READ-BACK value per row as `precision_actual`; use it for
+> anything whose numbers will be fitted, and treat any CSV without that column as
+> being of unknown precision.
 
 #### Hardware FPU
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -629,7 +629,8 @@ until it has a precision-4 basis of its own (#529 follow-up).
 `voltagePrecision` gates the refit to `<= 4`: 0 is `int_to_str` and 1..4 emit
 fewer or equal characters than the precision-4 basis, while 5..10 emit **more**
 and were never measured, so they fall through to the #563 law.
-`CONFigure:VOLTage:PRECision` and `:LOAD` are both rejected while streaming
+`CONFigure:VOLTage:PRECision` and `CONFigure:VOLTage:LOAD` are both
+rejected while streaming
 (same idiom as the `CONF:ADC:CHANnel` #116 guard) so a session cannot move onto
 a costlier encoder after its rate was admitted — see #844 for the residual
 start-window race, which every cap-input guard shares.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,10 +616,23 @@ SYSTem:STReam:LOSS:WINDow?           # Query current override (0=auto)
 The firmware computes a maximum safe streaming frequency as a `min()` of an **ADC/scan** term and a **per-interface/per-format TRANSPORT** term. Since #524 the cap is a **HARD limit**: `SYST:STR:START <freq>` above the cap is **rejected** with SCPI `-222` plus a `LOG_E` detail line stating the achievable max — the rate is never silently changed. Clients pre-validate against `current_max_rate_hz` (`CONF:CAP:JSON?` — equals this cap) or handle the error. Mid-stream `CONF:ADC:CHANnel` / `OBDiag` / `SAMC` are likewise **rejected** (#116/#541). `SYST:STR:BENCHmark 1/2` bypasses the cap — bench use only.
 
 **The ADC/scan term is board-variant-specific (#563/#557):**
-- **NQ1** (v3.6.2+): a fitted **freeze-aware additive model** `Streaming_AdcAdditiveCap_NQ1(nT1, nT2user, nMon, isPB)` (streaming.h), min()'d **only** with the SAMC-dependent **scan-busy** bound `MC12b_HardwareScanMaxFreq()` (the real FRM-documented **#539** limit). This **replaced** the old EOS-rate (10,400 Hz) / event-rate (60,000 ev/s) / tick-budget / `MC12b_ScanMaxFreq` terms: those old sweeps were **drop-blind** (counted frozen scanned data as clean → inflated T2 ceilings). The additive model was fitted to the 2026-06-22 freeze-aware sweep (the first to count `ScanStaleDropped` as loss) with a safe never-over margin (PB ×0.88, CSV ×0.80) and revalidated at-cap (see `validate_557_additive_cap.py` + `benchmarks/557_additive_cap/`). The former "USB-fatal" rationale for the EOS/event caps was the **#525** EOS-task `vsnprintf` overflow, re-tested **gone** on v3.6.1 (#557) — never a silicon limit.
+- **NQ1** (v3.6.2+): a fitted **freeze-aware additive model** `Streaming_AdcAdditiveCap_NQ1(nT1, nT2user, nMon, isPB, isJson, voltagePrecision)` (streaming.h), min()'d **only** with the SAMC-dependent **scan-busy** bound `MC12b_HardwareScanMaxFreq()` (the real FRM-documented **#539** limit). This **replaced** the old EOS-rate (10,400 Hz) / event-rate (60,000 ev/s) / tick-budget / `MC12b_ScanMaxFreq` terms: those old sweeps were **drop-blind** (counted frozen scanned data as clean → inflated T2 ceilings). The additive model was fitted to the 2026-06-22 freeze-aware sweep (the first to count `ScanStaleDropped` as loss) with a safe never-over margin (PB ×0.88, CSV ×0.80) and revalidated at-cap (see `validate_557_additive_cap.py` + `benchmarks/557_additive_cap/`). The former "USB-fatal" rationale for the EOS/event caps was the **#525** EOS-task `vsnprintf` overflow, re-tested **gone** on v3.6.1 (#557) — never a silicon limit.
 - **NQ2/NQ3** (AD7609 — no MODULE7 scan): the legacy `min(ISR_MAX 16000, 55000/type1Count, 110000/(6+totalEnabled), MC12b_ScanMaxFreq)` formula, which still carries the (conservative, placeholder) EOS/event terms pending a per-variant headroom review.
 
-**Effective limit (NQ1):** `min(Streaming_AdcAdditiveCap_NQ1(nT1, nT2user, nMon, isPB), MC12b_HardwareScanMaxFreq(scanCount) [only when a scan is armed], TransportMax(interface, encoding, n))`
+**Effective limit (NQ1):** `min(Streaming_AdcAdditiveCap_NQ1(nT1, nT2user, nMon, isPB, isJson, voltagePrecision), MC12b_HardwareScanMaxFreq(scanCount) [only when a scan is armed], TransportMax(interface, encoding, n))`
+
+The last two additive arguments are **#832** and both exist to keep a raise
+inside the conditions it was measured under. `isJson` excludes JSON from the
+pure-T1 CSV refit — it shares that branch and is *additive-bound* at USB 1ch,
+so a CSV-measured raise would silently lift JSON's cap; it keeps the #563 law
+until it has a precision-4 basis of its own (#529 follow-up).
+`voltagePrecision` gates the refit to `<= 4`: 0 is `int_to_str` and 1..4 emit
+fewer or equal characters than the precision-4 basis, while 5..10 emit **more**
+and were never measured, so they fall through to the #563 law.
+`CONFigure:VOLTage:PRECision` and `:LOAD` are both rejected while streaming
+(same idiom as the `CONF:ADC:CHANnel` #116 guard) so a session cannot move onto
+a costlier encoder after its rate was admitted — see #844 for the residual
+start-window race, which every cap-input guard shares.
 
 **Effective limit (NQ2/NQ3):** `min(ISR_MAX 16000, 55000/type1Count, 110000/(6+totalEnabled), TransportMax(interface, encoding, n), ScanBounds(scan list, SAMC))`
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4107,6 +4107,23 @@ static scpi_result_t SCPI_SetDataPrecision(scpi_t * context) {
         SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
         return SCPI_RES_ERR;
     }
+    /* #832: reject while streaming, mirroring the CONF:ADC:CHANnel (#116) and
+     * CONF:ADC:USECal (#158/#270) guards, and for the same reason: the session
+     * cap is computed at START and precision is an INPUT to it. csv_Encode
+     * reads VoltagePrecision live per buffer, so raising it mid-session would
+     * make the encoder do more work per sample than the admitted rate was
+     * checked against -- silently, since nothing recomputes the cap. Concretely
+     * a 1xT1 CSV session admitted at 15263 Hz (precision <= 4) could be pushed
+     * to precision 10, whose cap for the same config is 10589.
+     *
+     * Rejecting is right rather than re-capping: the cap is a hard limit at
+     * START (#524), there is no mechanism to lower an already-running session,
+     * and silently changing the rate under a client is what #524 removed. */
+    if (pRunTimeStreamConfig->IsEnabled || pRunTimeStreamConfig->Running) {
+        LOG_E("Voltage-precision change rejected: streaming is active (stop streaming first)");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
     pRunTimeStreamConfig->VoltagePrecision = (uint8_t)param1;
     return SCPI_RES_OK;
 }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4152,6 +4152,18 @@ static scpi_result_t SCPI_SaveDataPrecision(scpi_t * context) {
 
 static scpi_result_t SCPI_LoadDataPrecision(scpi_t * context) {
     DaqifiSettings settings;
+    /* #832: the SAME guard as SCPI_SetDataPrecision, for the same reason —
+     * this is the other way the live VoltagePrecision moves. Guarding only the
+     * setter left LOAD as an unguarded twin: `CONF:VOLT:PREC 10` +
+     * `CONF:VOLT:SAVE` while idle, then `CONF:VOLT:LOAD` mid-session, reaches
+     * precision 10 on a stream admitted under the precision-4 cap. */
+    StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_STREAMING_CONFIGURATION);
+    if (pRunTimeStreamConfig->IsEnabled || pRunTimeStreamConfig->Running) {
+        LOG_E("Voltage-precision load rejected: streaming is active (stop streaming first)");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
     memset(&settings, 0, sizeof(DaqifiSettings));
     if (!daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings, &settings)) {
         return SCPI_RES_ERR;

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -664,10 +664,19 @@ uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
          * those terms were both over-conservative (T1) AND wrong (inflated T2).
          * monitoring channels in the scan = scanCount - userT2 (8 when OBDiag). */
         uint32_t nMon = (scanCount > userT2) ? (scanCount - userT2) : 0u;
+        /* Read Encoding ONCE. Deriving isProtoBuf and isJson from two separate
+         * reads let a concurrent change between them produce a flag pair that
+         * matches NO encoding -- e.g. both 0, which is the CSV class, for a
+         * session that is actually JSON. That would hand JSON the pure-T1 CSV
+         * raise, which is the one thing the isJson argument exists to prevent.
+         * One read cannot be internally inconsistent (32-bit loads are atomic
+         * on PIC32MZ). It does not close the wider start-window race -- that is
+         * #844 -- but this part costs nothing to get right. */
+        StreamingEncoding enc = sc->Encoding;
         maxFreq = Streaming_AdcAdditiveCap_NQ1(
                 type1, userT2, nMon,
-                (sc->Encoding == Streaming_ProtoBuffer) ? 1u : 0u,
-                (sc->Encoding == Streaming_Json) ? 1u : 0u,
+                (enc == Streaming_ProtoBuffer) ? 1u : 0u,
+                (enc == Streaming_Json) ? 1u : 0u,
                 (uint32_t)sc->VoltagePrecision);
         /* #563: the additive model was fit at the default SAMC. It replaces the
          * EOS-rate/event-rate caps, but the SAMC/divider-dependent scan-busy
@@ -685,7 +694,7 @@ uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
         if (iface == StreamingInterface_SD) {
             uint32_t sdMax = Streaming_SdAdditiveCap_NQ1(
                     type1, userT2, nMon,
-                    (sc->Encoding == Streaming_ProtoBuffer) ? 1u : 0u);
+                    (enc == Streaming_ProtoBuffer) ? 1u : 0u);
             if (sdMax < maxFreq) maxFreq = sdMax;
         }
     } else {

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -667,7 +667,8 @@ uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
         maxFreq = Streaming_AdcAdditiveCap_NQ1(
                 type1, userT2, nMon,
                 (sc->Encoding == Streaming_ProtoBuffer) ? 1u : 0u,
-                (sc->Encoding == Streaming_Json) ? 1u : 0u);
+                (sc->Encoding == Streaming_Json) ? 1u : 0u,
+                (uint32_t)sc->VoltagePrecision);
         /* #563: the additive model was fit at the default SAMC. It replaces the
          * EOS-rate/event-rate caps, but the SAMC/divider-dependent scan-busy
          * limit (#539) must still apply so a non-default SAMC can't push the cap

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -665,7 +665,9 @@ uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
          * monitoring channels in the scan = scanCount - userT2 (8 when OBDiag). */
         uint32_t nMon = (scanCount > userT2) ? (scanCount - userT2) : 0u;
         maxFreq = Streaming_AdcAdditiveCap_NQ1(
-                type1, userT2, nMon, (sc->Encoding == Streaming_ProtoBuffer) ? 1u : 0u);
+                type1, userT2, nMon,
+                (sc->Encoding == Streaming_ProtoBuffer) ? 1u : 0u,
+                (sc->Encoding == Streaming_Json) ? 1u : 0u);
         /* #563: the additive model was fit at the default SAMC. It replaces the
          * EOS-rate/event-rate caps, but the SAMC/divider-dependent scan-busy
          * limit (#539) must still apply so a non-default SAMC can't push the cap

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -656,6 +656,21 @@ uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
     uint32_t scanCount = MC12b_ComputeScanList(true, sc->OnboardDiagEnabled, NULL, NULL);
     uint32_t userT2    = MC12b_ComputeScanList(true, false, NULL, NULL);
 
+    /* Read Encoding ONCE, for EVERY term of the min() below. Deriving the
+     * flags from separate reads let a concurrent change between them produce a
+     * pair matching NO encoding -- e.g. both 0, the CSV class, for a session
+     * that is actually JSON, which would hand JSON the pure-T1 CSV raise that
+     * the isJson argument exists to prevent. Worse, the ADDITIVE and TRANSPORT
+     * terms could disagree with each other inside one computation: a CSV
+     * additive of 15263 min()'d with a JSON transport of 11000 is a cap for a
+     * configuration that never existed.
+     *
+     * One read cannot be internally inconsistent (32-bit loads are atomic on
+     * PIC32MZ). This does not close the wider start-window race -- that is
+     * #844, and it needs a re-validate-before-arming change to the START path
+     * -- but a single computation contradicting itself costs nothing to fix. */
+    StreamingEncoding enc = sc->Encoding;
+
     uint32_t maxFreq;
     if (bc != NULL && bc->BoardVariant == 1u && total > 0u) {
         /* NQ1 (#557): freeze-aware additive ADC/scan cap replaces the
@@ -664,15 +679,6 @@ uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
          * those terms were both over-conservative (T1) AND wrong (inflated T2).
          * monitoring channels in the scan = scanCount - userT2 (8 when OBDiag). */
         uint32_t nMon = (scanCount > userT2) ? (scanCount - userT2) : 0u;
-        /* Read Encoding ONCE. Deriving isProtoBuf and isJson from two separate
-         * reads let a concurrent change between them produce a flag pair that
-         * matches NO encoding -- e.g. both 0, which is the CSV class, for a
-         * session that is actually JSON. That would hand JSON the pure-T1 CSV
-         * raise, which is the one thing the isJson argument exists to prevent.
-         * One read cannot be internally inconsistent (32-bit loads are atomic
-         * on PIC32MZ). It does not close the wider start-window race -- that is
-         * #844 -- but this part costs nothing to get right. */
-        StreamingEncoding enc = sc->Encoding;
         maxFreq = Streaming_AdcAdditiveCap_NQ1(
                 type1, userT2, nMon,
                 (enc == Streaming_ProtoBuffer) ? 1u : 0u,
@@ -717,7 +723,7 @@ uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
      * (#595 — NQ1-only basis) vs the conservative pre-#595 PB caps for NQ2/NQ3
      * (their wider ADC samples push more PB bytes/sample per Hz). */
     uint32_t transportMax = Streaming_TransportMaxFreq(
-            iface, sc->Encoding, total,
+            iface, enc, total,
             (bc != NULL && bc->BoardVariant == 1u) ? 1u : 0u);
     if (transportMax < maxFreq) maxFreq = transportMax;
     return maxFreq;

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -116,7 +116,11 @@ static inline uint32_t Streaming_ComputeMaxFreq(uint32_t type1Count, uint32_t to
  * PB path as a PIECEWISE model split by scan class — pure-T1 (no scan),
  * armed OBDiag-off, and OBDiag-on (the last keeps the #563 coefficients,
  * 600 s at-cap revalidated) — because a single additive law under-fit the
- * grid (tightness 0.74). CSV keeps the #563 single law (no CSV grid basis).
+ * grid (tightness 0.74). CSV keeps the #563 single law EXCEPT for the pure-T1
+ * (no-scan) class, which #832 re-fitted at 252 MHz and at CONF:VOLT:PRECision 4
+ * -- the NQ1 shipped default, and a materially more expensive encoder path than
+ * the precision-0 integer fast path every earlier CSV basis was measured on.
+ * JSON shares the CSV branch but is EXCLUDED from that refit (see below).
  *   - PB: margin 0.88 keeps each class a safe never-over envelope.
  *   - CSV is byte/transport-bound (noisier) -> margin 0.80 here, AND the
  *     per-format transport term is still min()'d downstream (binds CSV lower).
@@ -125,7 +129,8 @@ static inline uint32_t Streaming_ComputeMaxFreq(uint32_t type1Count, uint32_t to
  * channels in the scan (8 when OBDiag on, else 0); arm = any scanned channel.
  */
 static inline uint32_t Streaming_AdcAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2user,
-                                                    uint32_t nMon, uint32_t isProtoBuf) {
+                                                    uint32_t nMon, uint32_t isProtoBuf,
+                                                    uint32_t isJson) {
     uint32_t armed = (nT2user > 0u || nMon > 0u) ? 1u : 0u;
     uint64_t period_ns, num;
     if (isProtoBuf) {
@@ -158,6 +163,76 @@ static inline uint32_t Streaming_AdcAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2us
             period_ns = 52700ULL + 3000ULL*nT1;
         }
         num = 880000000ULL;   /* 1e9 * 0.88 (PB safe envelope) */
+    } else if (armed == 0u && isJson == 0u) {
+        /* #832 (2026-08-23): pure-T1 CSV/CsvCompact, re-fitted at 252 MHz AND
+         * at CONF:VOLTage:PRECision 4 -- the NQ1 SHIPPED DEFAULT.
+         *
+         * WHY PRECISION IS NAMED HERE. csv_encoder takes an integer fast path
+         * (int_to_str) at precision 0 and formats a float per channel per
+         * sample at 4. The first attempt at this refit was fitted to ceilings
+         * measured on a bench board whose NVM held 0, and the device then
+         * dropped 21,286 samples AT ITS OWN NEW CAP -- the #714/#715 failure
+         * mode, reached through the instrument rather than through the fit.
+         * An A/B at one rate measured precision 0 clean vs precision 4 losing
+         * 10.8%, at byte rates within 1% of each other: encoder CPU, not
+         * bandwidth. The basis below is measured with precision PINNED to 4
+         * and recorded per row (test-suite #233), 600 s freeze-aware soaks
+         * (ScanStaleDropped and T1ArdyMisses both count as loss), real ADC,
+         * OBDiag off, USB, board 7E2898F46200E8A7.
+         *
+         * BASIS (600 s per step, board 7E2898F46200E8A7, fw 3.7.2 crc32
+         * 62067B0C, atcap_20260823_0737/0809/0850 in the test suite):
+         *   nT1=1  clean 16413   FAIL 17472 (T1ArdyMisses 845)
+         *   nT1=3  clean 12285   FAIL 13230 (T1ArdyMisses 228)
+         *   nT1=5  clean  9386   FAIL 10240 (T1ArdyMisses   5)
+         * Every ceiling here is bounded by T1ArdyMisses -- the ARDY-gated
+         * direct read missing a conversion (#541) -- NOT by a transport drop,
+         * so this really is an ADC-side term and belongs in this model.
+         *
+         * ONLY nT1==1 MOVES: 10589 -> 15263 Hz (800e6/52412, i.e. 93.0% of the
+         * measured 16413). n=3 and n=5 have real headroom (12285 against an
+         * enforced 9450; 9386 against 8533) but n=2 and n=4 have no
+         * measurement, and bracketing them by the nearest measured ceiling
+         * ABOVE (ceilings fall monotonically with channel count) puts n=4's
+         * never-over bound at 0.93*9386 = 8729 -- BELOW its current enforced
+         * 8968. So any line covering n>=2 would have to REGRESS n=4 to stay
+         * never-over, and raising it instead would be an unmeasured guess.
+         * n=4 is not over-capped today (8968 <= 9386); there is simply no
+         * basis to move it. A 2/4-channel grid is the follow-up that unlocks
+         * the rest, the way #596's fine-grain grid did for PB.
+         *
+         * SINGLE-CHANNEL SPECIAL CASE, for the reason Streaming_TransportMaxFreq
+         * gives for its own: "1-channel sits far above the multi-channel curve,
+         * which a single A/(B+n) cannot hug". Forcing one straight line through
+         * the 1-channel and multi-channel points spends nearly all of the
+         * 1-channel headroom to reach the others.
+         *
+         * JSON IS EXCLUDED and keeps the #563 law. It shares this branch, and
+         * at USB 1ch the additive is its BINDING term (10589, below its own
+         * #529/#831 transport single of 11000) -- so raising this branch would
+         * lift JSON's enforced cap on the strength of a CSV measurement, and
+         * JSON has never been characterised at precision 4. Its own precision-4
+         * basis is #529 follow-up work. CsvCompact IS included: it emits
+         * strictly fewer bytes per row than CSV (#619), so a CSV-fitted cap is
+         * never-over for it. */
+        if (nT1 <= 1u) {
+            /* 52412 ns -> 800e6/52412 = 15263 Hz. The MINIMAL never-over
+             * period is 52411 (the fit recipe prints that); both floor to the
+             * same 15263 Hz, so the extra nanosecond is free conservatism and
+             * the two numbers do not disagree. */
+            period_ns = 52412ULL;
+        } else {
+            /* nT1 >= 2 keeps the #563 single law, unchanged. The 3xT1 and 5xT1
+             * ceilings measured at precision 4 leave no room to raise n=2 and
+             * n=4 under the never-over + no-regress constraints, and n=2/n=4
+             * have no measurement of their own -- bracketing them by the
+             * nearest measured ceiling ABOVE (ceilings fall monotonically with
+             * channel count) puts the bound below their CURRENT enforced cap.
+             * Raising them would be a guess, and this ticket exists because
+             * the last guess here dropped data at its own cap. */
+            period_ns = 71000ULL + 4550ULL*nT1;
+        }
+        num = 800000000ULL;   /* 1e9 * 0.80 (CSV; transport min'd downstream) */
     } else {
         period_ns = 71000ULL + 21300ULL*armed + 4550ULL*nT1 + 15190ULL*nT2user + 2680ULL*nMon;
         num = 800000000ULL;   /* 1e9 * 0.80 (CSV; transport min'd downstream) */

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -57,6 +57,12 @@ extern "C" {
 // override it. NQ1 note: the ADC additive model binds T1-only cells below this
 // anyway; NQ2/NQ3's legacy formula keeps its own 16000 start via
 // STREAMING_ISR_MAX_HZ_LEGACY below.
+// #832: the highest CONF:VOLTage:PRECision the pure-T1 CSV refit was measured
+// at, and therefore the highest it may be applied at. NQ1's shipped default is
+// 4; 0..3 drive an encoder that is cheaper or equal (0 is int_to_str, 1..3 emit
+// fewer characters), so the precision-4 basis is never-over for them. 5..10
+// emit MORE per value and have no basis, so they keep the #563 law.
+#define STREAMING_CSV_REFIT_MAX_PRECISION 4
 #define STREAMING_ISR_MAX_HZ        22000
 // NQ2/NQ3 legacy-formula start value and additive-clamp ceiling for paths
 // characterized only at 16 kHz (pre-252 MHz basis). Do not raise without a
@@ -130,7 +136,8 @@ static inline uint32_t Streaming_ComputeMaxFreq(uint32_t type1Count, uint32_t to
  */
 static inline uint32_t Streaming_AdcAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2user,
                                                     uint32_t nMon, uint32_t isProtoBuf,
-                                                    uint32_t isJson) {
+                                                    uint32_t isJson,
+                                                    uint32_t voltagePrecision) {
     uint32_t armed = (nT2user > 0u || nMon > 0u) ? 1u : 0u;
     uint64_t period_ns, num;
     if (isProtoBuf) {
@@ -163,7 +170,8 @@ static inline uint32_t Streaming_AdcAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2us
             period_ns = 52700ULL + 3000ULL*nT1;
         }
         num = 880000000ULL;   /* 1e9 * 0.88 (PB safe envelope) */
-    } else if (armed == 0u && isJson == 0u) {
+    } else if (armed == 0u && isJson == 0u
+               && voltagePrecision <= STREAMING_CSV_REFIT_MAX_PRECISION) {
         /* #832 (2026-08-23): pure-T1 CSV/CsvCompact, re-fitted at 252 MHz AND
          * at CONF:VOLTage:PRECision 4 -- the NQ1 SHIPPED DEFAULT.
          *
@@ -215,6 +223,18 @@ static inline uint32_t Streaming_AdcAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2us
          * basis is #529 follow-up work. CsvCompact IS included: it emits
          * strictly fewer bytes per row than CSV (#619), so a CSV-fitted cap is
          * never-over for it. */
+        /* PRECISION-GATED. The basis is precision 4, and precision changes how
+         * much work csv_encoder does per value, so the raise may only be
+         * applied where the encoder is no more expensive than it was when
+         * measured:
+         *   0      integer fast path (int_to_str) -- strictly cheaper.
+         *   1..4   same float path, FEWER OR EQUAL characters emitted.
+         *   5..10  MORE characters per value, and NOT measured.
+         * So >4 falls through to the #563 law, which is unchanged and already
+         * safe at every precision. Without this gate a user who set precision
+         * 7 or 10 on an NQ1 would get a cap fitted for a cheaper encoder --
+         * an over-cap of exactly the kind this ticket exists to prevent, just
+         * reached through a setting instead of through a fit. */
         if (nT1 <= 1u) {
             /* 52412 ns -> 800e6/52412 = 15263 Hz. The MINIMAL never-over
              * period is 52411 (the fit recipe prints that); both floor to the

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -57,7 +57,7 @@ extern "C" {
 // override it. NQ1 note: the ADC additive model binds T1-only cells below this
 // anyway; NQ2/NQ3's legacy formula keeps its own 16000 start via
 // STREAMING_ISR_MAX_HZ_LEGACY below.
-// #832: the highest CONF:VOLTage:PRECision the pure-T1 CSV refit was measured
+// #832: the highest CONFigure:VOLTage:PRECision the pure-T1 CSV refit was measured
 // at, and therefore the highest it may be applied at. NQ1's shipped default is
 // 4; 0..3 drive an encoder that is cheaper or equal (0 is int_to_str, 1..3 emit
 // fewer characters), so the precision-4 basis is never-over for them. 5..10
@@ -123,7 +123,7 @@ static inline uint32_t Streaming_ComputeMaxFreq(uint32_t type1Count, uint32_t to
  * armed OBDiag-off, and OBDiag-on (the last keeps the #563 coefficients,
  * 600 s at-cap revalidated) — because a single additive law under-fit the
  * grid (tightness 0.74). CSV keeps the #563 single law EXCEPT for the pure-T1
- * (no-scan) class, which #832 re-fitted at 252 MHz and at CONF:VOLT:PRECision 4
+ * (no-scan) class, which #832 re-fitted at 252 MHz and at CONFigure:VOLTage:PRECision 4
  * -- the NQ1 shipped default, and a materially more expensive encoder path than
  * the precision-0 integer fast path every earlier CSV basis was measured on.
  * JSON shares the CSV branch but is EXCLUDED from that refit (see below).
@@ -173,7 +173,7 @@ static inline uint32_t Streaming_AdcAdditiveCap_NQ1(uint32_t nT1, uint32_t nT2us
     } else if (armed == 0u && isJson == 0u
                && voltagePrecision <= STREAMING_CSV_REFIT_MAX_PRECISION) {
         /* #832 (2026-08-23): pure-T1 CSV/CsvCompact, re-fitted at 252 MHz AND
-         * at CONF:VOLTage:PRECision 4 -- the NQ1 SHIPPED DEFAULT.
+         * at CONFigure:VOLTage:PRECision 4 -- the NQ1 SHIPPED DEFAULT.
          *
          * WHY PRECISION IS NAMED HERE. csv_encoder takes an integer fast path
          * (int_to_str) at precision 0 and formats a float per channel per


### PR DESCRIPTION
Refs #832. Companion test: daqifi/daqifi-python-test-suite#236.

`Streaming_AdcAdditiveCap_NQ1`'s non-PB branch is the #563 single law, fitted
before the 252 MHz clock change, and it **binds every pure-T1 CSV cell** — the
#712 USB CSV transport curve sits far above it (20000 at n=1). At one channel
it capped CSV at `800e6/(71000+4550)` = **10,589 Hz** against a measured
ceiling of **16,413**.

**USB CSV 1×T1 OBDiag=0: 10,589 → 15,263 Hz (+44.1%).** CsvCompact rides with
it (strictly fewer bytes per row, #619). Nothing else moves.

## Precision is why the first attempt at this ticket failed

`csv_encoder` takes an integer fast path (`int_to_str`) at precision **0** and
formats a float per channel per sample at **4** — the NQ1 **shipped** default.
The earlier fit for #832 was built on ceilings measured with the bench board's
NVM at 0, and the device then dropped **21,286 samples at its own new cap**:
the #714/#715 failure mode, arrived at through the *instrument* rather than
through the fit. An A/B at one rate measured precision 0 clean against
precision 4 losing **10.8 %**, at byte rates within 1 % of each other —
encoder CPU, not bandwidth.

This basis is measured with precision **pinned to 4 and recorded per row** as
`precision_actual` (test-suite #233 / PR #235), 600 s freeze-aware soaks
(`ScanStaleDropped` and `T1ArdyMisses` both count as loss), real ADC, OBDiag
off, USB, board `7E2898F46200E8A7`:

| nT1 | highest clean | first FAIL | bounded by |
|----:|--------------:|-----------:|---|
| 1 | **16,413** | 17,472 | `T1ArdyMisses` 845 |
| 3 | **12,285** | 13,230 | `T1ArdyMisses` 228 |
| 5 | **9,386** | 10,240 | `T1ArdyMisses` 5 |

Every ceiling is bounded by `T1ArdyMisses` — the ARDY-gated direct read missing
a conversion (#541) — **not** by a transport drop. So this genuinely is an
ADC-side term and belongs in this model rather than the transport one.

## Why only nT1 == 1 moves

n=3 and n=5 have real headroom (12,285 against an enforced 9,450; 9,386 against
8,533), but **n=2 and n=4 were not measured**. Bracketing them by the nearest
measured ceiling *above* — ceilings fall monotonically with channel count, so
C4 >= C5 — puts n=4's never-over bound at 0.93 x 9,386 = **8,729**, which is
*below* its currently enforced **8,968**. Any line covering n>=2 would
therefore have to **regress** n=4 to stay never-over, and raising it instead
would be exactly the unmeasured guess this ticket exists to prevent. n=4 is not
over-capped today (8,968 <= 9,386); there is simply no basis to move it.

The fit recipe reports this itself rather than leaving it as prose —
`refit_832_csv_additive.py --single 1:16413 3:12285 5:9386`:

```
SINGLE-CASE period_ns(1) = 52411  -> cap 15263 (93.0% of measured 16413, +44.1% vs 10589)

n>=2: NO ADMISSIBLE CURVE -- leaving the #563 law in place.
  n=4: need period in [91649, 89206]  (bracketed by <=9386, enforced 8968)  <-- empty window
```

The single-channel special case follows `Streaming_TransportMaxFreq`'s own
stated reason: *"1-channel sits far above the multi-channel curve, which a
single A/(B+n) cannot hug"*.

## JSON is excluded, deliberately

JSON shares this branch, and at USB 1ch **the additive is its binding term**
(10,589, below its own #529/#831 transport single of 11,000). Raising the
shared branch would lift JSON's enforced cap on the strength of a CSV
measurement — and JSON has never been characterised at precision 4. So the
function takes an `isJson` flag as a **fifth parameter**, chosen so a missed
call site is a *compile error* rather than a silent behaviour change, and JSON
keeps the #563 law untouched. Its precision-4 basis is #529 follow-up work.

## Verified on hardware

Built, flashed to `7E2898F46200E8A7` (`-TSBUR184882598`), crc32 `62067B0C` ->
**`D053CB19`**.

Device-reported caps — the raise is exactly as scoped:

```
CSV  1xT1 OBD0 15263  <- RAISED     JSON 1xT1 OBD0 10589  <- NOT raised
CSV  3xT1       9450  unchanged     JSON 5xT1 OBD0  4571  unchanged
CSV  5xT1 OBD0  8533  unchanged     PB   1xT1 OBD0 15798  unchanged
CSV  1xT2       7442  unchanged     CCMP 1xT1 OBD0 15263  <- rides with CSV
CSV  5xT2       4754  unchanged
CSV  10ch       4188  unchanged
CSV  16ch       2835  unchanged
CSV  1xT1 OBD1  6919  unchanged (armed=1)
```

**At-cap validation on the flashed image, 600 s each, precision 4, real ADC**
(`benchmarks/atcap_20260823_091734.csv`) — the check #714/#715 exists to force,
and which the first attempt at this ticket failed:

| config | cap | fw_sps | KB/s | qd | usb | enc | stale | ardy | |
|---|--:|--:|--:|--:|--:|--:|--:|--:|---|
| 1xT1 OBD=OFF | **15,263** | 15,261 | 264.3 | 0 | 0 | 0 | 0 | 0 | **PASS** |
| 3xT1 | 9,450 | 9,442 | 490.6 | 0 | 0 | 0 | 0 | 0 | PASS (no-regress control) |
| 5xT1 OBD=OFF | 8,533 | 8,529 | 738.7 | 0 | 0 | 0 | 0 | 0 | PASS (no-regress control) |

Every counter zero, at the shipped default precision.

CLAUDE.md gains the precision warning, because the trap is general: any cap
work that does not pin `CONFigure:VOLTage:PRECision` is measuring whatever
encoder path the board happened to be left in.
