### PR TITLE
fix(streaming): re-validate the cap at arm time, and guard the two unguarded cap inputs (#844)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3371,6 +3371,16 @@ static bool SCPI_QuiesceAndResetCoherentPool(void) {
     return true;
 }
 
+/* #844: bumped on every accepted SYST:STR:INT store. SCPI_StartStreaming pins
+ * it alongside ActiveInterface so its arm-time check catches an A->B->A
+ * sequence: comparing the VALUE alone passes if the interface is put back,
+ * even though the buffer partition in between was carved for B (WiFi would
+ * then stream through the 1400-byte inactive ring instead of its 96 KB one).
+ * Written only inside the setter's critical section, so the RMW is safe;
+ * 32-bit reads are atomic on PIC32MZ. Wrap is harmless -- it would take 2^32
+ * interface changes inside one START. */
+static volatile uint32_t gStreamIfaceGen = 0;
+
 static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     int32_t freq;
 
@@ -3642,11 +3652,19 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
      * re-validation refuses on a mismatch; see the arm site for the concrete
      * failure it prevents. */
     const StreamingInterface ifaceAtSetup = pRunTimeStreamConfig->ActiveInterface;
+    const uint32_t ifaceGenAtSetup = gStreamIfaceGen;
     bool sdLoggingRequested = (ifaceAtSetup != StreamingInterface_WiFi) &&
                               pSDCardSettings != NULL && pSDCardSettings->enable &&
                               pSDCardSettings->file[0] != '\0';
 
-    if (pRunTimeStreamConfig->ActiveInterface == StreamingInterface_WiFi &&
+    /* ifaceAtSetup, not a fresh read: every setup-phase decision must be made
+     * against the SAME interface value, or two of them can disagree. A live
+     * read here could see WiFi while sdLoggingRequested one line above was
+     * computed for USB, refusing a start for a conflict that does not apply to
+     * the interface actually being set up (Qodo, importance 9). The arm site
+     * is the one place that deliberately reads it live -- comparing against
+     * this pin is the whole point there. */
+    if (ifaceAtSetup == StreamingInterface_WiFi &&
         pSDCardSettings != NULL && pSDCardSettings->enable &&
         pSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
         LOG_E("Cannot start WiFi streaming while SD logging is active (SPI bus conflict)");
@@ -3976,7 +3994,15 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
      * against the SD cap and arms -- with the SD manager still in mode NONE.
      * streaming_Task then writes to neither SD nor WiFi, and START returns OK
      * on a session that emits nothing at all. */
-    if (pRunTimeStreamConfig->ActiveInterface != ifaceAtSetup) {
+    if (pRunTimeStreamConfig->ActiveInterface != ifaceAtSetup ||
+        gStreamIfaceGen != ifaceGenAtSetup) {
+        /* The generation is what makes this an ABA-proof test. Comparing the
+         * value alone accepts A->B->A, and the partition carved in the middle
+         * of that -- PrepareStreamingBuffers reads ActiveInterface to size the
+         * rings -- would be the one for B. The session would then stream over
+         * A through B's buffers: WiFi on the 1400-byte inactive ring rather
+         * than its 96 KB one, or SD on the 4 KB inactive circular buffer, at a
+         * rate the cap admitted for the real partition. */
         ifaceMoved = true;
     } else if (Streaming_GetBenchmarkMode() == BENCHMARK_OFF) {
         revalidatedMax = Streaming_ComputeMaxFreqForConfig();
@@ -4429,6 +4455,7 @@ static scpi_result_t SCPI_SetStreamInterface(scpi_t * context) {
         rejectWifiDuringSdWrite = true;
     } else {
         pRunTimeStreamConfig->ActiveInterface = (StreamingInterface) param1;
+        gStreamIfaceGen++;      /* #844: see the counter's declaration */
     }
     taskEXIT_CRITICAL();
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3890,7 +3890,61 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         }
     }
 
-    pRunTimeStreamConfig->IsEnabled = true;
+    /* #844: re-validate the cap against the configuration actually being armed.
+     *
+     * The admitting check ~340 lines above runs while IsEnabled is still false,
+     * and every "reject while streaming" guard on a cap input keys off
+     * `IsEnabled || Running` -- so for that whole window (which contains
+     * multi-second vTaskDelay polls on the SD path) those guards read false and
+     * a command on the OTHER SCPI transport can move an input to the cap. The
+     * session would then arm at a rate admitted against a configuration it no
+     * longer has. Every cap-input guard shares this window: CONF:ADC:CHANnel
+     * (#116), USECal (#158/#270), OBDiag/SAMC, SYST:STR:FORmat, and
+     * CONF:VOLTage:PRECision / :LOAD (#832).
+     *
+     * The recompute, the comparison and the store share ONE critical section
+     * because recomputing alone would only SHRINK the window: a START hosted on
+     * the WiFi task (pri 2) can be preempted by USB SCPI (pri 7) at any
+     * instruction boundary. Holding interrupts off across the computation is
+     * legal and affordable -- it is integer-only and non-blocking (two bounded
+     * channel-array walks plus 64-bit arithmetic; no locks, logging, waits or
+     * SFR writes) and runs once per START. Once IsEnabled is published the
+     * ordinary guards take over, so Streaming_UpdateState() stays outside.
+     *
+     * Benchmark mode bypasses this exactly as it bypasses the front door; the
+     * resulting asymmetry is the correct direction (benchmark turned OFF inside
+     * the window means an uncapped rate now faces the real cap).
+     *
+     * Logging and the SCPI error stay OUTSIDE the section (the #759 pattern). */
+    bool capRevoked = false;
+    uint32_t revalidatedMax = 0;
+    taskENTER_CRITICAL();
+    if (Streaming_GetBenchmarkMode() == BENCHMARK_OFF) {
+        revalidatedMax = Streaming_ComputeMaxFreqForConfig();
+        /* freq >= 1 was validated above, so the unsigned compare is exact and,
+         * unlike the front door's (int32_t) cast, cannot misread a cap above
+         * INT32_MAX as negative. */
+        capRevoked = ((uint32_t)freq > revalidatedMax);
+    }
+    if (!capRevoked) {
+        pRunTimeStreamConfig->IsEnabled = true;
+    }
+    taskEXIT_CRITICAL();
+
+    if (capRevoked) {
+        /* Mirror the SD aborts immediately above: never leave a logging file
+         * open behind a start that did not happen (#690). */
+        if (sdLoggingRequested) {
+            pSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
+            sd_card_manager_UpdateSettings(pSDCardSettings);
+        }
+        LOG_E("STR:START refused (#844): config changed during start - %d Hz now "
+              "exceeds max %u Hz. Re-read CONF:CAP:JSON? and retry",
+              (int)freq, (unsigned)revalidatedMax);
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
+
     Streaming_UpdateState();
 
     // Update STATus:OPERation condition register

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3985,6 +3985,12 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     bool capRevoked = false;
     bool ifaceMoved = false;
     uint32_t revalidatedMax = 0;
+    /* Captured INSIDE the section so the refusal log names the value that
+     * actually triggered the decision. Re-reading it for the message after
+     * taskEXIT_CRITICAL can print a THIRD interface -- whatever a later
+     * command set -- which is precisely the wrong thing to hand someone
+     * debugging this refusal (Qodo). */
+    StreamingInterface ifaceObserved = ifaceAtSetup;
     taskENTER_CRITICAL();
     /* The interface must still be the one everything above was set up for.
      * The rate check alone does not catch this, because the new interface's
@@ -3994,7 +4000,8 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
      * against the SD cap and arms -- with the SD manager still in mode NONE.
      * streaming_Task then writes to neither SD nor WiFi, and START returns OK
      * on a session that emits nothing at all. */
-    if (pRunTimeStreamConfig->ActiveInterface != ifaceAtSetup ||
+    ifaceObserved = pRunTimeStreamConfig->ActiveInterface;
+    if (ifaceObserved != ifaceAtSetup ||
         gStreamIfaceGen != ifaceGenAtSetup) {
         /* The generation is what makes this an ABA-proof test. Comparing the
          * value alone accepts A->B->A, and the partition carved in the middle
@@ -4023,7 +4030,7 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         }
         LOG_E("STR:START refused (#844): stream interface changed during start "
               "(%d -> %d); the SD/buffer setup no longer matches. Retry.",
-              (int)ifaceAtSetup, (int)pRunTimeStreamConfig->ActiveInterface);
+              (int)ifaceAtSetup, (int)ifaceObserved);
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         return SCPI_RES_ERR;
     }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4348,9 +4348,22 @@ static scpi_result_t SCPI_SetStreamInterface(scpi_t * context) {
      * Logging and the SCPI error stay OUTSIDE the section. */
     bool rejectSdNotEnabled = false;
     bool rejectWifiDuringSdWrite = false;
+    bool rejectStreaming = false;
 
     taskENTER_CRITICAL();
-    if ((param1 == StreamingInterface_SD ||
+    if (pRunTimeStreamConfig->IsEnabled || pRunTimeStreamConfig->Running) {
+        /* #844: ActiveInterface is a CAP INPUT -- Streaming_ComputeMaxFreqForConfig
+         * selects the whole transport term from it -- and it was the one such
+         * input with no stream-state guard at all. Without this, a running
+         * session could be redirected mid-flight (SYST:STR:INT 1 on a 15 kHz
+         * USB PB stream re-points it at WiFi, whose 1-channel PB cap is far
+         * lower) with buffers still partitioned for the old interface: the cap
+         * that admitted the session no longer describes where its bytes go.
+         *
+         * Inside the SAME critical section as the test-and-publish below, so
+         * the refusal cannot itself race the store it guards. */
+        rejectStreaming = true;
+    } else if ((param1 == StreamingInterface_SD ||
          param1 == StreamingInterface_UsbAndSd) && !pSDCardSettings->enable) {
         // Cannot stream to a card that is not enabled.
         rejectSdNotEnabled = true;
@@ -4366,6 +4379,12 @@ static scpi_result_t SCPI_SetStreamInterface(scpi_t * context) {
     }
     taskEXIT_CRITICAL();
 
+    if (rejectStreaming) {
+        LOG_E("Stream interface change rejected: streaming is active "
+              "(stop streaming first)");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
     if (rejectSdNotEnabled) {
         LOG_E("Cannot set SD/USB+SD interface - SD card not enabled. Use SYSTem:STORage:SD:ENAble 1");
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3984,6 +3984,7 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
      * Logging and the SCPI error stay OUTSIDE the section (the #759 pattern). */
     bool capRevoked = false;
     bool ifaceMoved = false;
+    bool inputsGone = false;
     uint32_t revalidatedMax = 0;
     /* Captured INSIDE the section so the refusal log names the value that
      * actually triggered the decision. Re-reading it for the message after
@@ -4000,8 +4001,30 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
      * against the SD cap and arms -- with the SD manager still in mode NONE.
      * streaming_Task then writes to neither SD nor WiFi, and START returns OK
      * on a session that emits nothing at all. */
+    /* The other admission check START made up front: at least one input. It
+     * can be taken away inside the window too -- DIO:PORT:ENABLE 0 on a
+     * DIO-only session is the reachable case, since SCPI_GPIOEnableSet has no
+     * stream-state guard and IsEnabled is still false. The cap recompute below
+     * cannot catch it: Streaming_ComputeMaxFreqForConfig ignores DIO entirely
+     * and returns a perfectly healthy max for zero analog channels, so the
+     * session would arm and then emit nothing at all -- the same "START says
+     * OK, nothing comes out" failure as the interface case (merge-gate audit).
+     *
+     * With this, the arm re-checks every admission test START performed up
+     * front: inputs exist, the interface is the one that was set up, and the
+     * rate is still admissible. */
+    {
+        uint16_t t1Now = 0, totNow = 0;
+        Streaming_CountActiveChannels(&t1Now, &totNow, NULL);
+        bool dioNow = (pDIOGlobalEnable != NULL && *pDIOGlobalEnable);
+        if (totNow == 0u && !dioNow) {
+            inputsGone = true;
+        }
+    }
     ifaceObserved = pRunTimeStreamConfig->ActiveInterface;
-    if (ifaceObserved != ifaceAtSetup ||
+    if (inputsGone) {
+        /* handled below; skip the rest so the reasons stay mutually exclusive */
+    } else if (ifaceObserved != ifaceAtSetup ||
         gStreamIfaceGen != ifaceGenAtSetup) {
         /* The generation is what makes this an ABA-proof test. Comparing the
          * value alone accepts A->B->A, and the partition carved in the middle
@@ -4018,10 +4041,21 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
          * INT32_MAX as negative. */
         capRevoked = ((uint32_t)freq > revalidatedMax);
     }
-    if (!capRevoked && !ifaceMoved) {
+    if (!capRevoked && !ifaceMoved && !inputsGone) {
         pRunTimeStreamConfig->IsEnabled = true;
     }
     taskEXIT_CRITICAL();
+
+    if (inputsGone) {
+        if (sdLoggingRequested) {
+            pSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
+            sd_card_manager_UpdateSettings(pSDCardSettings);
+        }
+        LOG_E("STR:START refused (#844): every ADC and DIO input was disabled "
+              "during start - nothing left to stream");
+        SCPI_ErrorPush(context, SCPI_ERROR_SETTINGS_CONFLICT);
+        return SCPI_RES_ERR;
+    }
 
     if (ifaceMoved) {
         if (sdLoggingRequested) {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2048,7 +2048,17 @@ static scpi_result_t SCPI_SetBenchmarkMode(scpi_t * context) {
     // Block changes while streaming
     StreamingRuntimeConfig* pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
-    if (pStreamCfg->IsEnabled && pStreamCfg->Running) {
+    /* #844: `||`, not `&&` -- this guard was the one holdout from the form
+     * every other stream-state guard uses (#116 and its mirrors all say so
+     * explicitly). IsEnabled and Running are set in SEPARATE steps at start,
+     * so an `&&` test reads false for the whole interval between them, and
+     * SYST:STR:BENCH lands in it: the START has already committed the rate
+     * that benchmark mode admitted, and flipping the mode there leaves the
+     * session running with a benchmark-only rate while reporting itself as a
+     * normal capped session. Refusing in the transition window costs nothing
+     * -- SYST:STR:THRoughput restores the mode through
+     * Streaming_SetBenchmarkMode directly, not through this callback. */
+    if (pStreamCfg->IsEnabled || pStreamCfg->Running) {
         SCPI_ExecutionError(context, "SYST:STR:BENCH: cannot change while streaming");
         return SCPI_RES_ERR;
     }
@@ -3914,6 +3924,14 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
      * Benchmark mode bypasses this exactly as it bypasses the front door; the
      * resulting asymmetry is the correct direction (benchmark turned OFF inside
      * the window means an uncapped rate now faces the real cap).
+     *
+     * SCOPE -- this closes the RATE hazard, not the whole window. A change that
+     * leaves the cap UNCHANGED still gets through: swapping AIN0 for AIN1 keeps
+     * the channel count, so the recomputed cap matches and the start is
+     * admitted while gChannelMapping (built ~500 lines up) still describes the
+     * old set. That mislabels CSV columns and needs a mapping fingerprint
+     * rather than a cap comparison -- tracked as #846. Do not read the
+     * critical section below as making the window safe for every input.
      *
      * Logging and the SCPI error stay OUTSIDE the section (the #759 pattern). */
     bool capRevoked = false;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4461,8 +4461,16 @@ static scpi_result_t SCPI_SetStreamInterface(scpi_t * context) {
          * (no WiFi), so no check needed for All. */
         rejectWifiDuringSdWrite = true;
     } else {
-        pRunTimeStreamConfig->ActiveInterface = (StreamingInterface) param1;
-        gStreamIfaceGen++;      /* #844: see the counter's declaration */
+        /* Bump ONLY on a real change. Counting a redundant write (SYST:STR:INT
+         * set to the value it already has -- clients do this routinely) would
+         * make START's arm-time check conclude the interface moved and refuse
+         * a perfectly good start. ABA detection is unaffected: A->B->A is two
+         * REAL changes and still bumps twice (Qodo). */
+        StreamingInterface newIface = (StreamingInterface) param1;
+        if (pRunTimeStreamConfig->ActiveInterface != newIface) {
+            pRunTimeStreamConfig->ActiveInterface = newIface;
+            gStreamIfaceGen++;      /* #844: see the counter's declaration */
+        }
     }
     taskEXIT_CRITICAL();
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2058,11 +2058,28 @@ static scpi_result_t SCPI_SetBenchmarkMode(scpi_t * context) {
      * normal capped session. Refusing in the transition window costs nothing
      * -- SYST:STR:THRoughput restores the mode through
      * Streaming_SetBenchmarkMode directly, not through this callback. */
+    /* Test and store in ONE critical section. The `||` above closes the window
+     * on START's side; this closes it on THIS side. Without it the sequence
+     * inverts: this task reads the flags as idle, a START on the OTHER SCPI
+     * transport preempts it (USB is pri 7, WiFi pri 2, so either can preempt
+     * the other) and arms a session, and the write below then lands on a
+     * RUNNING stream -- the very state the guard exists to refuse. A guard
+     * that only reads is half a guard.
+     *
+     * The SCPI error is raised outside the section (the #759 pattern). */
+    bool rejectStreaming = false;
+    taskENTER_CRITICAL();
     if (pStreamCfg->IsEnabled || pStreamCfg->Running) {
+        rejectStreaming = true;
+    } else {
+        Streaming_SetBenchmarkMode((uint32_t)val);
+    }
+    taskEXIT_CRITICAL();
+
+    if (rejectStreaming) {
         SCPI_ExecutionError(context, "SYST:STR:BENCH: cannot change while streaming");
         return SCPI_RES_ERR;
     }
-    Streaming_SetBenchmarkMode((uint32_t)val);
     return SCPI_RES_OK;
 }
 
@@ -3618,7 +3635,14 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
      * card is enabled and a filename is set. */
     sd_card_manager_settings_t* pSDCardSettings =
         BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
-    bool sdLoggingRequested = (pRunTimeStreamConfig->ActiveInterface != StreamingInterface_WiFi) &&
+    /* #844: remember WHICH interface the setup below is being done for. The
+     * whole rest of START -- sdLoggingRequested, the SD file open, the buffer
+     * partition -- is derived from this value, so if it moves before the arm,
+     * that setup describes an interface the session is no longer using. The
+     * re-validation refuses on a mismatch; see the arm site for the concrete
+     * failure it prevents. */
+    const StreamingInterface ifaceAtSetup = pRunTimeStreamConfig->ActiveInterface;
+    bool sdLoggingRequested = (ifaceAtSetup != StreamingInterface_WiFi) &&
                               pSDCardSettings != NULL && pSDCardSettings->enable &&
                               pSDCardSettings->file[0] != '\0';
 
@@ -3925,29 +3949,58 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
      * resulting asymmetry is the correct direction (benchmark turned OFF inside
      * the window means an uncapped rate now faces the real cap).
      *
-     * SCOPE -- this closes the RATE hazard, not the whole window. A change that
-     * leaves the cap UNCHANGED still gets through: swapping AIN0 for AIN1 keeps
-     * the channel count, so the recomputed cap matches and the start is
-     * admitted while gChannelMapping (built ~500 lines up) still describes the
-     * old set. That mislabels CSV columns and needs a mapping fingerprint
-     * rather than a cap comparison -- tracked as #846. Do not read the
-     * critical section below as making the window safe for every input.
+     * SCOPE -- this closes the RATE hazard from START's side, and not more
+     * than that. Two neighbours remain, both tracked, and neither is a reason
+     * to read the section below as making the window safe:
+     *   - A CAP-NEUTRAL change still gets through: swapping AIN0 for AIN1 keeps
+     *     the channel count, so the recomputed cap matches and the start is
+     *     admitted while gChannelMapping (built ~500 lines up) still describes
+     *     the old set. That mislabels CSV columns and needs a mapping
+     *     fingerprint rather than a cap comparison -- #846.
+     *   - The SETTER side is the same window inverted: a cap-input setter that
+     *     has read the flags as idle can be PREEMPTED by a START on the other
+     *     transport and store afterwards, onto a session this code just armed.
+     *     The two setters this change touches (SYST:STR:BENCH, SYST:STR:INT)
+     *     now test-and-store atomically; the seven older ones do not -- #847.
      *
      * Logging and the SCPI error stay OUTSIDE the section (the #759 pattern). */
     bool capRevoked = false;
+    bool ifaceMoved = false;
     uint32_t revalidatedMax = 0;
     taskENTER_CRITICAL();
-    if (Streaming_GetBenchmarkMode() == BENCHMARK_OFF) {
+    /* The interface must still be the one everything above was set up for.
+     * The rate check alone does not catch this, because the new interface's
+     * cap can be perfectly happy with the requested rate: a WiFi START whose
+     * ActiveInterface is switched to SD inside the window skips the SD setup
+     * (sdLoggingRequested was computed false for WiFi), then admits 1000 Hz
+     * against the SD cap and arms -- with the SD manager still in mode NONE.
+     * streaming_Task then writes to neither SD nor WiFi, and START returns OK
+     * on a session that emits nothing at all. */
+    if (pRunTimeStreamConfig->ActiveInterface != ifaceAtSetup) {
+        ifaceMoved = true;
+    } else if (Streaming_GetBenchmarkMode() == BENCHMARK_OFF) {
         revalidatedMax = Streaming_ComputeMaxFreqForConfig();
         /* freq >= 1 was validated above, so the unsigned compare is exact and,
          * unlike the front door's (int32_t) cast, cannot misread a cap above
          * INT32_MAX as negative. */
         capRevoked = ((uint32_t)freq > revalidatedMax);
     }
-    if (!capRevoked) {
+    if (!capRevoked && !ifaceMoved) {
         pRunTimeStreamConfig->IsEnabled = true;
     }
     taskEXIT_CRITICAL();
+
+    if (ifaceMoved) {
+        if (sdLoggingRequested) {
+            pSDCardSettings->mode = SD_CARD_MANAGER_MODE_NONE;
+            sd_card_manager_UpdateSettings(pSDCardSettings);
+        }
+        LOG_E("STR:START refused (#844): stream interface changed during start "
+              "(%d -> %d); the SD/buffer setup no longer matches. Retry.",
+              (int)ifaceAtSetup, (int)pRunTimeStreamConfig->ActiveInterface);
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
 
     if (capRevoked) {
         /* Mirror the SD aborts immediately above: never leave a logging file

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -666,9 +666,12 @@ uint32_t Streaming_ComputeMaxFreqForConfigIface(StreamingInterface iface) {
      * configuration that never existed.
      *
      * One read cannot be internally inconsistent (32-bit loads are atomic on
-     * PIC32MZ). This does not close the wider start-window race -- that is
-     * #844, and it needs a re-validate-before-arming change to the START path
-     * -- but a single computation contradicting itself costs nothing to fix. */
+     * PIC32MZ). The wider start-window race -- an input moving between START's
+     * admitting check and the arm -- is a separate problem, closed since #844
+     * by re-validating this function's result inside the same critical section
+     * that publishes IsEnabled (SCPI_StartStreaming). Both fixes are needed:
+     * this one keeps a single computation self-consistent, #844 keeps the
+     * admitted computation true of the session that actually starts. */
     StreamingEncoding enc = sc->Encoding;
 
     uint32_t maxFreq;


### PR DESCRIPTION
Fixes #844.

## The bug

`SCPI_StartStreaming` computes the frequency cap at `SCPIInterface.c:3556` and publishes `IsEnabled = true` ~340 lines later. Every "reject while streaming" guard on a **cap input** keys off `IsEnabled || Running` — so for that entire window, which contains multi-second `vTaskDelay` polls on the SD path, those guards read **false**.

Two live SCPI control sessions is a supported configuration (USB pri 7 and WiFi pri 2 both run SCPI), so a command arriving on the *other* transport in that window is accepted, moves an input to the cap, and START then arms the session at a rate that was admitted against a configuration it no longer has.

This is a property of the idiom, not of any one setter: `CONF:ADC:CHANnel` (#116), `CONF:ADC:USECal` (#158/#270), `CONF:ADC:OBDiag`/`SAMC`, `SYST:STR:FORmat`, and `CONF:VOLTage:PRECision`/`:LOAD` (#832) all share it. Found by the adversarial audit on [PR #843 — pure-T1 single-channel CSV cap re-fit](https://github.com/daqifi/daqifi-nyquist-firmware/pull/843).

## What this PR does

**1. Re-validate the cap against the configuration actually being armed.** Recompute, compare, and publish `IsEnabled` inside **one** critical section; refuse the start if the fresh cap no longer admits the rate.

Recomputing alone would only *shrink* the window: a START hosted on the WiFi task (pri 2) can be preempted by USB SCPI (pri 7) at any instruction boundary. Holding interrupts off across the computation is legal and affordable — it is integer-only and non-blocking (two bounded channel-array walks plus 64-bit arithmetic; **no locks** — `BoardConfig_Get`/`BoardRunTimeConfig_Get` are plain switches over statics — no logging, no waits, no SFR writes) and runs once per START, on a path that has already spent far longer waiting on SD.

Details worth calling out: benchmark mode bypasses this exactly as it bypasses the front door (and the asymmetry runs the safe way — benchmark turned *off* inside the window means an uncapped rate now faces the real cap); the refusal tears down an armed SD log, mirroring the aborts above it (#690); and the comparison is unsigned, since `freq >= 1` is already validated, so unlike the front door's `(int32_t)` cast it cannot misread a cap above `INT32_MAX` as negative.

**2. `SYST:STR:BENCH` used `IsEnabled && Running`** — the one holdout from the `||` form every sibling uses. The two flags are set in separate steps, so `&&` reads false for the whole start transition, and flipping benchmark mode there leaves a session running at a benchmark-only rate while reporting itself as normally capped.

**3. A START could arm a session with no output sink.** Everything START does after the cap check is derived from `ActiveInterface` — `sdLoggingRequested`, the SD file open, the buffer partition — and nothing pinned that value. A WiFi START (so `sdLoggingRequested` computed false) with `SYST:STR:INT 2` landing in its window skips the SD setup entirely, then re-validates 1000 Hz against the *SD* cap, which happily admits it, and arms with the SD manager still in mode `NONE`. `streaming_Task` then writes to neither SD nor WiFi: START returns OK, `Running` goes true, and the session emits nothing at all. The rate check could never catch this, because the rate was never the problem. `ActiveInterface` is now pinned where `sdLoggingRequested` is computed, and the arm refuses on a mismatch.

The one other writer of `ActiveInterface` in that span is the #759 SD release helper (`streaming.c:2442`), which falls back to USB when the card goes away mid-start. Refusing there is correct and is not a new refusal class: the pre-existing `!IsWriteReady()` abort already fails that start — this just catches it earlier and names the cause.

**4. `SYST:STR:INTerface` had no guard at all.** `ActiveInterface` is a cap input — `Streaming_ComputeMaxFreqForConfig` selects the entire transport term from it — so a running session could be re-pointed mid-flight (`SYST:STR:INT 1` on a 15 kHz USB PB stream sends it to WiFi, whose 1-channel PB cap is far lower) with buffers still partitioned for the old interface. This one also disproved a claim in the #844 comment itself: "once `IsEnabled` is published the ordinary guards take over" was not true of the input that had no guard. It is now.

Both guards now **test and store in one critical section**, not just test: guarding with `||` closes the window on START's side, but without atomicity the sequence simply inverts — the setter reads the flags as idle, a START on the other transport preempts it and arms, and the write lands on a running stream. A guard that only reads is half a guard.

Neither guard can lock anything out: `SCPI_StopStreaming` clears `IsEnabled` unconditionally and is itself ungated.

## What this PR deliberately does *not* fix — [#846](https://github.com/daqifi/daqifi-nyquist-firmware/issues/846)

The audit found two **cap-neutral** live inputs in the same family. Both are real, both are pre-existing, and neither is a cap problem:

- Swapping AIN0 for AIN1 keeps the channel count, so the recomputed cap matches and the start is admitted while `gChannelMapping` still describes the old set. `csv_encoder` reads the runtime config for the header (`:321`/`:596`) and the mapping for the data (`:381`), so the header names one channel and the rows carry another.
- `DIO:PORT:ENABLE` mid-session changes the CSV row shape under an already-emitted header (`SCPIDIO.c` `SCPI_GPIOEnableSet`, no guard).

Both need framing-level fixes (a mapping fingerprint; a DIO guard with its own bench validation) rather than an extension of the cap comparison, so they are filed on #846 with repros rather than bolted on here.

Separately, [#847](https://github.com/daqifi/daqifi-nyquist-firmware/issues/847) records the **setter-side** race in the seven older cap-input setters: each reads `IsEnabled || Running` and stores later, so a START can preempt between the two and the store lands on a running session. Both the audit and Qodo found it independently. It is pre-existing, this PR does not widen it, and two of the nine setters are now atomic — but the remaining seven are a mechanical refactor across two files that wants its own bench validation (and `CONF:VOLT:LOAD` does flash I/O, which must not go inside a critical section).

The code comment names #846 and #847 at the critical section, so it is not read as closing more than it does.

Finally, [#848](https://github.com/daqifi/daqifi-nyquist-firmware/issues/848) records two more, found by the merge-gate audit and **neither introduced nor worsened here**: START's own interface auto-detect can retarget an already-*running* session before a later check rejects the second START (it bypasses the setter guard because it lives inside START), and every refusal path — the pre-existing SD aborts included — leaves the rejected `Frequency`/`ClockPeriod` committed, so a later no-argument START reuses a rate that was refused. Both are START mutating shared state before it knows the start is accepted; fixing either uniformly is its own change.

## Bench validation — A/B, one instrument, board `7E2898F46200E8A7`, NQ1 @252 MHz

| build | crc32 | race arm | result |
|---|---|---|---|
| pre-#844 | `70DB256E` (bit-identical to merged `main`) | the session **armed** and its rows carry **10 decimal places** — it really ran a precision-10 encoder at 15,263 Hz, a rate admitted only for precision 4 (cap at 10 is 10,589). 162,675 B streamed, **no error raised** | **11 PASS / 1 FAIL** |
| final | `04E547F0` | start **refused `-222`**, 0 B on the wire, nothing armed | **12 PASS / 0 FAIL** |

The verdict is read from the **data the device emitted**, not from a precision readback: during a 15 kHz stream the WiFi SCPI task (pri 2) is starved by the encoder (pri 6), so a post-STOP `CONF:VOLT:PREC?` reports 10 for a session whose every row was precision 4. That distinction cost a false FAIL against correct firmware before it was caught.

**No cost at the cap.** Parts 1–4b pass on *both* builds. At-cap delivery is unchanged — 1xT1 PB 15,798 → 15,789; 1xT1 CSV 15,263 → 15,262; plus 5xT1 CSV, 1xT2 PB, 11xT2 CSV and 16ch PB OBDiag=1 all at ≥99.9% of their own advertised cap — and both SD interfaces still admit at cap (SD-only 7,500, USB+SD 6,500).

## Review

Eight adversarial audit rounds (codex, `--effort high`, SHA-pinned worktrees) and four Qodo passes produced **twenty-two findings across the pair, all real** — none were noise. Round 5 returned zero firmware findings; rounds 6–8 each found one more, twice in code a *previous* round's fix had introduced (the idempotent-generation false refusal, and `partial_ok` green-lighting an unexercised race arm) — both fixed. Everything numbered 2–5 above, all three follow-up issues, and every test-side hardening came out of that loop rather than the original push.

The final gate audit is **clean on the companion test** and returns only the two pre-existing #848 items on the firmware — the point at which the hunt had converged onto adjacent code this PR does not touch.

## Companion test

[daqifi-python-test-suite PR #237](https://github.com/daqifi/daqifi-python-test-suite/pull/237) — `test_844_start_cap_revalidation.py`.

Stated honestly: the `--race` arm is the **only** one that fails on pre-#844 firmware, because the defect is inherently two-transport (on a single USB session the USB SCPI task is the one sitting inside START). Parts 1–4b regress the code this PR *adds* — which runs on every START and is a second, independent chance to refuse a legitimate start.

## Scope

- No SCPI command added or changed — **no wiki update needed**. Two commands become stricter while streaming; both were already documented as configuration commands.
- NQ1 and NQ2/NQ3 share the code path; the re-validation calls the same variant-aware `Streaming_ComputeMaxFreqForConfig` the front door does. Bench validation is NQ1 (no AD7609 board here).
