### PR TITLE
fix(sd): refuse SYST:STOR:SD:BENCHmark while a stream is running (#854)

### DIFF
--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -1166,10 +1166,25 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
      * immediately before the mode write is the same "re-validate at the arm,
      * not just at the gate" shape #845 gave SCPI_StartStreaming's cap inputs.
      *
-     * The exit path is already correct for a refusal here: `file` has been
-     * clobbered, so logFileClobbered restores it, and nothing has been
-     * published to the manager yet (no UpdateSettings call has run since the
-     * clobber), so the manager's own copy still holds the user's name.
+     * Why refusing HERE is safe even though `file` has already been
+     * clobbered, and it is NOT the reason you would guess. The manager does
+     * not keep a private copy to fall back on: sd_card_manager_Init stores
+     * the caller's POINTER (`gpSDCardSettings = pSettings`,
+     * sd_card_manager.c:1012) and app_freertos.c:447 hands it
+     * `&gpBoardRuntimeConfig->sdCardConfig` -- the very object
+     * BoardRunTimeConfig_Get returns here (BoardRuntimeConfig.c:59). The two
+     * ALIAS, which is also why UpdateSettings' memcpy is a self-copy for every
+     * SCPI caller. So the benchmark name written above is visible to the SD
+     * task the instant it is written.
+     *
+     * It is INERT, which is the actual guarantee. The SD task does no work
+     * unless `mode != SD_CARD_MANAGER_MODE_NONE` (sd_card_manager.c:1397), and
+     * this refusal returns BEFORE the `mode = WRITE` write below -- so `mode`
+     * is still whatever it was when the enable/present/claim checks passed,
+     * and the only mode that would open `file` is the WRITE this refusal
+     * declines to arm (READ / CRC / DELETE open the transient `opFile`
+     * instead, :1407). logFileClobbered then restores the name at
+     * __exit_point, under the same critical section every other writer uses.
      *
      * It DOES leave the result counters zeroed, so a `BENCH?` afterwards
      * reports "no benchmark result available" rather than the previous run's
@@ -1179,14 +1194,39 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
      * at the claim draws: destroying results is only wrong for a caller that
      * never became the owner. This one did.
      *
-     * What REMAINS after this, stated plainly: a START that publishes
-     * IsEnabled in the few instructions between this test and the mode write
-     * still overlaps. Closing that needs the gate on START's side -- an
-     * exported "benchmark in progress" accessor -- which is #739, closed
-     * won't-fix by the owner because it needs simultaneous two-transport use
-     * and costs a scratch artifact rather than user data. This test does not
-     * change that trade; it just removes the millisecond-scale part of the
-     * window that had nothing to do with it. */
+     * WHAT THIS DOES NOT CATCH, and it is much bigger than it looks. An
+     * earlier revision of this comment said the residual was "the few
+     * instructions between this test and the mode write". That is wrong by
+     * about three orders of magnitude, and the adversarial audit on PR #855
+     * is what corrected it.
+     *
+     * SCPI_StartStreaming publishes IsEnabled LAST. It arms SD -- `mode =
+     * WRITE` plus sd_card_manager_UpdateSettingsForStreamingLog
+     * (SCPIInterface.c:4329-4330) -- and then waits for the file to open in a
+     * `readyWait < 500` loop of `vTaskDelay(10 ms)` (:4338), i.e. up to FIVE
+     * SECONDS, all before `IsEnabled = true` at :4508. `Running` is set later
+     * still, inside Streaming_Start. So for that entire span both flags read
+     * false and every test in this function -- fast path, claim and this one
+     * -- sees "no stream".
+     *
+     * The consequence is the #728 hazard from the other direction: this
+     * callback has already published benchmark_<tick>.dat into the SHARED
+     * `file` (the manager aliases it, see below), so a START arriving in that
+     * span opens the BENCHMARK'S name and logs the user's session into it.
+     *
+     * That race is pre-existing and is NOT widened here: the clobber, its
+     * duration and START's ordering are all unchanged by this PR, and these
+     * guards only ever refuse more than before. Closing it needs the gate on
+     * START's side -- an exported "benchmark in progress" accessor -- which is
+     * #739, closed won't-fix. Note though that #739 was decided against a
+     * "~10 ms teardown window"; THIS window is a different and much larger one,
+     * which is worth knowing before inheriting that decision. The evidence is
+     * posted on #739 rather than acted on here.
+     *
+     * What this test DOES catch is a session that was already fully live when
+     * this callback reached the arm -- the ordinary single-transport case, and
+     * any START that got as far as publishing IsEnabled while we were between
+     * the claim and here. */
     if (SD_StreamingIsLive()) {
         SCPI_ExecutionError(context,
                             "SYST:STOR:SD:BENCH: rejected, streaming started "
@@ -1380,15 +1420,31 @@ __exit_point:
      * #728: put the user's logging target back before returning, on EVERY
      * path — normal completion, the not-ready timeout, the buffer-take
      * failure, the write failure and the #854 arm-time streaming refusal all
-     * land here. That last one is the only refusal that lands here having
-     * clobbered `file` WITHOUT having published it, which is why it needs
-     * nothing else: the restore below puts the field back, and the manager
-     * never saw the benchmark name. Re-publishing through
-     * UpdateSettings matters as much as the field itself: the manager keeps
-     * its own memcpy'd copy, so restoring only the runtime config would leave
-     * the benchmark name live inside sd_card_manager.
-     * The early parameter/enable/present errors return before the name is
-     * overwritten, so the flag keeps this a no-op for them. */
+     * land here.
+     *
+     * Restoring the FIELD is sufficient, and an earlier revision of this
+     * comment said the opposite -- that "the manager keeps its own memcpy'd
+     * copy, so restoring only the runtime config would leave the benchmark
+     * name live inside sd_card_manager". There is no such copy.
+     * sd_card_manager_Init stores the caller's POINTER (`gpSDCardSettings =
+     * pSettings`, sd_card_manager.c:1012) and app_freertos.c:447 hands it
+     * `&gpBoardRuntimeConfig->sdCardConfig` -- the same object
+     * BoardRunTimeConfig_Get returns here (BoardRuntimeConfig.c:59). The two
+     * ALIAS, which is why UpdateSettings' memcpy is a self-copy for every SCPI
+     * caller, and why the block below can deliberately skip UpdateSettings
+     * without stranding the name. That contradiction -- a paragraph arguing
+     * re-publication is essential, sitting above a block explaining why it is
+     * deliberately omitted -- is how the wrong belief was visible.
+     *
+     * What restoring the name CANNOT undo is a file already OPEN under it: the
+     * handle outlives the field. That is the real reason this runs only after
+     * the idle poll above, not the phantom second copy.
+     *
+     * The early parameter / enable / present / streaming errors return before
+     * the name is overwritten, so the flag keeps this a no-op for them. The
+     * #854 arm-time refusal is the one path that lands here having clobbered
+     * `file` while never arming a WRITE against it -- inert, because the SD
+     * task needs `mode != MODE_NONE` to act at all (sd_card_manager.c:1397). */
     /* #736 audit: restore ONLY if the field still holds the name we wrote.
      * Once the manager reaches IDLE (polled just above), SD:FILE from the
      * OTHER transport is accepted — USB and WiFi run separate SCPI contexts

--- a/firmware/src/services/SCPI/SCPIStorageSD.c
+++ b/firmware/src/services/SCPI/SCPIStorageSD.c
@@ -886,6 +886,43 @@ __exit_point:
 
 }
 
+/* #854: is a streaming session live right now?
+ *
+ * SYST:STOR:SD:BENCHmark arms SD_CARD_MANAGER_MODE_WRITE on the SHARED SD
+ * settings, and streaming_Task recomputes its SD routing from that mode on
+ * EVERY task wake (streaming.c, the "SD card logging enabled" override):
+ *
+ *     enable && mode == WRITE && ActiveInterface != WiFi  ->  hasSD
+ *
+ * So a benchmark started during a USB-only session -- one that never asked
+ * for SD at all -- flips that session's hasSD true, and its encoded rows go
+ * into benchmark_<tick>.dat beside the requested pattern. Three things are
+ * wrong at once: the artifact no longer matches `size_kb x 1024` bytes of the
+ * pattern; `writeSpeedBps` times a card that is absorbing someone else's
+ * writes and reports the result as the card's speed; and the session's rows
+ * land in a file the user never named, which the benchmark's own exit restore
+ * then erases the last pointer to.
+ *
+ * `IsEnabled || Running`, not `&&`: the two flags are set (and cleared) in
+ * separate steps at start and stop, so an `&&` test leaves a window open in
+ * both directions. Same form as SCPI_SetStreamFormat's #619 guard and
+ * SCPI_ADCChanEnableSet's #116 guard.
+ *
+ * Read under a critical section so the PAIR is one snapshot. Each flag is
+ * individually atomic on PIC32MZ, but reading them a few instructions apart
+ * can straddle a start that sets IsEnabled between the two loads. That is a
+ * snapshot and not a lock -- see the arm site for what remains. */
+static bool SD_StreamingIsLive(void) {
+    const StreamingRuntimeConfig *cfg =
+            (const StreamingRuntimeConfig *)BoardRunTimeConfig_Get(
+                    BOARDRUNTIME_STREAMING_CONFIGURATION);
+    bool live;
+    taskENTER_CRITICAL();
+    live = (cfg->IsEnabled || (cfg->Running != 0u));
+    taskEXIT_CRITICAL();
+    return live;
+}
+
 /**
  * @brief Perform SD card write speed benchmark
  * 
@@ -963,7 +1000,30 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
-    
+
+    /* #854: refuse while a streaming session is live -- see SD_StreamingIsLive
+     * for the coupling. A refusal, rather than a narrower window, is the only
+     * option available here: unlike SCPI_StartStreaming (#851) the benchmark
+     * has no "stop the previous session" step to arm below, and it cannot arm
+     * a write the streaming task would ignore, because that task routes on the
+     * shared mode and not on the arming caller.
+     *
+     * This is a fast path only, like the testInProgress check above it --
+     * parameter parsing follows, and USB SCPI (pri 7) preempts WiFi SCPI
+     * (pri 2) with no shared dispatch mutex. The authoritative tests are the
+     * one folded into the ownership claim below and the one at the arm.
+     *
+     * Before parsing, deliberately: the command is refused whatever its
+     * operands say, and the enable / card-present rejects above return before
+     * parsing too. */
+    if (SD_StreamingIsLive()) {
+        SCPI_ExecutionError(context,
+                            "SYST:STOR:SD:BENCH: rejected, streaming is active "
+                            "(stop streaming first)");
+        result = SCPI_RES_ERR;
+        goto __exit_point;
+    }
+
     // Get test size parameter (required)
     if (!SCPI_ParamInt32(context, &testSizeKB, TRUE)) {
         SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
@@ -1007,14 +1067,44 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
      * letting BENCH? read resultAvailable=true beside zeroed counters, from a
      * call that never ran. Everything below this point is owner-only. */
     bool benchAlreadyRunning;
+    bool streamWentLive;
     taskENTER_CRITICAL();
+    /* #854: the streaming test belongs INSIDE this critical section, not
+     * beside it. Split out, it would be a second check-then-act on the same
+     * decision -- and the whole point of claiming under a critical section is
+     * that the claim is taken only when the conditions to run were true at
+     * the instant of the claim. Folding it in means a claimed benchmark never
+     * exists concurrently with a session that was ALREADY live; only a start
+     * that publishes IsEnabled afterwards can still overlap, and that is what
+     * the arm-time test below is for.
+     *
+     * The helper is CALLED rather than its predicate re-typed here, even
+     * though it takes a critical section of its own. FreeRTOS critical
+     * sections nest -- vTaskEnterCritical counts into
+     * pxCurrentTCB->uxCriticalNesting (FreeRTOS_tasks.c) and only the
+     * outermost exit re-enables interrupts -- so the read still happens with
+     * this section held. Inlining the test instead would have put a second
+     * copy of `IsEnabled || Running` two hundred lines from the first, which
+     * is how the two drift apart. */
+    streamWentLive = SD_StreamingIsLive();
     benchAlreadyRunning = gSDBenchmarkResults.testInProgress;
-    if (!benchAlreadyRunning) {
+    if (!benchAlreadyRunning && !streamWentLive) {
         gSDBenchmarkResults.testInProgress = true;
     }
     taskEXIT_CRITICAL();
     if (benchAlreadyRunning) {
         SCPI_ExecutionError(context, "SYST:STOR:SD:BENCH: benchmark already in progress");
+        result = SCPI_RES_ERR;
+        goto __exit_point;
+    }
+    if (streamWentLive) {
+        /* Reported separately from the fast path above so the log says which
+         * of the two observed it: reaching HERE means streaming started while
+         * this command was parsing its operands, which is a different fact
+         * about the device from "streaming was already running". */
+        SCPI_ExecutionError(context,
+                            "SYST:STOR:SD:BENCH: rejected, streaming started "
+                            "during parameter validation");
         result = SCPI_RES_ERR;
         goto __exit_point;
     }
@@ -1065,6 +1155,46 @@ scpi_result_t SCPI_StorageSDBenchmark(scpi_t * context) {
     taskEXIT_CRITICAL();
     logFileClobbered = true;   /* #728: restore the logging target on exit */
     
+    /* #854: re-validate at the ARM, not only at the claim.
+     *
+     * The claim above is the last point at which this callback observed the
+     * streaming flags, and everything between there and here -- the target
+     * snapshot, the counter reset, building and publishing benchmark_<tick>
+     * -- is preemptible by the other transport's SCPI task. A START landing
+     * in that gap would publish IsEnabled and then find mode == WRITE waiting
+     * for it, which is exactly the adoption this issue is about. Re-testing
+     * immediately before the mode write is the same "re-validate at the arm,
+     * not just at the gate" shape #845 gave SCPI_StartStreaming's cap inputs.
+     *
+     * The exit path is already correct for a refusal here: `file` has been
+     * clobbered, so logFileClobbered restores it, and nothing has been
+     * published to the manager yet (no UpdateSettings call has run since the
+     * clobber), so the manager's own copy still holds the user's name.
+     *
+     * It DOES leave the result counters zeroed, so a `BENCH?` afterwards
+     * reports "no benchmark result available" rather than the previous run's
+     * numbers. That is the existing contract for every post-claim failure --
+     * the not-ready timeout, the buffer-take failure and the write failure all
+     * do the same -- and it is the right side of the line the ordering comment
+     * at the claim draws: destroying results is only wrong for a caller that
+     * never became the owner. This one did.
+     *
+     * What REMAINS after this, stated plainly: a START that publishes
+     * IsEnabled in the few instructions between this test and the mode write
+     * still overlaps. Closing that needs the gate on START's side -- an
+     * exported "benchmark in progress" accessor -- which is #739, closed
+     * won't-fix by the owner because it needs simultaneous two-transport use
+     * and costs a scratch artifact rather than user data. This test does not
+     * change that trade; it just removes the millisecond-scale part of the
+     * window that had nothing to do with it. */
+    if (SD_StreamingIsLive()) {
+        SCPI_ExecutionError(context,
+                            "SYST:STOR:SD:BENCH: rejected, streaming started "
+                            "while arming the benchmark");
+        result = SCPI_RES_ERR;
+        goto __exit_point;
+    }
+
     // Set SD card to write mode
     /* #690: this WRITE-mode open goes through the #689 dir-file-cap guard too.
      * Clear the flag first so the poll observes only THIS request's outcome
@@ -1249,7 +1379,11 @@ __exit_point:
      *
      * #728: put the user's logging target back before returning, on EVERY
      * path — normal completion, the not-ready timeout, the buffer-take
-     * failure and the write failure all land here. Re-publishing through
+     * failure, the write failure and the #854 arm-time streaming refusal all
+     * land here. That last one is the only refusal that lands here having
+     * clobbered `file` WITHOUT having published it, which is why it needs
+     * nothing else: the restore below puts the field back, and the manager
+     * never saw the benchmark name. Re-publishing through
      * UpdateSettings matters as much as the field itself: the manager keeps
      * its own memcpy'd copy, so restoring only the runtime config would leave
      * the benchmark name live inside sd_card_manager.


### PR DESCRIPTION
Closes #854.

## The defect

`SCPI_StorageSDBenchmark` arms `SD_CARD_MANAGER_MODE_WRITE` on the **shared**
SD settings and opens `benchmark_<tick>.dat`. It had no guard on the streaming
state at all — not `IsEnabled`, not `Running`, and by its own preamble comment
not `IsBusy()` either (#736: a running benchmark OWNS the logging target).

`streaming_Task` does not route to SD on the requesting session's own
`sdLoggingRequested`. It recomputes the routing from the SD **manager's** live
state on every task wake (`streaming.c`, the "SD card logging enabled"
override):

```c
if (pSDCardSettings && pSDCardSettings->enable &&
    pSDCardSettings->mode == SD_CARD_MANAGER_MODE_WRITE) {
    if (pRunTimeStreamConf->ActiveInterface != StreamingInterface_WiFi) {
        hasSD = (sdSize >= 128);
    }
}
```

**(V)** — that block is inside `while(1)` after `ulTaskNotifyTake`, so it is a
per-wake decision, not a per-session one. A benchmark started during a USB-only
session — one that never asked for SD — therefore flips that session's `hasSD`
true, and its encoded rows go into `benchmark_<tick>.dat` beside the requested
pattern.

Three things go wrong at once: the artifact stops being `size_kb × 1024` bytes
of the pattern; `writeSpeedBps` times a card absorbing someone else's writes
and reports the result as the card's speed; and the session's rows land in a
file the user never named — which the benchmark's own exit restore then erases
the last pointer to.

Same class as #851 (START's SD arm running before the previous session was
stopped), reached through a different arming site.

## The fix

A refusal, because nothing else is available here: unlike `SCPI_StartStreaming`
the benchmark has no "stop the previous session" step to arm below, and it
cannot arm a write the streaming task would ignore, because that task routes on
the shared mode and not on the arming caller.

`IsEnabled || Running`, not `&&` — the two flags are set and cleared in
separate steps at start and stop. Same form as `SCPI_SetStreamFormat`'s #619
guard and `SCPI_ADCChanEnableSet`'s #116 guard.

Tested at three points, because one is not enough:

| where | why |
|---|---|
| fast path, before parameter parsing | an operand-invalid command during a stream is still refused for the reason that matters |
| folded **into** the atomic `testInProgress` claim | a claimed benchmark then never coexists with a session that was **already** live |
| immediately before the mode write | everything between the claim and the arm is preemptible by the other transport's SCPI task — the "re-validate at the arm, not just at the gate" shape #845 gave START's cap inputs |

The three report separately, so `SYST:LOG?` says which one observed it —
"streaming was already running" and "streaming started while this command was
parsing" are different facts about the device.

## What this does NOT do — stated rather than left implied

**The residual race — and this paragraph was WRONG in the first version of
this PR.** It said a START could only overlap "in the few instructions between
the last test and the mode write". The adversarial audit (codex, high) showed
that is wrong by about three orders of magnitude, and it is right:

`SCPI_StartStreaming` publishes `IsEnabled` **last**. It arms SD at
`SCPIInterface.c:4329-4330`, then waits for the file to open in a
`readyWait < 500` loop of `vTaskDelay(10 ms)` (`:4338`) — **up to five
seconds** — and only sets `IsEnabled = true` at `:4508`, with `Running` later
still inside `Streaming_Start`. For that whole span both flags read false and
every guard in this function sees "no stream".

The race itself is **pre-existing and is not widened here** — the clobber, its
duration and START's ordering are unchanged, and these guards only ever refuse
more than before. It is #739, closed won't-fix. But #739 was decided against a
"~10 ms teardown window" and this is a different, much larger one, so the
corrected evidence is [posted on #739](https://github.com/daqifi/daqifi-nyquist-firmware/issues/739#issuecomment-5392638385)
for the owner to re-decide rather than silently inherited here. The source
comment at the arm site now says all of this.

**The reader side in `streaming.c` is deliberately untouched.** Adding
`sd_card_manager_WriteIsStreamingLog()` (the #851 accessor) to the `hasSD`
override would harden one of the two routes into that flag — but not the
`StreamingInterface_SD` / `UsbAndSd` switch immediately above it, which sets
`hasSD` from the interface **without consulting `mode` at all**. So it would be
a partial fix where the refusal is a complete one, and it changes a hot-path
predicate. Worth doing as its own change with its own bench validation; not
smuggled in here.

**A refused-at-arm benchmark zeroes the result counters**, so a following
`BENCH?` reports "no benchmark result available" rather than the previous run's
numbers. That is the existing contract for every post-claim failure (the
not-ready timeout, the buffer-take failure and the write failure all do the
same) and the right side of the line the ordering comment at the claim draws:
destroying results is only wrong for a caller that never became the owner.

**Two further comment claims in this PR were false and are corrected**
(commit 2, no behaviour change). Both came from the same wrong belief — that
`sd_card_manager` keeps a private copy of the SD settings. It does not:
`sd_card_manager_Init` stores the caller's **pointer**
(`sd_card_manager.c:1012`) and `app_freertos.c:447` hands it
`&gpBoardRuntimeConfig->sdCardConfig`, the same object `BoardRunTimeConfig_Get`
returns (`BoardRuntimeConfig.c:59`). The manager **aliases** the runtime
config, so `UpdateSettings`' memcpy is a self-copy for every SCPI caller.

The arm-time refusal is still safe, for the real reason: the clobbered `file`
is **inert** because the SD task does no work unless `mode != MODE_NONE`
(`sd_card_manager.c:1397`) and the refusal returns before the `mode = WRITE`
write. The second instance of the wrong belief was **pre-existing**, one screen
below in the #728 restore block, and was self-refuting in place — it argued
re-publication was essential while sitting directly above the block explaining
why `UpdateSettings` is deliberately not called. Corrected rather than left as
the twin of a claim I had just fixed.

## Validation

- **Builds clean at -O3 with `-Werror`, 0 errors, in BOTH configurations** —
  `default` (NQ1) and `Nq3`.
- **cppcheck: 0 findings**, baseline unchanged.
- No new SCPI pattern, so the `scpi-wiki-sync` gate does not fire (it runs only
  on `SCPIInterface.c` / the checker). ⚠️ **The wiki row for
  `SYSTem:STORage:SD:BENCHmark` should still gain a line saying it is refused
  while streaming** — a behaviour change to a documented command. Not pushed
  here: the wiki is a separate repo and cross-repo writes are outside what this
  work is authorised to do unattended.
- **Bench A/B: NOT RUN.** The bench device-guard has this board pinned to
  another agent, and the documented `BENCH_AGENT=<owner> <cmd>` override was
  re-verified this session as unable to reach the hook from a Claude Code Bash
  call. No hardware guard was bypassed and no registry or settings file was
  edited to grant access. The run is queued.

## Companion regression test

daqifi/daqifi-python-test-suite `test_854_benchmark_refused_during_stream.py`
— PR linked below. Two parts (no artifact created mid-stream; `SYST:LOG?` names
streaming as the reason), three ABORT-not-vote arrangement guards including a
positive control, and 49 bench-free `--self-test` cases proven against 14
mutants.

Note the test does **not** use the issue's literal repro, because that one is
not reachable: `file` defaults to `default.bin` and there is no SCPI way to
clear it, so a USB START with SD already enabled arms SD logging. The test
enables SD *after* the session is running instead, which is the same hazard
through a reachable door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLsu2xQ4a5aSvA15feGx2n

