### PR TITLE
fix(scpi): a cap-input setter's store must not land on a session START armed (#847)

### DIFF
--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -355,9 +355,9 @@ static scpi_result_t ADCChanEnableSetClaimed(scpi_t * context) {
     // Frequency, TSClockPeriod and ChannelScanFreqDiv on the session START had
     // just armed -- a channel-enable command silently re-rating a live stream
     // to its own locally-capped freq. It is kept as a defensive path rather
-    // than deleted because two benchmark-only arm sites (SYST:STR:THRoughput
-    // and the WiFi rate finder, both in SCPIInterface.c) still set IsEnabled
-    // without consulting the claim.
+    // than deleted because "unreachable" here rests on every arm site
+    // observing the claim, which is an invariant across three call sites in
+    // another file rather than something this function can enforce.
     if (!pRunTimeStreamConfig->IsEnabled) {
         return SCPI_RES_OK;
     }

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -110,7 +110,27 @@ scpi_result_t SCPI_ADCVoltageGet(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+static scpi_result_t ADCChanEnableSetClaimed(scpi_t * context);
+
+/* #847: the claim is taken HERE and released on the single path out, so no
+ * error return inside the body can leak it. The body is ~200 lines with ten
+ * returns; wrapping it is what makes the release provably unconditional.
+ *
+ * The claim replaces the old inline stream-state guard, in the same position,
+ * so the order in which this command reports its errors is unchanged. */
 scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "CONF:ADC:CHANnel");
+    }
+    scpi_result_t result = ADCChanEnableSetClaimed(context);
+    Streaming_EndConfigChange();
+    return result;
+}
+
+static scpi_result_t ADCChanEnableSetClaimed(scpi_t * context) {
     int param1, param2;
     StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
@@ -132,18 +152,13 @@ scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
     // reconfigure, restart. Rejecting BEFORE ADC_WriteChannelStateAll() leaves both
     // runtime config and ADC hardware untouched (no snapshot/rollback needed).
     //
-    // Use IsEnabled || Running (not &&): the two flags are set/cleared in separate
-    // steps at stream start/stop (StartStreaming arms IsEnabled, then
-    // Streaming_UpdateState flips Running; stop clears them in turn). An && guard
-    // would leave a transition window — IsEnabled set but Running not yet, or vice
-    // versa — through which a concurrent SCPI session (USB pri 7 vs WiFi pri 2)
-    // could slip a channel change after the pool/mapping was sized. Reject unless
-    // streaming is FULLY idle (both flags clear).
-    if (pRunTimeStreamConfig->IsEnabled || pRunTimeStreamConfig->Running) {
-        LOG_E("Channel enable rejected: streaming is active (stop streaming first)");
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        return SCPI_RES_ERR;
-    }
+    // The stream-state test itself now lives in the wrapper's
+    // Streaming_BeginConfigChange() (#847), which tests IsEnabled || Running --
+    // never && -- and TAKES the claim in the same critical section. The two
+    // flags are set/cleared in separate steps at stream start/stop
+    // (StartStreaming arms IsEnabled, then Streaming_UpdateState flips Running;
+    // stop clears them in turn), so an && test would read false for the whole
+    // interval between them. Reject unless streaming is FULLY idle.
 
     if (!SCPI_ParamInt32(context, &param1, TRUE)) {
         return SCPI_RES_ERR;
@@ -322,7 +337,23 @@ scpi_result_t SCPI_ADCChanEnableSet(scpi_t * context) {
         return SCPI_RES_ERR;
     }
 
-    // If streaming is globally disabled, channel states updated but no timer recalculation needed
+    // If streaming is globally disabled, channel states updated but no timer
+    // recalculation needed.
+    //
+    // #847: this is now the branch taken on every normal path. The wrapper
+    // holds the config-change claim for the whole of this function, and
+    // SCPI_StartStreaming's arm-time critical section refuses to publish
+    // IsEnabled while it is held -- so START can no longer flip it under us.
+    //
+    // That matters because of what the fall-through DID: before #847 it was
+    // reachable ONLY through the race (the guard at entry rejects when
+    // IsEnabled is already set), and there it overwrote ClockPeriod,
+    // Frequency, TSClockPeriod and ChannelScanFreqDiv on the session START had
+    // just armed -- a channel-enable command silently re-rating a live stream
+    // to its own locally-capped freq. It is kept as a defensive path rather
+    // than deleted because two benchmark-only arm sites (SYST:STR:THRoughput
+    // and the WiFi rate finder, both in SCPIInterface.c) still set IsEnabled
+    // without consulting the claim.
     if (!pRunTimeStreamConfig->IsEnabled) {
         return SCPI_RES_OK;
     }
@@ -701,7 +732,24 @@ scpi_result_t SCPI_ADCCalFLoad(scpi_t * context) {
     }
 }
 
+static scpi_result_t ADCUseCalSetClaimed(scpi_t * context);
+
+/* #847: wrapped for the same reason as SCPI_ADCChanEnableSet -- the body has
+ * seven returns and its "store" reaches an NVM save, which cannot run inside a
+ * critical section. One claim, one release, no path that skips it. */
 scpi_result_t SCPI_ADCUseCalSet(scpi_t * context) {
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "CONF:ADC:USECal");
+    }
+    scpi_result_t result = ADCUseCalSetClaimed(context);
+    Streaming_EndConfigChange();
+    return result;
+}
+
+static scpi_result_t ADCUseCalSetClaimed(scpi_t * context) {
     int param1;
     DaqifiSettings tmpTopLevelSettings;
     AInRuntimeArray * pRuntimeAInChannels = BoardRunTimeConfig_Get(
@@ -711,14 +759,11 @@ scpi_result_t SCPI_ADCUseCalSet(scpi_t * context) {
 
     // #158/#270: this command also switches the encoder output format
     // (value 2 = raw codes), so changing it mid-stream would alter the wire
-    // format under an active session. Reject while streaming (mirrors the
-    // CONF:ADC:CHANnel #116 guard); it also protects the mid-stream cal
-    // coefficient reload for values 0/1.
-    if (pRunTimeStreamConfig->IsEnabled || pRunTimeStreamConfig->Running) {
-        LOG_E("Calibration-mode change rejected: streaming is active (stop streaming first)");
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        return SCPI_RES_ERR;
-    }
+    // format under an active session. Rejecting while streaming (mirrors the
+    // CONF:ADC:CHANnel #116 guard) also protects the mid-stream cal
+    // coefficient reload for values 0/1. The test now lives in the wrapper's
+    // Streaming_BeginConfigChange() (#847), which performs it and takes the
+    // claim in one critical section.
 
     if (!SCPI_ParamInt32(context, &param1, TRUE)) {
         return SCPI_RES_ERR;
@@ -808,15 +853,19 @@ scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context) {
     }
     StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
-    // IsEnabled || Running (matches the #116 channel-enable gate): the two
-    // flags transition in separate steps at start/stop, and a change slipped
-    // through the window would desync the session scan list (#541 D-B builds
-    // ADCCSS from OnboardDiagEnabled at stream start).
-    if (pStreamCfg->IsEnabled || pStreamCfg->Running) {
-        SCPI_ExecutionError(context, "CONF:ADC:OBDiag: cannot change while streaming");
-        return SCPI_RES_ERR;
+    // #847: the claim performs the IsEnabled || Running test (the two flags
+    // transition in separate steps at start/stop, and a change slipped through
+    // that window would desync the session scan list -- #541 D-B builds ADCCSS
+    // from OnboardDiagEnabled at stream start) AND excludes a concurrent arm
+    // until the store below has landed.
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "CONF:ADC:OBDiag");
     }
     pStreamCfg->OnboardDiagEnabled = (val != 0);
+    Streaming_EndConfigChange();
     LOG_I("Onboard diagnostics during streaming: %s", val ? "enabled" : "disabled");
     return SCPI_RES_OK;
 }
@@ -859,15 +908,23 @@ scpi_result_t SCPI_ADCThresholdSet(scpi_t * context) {
     }
     // Config change: reject while streaming (consistent with the CONF:ADC family;
     // the session scan is frozen at start, #116/#541).
-    StreamingRuntimeConfig *pStreamCfg =
-            BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
-    if (pStreamCfg->IsEnabled || pStreamCfg->Running) {
-        SCPI_ExecutionError(context, "CONF:ADC:THRE: cannot change while streaming");
-        return SCPI_RES_ERR;
+    //
+    // #847: via the claim rather than a bare read, because AdcThreshold_Configure
+    // takes a FreeRTOS mutex with portMAX_DELAY -- it cannot share a critical
+    // section with the test, so the exclusion has to outlive one.
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "CONF:ADC:THREshold");
     }
     const char* err = NULL;
-    if (!AdcThreshold_Configure((uint8_t)ch, (AdcThresholdMode)mode,
-                                (uint16_t)lo, (uint16_t)hi, &err)) {
+    bool configured = AdcThreshold_Configure((uint8_t)ch, (AdcThresholdMode)mode,
+                                             (uint16_t)lo, (uint16_t)hi, &err);
+    /* Released as soon as the hardware write is done, on the single path that
+     * covers both outcomes -- the error return below must not skip it. */
+    Streaming_EndConfigChange();
+    if (!configured) {
         SCPI_ExecutionError(context, (err != NULL) ? err : "CONF:ADC:THRE: rejected");
         return SCPI_RES_ERR;
     }
@@ -925,17 +982,22 @@ static scpi_result_t SamcSetCommon(scpi_t *context, bool isDedicated) {
         SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
         return SCPI_RES_ERR;
     }
-    StreamingRuntimeConfig *pStreamCfg =
-            BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
-    // IsEnabled || Running (matches #116 / OBDiag): SAMC feeds the live
-    // scan-rate bound (#541 D-C reads ADCCON2.SAMC), so a mid-stream change
-    // would invalidate the cap the session was admitted under.
-    if (pStreamCfg->IsEnabled || pStreamCfg->Running) {
-        SCPI_ExecutionError(context, "CONF:ADC:SAMC: cannot change while streaming");
-        return SCPI_RES_ERR;
+    // SAMC feeds the live scan-rate bound (#541 D-C reads ADCCON2.SAMC), so a
+    // mid-stream change would invalidate the cap the session was admitted
+    // under. The claim performs the IsEnabled || Running test (#116 / OBDiag
+    // form) and holds the exclusion across the write (#847) -- which it must,
+    // because MC12b_SetAcquisitionSamc spins up to ~20 ms on BGVRRDY and so
+    // cannot share a critical section with the test.
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "CONF:ADC:SAMC");
     }
     bool ok = isDedicated ? MC12b_SetAcquisitionSamc(val, -1)
                           : MC12b_SetAcquisitionSamc(-1, val);
+    /* Single release, before the branch, so the error return cannot skip it. */
+    Streaming_EndConfigChange();
     if (!ok) {
         SCPI_ExecutionError(context, "CONF:ADC:SAMC: set failed");
         return SCPI_RES_ERR;

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -113,7 +113,7 @@ scpi_result_t SCPI_ADCVoltageGet(scpi_t * context) {
 static scpi_result_t ADCChanEnableSetClaimed(scpi_t * context);
 
 /* #847: the claim is taken HERE and released on the single path out, so no
- * error return inside the body can leak it. The body is ~200 lines with ten
+ * error return inside the body can leak it. The body is 259 lines with twelve
  * returns; wrapping it is what makes the release provably unconditional.
  *
  * The claim replaces the old inline stream-state guard, in the same position,
@@ -739,7 +739,7 @@ scpi_result_t SCPI_ADCCalFLoad(scpi_t * context) {
 static scpi_result_t ADCUseCalSetClaimed(scpi_t * context);
 
 /* #847: wrapped for the same reason as SCPI_ADCChanEnableSet -- the body has
- * seven returns and its "store" reaches an NVM save, which cannot run inside a
+ * nine returns and its "store" reaches an NVM save, which cannot run inside a
  * critical section. One claim, one release, no path that skips it. */
 scpi_result_t SCPI_ADCUseCalSet(scpi_t * context) {
     StreamingCfgClaim claim = Streaming_BeginConfigChange();
@@ -990,8 +990,9 @@ static scpi_result_t SamcSetCommon(scpi_t *context, bool isDedicated) {
     // mid-stream change would invalidate the cap the session was admitted
     // under. The claim performs the IsEnabled || Running test (#116 / OBDiag
     // form) and holds the exclusion across the write (#847) -- which it must,
-    // because MC12b_SetAcquisitionSamc spins up to ~20 ms on BGVRRDY and so
-    // cannot share a critical section with the test.
+    // because MC12b_SetAcquisitionSamc spins up to 2,000,000 poll iterations
+    // on ADCCON2bits.BGVRRDY and so cannot share a critical section with the
+    // test.
     StreamingCfgClaim claim = Streaming_BeginConfigChange();
     if (claim != STREAM_CFG_CLAIM_OK) {
         return SCPI_RejectCfgClaim(context,

--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -142,6 +142,11 @@ static scpi_result_t ADCChanEnableSetClaimed(scpi_t * context) {
             BOARDCONFIG_AIN_CHANNELS,
             0);
 
+    // The stream-state rejection for this command is in the WRAPPER above, not
+    // here: Streaming_BeginConfigChange() performs it and takes the claim in
+    // one critical section (#847). The rationale it enforces is #116's, and is
+    // kept here because it is about THIS body:
+    //
     // #116: reject channel enable/disable while streaming is active. The sample
     // pool element stride is fixed at StartStreamData for the then-current channel
     // count (AInSampleList_InitializeExternal is only called at stream start, never
@@ -152,13 +157,12 @@ static scpi_result_t ADCChanEnableSetClaimed(scpi_t * context) {
     // reconfigure, restart. Rejecting BEFORE ADC_WriteChannelStateAll() leaves both
     // runtime config and ADC hardware untouched (no snapshot/rollback needed).
     //
-    // The stream-state test itself now lives in the wrapper's
-    // Streaming_BeginConfigChange() (#847), which tests IsEnabled || Running --
-    // never && -- and TAKES the claim in the same critical section. The two
-    // flags are set/cleared in separate steps at stream start/stop
-    // (StartStreaming arms IsEnabled, then Streaming_UpdateState flips Running;
-    // stop clears them in turn), so an && test would read false for the whole
-    // interval between them. Reject unless streaming is FULLY idle.
+    // The claim tests IsEnabled || Running -- never && -- because the two flags
+    // are set/cleared in separate steps at stream start/stop (StartStreaming
+    // arms IsEnabled, then Streaming_UpdateState flips Running; stop clears
+    // them in turn), so an && test would read false for the whole interval
+    // between them and a concurrent SCPI session (USB pri 7 vs WiFi pri 2)
+    // could slip a channel change through after the pool/mapping was sized.
 
     if (!SCPI_ParamInt32(context, &param1, TRUE)) {
         return SCPI_RES_ERR;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4436,6 +4436,7 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     bool capRevoked = false;
     bool ifaceMoved = false;
     bool inputsGone = false;
+    bool cfgChanging = false;
     uint32_t revalidatedMax = 0;
     /* Captured INSIDE the section so the refusal log names the value that
      * actually triggered the decision. Re-reading it for the message after
@@ -4464,7 +4465,15 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
      * With this, the arm re-checks every admission test START performed up
      * front: inputs exist, the interface is the one that was set up, and the
      * rate is still admissible. */
-    {
+    /* #847: a guarded cap-input setter is mid-flight on the other transport.
+     * Its guard read the flags as idle before this section ran, so publishing
+     * IsEnabled here would let its store land on the session we are about to
+     * arm -- the setter-side half of the #844 window, which no amount of cap
+     * re-validation below can catch (the store happens AFTER it). Tested first
+     * so the refusal reasons stay mutually exclusive, and because the checks
+     * below read a configuration that is being mutated right now. */
+    cfgChanging = Streaming_ConfigChangeInProgress();
+    if (!cfgChanging) {
         uint16_t t1Now = 0, totNow = 0;
         Streaming_CountActiveChannels(&t1Now, &totNow, NULL);
         bool dioNow = (pDIOGlobalEnable != NULL && *pDIOGlobalEnable);
@@ -4473,7 +4482,7 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         }
     }
     ifaceObserved = pRunTimeStreamConfig->ActiveInterface;
-    if (inputsGone) {
+    if (cfgChanging || inputsGone) {
         /* handled below; skip the rest so the reasons stay mutually exclusive */
     } else if (ifaceObserved != ifaceForStart ||
         gStreamIfaceGen != ifaceGenAtPublish ||
@@ -4493,7 +4502,7 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
          * INT32_MAX as negative. */
         capRevoked = ((uint32_t)freq > revalidatedMax);
     }
-    if (!capRevoked && !ifaceMoved && !inputsGone) {
+    if (!capRevoked && !ifaceMoved && !inputsGone && !cfgChanging) {
         /* #848: the rate becomes visible HERE, in the same section that
          * publishes IsEnabled, so no refusal path can leave a rejected rate
          * behind and no reader can see a rate the session is not running at.
@@ -4508,6 +4517,24 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
         pRunTimeStreamConfig->IsEnabled = true;
     }
     taskEXIT_CRITICAL();
+
+    if (cfgChanging) {
+        /* Same unwind as the inputsGone branch below: the interface WAS
+         * published by this START, so it must be put back (unlike ifaceMoved,
+         * where another writer owns the field). */
+        if (sdLoggingRequested) {
+            SCPI_ReleaseSdLoggingArm(pSDCardSettings);
+        }
+        SCPI_ClearStreamingOperBits(pRunTimeStreamConfig);
+        SCPI_UnpublishStartInterface(pRunTimeStreamConfig, ifaceForStart,
+                                     ifaceAtDetect, ifaceGenPinned,
+                                     ifaceSetsPinned);
+        LOG_E("STR:START refused (#847): a streaming config change is in "
+              "flight on the other SCPI transport - its store would land on "
+              "this session. Retry.");
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
 
     if (inputsGone) {
         if (sdLoggingRequested) {
@@ -4710,12 +4737,17 @@ static scpi_result_t SCPI_SetStreamFormat(scpi_t * context) {
      *
      * Mirrors SCPI_ADCChanEnableSet's #116 guard, including its IsEnabled ||
      * Running form -- the two flags are set and cleared in separate steps at
-     * start/stop, so an && test would leave a window open. */
-    if (pRunTimeStreamConfig->IsEnabled || pRunTimeStreamConfig->Running) {
-        LOG_E("Stream format change rejected: streaming is active "
-              "(stop streaming first)");
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        return SCPI_RES_ERR;
+     * start/stop, so an && test would leave a window open.
+     *
+     * #847: taken as a CLAIM, not a bare read, so a START on the other SCPI
+     * transport cannot arm between this test and the store below and receive
+     * the encoding change on a session whose cap was computed for the old
+     * one. */
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "SYST:STR:FORmat");
     }
 
     /* #801: reject an unrecognised encoding rather than quietly picking one.
@@ -4738,19 +4770,25 @@ static scpi_result_t SCPI_SetStreamFormat(scpi_t * context) {
      * Bounded by the enum's own COUNT rather than by naming the highest
      * encoding here, so adding one does not leave a second place to update
      * (Qodo). */
+    scpi_result_t result = SCPI_RES_OK;
     if (param1 < (int)Streaming_ProtoBuffer
             || param1 >= (int)Streaming_Encoding_COUNT) {
         LOG_E("Stream format %d is not a known encoding (0=PB, 1=JSON, "
               "2=CSV, 3=CsvCompact)", param1);
         SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
-        return SCPI_RES_ERR;
+        result = SCPI_RES_ERR;
+    } else {
+        /* Assigned only after the range check, so a rejected set cannot leave
+         * the encoding half-changed: FORmat? still reports what it reported
+         * before. */
+        pRunTimeStreamConfig->Encoding = (StreamingEncoding)param1;
     }
 
-    /* Assigned only after the range check, so a rejected set cannot leave the
-     * encoding half-changed: FORmat? still reports what it reported before. */
-    pRunTimeStreamConfig->Encoding = (StreamingEncoding)param1;
-
-    return SCPI_RES_OK;
+    /* #847: single release, reached by both outcomes. Structured as one exit
+     * rather than a release before each `return` so a later edit cannot add a
+     * third path that leaks the claim. */
+    Streaming_EndConfigChange();
+    return result;
 }
 
 static scpi_result_t SCPI_GetStreamFormat(scpi_t * context) {
@@ -4784,12 +4822,17 @@ static scpi_result_t SCPI_SetDataPrecision(scpi_t * context) {
      * Rejecting is right rather than re-capping: the cap is a hard limit at
      * START (#524), there is no mechanism to lower an already-running session,
      * and silently changing the rate under a client is what #524 removed. */
-    if (pRunTimeStreamConfig->IsEnabled || pRunTimeStreamConfig->Running) {
-        LOG_E("Voltage-precision change rejected: streaming is active (stop streaming first)");
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        return SCPI_RES_ERR;
+    /* #847: a claim rather than a bare read of the two flags -- the store
+     * below must not be able to land on a session a concurrent START armed in
+     * between, which is precisely the cap input this guard exists to pin. */
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "CONF:VOLTage:PRECision");
     }
     pRunTimeStreamConfig->VoltagePrecision = (uint8_t)param1;
+    Streaming_EndConfigChange();
     return SCPI_RES_OK;
 }
 
@@ -4822,26 +4865,36 @@ static scpi_result_t SCPI_LoadDataPrecision(scpi_t * context) {
      * setter left LOAD as an unguarded twin: `CONF:VOLT:PREC 10` +
      * `CONF:VOLT:SAVE` while idle, then `CONF:VOLT:LOAD` mid-session, reaches
      * precision 10 on a stream admitted under the precision-4 cap. */
+    /* #847: as a claim, held across the NVM read below -- which cannot run in
+     * a critical section, so the test and the store could not otherwise be
+     * made atomic with respect to a concurrent START.
+     *
+     * One fetch of the streaming config, used for the store below. The
+     * pre-#847 code fetched it twice and NULL-checked the second: this
+     * accessor indexes a static array initialised at boot and never returns
+     * NULL, so the check was dead (CLAUDE.md, "Atomicity & Concurrency
+     * Rules"). */
     StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
-    if (pRunTimeStreamConfig->IsEnabled || pRunTimeStreamConfig->Running) {
-        LOG_E("Voltage-precision load rejected: streaming is active (stop streaming first)");
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        return SCPI_RES_ERR;
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "CONFigure:VOLTage:LOAD");
     }
     memset(&settings, 0, sizeof(DaqifiSettings));
+    scpi_result_t result = SCPI_RES_OK;
     if (!daqifi_settings_LoadFromNvm(DaqifiSettings_TopLevelSettings, &settings)) {
-        return SCPI_RES_ERR;
-    }
-    uint8_t savedPrec = settings.settings.topLevelSettings.voltagePrecision;
-    if (savedPrec <= 10) {
-        StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
-                BOARDRUNTIME_STREAMING_CONFIGURATION);
-        if (pStreamCfg != NULL) {
-            pStreamCfg->VoltagePrecision = savedPrec;
+        result = SCPI_RES_ERR;
+    } else {
+        uint8_t savedPrec = settings.settings.topLevelSettings.voltagePrecision;
+        if (savedPrec <= 10) {
+            pRunTimeStreamConfig->VoltagePrecision = savedPrec;
         }
     }
-    return SCPI_RES_OK;
+    /* Single release covering both outcomes (see SCPI_SetStreamFormat). */
+    Streaming_EndConfigChange();
+    return result;
 }
 
 // #14: user-definable device friendly name (emitted in the PB/JSON info

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2228,12 +2228,28 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
     if (periodCycles < 2) periodCycles = 2;
     pStreamCfg->ClockPeriod = periodCycles - 1;
     StreamFreq_Set(pStreamCfg, freq);
-    pStreamCfg->IsEnabled = true;
+    /* #847: this is an ARM, so it observes the config-change claim exactly as
+     * SCPI_StartStreaming's does -- read and publish in ONE critical section,
+     * because a read that merely precedes the publish still lets a setter take
+     * the claim in between and store onto the session armed here.
+     *
+     * No new unwind: leaving IsEnabled false makes Streaming_UpdateState() a
+     * no-op, Running stays false, and the existing "failed to start" branch
+     * below restores every saved value. */
+    bool cfgBusy;
+    taskENTER_CRITICAL();
+    cfgBusy = Streaming_ConfigChangeInProgress();
+    if (!cfgBusy) {
+        pStreamCfg->IsEnabled = true;
+    }
+    taskEXIT_CRITICAL();
     Streaming_UpdateState();
 
     // Verify streaming actually started
     if (!pStreamCfg->Running) {
-        LOG_E("Throughput benchmark: streaming failed to start");
+        LOG_E("Throughput benchmark: streaming failed to start%s",
+              cfgBusy ? " (a streaming config change was in flight - #847)"
+                      : "");
         pStreamCfg->IsEnabled = false;
         Streaming_SetBenchmarkMode(savedBenchmark);
         Streaming_SetTestPattern(savedPattern);
@@ -2393,7 +2409,16 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
     Streaming_ClearStats();
     cfg->ClockPeriod = periodCycles - 1;
     StreamFreq_Set(cfg, freq);
-    cfg->IsEnabled = true;
+    /* #847: same arm-time claim observation as SCPI_StartStreaming and
+     * SYST:STR:THRoughput -- read and publish in ONE critical section. If a
+     * config change holds the claim, IsEnabled stays false, Running stays
+     * false, and the existing start-failure branch just below unwinds and
+     * reports it through *outStartFailed, so no new exit path is introduced. */
+    taskENTER_CRITICAL();
+    if (!Streaming_ConfigChangeInProgress()) {
+        cfg->IsEnabled = true;
+    }
+    taskEXIT_CRITICAL();
     Streaming_UpdateState();
     if (!cfg->Running) {
         // Clean teardown so the start-fail path leaves IsEnabled=false like the

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2226,26 +2226,33 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
     // PIC32MZ type-B timer counts 0..PR inclusive (PR+1 cycles per match).
     uint32_t periodCycles = (clkFreq + freq - 1) / freq;
     if (periodCycles < 2) periodCycles = 2;
-    pStreamCfg->ClockPeriod = periodCycles - 1;
-    StreamFreq_Set(pStreamCfg, freq);
     /* #847: this is an ARM, so it observes the config-change claim exactly as
-     * SCPI_StartStreaming's does -- read and publish in ONE critical section,
-     * because a read that merely precedes the publish still lets a setter take
-     * the claim in between and store onto the session armed here.
+     * SCPI_StartStreaming's does -- and, like #848 made START do, it makes ALL
+     * of its shared-config writes inside the SAME critical section as the
+     * claim test. Checking the claim only at the publish, with ClockPeriod and
+     * Frequency already written above it, leaves a refused arm having mutated
+     * the config anyway and then restoring saved values over whatever else
+     * moved (Qodo). Frequency is uint64_t, so the section is what makes that
+     * store atomic too -- assigned directly here rather than through
+     * StreamFreq_Set, which would merely nest another critical section.
      *
-     * No new unwind is needed, and the reason is precise rather than "it is a
-     * no-op": with IsEnabled false, Streaming_Stop() does nothing (Running is
-     * already false) and Streaming_Start() skips its `if (IsEnabled)` session
-     * setup, so RUNNING STAYS FALSE -- which is the condition the existing
-     * "failed to start" branch below already tests, and that branch restores
-     * every saved value. Streaming_Start() does still drain the sample queues
-     * and invalidate BOARDDATA_AIN_LATEST on the way through; that is the same
-     * work an ordinary STOP does, on a device with no session running, so it
-     * is harmless here rather than merely absent. */
+     * On the refused path nothing was written, so the "failed to start" branch
+     * below restores values that never changed -- correct, and a no-op.
+     *
+     * The refusal leaves IsEnabled false, so Streaming_Stop() does nothing
+     * (Running is already false) and Streaming_Start() skips its
+     * `if (IsEnabled)` session setup: RUNNING STAYS FALSE, which is the
+     * condition that branch tests. Streaming_Start() does still drain the
+     * sample queues and invalidate BOARDDATA_AIN_LATEST on the way through --
+     * NOT "the same work a STOP does" (Streaming_Stop is itself a no-op when
+     * Running is false); it is the same work the NEXT successful start would
+     * do, and with no session running it can only discard stale samples. */
     bool cfgBusy;
     taskENTER_CRITICAL();
     cfgBusy = Streaming_ConfigChangeInProgress();
     if (!cfgBusy) {
+        pStreamCfg->ClockPeriod = periodCycles - 1;
+        pStreamCfg->Frequency = (uint64_t)freq;
         pStreamCfg->IsEnabled = true;
     }
     taskEXIT_CRITICAL();
@@ -2413,19 +2420,24 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
     if (periodCycles < 2) periodCycles = 2;
 
     Streaming_ClearStats();
-    cfg->ClockPeriod = periodCycles - 1;
-    StreamFreq_Set(cfg, freq);
     /* #847: same arm-time claim observation as SCPI_StartStreaming and
-     * SYST:STR:THRoughput -- read and publish in ONE critical section. If a
-     * config change holds the claim IsEnabled stays false, so Streaming_Start()
-     * skips its `if (IsEnabled)` setup and Running stays false -- which is
-     * exactly what the existing start-failure branch just below tests. It
-     * unwinds and reports through *outStartFailed, so no new exit path is
-     * introduced. (Not a no-op: Streaming_Start still drains the sample queues
-     * on the way through, which is what a STOP does anyway and is harmless
-     * with nothing running.) */
+     * SYST:STR:THRoughput, and like them ALL the shared-config writes happen
+     * inside the SAME critical section as the claim test -- a refused arm must
+     * not have mutated ClockPeriod/Frequency on its way to refusing (Qodo).
+     * Frequency is uint64_t, so the section is also what makes that store
+     * atomic; assigned directly rather than through StreamFreq_Set, which
+     * would nest a second critical section for no benefit.
+     *
+     * A held claim leaves IsEnabled false, so Streaming_Start() skips its
+     * `if (IsEnabled)` setup and Running stays false -- exactly what the
+     * start-failure branch just below tests. It unwinds and reports through
+     * *outStartFailed, so no new exit path is introduced. (Streaming_Start
+     * still drains the sample queues on the way through: the same work the
+     * next successful start would do, harmless with nothing running.) */
     taskENTER_CRITICAL();
     if (!Streaming_ConfigChangeInProgress()) {
+        cfg->ClockPeriod = periodCycles - 1;
+        cfg->Frequency = (uint64_t)freq;
         cfg->IsEnabled = true;
     }
     taskEXIT_CRITICAL();

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2256,14 +2256,28 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
         pStreamCfg->IsEnabled = true;
     }
     taskEXIT_CRITICAL();
-    Streaming_UpdateState();
 
-    // Verify streaming actually started
-    if (!pStreamCfg->Running) {
-        LOG_E("Throughput benchmark: streaming failed to start%s",
-              cfgBusy ? " (a streaming config change was in flight - #847)"
-                      : "");
-        pStreamCfg->IsEnabled = false;
+    /* Only pump the state machine if we actually armed. On the refused path
+     * Streaming_UpdateState() would call Streaming_Stop(), and if a concurrent
+     * session were running that would STOP SOMEONE ELSE'S STREAM. */
+    if (!cfgBusy) {
+        Streaming_UpdateState();
+    }
+
+    /* Verify streaming actually started -- and treat the refusal as its OWN
+     * reason rather than inferring it from Running. Inferring was wrong: a
+     * concurrent session that armed after this command's front-door check
+     * leaves Running true, and the benchmark would then adopt that session as
+     * its own and stop it after the dwell (Qodo). */
+    if (cfgBusy || !pStreamCfg->Running) {
+        LOG_E("Throughput benchmark: %s",
+              cfgBusy ? "refused, a streaming config change is in flight (#847)"
+                      : "streaming failed to start");
+        if (!cfgBusy) {
+            /* Disarm only what THIS call armed. On the refused path IsEnabled
+             * was never set here, and a concurrent session may own it. */
+            pStreamCfg->IsEnabled = false;
+        }
         Streaming_SetBenchmarkMode(savedBenchmark);
         Streaming_SetTestPattern(savedPattern);
         StreamFreq_Set(pStreamCfg, savedFrequency);
@@ -2434,19 +2448,32 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
      * *outStartFailed, so no new exit path is introduced. (Streaming_Start
      * still drains the sample queues on the way through: the same work the
      * next successful start would do, harmless with nothing running.) */
+    bool cfgBusy;
     taskENTER_CRITICAL();
-    if (!Streaming_ConfigChangeInProgress()) {
+    cfgBusy = Streaming_ConfigChangeInProgress();
+    if (!cfgBusy) {
         cfg->ClockPeriod = periodCycles - 1;
         cfg->Frequency = (uint64_t)freq;
         cfg->IsEnabled = true;
     }
     taskEXIT_CRITICAL();
-    Streaming_UpdateState();
-    if (!cfg->Running) {
+    /* Only pump the state machine if we actually armed -- on the refused path
+     * Streaming_UpdateState() would Streaming_Stop() a concurrent session. */
+    if (!cfgBusy) {
+        Streaming_UpdateState();
+    }
+    /* The refusal is its OWN reason, not an inference from Running: a
+     * concurrent session leaves Running true, and this step would otherwise
+     * adopt it as its own and measure/stop it (Qodo). */
+    if (cfgBusy || !cfg->Running) {
         // Clean teardown so the start-fail path leaves IsEnabled=false like the
         // normal path (the finder's exit assumes streaming is stopped) (Qodo #521).
-        cfg->IsEnabled = false;
-        Streaming_UpdateState();
+        // Skipped when refused: IsEnabled was never set here, and a concurrent
+        // session may own it.
+        if (!cfgBusy) {
+            cfg->IsEnabled = false;
+            Streaming_UpdateState();
+        }
         *outStartFailed = true; *outKBps = 0;
         return false;   // not "saturated" — start failure is signaled via *outStartFailed
     }

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2233,9 +2233,15 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
      * because a read that merely precedes the publish still lets a setter take
      * the claim in between and store onto the session armed here.
      *
-     * No new unwind: leaving IsEnabled false makes Streaming_UpdateState() a
-     * no-op, Running stays false, and the existing "failed to start" branch
-     * below restores every saved value. */
+     * No new unwind is needed, and the reason is precise rather than "it is a
+     * no-op": with IsEnabled false, Streaming_Stop() does nothing (Running is
+     * already false) and Streaming_Start() skips its `if (IsEnabled)` session
+     * setup, so RUNNING STAYS FALSE -- which is the condition the existing
+     * "failed to start" branch below already tests, and that branch restores
+     * every saved value. Streaming_Start() does still drain the sample queues
+     * and invalidate BOARDDATA_AIN_LATEST on the way through; that is the same
+     * work an ordinary STOP does, on a device with no session running, so it
+     * is harmless here rather than merely absent. */
     bool cfgBusy;
     taskENTER_CRITICAL();
     cfgBusy = Streaming_ConfigChangeInProgress();
@@ -2411,9 +2417,13 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
     StreamFreq_Set(cfg, freq);
     /* #847: same arm-time claim observation as SCPI_StartStreaming and
      * SYST:STR:THRoughput -- read and publish in ONE critical section. If a
-     * config change holds the claim, IsEnabled stays false, Running stays
-     * false, and the existing start-failure branch just below unwinds and
-     * reports it through *outStartFailed, so no new exit path is introduced. */
+     * config change holds the claim IsEnabled stays false, so Streaming_Start()
+     * skips its `if (IsEnabled)` setup and Running stays false -- which is
+     * exactly what the existing start-failure branch just below tests. It
+     * unwinds and reports through *outStartFailed, so no new exit path is
+     * introduced. (Not a no-op: Streaming_Start still drains the sample queues
+     * on the way through, which is what a STOP does anyway and is harmless
+     * with nothing running.) */
     taskENTER_CRITICAL();
     if (!Streaming_ConfigChangeInProgress()) {
         cfg->IsEnabled = true;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4895,10 +4895,14 @@ static scpi_result_t SCPI_LoadDataPrecision(scpi_t * context) {
      * made atomic with respect to a concurrent START.
      *
      * One fetch of the streaming config, used for the store below. The
-     * pre-#847 code fetched it twice and NULL-checked the second: this
-     * accessor indexes a static array initialised at boot and never returns
-     * NULL, so the check was dead (CLAUDE.md, "Atomicity & Concurrency
-     * Rules"). */
+     * pre-#847 code fetched it twice and NULL-checked the second, and the
+     * check was dead -- but for a narrower reason than the usual shorthand:
+     * BoardRunTimeConfig_Get returns NULL on its `NUM_OF_ELEMENTS`/`default`
+     * arm (BoardRuntimeConfig.c:62-64), and non-NULL for every other
+     * eBoardRunTimeParameter. Called with a named constant, as here, the NULL
+     * arm is unreachable. Also: the SAME pointer is dereferenced above, so a
+     * check placed after that would guard nothing anyway (Qodo, citing
+     * PR #752). */
     StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
     StreamingCfgClaim claim = Streaming_BeginConfigChange();

--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -220,6 +220,35 @@ extern "C" {
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
     }
 
+    /**
+     * #847: report a refused streaming config-change claim.
+     *
+     * Shared so every converted cap-input setter reports the same two refusal
+     * reasons the same way -- the old inline `IsEnabled || Running` guards each
+     * wrote their own message, and the "another change is in flight" case is
+     * new with the claim and would otherwise have been silent at some sites.
+     *
+     * Takes a bool rather than StreamingCfgClaim so this header does not have
+     * to pull in streaming.h; the callers already have the enum in scope.
+     *
+     * @param context SCPI context
+     * @param busy    true when the claim was refused because ANOTHER config
+     *                change holds it, false when a session is armed/running
+     * @param what    the command name, e.g. "CONF:ADC:CHANnel"
+     */
+    static inline scpi_result_t SCPI_RejectCfgClaim(scpi_t *context, bool busy,
+                                                    const char *what) {
+        if (busy) {
+            LOG_E("%s rejected: another streaming config change is in flight "
+                  "(retry)", what);
+        } else {
+            LOG_E("%s rejected: streaming is active (stop streaming first)",
+                  what);
+        }
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+
 #ifdef	__cplusplus
 }
 #endif

--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -229,7 +229,12 @@ extern "C" {
      * new with the claim and would otherwise have been silent at some sites.
      *
      * Takes a bool rather than StreamingCfgClaim so this header does not have
-     * to pull in streaming.h; the callers already have the enum in scope.
+     * to pull in streaming.h (which every SCPI translation unit would then
+     * inherit, cap math included); the callers already have the enum in scope.
+     * The cost is that the bool collapses "not OK" into exactly two messages --
+     * if a THIRD refusal reason is ever added to StreamingCfgClaim it will
+     * report as "streaming is active", so add a parameter here at the same
+     * time rather than letting it fall through.
      *
      * @param context SCPI context
      * @param busy    true when the claim was refused because ANOTHER config

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -3527,6 +3527,58 @@ void Streaming_RestoreRateConfigured(bool configured) {
     gStreamRateConfigured = configured ? 1u : 0u;
 }
 
+/* --- #847: the streaming config-change claim ------------------------------
+ *
+ * Rationale, the sequence it closes, and why the #845 critical-section idiom
+ * could not be reused for these setters: see the block comment on
+ * StreamingCfgClaim in streaming.h.
+ *
+ * uint32_t rather than bool so the READ side (Streaming_ConfigChangeInProgress,
+ * called from START's arm-time critical section) is an atomic 32-bit load on
+ * PIC32MZ -- the same reason gBenchmarkMode and gStreamRateConfigured above are
+ * uint32_t. Every WRITE happens inside a critical section anyway.
+ */
+static volatile uint32_t gCfgChangeBusy = 0u;
+
+StreamingCfgClaim Streaming_BeginConfigChange(void) {
+    /* Fetched OUTSIDE the section: BoardRunTimeConfig_Get is an index into a
+     * static array initialised at boot and never returns NULL, so there is
+     * nothing to gain from holding interrupts off across it. */
+    StreamingRuntimeConfig* pStreamCfg = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_STREAMING_CONFIGURATION);
+    StreamingCfgClaim result;
+
+    taskENTER_CRITICAL();
+    if (pStreamCfg->IsEnabled || pStreamCfg->Running) {
+        /* IsEnabled || Running, not &&: the two flags are set and cleared in
+         * separate steps at start/stop, so an && test reads false for the whole
+         * interval between them (#116 and every mirror of it says so). */
+        result = STREAM_CFG_CLAIM_STREAMING;
+    } else if (gCfgChangeBusy != 0u) {
+        /* Two config changes from the two SCPI transports. Pre-existing and
+         * not what #847 is about, but the claim makes it visible instead of
+         * letting them interleave, and refusing costs the loser a retry. */
+        result = STREAM_CFG_CLAIM_BUSY;
+    } else {
+        gCfgChangeBusy = 1u;
+        result = STREAM_CFG_CLAIM_OK;
+    }
+    taskEXIT_CRITICAL();
+
+    return result;
+}
+
+void Streaming_EndConfigChange(void) {
+    /* A single unconditional 32-bit store, atomic on PIC32MZ -- no read-modify-
+     * write, so no critical section is needed to make it safe. It is also the
+     * ONLY writer of 0, and only the holder ever calls it. */
+    gCfgChangeBusy = 0u;
+}
+
+bool Streaming_ConfigChangeInProgress(void) {
+    return (gCfgChangeBusy != 0u);
+}
+
 /* #730: the rate the hardware ACTUALLY runs, in millihertz.
  *
  * `StreamingRuntimeConfig.Frequency` stores what the client ASKED for; the

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -3541,9 +3541,20 @@ void Streaming_RestoreRateConfigured(bool configured) {
 static volatile uint32_t gCfgChangeBusy = 0u;
 
 StreamingCfgClaim Streaming_BeginConfigChange(void) {
-    /* Fetched OUTSIDE the section: BoardRunTimeConfig_Get is an index into a
-     * static array initialised at boot and never returns NULL, so there is
-     * nothing to gain from holding interrupts off across it. */
+    /* Fetched OUTSIDE the section: it is a switch over a compile-time constant
+     * returning the address of a member of one static struct, so it neither
+     * blocks nor touches shared state and there is nothing to gain from
+     * holding interrupts off across it.
+     *
+     * No NULL check, and the reason is narrower than the shorthand usually
+     * given. BoardRunTimeConfig_Get is NOT total: its `NUM_OF_ELEMENTS` /
+     * `default` arm returns NULL (BoardRuntimeConfig.c:62-64). It returns
+     * non-NULL for every OTHER eBoardRunTimeParameter, and every call site
+     * including this one passes a named constant, so the NULL arm is
+     * unreachable here by construction. A check would be dead code, which is
+     * why the project declines to add them (CLAUDE.md) -- but "never returns
+     * NULL" is not true of the function, and stating it that way is what
+     * licenses an unsafe refactor later (Qodo, citing PR #752). */
     StreamingRuntimeConfig* pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
     StreamingCfgClaim result;

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -639,8 +639,8 @@ void Streaming_CountActiveChannels(uint16_t* out_type1Count,
  * testing and storing in ONE critical section. That idiom does not generalise
  * to the rest of the family, because their "store" is not a store:
  *
- *   - CONF:ADC:SAMC -> MC12b_SetAcquisitionSamc() spins up to ~20 ms waiting
- *     on ADCCON2bits.BGVRRDY (MC12bADC.c);
+ *   - CONF:ADC:SAMC -> MC12b_SetAcquisitionSamc() spins up to 2,000,000 poll
+ *     iterations waiting on ADCCON2bits.BGVRRDY (MC12bADC.c);
  *   - CONF:ADC:THREshold -> AdcThreshold_Configure() takes a FreeRTOS mutex
  *     with portMAX_DELAY (AdcThreshold.c) -- blocking with interrupts off;
  *   - CONF:ADC:CHANnel -> LOG_I plus ADC_WriteChannelStateAll() SFR writes;

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -616,6 +616,86 @@ void Streaming_CountActiveChannels(uint16_t* out_type1Count,
                                    uint16_t* out_totalPublic,
                                    bool* out_hasAD7609);
 
+/* --- #847: the streaming config-change claim ------------------------------
+ *
+ * Every cap-input setter is guarded by `IsEnabled || Running`, and #844 closed
+ * that window from START's side (the arm re-validates the cap it was admitted
+ * under). The SAME window exists inverted, on the SETTER's side, and no cap
+ * re-validation can see it:
+ *
+ *   1. a setter on transport A reads the flags -- idle -- and proceeds;
+ *   2. a SYST:STR:START on transport B preempts it (USB SCPI is priority 7,
+ *      WiFi SCPI priority 2, so either can preempt the other), computes the
+ *      cap, re-validates it and ARMS the session;
+ *   3. the setter resumes and performs its store -- onto a RUNNING stream,
+ *      which is exactly the state its guard exists to refuse.
+ *
+ * #844's re-validation happens at step 2, BEFORE the store, so it cannot see
+ * it: the session is left running with a cap input the cap was never computed
+ * for. The trigger window is a few instructions; the consequence window is
+ * not -- step 2 contains START's SD readiness poll, which runs for seconds.
+ *
+ * PR #845 fixed the two setters it touched (SYST:STR:BENCH, SYST:STR:INT) by
+ * testing and storing in ONE critical section. That idiom does not generalise
+ * to the rest of the family, because their "store" is not a store:
+ *
+ *   - CONF:ADC:SAMC -> MC12b_SetAcquisitionSamc() spins up to ~20 ms waiting
+ *     on ADCCON2bits.BGVRRDY (MC12bADC.c);
+ *   - CONF:ADC:THREshold -> AdcThreshold_Configure() takes a FreeRTOS mutex
+ *     with portMAX_DELAY (AdcThreshold.c) -- blocking with interrupts off;
+ *   - CONF:ADC:CHANnel -> LOG_I plus ADC_WriteChannelStateAll() SFR writes;
+ *   - CONF:ADC:USECal -> an NVM save.
+ *
+ * None of those may run with interrupts disabled, so for them the guard and
+ * the store cannot share a critical section. This claim is the same exclusion
+ * expressed as a flag instead: the setter takes it (atomically with the idle
+ * test), does its work at task priority, and releases it. SCPI_StartStreaming
+ * OBSERVES it in the arm-time critical section #844 added and refuses to arm
+ * while it is held -- so a config change and an arm are mutually exclusive in
+ * both directions, and a setter's store can no longer land on a live session.
+ *
+ * SCOPE. This is not a lock over the runtime config in general. It excludes a
+ * guarded setter against an ARM; two STARTs racing each other is #850, and
+ * serialising SCPI execution across transports outright is #694. It is also
+ * advisory-only -- nothing blocks on it. The loser is refused with an error,
+ * which is the behaviour these guards already had.
+ *
+ * The "ARM" it excludes is SCPI_StartStreaming's, and only that one. TWO OTHER
+ * SITES publish IsEnabled without consulting the claim -- SYST:STR:THRoughput
+ * and the WiFi rate finder, both in SCPIInterface.c -- so a setter racing
+ * either of those is still exposed. Left that way deliberately: both are
+ * self-contained BENCH commands that arm, measure and stop inside one SCPI
+ * callback, neither appears in a production client, and wiring the claim into
+ * the finder's per-step arm would need a refusal path through its search loop.
+ * Named here rather than left implicit, because "nothing can arm while the
+ * claim is held" is what the rest of this comment would otherwise imply.
+ */
+typedef enum {
+    STREAM_CFG_CLAIM_OK = 0,      /* claim taken -- caller MUST release it */
+    STREAM_CFG_CLAIM_STREAMING,   /* a session is armed or running */
+    STREAM_CFG_CLAIM_BUSY         /* another config change is in flight */
+} StreamingCfgClaim;
+
+/**
+ * Take the config-change claim if the stream is fully idle and no other config
+ * change holds it. Tests IsEnabled/Running and takes the claim inside ONE
+ * critical section, so the pair cannot be split by a preempting START.
+ *
+ * @return STREAM_CFG_CLAIM_OK when taken -- and ONLY then must the caller call
+ *         Streaming_EndConfigChange() on every path out.
+ */
+StreamingCfgClaim Streaming_BeginConfigChange(void);
+
+/** Release a claim taken by Streaming_BeginConfigChange(). */
+void Streaming_EndConfigChange(void);
+
+/**
+ * True while a guarded config change is in flight. Read by the START arm to
+ * refuse a session whose configuration is mid-change. 32-bit read, atomic on
+ * PIC32MZ.
+ */
+bool Streaming_ConfigChangeInProgress(void);
+
 /*! Initializes the streaming component
  * @param[in] pStreamingConfigInit Streaming configuration
  * @param[out] pStreamingRuntimeConfigInit Streaming configuration in runtime

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -660,15 +660,14 @@ void Streaming_CountActiveChannels(uint16_t* out_type1Count,
  * advisory-only -- nothing blocks on it. The loser is refused with an error,
  * which is the behaviour these guards already had.
  *
- * The "ARM" it excludes is SCPI_StartStreaming's, and only that one. TWO OTHER
- * SITES publish IsEnabled without consulting the claim -- SYST:STR:THRoughput
- * and the WiFi rate finder, both in SCPIInterface.c -- so a setter racing
- * either of those is still exposed. Left that way deliberately: both are
- * self-contained BENCH commands that arm, measure and stop inside one SCPI
- * callback, neither appears in a production client, and wiring the claim into
- * the finder's per-step arm would need a refusal path through its search loop.
- * Named here rather than left implicit, because "nothing can arm while the
- * claim is held" is what the rest of this comment would otherwise imply.
+ * ALL THREE sites that publish IsEnabled observe it: SCPI_StartStreaming's arm,
+ * SYST:STR:THRoughput, and the WiFi rate finder's per-step arm (the latter two
+ * in SCPIInterface.c). Each reads the claim and publishes IsEnabled in ONE
+ * critical section -- a read that merely PRECEDES the publish is not enough,
+ * because a setter can take the claim in between and store onto the session
+ * that arm is about to publish. So "no session can arm while the claim is
+ * held" is unconditional; if a fourth arm site is ever added it must join
+ * them, and grepping for Streaming_ConfigChangeInProgress finds the pattern.
  */
 typedef enum {
     STREAM_CFG_CLAIM_OK = 0,      /* claim taken -- caller MUST release it */


### PR DESCRIPTION
Fixes #847.

## The window, from the other side

[#844](https://github.com/daqifi/daqifi-nyquist-firmware/issues/844) closed the
cap-input TOCTOU from **START's** side: the arm now recomputes the cap and
publishes `IsEnabled` in one critical section
([PR #845](https://github.com/daqifi/daqifi-nyquist-firmware/pull/845)). The
same window exists inverted, on the **setter's** side, and no amount of cap
re-validation can see it.

Every guard has this shape:

```c
if (pStreamCfg->IsEnabled || pStreamCfg->Running) { ...reject...; }
...
pStreamCfg->SomeCapInput = value;          /* not atomic with the test */
```

USB SCPI runs at priority 7 and WiFi SCPI on the WifiTask at priority 2, so:

1. a setter on transport A reads the flags — idle — and proceeds;
2. a `SYST:STR:START` on transport B preempts it, computes the cap,
   re-validates it and **arms** the session;
3. the setter resumes and performs its store — onto a **running** stream,
   which is exactly the state its guard exists to refuse.

#844's re-validation runs at step 2, *before* the store. The trigger window is
a few instructions wide; the consequence window is not — step 2 contains
START's SD readiness poll, which runs for seconds.

### One concrete instance, already in the tree

`SCPI_ADCChanEnableSet`'s tail — `if (!IsEnabled) return OK;` followed by the
`ClockPeriod` / `Frequency` / `TSClockPeriod` / `ChannelScanFreqDiv` writes —
is reachable **only** through this race, because its entry guard rejects when
`IsEnabled` is already set. What it did there was overwrite the rate of the
session `START` had just committed: a channel-enable command silently
re-rating a live stream to its own locally-capped `freq`.

## Why a claim and not #845's critical section

PR #845 fixed the two setters it touched by testing and storing in **one**
critical section. That idiom does not generalise to the rest of the family,
because their "store" is not a store and **cannot run with interrupts
disabled** — all four source-verified:

| setter | what its "store" actually does |
|---|---|
| `CONF:ADC:SAMC` | `MC12b_SetAcquisitionSamc` spins up to **2,000,000 poll iterations** on `ADCCON2bits.BGVRRDY` (`MC12bADC.c`) |
| `CONF:ADC:THREshold` | `AdcThreshold_Configure` takes a FreeRTOS mutex with `portMAX_DELAY` (`AdcThreshold.c`) — blocking with interrupts off |
| `CONF:ADC:CHANnel` | `LOG_I` plus `ADC_WriteChannelStateAll()` SFR writes |
| `CONF:ADC:USECal` | an NVM save |

So the exclusion is expressed as a flag instead:

- `Streaming_BeginConfigChange()` tests `IsEnabled || Running` **and** takes
  the claim in one critical section;
- the setter does its work at task priority and releases it;
- `SCPI_StartStreaming`'s arm-time critical section (the one #844 added)
  refuses to publish `IsEnabled` while the claim is held.

A config change and an arm become mutually exclusive **in both directions**.
Nothing blocks — the loser is refused with an error, which is the behaviour
these guards already had.

## The eight converted setters, and how each releases

`CONF:ADC:CHANnel`, `CONF:ADC:USECal`, `CONF:ADC:OBDiag`, `CONF:ADC:THREshold`,
`CONF:ADC:SAMC` (both spellings), `SYST:STR:FORmat`,
`CONFigure:VOLTage:PRECision`, `CONFigure:VOLTage:LOAD`.

A leaked claim would be worse than the bug — it refuses every later config
change and every `START` until reboot — so the release is structural, never a
line before each `return`:

- **CHANnel** and **USECal** (259 lines with twelve returns, and nine returns — counted, not estimated) are
  split into a thin wrapper plus a `*Claimed` body. The wrapper has one call
  and one release, so no return inside the body can skip it.
- The rest release at a **single point before their own branching** — e.g.
  SAMC releases immediately after `MC12b_SetAcquisitionSamc` returns, ahead of
  the success/failure branch; `SYST:STR:FORmat` and `CONF:VOLT:LOAD` compute a
  `result` and release once on the way out.

The claims sit in the same position as the guards they replace, so **the order
in which each command reports its errors is unchanged** (part 3 of the
companion test pins that).

## Scope — what this does NOT close

Stated here rather than left implied, and repeated in the header comment:

- **Two STARTs racing each other** is [#850](https://github.com/daqifi/daqifi-nyquist-firmware/issues/850);
  serialising SCPI execution across transports is
  [#694](https://github.com/daqifi/daqifi-nyquist-firmware/issues/694).
- **A cap-neutral channel change** during the START window is
  [#846](https://github.com/daqifi/daqifi-nyquist-firmware/issues/846) — this
  PR stops the *setter* landing after the arm, not the mapping going stale
  before it.
- **The `SYST:MEM:*` family** has the same two defects and one worse payload
  — its guard is `&&` where the whole family uses `||`, it test-then-stores,
  and `SYST:MEM:AUTO` re-partitions the streaming buffer pool through the
  window. Found while scoping this PR and filed as
  [#857](https://github.com/daqifi/daqifi-nyquist-firmware/issues/857) rather
  than folded in: different family, `&&`→`||` is a behaviour change, and
  holding the claim across `PrepareStreamingBuffers` wants its own test.
- `SYST:STR:THRoughput` and the **WiFi rate finder** publish `IsEnabled`
  without consulting the claim. Both are self-contained bench commands that
  arm, measure and stop inside one SCPI callback and neither appears in a
  production client; wiring the claim into the finder's per-step arm would
  need a refusal path through its search loop. Named in `streaming.h` so
  "nothing can arm while the claim is held" is not read as unconditional.

## Verification

- `default` (NQ1) and `Nq3` both build clean at **-O3 with `-Werror`**, 0 errors,
  0 warnings.
- `tools/lint/cppcheck.sh`: **0 findings**, baseline unchanged.
- No new SCPI patterns, so no wiki change is required.
- No internal callers: all eight are SCPI callbacks only
  (`grep` over `firmware/src`), so the claim cannot be taken re-entrantly.

## Companion test

[daqifi-python-test-suite#241](https://github.com/daqifi/daqifi-python-test-suite/pull/241)
— `test_847_cap_input_setter_atomic.py`, four deterministic parts plus an
opt-in `--race` arm whose hammer (`SYST:STR:FOR 3`) is deliberately
cap-neutral so it isolates #847 from #844. `--self-test` 94 checks / 18
mutants, none survived.

**Bench A/B NOT YET RUN:** the device-guard has this station's board pinned to
another agent identity and the documented `BENCH_AGENT` override does not reach
the PreToolUse hook; the sanctioned `bench serial` helper cannot drive this
device's CDC (it does not assert DTR). No guard was bypassed and no registry or
settings file was edited. The A/B shape to fill in is recorded in the test's
docstring.
