### PR TITLE
fix(scpi): the SYST:MEM:* guard refused only the middle of a session (#857)

### DIFF
--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -153,8 +153,13 @@ static scpi_result_t ADCChanEnableSetClaimed(scpi_t * context) {
     // mid-stream), so changing the channel set live would desync the pool layout
     // from the ISR write width. The old behavior here silently re-capped the
     // frequency (LOG_I only) without re-partitioning the pool — unsound and
-    // invisible to the client. Mirror SCPI_MemRejectIfStreaming: stop streaming,
-    // reconfigure, restart. Rejecting BEFORE ADC_WriteChannelStateAll() leaves both
+    // invisible to the client. The contract is: stop streaming, reconfigure,
+    // restart -- the same one every SYST:MEM:* command states, and since #857
+    // they reach it through this same claim. (This sentence used to say "mirror
+    // SCPI_MemRejectIfStreaming", which #857 deleted; that guard was also the
+    // one hand-rolling the && form this comment goes on to warn against, so it
+    // was the wrong thing to point at even while it existed.)
+    // Rejecting BEFORE ADC_WriteChannelStateAll() leaves both
     // runtime config and ADC hardware untouched (no snapshot/rollback needed).
     //
     // The claim tests IsEnabled || Running -- never && -- because the two flags

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2799,7 +2799,20 @@ static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
 static bool Iperf2_RefuseIfStreaming(scpi_t * context) {
     StreamingRuntimeConfig* pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
-    if (pStreamCfg->IsEnabled && pStreamCfg->Running) {
+    /* #857: `IsEnabled || Running`, not &&. Found as the twin of the SYST:MEM:*
+     * guard this PR converts -- the same defect, in the other direction: an &&
+     * test reads FALSE for the whole interval between the two flags (START
+     * publishes IsEnabled, then Streaming_UpdateState flips Running; stop
+     * clears them in turn), so it refused only the fully-established middle of
+     * a session and admitted both ends. Starting an iperf2 server or client
+     * there puts a saturating TCP load on the WINC while a session arms.
+     *
+     * Only the test is corrected. This command is NOT converted to the
+     * config-change claim, because it is not a config change: it starts a
+     * network task rather than mutating a cap input or MemoryConfig, so it has
+     * nothing for START's arm-time observation to protect, and taking the claim
+     * would refuse unrelated setters for the length of an iperf run. */
+    if (pStreamCfg->IsEnabled || pStreamCfg->Running) {
         SCPI_ExecutionError(context, "SYST:WIFI:IPERF: stop streaming first");
         return true;
     }
@@ -5356,22 +5369,80 @@ static scpi_result_t SCPI_GetCommandHistory(scpi_t * context) {
 //   Sample pool:   0 (auto = DEFAULT_AIN_SAMPLE_COUNT), or 100 - MAX_AIN_SAMPLE_COUNT (10000)
 // =============================================================================
 
-/**
- * @brief Guard: reject memory config changes while streaming is active.
- * @return true if streaming is active (caller should return SCPI_RES_ERR)
+/* --- #857: the SYST:MEM:* stream-state guard ------------------------------
+ *
+ * This family had BOTH defects #847 found in the cap-input setters, and one of
+ * them with a worse payload.
+ *
+ * 1. The old guard tested `IsEnabled && Running`. Those two flags are set in
+ *    separate steps at stream start (SCPI_StartStreaming publishes IsEnabled,
+ *    then Streaming_UpdateState flips Running) and cleared in turn at stop, so
+ *    an && test reads FALSE for the whole interval between them -- it refuses
+ *    only the fully-established middle of a session and admits both ends. Every
+ *    other stream-state guard in the tree says `IsEnabled || Running` and says
+ *    why (#116, #619, #832, OBDiag, SAMC); this was the second holdout after
+ *    the one PR #845 fixed. Streaming_BeginConfigChange performs the || form,
+ *    so the fix here is to stop hand-rolling the test at all.
+ *
+ * 2. Test-then-store: the guard read the flags, then the body parsed, validated
+ *    and stored, and a SYST:STR:START on the OTHER SCPI transport (USB SCPI is
+ *    priority 7, WiFi SCPI priority 2) could arm in between -- the #847 window,
+ *    reached through a different family. The claim closes it in both directions:
+ *    the test and the take share one critical section here, and all three sites
+ *    that publish IsEnabled refuse to arm while the claim is held.
+ *
+ * WHY THIS FAMILY IS WORSE THAN A LATE SCALAR STORE. SYST:MEM:AUTO and
+ * SYST:MEM:RESet do not merely store a number. AUTO memsets the whole
+ * MemoryConfig and calls PrepareStreamingBuffers, which re-partitions the
+ * streaming buffer pool and swaps the sample-pool pointers
+ * (StreamingBufferPool_Partition -> AInSampleList_InitializeExternal). Landing
+ * that on a session armed inside the window re-carves the memory the deferred
+ * task and the encoder are actively using. PrepareStreamingBuffers also blocks
+ * (it quiesces SD), which is exactly why the claim is a flag rather than a
+ * critical section -- the whole body can hold it at task priority.
+ *
+ * The claim is taken and released in ONE place, here, with the command body
+ * passed in. Each body keeps its own error returns and cannot leak the claim,
+ * which is the same property #847's per-command wrappers buy; a single runner
+ * is used because all seven commands share one guard and always did.
+ *
+ * `body` and `what` are deliberately not NULL-checked. Every caller is a
+ * three-line wrapper in this file passing a named static function and a string
+ * literal, so a NULL is a compile-time impossibility rather than a runtime one,
+ * and the check would be dead code -- the same reasoning the project applies to
+ * BoardRunTimeConfig_Get. Stated because they are NEW parameters, and an
+ * unexplained absence reads as an oversight.
+ *
+ * NOT CLOSED HERE, and pre-existing rather than introduced. SYST:STR:THRoughput
+ * and the WiFi rate finder call PrepareStreamingBuffers BEFORE they observe the
+ * claim (SCPIInterface.c -- the prepare, then the arm-time critical section), so
+ * a SYST:MEM:AUTO holding the claim can still be re-partitioning while one of
+ * them partitions too. The old && guard admitted exactly the same overlap, so
+ * this is unchanged by the conversion, and the outcome is strictly better: the
+ * arm now sees the claim and refuses instead of arming onto a pool being
+ * re-carved. Making it airtight needs those two to TAKE the claim rather than
+ * observe it, which they cannot do as written -- they would then read their own
+ * claim at the arm and refuse themselves. What the claim does close outright is
+ * two SYST:MEM:AUTO commands racing each other: the loser now gets
+ * STREAM_CFG_CLAIM_BUSY instead of a second concurrent re-partition.
  */
-static bool SCPI_MemRejectIfStreaming(scpi_t * context) {
-    StreamingRuntimeConfig* sc = BoardRunTimeConfig_Get(BOARDRUNTIME_STREAMING_CONFIGURATION);
-    if (sc->IsEnabled && sc->Running) {
-        LOG_E("Memory config rejected: streaming is active");
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        return true;
+static scpi_result_t SCPI_MemRunClaimed(scpi_t * context,
+                                        scpi_result_t (*body)(scpi_t *),
+                                        const char *what) {
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   what);
     }
-    return false;
+    scpi_result_t result = body(context);
+    Streaming_EndConfigChange();
+    return result;
 }
 
-static scpi_result_t SCPI_SetMemSdBuf(scpi_t * context) {
-    if (SCPI_MemRejectIfStreaming(context)) return SCPI_RES_ERR;
+static scpi_result_t SCPI_SetMemSdBufClaimed(scpi_t * context) {
+    /* #857: the stream-state rejection lives in this command's
+     * SCPI_MemRunClaimed wrapper below, not here. */
     int32_t val;
     if (!SCPI_ParamInt32(context, &val, TRUE)) return SCPI_RES_ERR;
     // Must be 4096-65536 and a multiple of 512 (SD sector alignment)
@@ -5382,6 +5453,11 @@ static scpi_result_t SCPI_SetMemSdBuf(scpi_t * context) {
     MemoryConfig* mc = BoardRunTimeConfig_Get(BOARDRUNTIME_MEMORY_CONFIG);
     mc->sdCircularBufSize = (uint32_t)val;
     return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_SetMemSdBuf(scpi_t * context) {
+    return SCPI_MemRunClaimed(context, SCPI_SetMemSdBufClaimed,
+                              "SYSTem:MEMory:SD:BUFfer");
 }
 
 static scpi_result_t SCPI_GetMemSdBuf(scpi_t * context) {
@@ -5397,8 +5473,9 @@ static scpi_result_t SCPI_GetMemSdBuf(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
-static scpi_result_t SCPI_SetMemWifiBuf(scpi_t * context) {
-    if (SCPI_MemRejectIfStreaming(context)) return SCPI_RES_ERR;
+static scpi_result_t SCPI_SetMemWifiBufClaimed(scpi_t * context) {
+    /* #857: the stream-state rejection lives in this command's
+     * SCPI_MemRunClaimed wrapper below, not here. */
     int32_t val;
     if (!SCPI_ParamInt32(context, &val, TRUE)) return SCPI_RES_ERR;
     // Min = SOCKET_BUFFER_MAX_LENGTH (1400), max = 65536
@@ -5411,14 +5488,20 @@ static scpi_result_t SCPI_SetMemWifiBuf(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+static scpi_result_t SCPI_SetMemWifiBuf(scpi_t * context) {
+    return SCPI_MemRunClaimed(context, SCPI_SetMemWifiBufClaimed,
+                              "SYSTem:MEMory:WIFI:BUFfer");
+}
+
 static scpi_result_t SCPI_GetMemWifiBuf(scpi_t * context) {
     // #494: see SCPI_GetMemSdBuf.
     SCPI_ResultInt32(context, (int32_t)StreamingBufferPool_WifiSize());
     return SCPI_RES_OK;
 }
 
-static scpi_result_t SCPI_SetMemUsbBuf(scpi_t * context) {
-    if (SCPI_MemRejectIfStreaming(context)) return SCPI_RES_ERR;
+static scpi_result_t SCPI_SetMemUsbBufClaimed(scpi_t * context) {
+    /* #857: the stream-state rejection lives in this command's
+     * SCPI_MemRunClaimed wrapper below, not here. */
     int32_t val;
     if (!SCPI_ParamInt32(context, &val, TRUE)) return SCPI_RES_ERR;
     // Min = USBCDC_WBUFFER_SIZE (circular buffer must hold one full USB CDC write), max = 65536
@@ -5431,14 +5514,20 @@ static scpi_result_t SCPI_SetMemUsbBuf(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+static scpi_result_t SCPI_SetMemUsbBuf(scpi_t * context) {
+    return SCPI_MemRunClaimed(context, SCPI_SetMemUsbBufClaimed,
+                              "SYSTem:MEMory:USB:BUFfer");
+}
+
 static scpi_result_t SCPI_GetMemUsbBuf(scpi_t * context) {
     // #494: see SCPI_GetMemSdBuf.
     SCPI_ResultInt32(context, (int32_t)StreamingBufferPool_UsbSize());
     return SCPI_RES_OK;
 }
 
-static scpi_result_t SCPI_SetMemSamplePool(scpi_t * context) {
-    if (SCPI_MemRejectIfStreaming(context)) return SCPI_RES_ERR;
+static scpi_result_t SCPI_SetMemSamplePoolClaimed(scpi_t * context) {
+    /* #857: the stream-state rejection lives in this command's
+     * SCPI_MemRunClaimed wrapper below, not here. */
     int32_t val;
     if (!SCPI_ParamInt32(context, &val, TRUE)) return SCPI_RES_ERR;
     // 0 = auto (DEFAULT_AIN_SAMPLE_COUNT), MIN..MAX_AIN_SAMPLE_COUNT (100-10000) = explicit
@@ -5451,6 +5540,11 @@ static scpi_result_t SCPI_SetMemSamplePool(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+static scpi_result_t SCPI_SetMemSamplePool(scpi_t * context) {
+    return SCPI_MemRunClaimed(context, SCPI_SetMemSamplePoolClaimed,
+                              "SYSTem:MEMory:SAMPle:POOL");
+}
+
 static scpi_result_t SCPI_GetMemSamplePool(scpi_t * context) {
     MemoryConfig* mc = BoardRunTimeConfig_Get(BOARDRUNTIME_MEMORY_CONFIG);
     uint32_t effective = mc->samplePoolCount ? mc->samplePoolCount : DEFAULT_AIN_SAMPLE_COUNT;
@@ -5458,8 +5552,9 @@ static scpi_result_t SCPI_GetMemSamplePool(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
-static scpi_result_t SCPI_SetMemEncoderBuf(scpi_t * context) {
-    if (SCPI_MemRejectIfStreaming(context)) return SCPI_RES_ERR;
+static scpi_result_t SCPI_SetMemEncoderBufClaimed(scpi_t * context) {
+    /* #857: the stream-state rejection lives in this command's
+     * SCPI_MemRunClaimed wrapper below, not here. */
     int32_t val;
     if (!SCPI_ParamInt32(context, &val, TRUE)) return SCPI_RES_ERR;
     // 0 = auto (ENCODER_BUFFER_DEFAULT), 1024-65536 = explicit
@@ -5470,6 +5565,11 @@ static scpi_result_t SCPI_SetMemEncoderBuf(scpi_t * context) {
     MemoryConfig* mc = BoardRunTimeConfig_Get(BOARDRUNTIME_MEMORY_CONFIG);
     mc->encoderBufSize = (uint32_t)val;
     return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_SetMemEncoderBuf(scpi_t * context) {
+    return SCPI_MemRunClaimed(context, SCPI_SetMemEncoderBufClaimed,
+                              "SYSTem:MEMory:ENCoder:BUFfer");
 }
 
 static scpi_result_t SCPI_GetMemEncoderBuf(scpi_t * context) {
@@ -5713,8 +5813,9 @@ static bool PrepareStreamingBuffers(uint32_t poolCount, size_t sampleElemSize) {
     return true;
 }
 
-static scpi_result_t SCPI_MemAutoBalance(scpi_t * context) {
-    if (SCPI_MemRejectIfStreaming(context)) return SCPI_RES_ERR;
+static scpi_result_t SCPI_MemAutoBalanceClaimed(scpi_t * context) {
+    /* #857: the stream-state rejection lives in this command's
+     * SCPI_MemRunClaimed wrapper below, not here. */
     MemoryConfig* mc = BoardRunTimeConfig_Get(BOARDRUNTIME_MEMORY_CONFIG);
 
     // Force auto mode by zeroing mc BEFORE partitioning, so the shared helper
@@ -5731,11 +5832,22 @@ static scpi_result_t SCPI_MemAutoBalance(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
-static scpi_result_t SCPI_MemReset(scpi_t * context) {
-    if (SCPI_MemRejectIfStreaming(context)) return SCPI_RES_ERR;
+static scpi_result_t SCPI_MemAutoBalance(scpi_t * context) {
+    return SCPI_MemRunClaimed(context, SCPI_MemAutoBalanceClaimed,
+                              "SYSTem:MEMory:AUTO");
+}
+
+static scpi_result_t SCPI_MemResetClaimed(scpi_t * context) {
+    /* #857: the stream-state rejection lives in this command's
+     * SCPI_MemRunClaimed wrapper below, not here. */
     MemoryConfig* mc = BoardRunTimeConfig_Get(BOARDRUNTIME_MEMORY_CONFIG);
     memset(mc, 0, sizeof(MemoryConfig));
     return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_MemReset(scpi_t * context) {
+    return SCPI_MemRunClaimed(context, SCPI_MemResetClaimed,
+                              "SYSTem:MEMory:RESet");
 }
 
 // =============================================================================

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5397,9 +5397,17 @@ static scpi_result_t SCPI_GetCommandHistory(scpi_t * context) {
  * streaming buffer pool and swaps the sample-pool pointers
  * (StreamingBufferPool_Partition -> AInSampleList_InitializeExternal). Landing
  * that on a session armed inside the window re-carves the memory the deferred
- * task and the encoder are actively using. PrepareStreamingBuffers also blocks
- * (it quiesces SD), which is exactly why the claim is a flag rather than a
- * critical section -- the whole body can hold it at task priority.
+ * task and the encoder are actively using.
+ *
+ * PrepareStreamingBuffers also CALLS vTaskDelay, which is exactly why the claim
+ * is a flag rather than a critical section -- the whole body can hold it at task
+ * priority. Note the justification is that it yields AT ALL, not that it is slow:
+ * its two vTaskDelay(1) loops are bounded at 1000 ms and 100 ms and
+ * SCPI_QuiesceAndResetCoherentPool has a third bounded at 500 x 10 ms, but all
+ * three are conditioned on work being in flight and fall straight through on an
+ * idle device ("No-op for idle callers", as the quiescence loop says of itself).
+ * A single vTaskDelay with interrupts disabled is fatal at any duration, so the
+ * flag is required either way -- do not read a duration into this.
  *
  * The claim is taken and released in ONE place, here, with the command body
  * passed in. Each body keeps its own error returns and cannot leak the claim,


### PR DESCRIPTION
Fixes #857.

## The defect

`SCPI_MemRejectIfStreaming` guarded all seven `SYST:MEM:*` commands and carried **both** defects [#847](https://github.com/daqifi/daqifi-nyquist-firmware/issues/847) found in the cap-input setters — one of them with a worse payload.

**1. The guard tested `IsEnabled && Running`.** Those two flags are set in *separate steps* at stream start (`SCPI_StartStreaming` publishes `IsEnabled`, then `Streaming_UpdateState` flips `Running`) and cleared in turn at stop, so an `&&` test reads FALSE for the whole interval between them: it refused only the fully-established **middle** of a session and admitted both ends. Every other stream-state guard in the tree says `IsEnabled || Running` and says why (#116, #619, #832, OBDiag, SAMC). [PR #845](https://github.com/daqifi/daqifi-nyquist-firmware/pull/845) called `SYST:STR:BENCH` "the one holdout from the form every other stream-state guard uses" — this was the second.

**2. Test-then-store.** The guard read the flags; the body then parsed, validated and stored. A `SYST:STR:START` on the other SCPI transport (USB SCPI is priority 7, WiFi SCPI priority 2) could arm in between — #847's window reached through a different family.

**Why this family is worse than a late scalar store.** `SYST:MEM:AUTO` and `SYST:MEM:RESet` do not merely store a number. `AUTO` memsets the whole `MemoryConfig` and calls `PrepareStreamingBuffers`, which re-partitions the streaming buffer pool and swaps the sample-pool pointers (`StreamingBufferPool_Partition` → `AInSampleList_InitializeExternal`). Landing that on a session armed inside the window **re-carves the memory the deferred task and the encoder are actively using**.

## The fix

All seven commands (`SD:BUFfer`, `WIFI:BUFfer`, `USB:BUFfer`, `SAMPle:POOL`, `ENCoder:BUFfer`, `AUTO`, `RESet`) run through `SCPI_MemRunClaimed`, which takes #847's config-change claim and releases it on the **single** path out. Each body keeps its own error returns and cannot leak the claim.

- The claim performs the `||` test **atomically with the take**, so the hand-rolled guard disappears rather than being patched.
- All three sites that publish `IsEnabled` already observe the claim (#847), so a memory-config change and an arm are now mutually exclusive **in both directions** — no change to the START path was needed.
- A flag rather than a critical section because `PrepareStreamingBuffers` **blocks** (it quiesces SD): the whole body must hold the exclusion at task priority. That is precisely the case #847 designed the claim for.

One runner rather than seven copies of take/call/release, because all seven commands share one guard and always did — one release site, provably unconditional.

### The twin, fixed in the same change

`Iperf2_RefuseIfStreaming` carried the **identical `&&` defect** and is corrected to `||` here rather than left as the next fire's rediscovery (standing lesson: *fixed one site, left the twin*). It is deliberately **not** converted to the claim — starting a network task is not a config change, so it has nothing for START's arm-time observation to protect, and holding the claim for the length of an iperf run would refuse unrelated setters.

### Residual, stated in the code rather than hidden

`SYST:STR:THRoughput` and the WiFi rate finder call `PrepareStreamingBuffers` **before** they observe the claim, so their partition can still overlap `AUTO`'s. The old `&&` guard admitted exactly the same overlap, so this is unchanged by the conversion — and the outcome is strictly better, because the arm now sees the claim and refuses instead of arming onto a pool being re-carved. Making it airtight needs those two to *take* the claim rather than observe it, which they cannot do as written: they would read their own claim at the arm and refuse themselves. What the claim *does* close outright is two `SYST:MEM:AUTO` commands racing each other — the loser now gets `STREAM_CFG_CLAIM_BUSY` instead of a second concurrent re-partition.

Also **not** in scope, and named in #857 itself: `DIO:PORT:ENABLE` still has no stream-state guard at all. That is tracked on [#846](https://github.com/daqifi/daqifi-nyquist-firmware/issues/846).

### One stale comment swept up

`SCPIADC.c` told the reader to "mirror `SCPI_MemRejectIfStreaming`" — a function this PR deletes, and one that was hand-rolling the very `&&` form the same comment goes on to warn against. Corrected to state the contract directly.

## Behaviour change

A `SYST:MEM:*` command is now refused in two situations where it previously succeeded: inside the START/STOP arming window, and while another guarded config change is in flight. Both are `-200` with a `LOG_E` line naming the command — the pre-existing refusal shape, now per-command instead of the generic `"Memory config rejected: streaming is active"`.

## Verification

| gate | result |
|---|---|
| `default` (NQ1) build, `-O3 -Werror -Wall` | clean |
| `Nq3` build | clean |
| cppcheck | 0 findings, baseline unchanged |
| SCPI wiki sync | OK — 294 registered / 305 wiki rows; **no pattern added, removed or renamed** |

No wiki update is required: this PR changes no command's spelling, arguments or success behaviour.

## Companion regression test

[daqifi-python-test-suite PR #242 — `test_857_mem_guard_claim.py`](https://github.com/daqifi/daqifi-python-test-suite/pull/242). Four deterministic single-transport arms (refusal **names the command**, no claim leaked on any path out, argument errors still win when idle, `AUTO` still re-partitions to a self-consistent pool) plus an opt-in two-transport `--race` arm that is the only one failing on pre-#857 firmware. `--self-test`: 137 checks, 22 mutants, none surviving.

**Not yet run on hardware** — the board is pinned to another bench agent identity and the device-guard hook blocks the port. Expected A/B is recorded in the test's docstring: pre-#857 fails part 1 (the generic message names no command); fixed passes 1–4 and the race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLsu2xQ4a5aSvA15feGx2n
