### PR TITLE
fix(streaming): serialize session starts across SCPI transports (#850)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2143,6 +2143,18 @@ static inline void StreamFreq_Set(StreamingRuntimeConfig* c, uint64_t f) {
     taskEXIT_CRITICAL();
 }
 
+/* #850: the shared refusal. SCPI_StartStreaming does NOT go through the
+ * runner (it must parse before claiming -- see its wrapper), so without this
+ * the two refusal sites would drift apart and an operator could not tell them
+ * apart in the log. */
+static scpi_result_t SCPI_RefuseSessionStartBusy(scpi_t * context,
+                                                 const char *what) {
+    LOG_E("%s refused (#850): another streaming session start is in "
+          "flight on the other SCPI transport. Retry.", what);
+    SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+    return SCPI_RES_ERR;
+}
+
 /* --- #850: the session-start claim runner ---------------------------------
  *
  * Every command that arms a streaming session runs its body through here, so
@@ -2166,10 +2178,7 @@ static scpi_result_t SCPI_RunSessionStartClaimed(scpi_t * context,
                                                  scpi_result_t (*body)(scpi_t *),
                                                  const char *what) {
     if (Streaming_BeginSessionStart() != STREAM_START_CLAIM_OK) {
-        LOG_E("%s refused (#850): another streaming session start is in "
-              "flight on the other SCPI transport. Retry.", what);
-        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
-        return SCPI_RES_ERR;
+        return SCPI_RefuseSessionStartBusy(context, what);
     }
     scpi_result_t result = body(context);
     Streaming_EndSessionStart();
@@ -3687,9 +3696,17 @@ static void SCPI_UnpublishStartInterface(StreamingRuntimeConfig *cfg,
 }
 
 /* #850: the session-start claim is taken by the SCPI_StartStreaming wrapper
- * below, which is the only caller of this body. */
-static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context) {
-    int32_t freq;
+ * below, which is the only caller of this body.
+ *
+ * The frequency arrives ALREADY PARSED, and that is load-bearing rather than
+ * tidiness: the wrapper has to parse before it claims, because `START 0` is the
+ * explicit DISABLE form -- a stop, not an arm -- and a stop must not be refused
+ * because some other transport is mid-start (pre-merge audit). `freqProvided`
+ * false means no argument was given and the stored Frequency is reused, which
+ * is resolved further down exactly as before. */
+static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context,
+                                                int32_t freq,
+                                                bool freqProvided) {
 
     StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
@@ -3765,38 +3782,6 @@ static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context) {
     // "abc", "100Hz") instead of starting. Mirrors libscpi's own
     // ParamSignUInt32 number-check. A no-argument START still reuses the stored
     // Frequency (resolved further down).
-    scpi_parameter_t freqParam;
-    bool freqProvided = SCPI_Parameter(context, &freqParam, FALSE);
-    // #674 (Qodo): a token that is PRESENT but unparseable — invalid string data,
-    // not a mnemonic (e.g. `SYST:STR:START #`) — makes SCPI_Parameter return FALSE
-    // with type SCPI_TOKEN_UNKNOWN, whereas a genuinely ABSENT parameter leaves
-    // type SCPI_TOKEN_PROGRAM_MNEMONIC. Distinguish them so invalid-syntax garbage
-    // is rejected too, instead of the number-check below only covering mnemonic
-    // garbage while non-mnemonic garbage falls through to the stored-rate restart.
-    // libscpi already queued -150 for the bad token; add a LOG_E and stop here.
-    if (!freqProvided && freqParam.type == SCPI_TOKEN_UNKNOWN) {
-        LOG_E("Streaming rejected: invalid frequency argument syntax "
-              "(expected an integer Hz, e.g. SYST:STR:START 5000)");
-        return SCPI_RES_ERR;
-    }
-    if (freqProvided) {
-        if (!SCPI_ParamIsNumber(&freqParam, FALSE) ||
-            !SCPI_ParamToInt32(context, &freqParam, &freq)) {
-            LOG_E("Streaming rejected: malformed frequency argument "
-                  "(expected an integer Hz, e.g. SYST:STR:START 5000)");
-            SCPI_ErrorPush(context, SCPI_ERROR_DATA_TYPE_ERROR);
-            return SCPI_RES_ERR;
-        }
-    }
-    if (freqProvided && freq == 0) {
-        // Frequency = 0 is the explicit disable form.  Always allowed,
-        // including under heap pressure (the user may be trying to
-        // stop streaming as a recovery action).
-        pRunTimeStreamConfig->IsEnabled = false;
-        Streaming_UpdateState();
-        UsbCdc_FlushWriteBuffer();
-        return SCPI_RES_OK;
-    }
 
     // #475 step 4 — heap-floor enforcement applied to every new-start
     // path (freq > 0 explicit, or no-argument re-start with current
@@ -4743,9 +4728,85 @@ static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+/* #850 + pre-merge audit: START parses BEFORE it claims.
+ *
+ * This one does not use SCPI_RunSessionStartClaimed, unlike the other two arm
+ * sites, because `SYST:STR:START 0` is the explicit DISABLE form -- a stop.
+ * A runner that claims on entry refuses it whenever another session start is
+ * in flight, so a stop could be blocked for the length of a 60 s throughput
+ * benchmark on the other transport. The claim is therefore taken only once we
+ * know this is actually an ARM.
+ *
+ * A malformed rate (`START abc`) now also fails ahead of the claim, which is a
+ * side benefit rather than the goal: a garbage START no longer takes the claim
+ * nor reaches Streaming_BuildChannelMapping's shared-state write.
+ *
+ * ERROR PRECEDENCE MOVED, deliberately. The parse used to run AFTER the power,
+ * ADC-pointer and channel-count gates, so `START abc` on an unpowered device
+ * reported -200 (not powered); it now reports -104 (malformed). A malformed
+ * command is malformed regardless of device state, and the alternative was to
+ * leave a stop refusable -- but it IS a behaviour change and the companion
+ * test pins both spellings. The claim/release pair stays a single take, one
+ * call, one release, so the body's twenty-plus return sites still cannot leak
+ * it. */
 static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
-    return SCPI_RunSessionStartClaimed(context, SCPI_StartStreamingClaimed,
-                                       "SYSTem:STReam:START");
+    int32_t freq = 0;
+    scpi_parameter_t freqParam;
+    bool freqProvided = SCPI_Parameter(context, &freqParam, FALSE);
+    // #674 (Qodo): a token that is PRESENT but unparseable — invalid string data,
+    // not a mnemonic (e.g. `SYST:STR:START #`) — makes SCPI_Parameter return FALSE
+    // with type SCPI_TOKEN_UNKNOWN, whereas a genuinely ABSENT parameter leaves
+    // type SCPI_TOKEN_PROGRAM_MNEMONIC. Distinguish them so invalid-syntax garbage
+    // is rejected too, instead of the number-check below only covering mnemonic
+    // garbage while non-mnemonic garbage falls through to the stored-rate restart.
+    // libscpi already queued -150 for the bad token; add a LOG_E and stop here.
+    if (!freqProvided && freqParam.type == SCPI_TOKEN_UNKNOWN) {
+        LOG_E("Streaming rejected: invalid frequency argument syntax "
+              "(expected an integer Hz, e.g. SYST:STR:START 5000)");
+        return SCPI_RES_ERR;
+    }
+    if (freqProvided) {
+        if (!SCPI_ParamIsNumber(&freqParam, FALSE) ||
+            !SCPI_ParamToInt32(context, &freqParam, &freq)) {
+            LOG_E("Streaming rejected: malformed frequency argument "
+                  "(expected an integer Hz, e.g. SYST:STR:START 5000)");
+            SCPI_ErrorPush(context, SCPI_ERROR_DATA_TYPE_ERROR);
+            return SCPI_RES_ERR;
+        }
+    }
+    if (freqProvided && freq == 0) {
+        /* Frequency = 0 is the explicit DISABLE form: a stop, not an arm.
+         *
+         * Handled HERE, ahead of the claim, and that placement is the whole
+         * point (pre-merge audit). Taking the claim first made this path
+         * refusable with -200 while a SYST:STR:THRoughput -- up to 60 s --
+         * held the claim on the other transport, which contradicts what this
+         * branch has always promised and what the interlock is FOR: #850
+         * serialises session STARTS against each other, and a stop is neither.
+         *
+         * It also now runs ahead of the power and channel-count gates, so it
+         * is unconditional in a way it previously was not. That is deliberate
+         * and matches SYST:STR:STOP, which has no such gates and performs the
+         * identical three actions -- stopping should never depend on the
+         * device still being in a state fit to START.
+         *
+         * Always allowed, including under heap pressure (the user may be
+         * trying to stop streaming as a recovery action). */
+        StreamingRuntimeConfig * cfg = BoardRunTimeConfig_Get(
+                BOARDRUNTIME_STREAMING_CONFIGURATION);
+        cfg->IsEnabled = false;
+        Streaming_UpdateState();
+        UsbCdc_FlushWriteBuffer();
+        return SCPI_RES_OK;
+    }
+
+    if (Streaming_BeginSessionStart() != STREAM_START_CLAIM_OK) {
+        return SCPI_RefuseSessionStartBusy(context, "SYSTem:STReam:START");
+    }
+    scpi_result_t result = SCPI_StartStreamingClaimed(context, freq,
+                                                      freqProvided);
+    Streaming_EndSessionStart();
+    return result;
 }
 
 static scpi_result_t SCPI_StopStreaming(scpi_t * context) {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4791,7 +4791,20 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
          * device still being in a state fit to START.
          *
          * Always allowed, including under heap pressure (the user may be
-         * trying to stop streaming as a recovery action). */
+         * trying to stop streaming as a recovery action).
+         *
+         * "ALLOWED" MEANS NOT REFUSED -- it does not mean the stop is
+         * guaranteed to take effect. A stop issued while ANOTHER transport
+         * is inside its pre-arm window clears an IsEnabled that is still
+         * false, and that start then publishes IsEnabled=true on its way
+         * out -- so the caller gets OK and the device streams anyway.
+         * SYSTem:STReam:STOP has the identical hole and always has; both
+         * predate the #850 claim, which serialises STARTS against each
+         * other and never claimed to order a stop against a start. Closing
+         * it needs the arm to observe a stop-requested generation, the way
+         * it already observes ifaceMoved/cfgChanging -- tracked separately,
+         * because the fix belongs to STOP as much as to this branch
+         * (pre-merge audit round 2). */
         StreamingRuntimeConfig * cfg = BoardRunTimeConfig_Get(
                 BOARDRUNTIME_STREAMING_CONFIGURATION);
         cfg->IsEnabled = false;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -2143,7 +2143,42 @@ static inline void StreamFreq_Set(StreamingRuntimeConfig* c, uint64_t f) {
     taskEXIT_CRITICAL();
 }
 
-static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
+/* --- #850: the session-start claim runner ---------------------------------
+ *
+ * Every command that arms a streaming session runs its body through here, so
+ * two of them can never be in flight at once. Rationale and the list of arm
+ * sites: the StreamingStartClaim block comment in streaming.h.
+ *
+ * The claim is taken and released in ONE place, with the command body passed
+ * in. That is the property #857's SCPI_MemRunClaimed established and the
+ * reason this is a runner rather than a take/release pair pasted into three
+ * functions: SCPI_StartStreaming alone has more than twenty return sites, and
+ * a claim released at only nineteen of them would wedge every subsequent
+ * START until reboot. Each body keeps its own error returns and cannot leak
+ * the claim.
+ *
+ * `body` and `what` are deliberately not NULL-checked: every caller is a
+ * three-line wrapper in this file passing a named static function and a string
+ * literal, so a NULL is a compile-time impossibility rather than a runtime
+ * one. Same reasoning, and the same statement of it, as SCPI_MemRunClaimed.
+ */
+static scpi_result_t SCPI_RunSessionStartClaimed(scpi_t * context,
+                                                 scpi_result_t (*body)(scpi_t *),
+                                                 const char *what) {
+    if (Streaming_BeginSessionStart() != STREAM_START_CLAIM_OK) {
+        LOG_E("%s refused (#850): another streaming session start is in "
+              "flight on the other SCPI transport. Retry.", what);
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+    scpi_result_t result = body(context);
+    Streaming_EndSessionStart();
+    return result;
+}
+
+/* #850: the session-start claim is taken by the SCPI_RunThroughputBench wrapper
+ * below, which is the only caller of this body. */
+static scpi_result_t SCPI_RunThroughputBenchClaimed(scpi_t * context) {
     int32_t freq, duration;
     if (!SCPI_ParamInt32(context, &freq, TRUE)) return SCPI_RES_ERR;
     if (!SCPI_ParamInt32(context, &duration, TRUE)) return SCPI_RES_ERR;
@@ -2341,6 +2376,11 @@ static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
     scpi_printf(context, "PoolMaxUsed=%u\r\n", (unsigned)AInSampleList_PoolMaxUsed());
 
     return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_RunThroughputBench(scpi_t * context) {
+    return SCPI_RunSessionStartClaimed(context, SCPI_RunThroughputBenchClaimed,
+                                       "SYSTem:STReam:THRoughput");
 }
 
 // =====================================================================
@@ -2543,7 +2583,9 @@ static bool FindMeasureStep(StreamingRuntimeConfig* cfg, uint32_t clkFreq,
     return tripped;
 }
 
-static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
+/* #850: the session-start claim is taken by the SCPI_WifiFindRate wrapper
+ * below, which is the only caller of this body. */
+static scpi_result_t SCPI_WifiFindRateClaimed(scpi_t * context) {
     // Optional params: startHz, maxHz (0/absent => defaults).
     int32_t startArg = 0, maxArg = 0;
     SCPI_ParamInt32(context, &startArg, FALSE);
@@ -2790,6 +2832,11 @@ static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
                 (unsigned)recommendedHz, (unsigned)recommendedKBps,
                 reason, (unsigned)lastGoodHz, (unsigned)lastGoodKBps);
     return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_WifiFindRate(scpi_t * context) {
+    return SCPI_RunSessionStartClaimed(context, SCPI_WifiFindRateClaimed,
+                                       "SYSTem:STReam:WIFI:FINd?");
 }
 
 // =====================================================================
@@ -3639,7 +3686,9 @@ static void SCPI_UnpublishStartInterface(StreamingRuntimeConfig *cfg,
     taskEXIT_CRITICAL();
 }
 
-static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
+/* #850: the session-start claim is taken by the SCPI_StartStreaming wrapper
+ * below, which is the only caller of this body. */
+static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context) {
     int32_t freq;
 
     StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
@@ -4692,6 +4741,11 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     SCPI_ClearOperBits(OPER_SD_FINALIZING);
 
     return SCPI_RES_OK;
+}
+
+static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
+    return SCPI_RunSessionStartClaimed(context, SCPI_StartStreamingClaimed,
+                                       "SYSTem:STReam:START");
 }
 
 static scpi_result_t SCPI_StopStreaming(scpi_t * context) {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4785,10 +4785,26 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
          * serialises session STARTS against each other, and a stop is neither.
          *
          * It also now runs ahead of the power and channel-count gates, so it
-         * is unconditional in a way it previously was not. That is deliberate
-         * and matches SYST:STR:STOP, which has no such gates and performs the
-         * identical three actions -- stopping should never depend on the
-         * device still being in a state fit to START.
+         * is unconditional in a way it previously was not. That is deliberate:
+         * SYSTem:STReam:STOP has no such gates either, and stopping should not
+         * depend on the device still being in a state fit to START.
+         *
+         * IT IS NOT, HOWEVER, EQUIVALENT TO SYSTem:STReam:STOP, and an earlier
+         * revision of this comment said it performed "the identical three
+         * actions", which is false (pre-merge audit). STOP additionally tears
+         * down SD logging -- mode to SD_CARD_MANAGER_MODE_NONE,
+         * sd_card_manager_UpdateSettings, then a bounded wait for the manager
+         * to drain and close the file -- and clears the streaming OPER bits.
+         * This branch does neither, so `START 0` on a logging session leaves
+         * the file open in WRITE mode and OPER reading MEASURING.
+         *
+         * Both gaps are PRE-EXISTING: main's disable branch is these same
+         * three statements. They are tracked in #860 rather than fixed here,
+         * because the fix is to make this branch a real stop, which is a
+         * behaviour change of its own and wants its own test. What changes
+         * here is only that the code no longer CLAIMS an equivalence it does
+         * not have -- a client that needs a complete stop should send
+         * SYSTem:STReam:STOP.
          *
          * Always allowed, including under heap pressure (the user may be
          * trying to stop streaming as a recovery action).

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -3601,6 +3601,21 @@ bool Streaming_ConfigChangeInProgress(void) {
  * unconditional store outside any section; the test-and-take is a read-modify-
  * write and is inside one, because `if (!busy) busy = 1` is exactly the
  * non-atomic sequence two transports must not interleave.
+ *
+ * NOT in Streaming_Init's #409 retained-RAM reset list, and that is checked
+ * rather than assumed. The hazard #409 describes is a file-static landing in
+ * its own `.bss.<name>` section placed by the best-fit allocator OUTSIDE
+ * [_bss_begin,_bss_end], where crt0 never zeroes it. This one is small enough
+ * to be GP-relative, so it lands in `.sbss.gSessionStartBusy` INSIDE that
+ * window and is zeroed on every reset including MCLR and an IPE flash --
+ * verified in the .map at 0x80000394, against _bss_begin 0x80000090 /
+ * _bss_end 0x800030c0. gCfgChangeBusy sits at 0x80000398 with the same
+ * property, which is why it is absent from that list too.
+ *
+ * Worth stating because the consequence of being wrong is asymmetric: a flag
+ * that survived a reset set would refuse EVERY streaming command until a
+ * power cycle. If a future change grows this past the GP-relative threshold
+ * or moves it out of that window, it must join the reset list.
  */
 static volatile uint32_t gSessionStartBusy = 0u;
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -3590,6 +3590,42 @@ bool Streaming_ConfigChangeInProgress(void) {
     return (gCfgChangeBusy != 0u);
 }
 
+/* --- #850: the session-start claim ----------------------------------------
+ *
+ * Rationale, why it is a second flag rather than a reuse of the config-change
+ * claim above, and why all three arm sites take it: see the block comment on
+ * StreamingStartClaim in streaming.h.
+ *
+ * uint32_t for the same reason as gCfgChangeBusy: a 32-bit load/store is
+ * atomic on PIC32MZ. Here that matters only for the release, which is a plain
+ * unconditional store outside any section; the test-and-take is a read-modify-
+ * write and is inside one, because `if (!busy) busy = 1` is exactly the
+ * non-atomic sequence two transports must not interleave.
+ */
+static volatile uint32_t gSessionStartBusy = 0u;
+
+StreamingStartClaim Streaming_BeginSessionStart(void) {
+    StreamingStartClaim result;
+
+    taskENTER_CRITICAL();
+    if (gSessionStartBusy != 0u) {
+        result = STREAM_START_CLAIM_BUSY;
+    } else {
+        gSessionStartBusy = 1u;
+        result = STREAM_START_CLAIM_OK;
+    }
+    taskEXIT_CRITICAL();
+
+    return result;
+}
+
+void Streaming_EndSessionStart(void) {
+    /* A single unconditional 32-bit store, atomic on PIC32MZ -- no read-modify-
+     * write, so no critical section is needed. It is also the ONLY writer of 0,
+     * and only the holder ever calls it. Mirrors Streaming_EndConfigChange. */
+    gSessionStartBusy = 0u;
+}
+
 /* #730: the rate the hardware ACTUALLY runs, in millihertz.
  *
  * `StreamingRuntimeConfig.Frequency` stores what the client ASKED for; the

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -655,10 +655,11 @@ void Streaming_CountActiveChannels(uint16_t* out_type1Count,
  * both directions, and a setter's store can no longer land on a live session.
  *
  * SCOPE. This is not a lock over the runtime config in general. It excludes a
- * guarded setter against an ARM; two STARTs racing each other is #850, and
- * serialising SCPI execution across transports outright is #694. It is also
- * advisory-only -- nothing blocks on it. The loser is refused with an error,
- * which is the behaviour these guards already had.
+ * guarded setter against an ARM; two STARTs racing each other is the SEPARATE
+ * session-start claim below (#850), and serialising SCPI execution across
+ * transports outright is #694. It is also advisory-only -- nothing blocks
+ * on it. The loser is refused with an error, which is the behaviour these
+ * guards already had.
  *
  * ALL THREE sites that publish IsEnabled observe it: SCPI_StartStreaming's arm,
  * SYST:STR:THRoughput, and the WiFi rate finder's per-step arm (the latter two
@@ -694,6 +695,84 @@ void Streaming_EndConfigChange(void);
  * PIC32MZ.
  */
 bool Streaming_ConfigChangeInProgress(void);
+
+/* --- #850: the session-start claim ----------------------------------------
+ *
+ * A SECOND claim, deliberately not the config-change one above. It excludes
+ * session STARTS against each other; that claim excludes guarded config
+ * SETTERS against an arm. The two are orthogonal, and START holds this one
+ * while OBSERVING that one.
+ *
+ * WHY START CANNOT SIMPLY TAKE Streaming_BeginConfigChange(). Two independent
+ * reasons, either one fatal:
+ *
+ *   1. That claim refuses when `IsEnabled || Running`. A START is EXPRESSLY
+ *      allowed to run while a session is live -- stopping the previous session
+ *      and starting a new one is what it does -- so it would refuse itself on
+ *      every restart.
+ *   2. START's arm-time critical section OBSERVES the config claim and refuses
+ *      while it is held (#847). Taking that claim would make START read its
+ *      own claim at the arm and refuse itself unconditionally.
+ *
+ * WHAT IT CLOSES. SCPI runs on two transports at different priorities (USB
+ * SCPI at 7, the WifiTask at 2), so a USB START can preempt a WiFi START at
+ * any instruction boundary -- including inside the multi-second waits in the
+ * SD readiness poll and in PrepareStreamingBuffers. Two STARTs in flight then:
+ *
+ *   - re-partition the SAME streaming buffer pool, one of them potentially
+ *     mid-swap (PrepareStreamingBuffers -> StreamingBufferPool_Partition ->
+ *     AInSampleList_InitializeExternal swaps the sample-pool pointers);
+ *   - arm and tear down the SAME SD manager;
+ *   - each publish IsEnabled from its own critical section, so whichever lands
+ *     last wins with the other's setup.
+ *
+ * The symptom #850 was filed for -- the second START reading the first's
+ * interface publish as an explicit user selection, returning OK, and handing
+ * its caller a session on the wrong transport -- is the bookkeeping face of
+ * that, which is why fixing the bookkeeping alone would not have been the fix.
+ *
+ * ALL THREE ARM SITES TAKE IT, not just START. SYST:STR:THRoughput and the
+ * WiFi rate finder also partition the pool and publish IsEnabled, and both
+ * guard their front door on `Running` ALONE -- which reads false for the whole
+ * pre-arm window of a START, and again between START's IsEnabled publish and
+ * Streaming_UpdateState flipping Running. Guarding START against itself while
+ * leaving those two would close one pairing out of four. Holding the claim
+ * across the whole of START's body (Streaming_UpdateState included) is also
+ * what lets those front-door tests stay as they are: no caller can observe the
+ * IsEnabled-set-but-Running-clear gap, because the claim is held throughout it.
+ *
+ * A FLAG, NOT A CRITICAL SECTION, and not a FreeRTOS mutex. Not a critical
+ * section because the bodies call vTaskDelay -- PrepareStreamingBuffers and
+ * SCPI_QuiesceAndResetCoherentPool both yield -- and a single vTaskDelay with
+ * interrupts disabled is fatal at any duration. Not a mutex because the
+ * required semantics are refuse-don't-block (a blocking take would park a
+ * priority-7 USB SCPI callback behind a priority-2 WifiTask for the length of
+ * a multi-second start), and because this mirrors the audited gCfgChangeBusy
+ * idiom one screen up rather than introducing a second mechanism for one job.
+ *
+ * ADVISORY. Nothing blocks on it; the loser is refused with -200 and retries.
+ * That is a BEHAVIOUR CHANGE -- a concurrent START previously returned OK and
+ * raced -- which is why it ships with its own companion test.
+ */
+typedef enum {
+    STREAM_START_CLAIM_OK = 0,   /* claim taken -- caller MUST release it */
+    STREAM_START_CLAIM_BUSY      /* another session start is in flight */
+} StreamingStartClaim;
+
+/**
+ * Take the session-start claim. Tests and takes inside ONE critical section,
+ * so two STARTs on the two SCPI transports cannot both pass the test.
+ *
+ * Deliberately does NOT test IsEnabled/Running: a START may legitimately
+ * restart a live session. See the block comment above.
+ *
+ * @return STREAM_START_CLAIM_OK when taken -- and ONLY then must the caller
+ *         call Streaming_EndSessionStart() on every path out.
+ */
+StreamingStartClaim Streaming_BeginSessionStart(void);
+
+/** Release a claim taken by Streaming_BeginSessionStart(). */
+void Streaming_EndSessionStart(void);
 
 /*! Initializes the streaming component
  * @param[in] pStreamingConfigInit Streaming configuration

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -738,8 +738,17 @@ bool Streaming_ConfigChangeInProgress(void);
  * Streaming_UpdateState flipping Running. Guarding START against itself while
  * leaving those two would close one pairing out of four. Holding the claim
  * across the whole of START's body (Streaming_UpdateState included) is also
- * what lets those front-door tests stay as they are: no caller can observe the
- * IsEnabled-set-but-Running-clear gap, because the claim is held throughout it.
+ * what lets those two front-door tests stay as they are: neither command can
+ * reach its `Running` test while a START is in that gap, because it must take
+ * this claim first and will be refused.
+ *
+ * Stated narrowly on purpose. It is NOT true that nothing can observe the
+ * IsEnabled-set-but-Running-clear window -- Streaming_BeginConfigChange reads
+ * `IsEnabled || Running` (streaming.c) and never takes this claim, so a cap-
+ * input or SYST:MEM:* setter still sees it. That is correct and wanted: the
+ * `||` form is precisely what makes it refuse there (#116, #857). The claim
+ * closes the gap for the two commands whose test is `Running` ALONE, and for
+ * nothing else.
  *
  * A FLAG, NOT A CRITICAL SECTION, and not a FreeRTOS mutex. Not a critical
  * section because the bodies call vTaskDelay -- PrepareStreamingBuffers and


### PR DESCRIPTION
Closes #850.

## The hazard

SCPI runs on two transports at different priorities (USB SCPI at 7, the WifiTask at 2), so a USB `SYST:STR:START` can preempt a WiFi one at any instruction boundary — including inside the multi-second waits in the SD readiness poll and in `PrepareStreamingBuffers`. Nothing excluded the two.

The symptom the issue was filed for is the bookkeeping face of it: the second START's auto-detect reads the interface the first START published, and because the adopt rule only takes the *detected* interface when the stored value is USB, a published WiFi reads as an explicit user selection. The second START keeps it, returns `OK`, and hands its caller a session on a transport it never asked for.

Fixing the bookkeeping would not have been the fix. Two STARTs in flight also re-partition the **same** streaming buffer pool (one potentially mid-swap, `StreamingBufferPool_Partition` → `AInSampleList_InitializeExternal`), arm and tear down the **same** SD manager, and each publish `IsEnabled` from their own critical section — so whichever lands last wins with the other's setup.

## The fix

A **session-start claim** (`Streaming_BeginSessionStart` / `_EndSessionStart`): test-and-set in one critical section, held for the length of the command body, released on every exit. The loser is refused with `-200` rather than blocked.

### All three arm sites take it, not just START

`SYST:STR:THRoughput` and the WiFi rate finder also partition the same pool and publish the same `IsEnabled`, and both guard their front door on **`Running` alone** — which reads false for the whole of a START's pre-arm window, and again between START's `IsEnabled` publish and `Streaming_UpdateState` flipping `Running`. Guarding START against itself would have closed one pairing out of four.

Holding the claim across the whole of START's arm body (`Streaming_UpdateState` included) is also what lets those two front-door tests stay as they are: neither command can reach its `Running` test while a START is in that gap, because it must take this claim first and will be refused.

Stated narrowly on purpose. It is **not** true that nothing can observe the `IsEnabled`-set-but-`Running`-clear window — `Streaming_BeginConfigChange` reads `IsEnabled || Running` and never takes this claim, so a cap-input or `SYST:MEM:*` setter still sees it. That is correct and wanted: the `||` form is precisely what makes it refuse there (#116, #857). The claim closes that gap for the two commands whose test is `Running` **alone**, and for nothing else. (An earlier revision of this description said "no caller", which was false.)

### Why a second claim rather than reusing #847's

Two independent reasons, either one fatal:

1. `Streaming_BeginConfigChange` refuses when `IsEnabled || Running`. A START is **expressly allowed** to restart a live session, so it would refuse itself on every restart.
2. START's arm-time critical section *observes* the config claim and refuses while it is held (#847). Taking that claim would make START read its own claim at the arm and refuse itself unconditionally.

`streaming.h`'s existing scope comment already named "two STARTs racing each other" as #850's open gap; that comment is updated here to point at the new claim.

### Why a flag, not a critical section or a mutex

Not a critical section: the bodies call `vTaskDelay` (`PrepareStreamingBuffers`, `SCPI_QuiesceAndResetCoherentPool`), and a single `vTaskDelay` with interrupts disabled is fatal at any duration. Not a mutex: the required semantics are refuse-don't-block — a blocking take would park a priority-7 USB SCPI callback behind a priority-2 WifiTask for the length of a multi-second start — and this mirrors the audited `gCfgChangeBusy` idiom rather than introducing a second mechanism for one job.

The runner idiom (one take/release with the body passed in) is #857's `SCPI_MemRunClaimed`. It is what keeps `SCPI_StartStreaming`'s twenty-plus return sites from each needing a release: a claim released at only nineteen of them would wedge every subsequent START until reboot.

## Behaviour change

A concurrent START now gets `-200` instead of racing. That is the point of the issue, and it is why this ships with its own companion test rather than riding on another PR.

## Pre-merge audit round 1 — one confirmed finding, fixed

Qodo's `/agentic_review` returned **0 bugs** on the first commit. The independent adversarial audit (codex, effort high) returned **BLOCK** with one confirmed finding, which is the entire reason that gate exists.

**`SYST:STR:START 0` is the explicit disable form — a stop, not an arm** — and the first cut took the claim in a wrapper that ran *before* argument parsing. So a stop could be refused with `-200` while a `SYST:STR:THRoughput` (up to 60 s) held the claim on the other transport. #850 serialises session *starts*; a stop is neither.

Fixed in `99251662`: `SCPI_StartStreaming` no longer uses the generic runner. It parses first, handles the disable form **unclaimed**, and takes the claim only once it knows this is an arm. The claim/release stays a single take → one call → one release, so the body's twenty-plus return sites still cannot leak it. A malformed rate now also fails ahead of the claim — a side benefit, not the goal: a garbage `START` no longer takes the claim nor reaches `Streaming_BuildChannelMapping`'s shared-state write.

Severity was reconciled at **low** by the audit's own skeptic and arbiter, because `SYST:STR:STOP` is unclaimed and remains a working stop path throughout. Fixed anyway — it is cheap, and it contradicted the branch's own long-standing comment.

### Error precedence moved, deliberately

The parse used to run *after* the power, ADC-pointer and channel-count gates. Both of these change:

| command | before | after |
|---|---|---|
| `START abc` on an unpowered device | `-200` (not powered) | `-104` (malformed) |
| `START 0` with every input disabled | `-221` (nothing to stream) | `OK` — stops |

A malformed command is malformed regardless of device state, and the disable form is now unconditional in a way it was not. `SYST:STR:STOP` has no such gates either, so stopping should not depend on the device still being in a state fit to start. The companion test pins both spellings.

**Correction (final audit round).** An earlier revision of this description and of the code comment justified that by saying `START 0` performs *"the identical three actions"* as `SYST:STR:STOP`. That is **false**: STOP additionally tears down SD logging (`mode=NONE` → `sd_card_manager_UpdateSettings` → bounded idle wait) and clears the streaming OPER bits, and the disable branch does neither. Both gaps are pre-existing — `main`'s disable branch is the same three statements — and are tracked in [#860](https://github.com/daqifi/daqifi-nyquist-firmware/issues/860). The code comment now says so; a client needing a complete stop should send `SYST:STR:STOP`.

## Pre-merge audit round 2 — no confirmed findings, but read this before trusting the PASS

Round 2 returned `gate: "PASS"` with an **empty** confirmed list. That is not on its own a clean bill, and the qodo-cycle rules say so explicitly: `unsound_refutations` was **non-empty** and the arbiter returned `keep_fixing`. A wrong refutation is the one failure mode of this pipeline that produces a PASS, so the flag was followed up rather than the gate taken at face value.

**The finding:** a stop issued while another transport is inside a START's pre-arm window is silently lost — `START 0` clears an `IsEnabled` that is still false, the in-flight START then publishes `IsEnabled = true`, and the caller got `OK`.

**The disagreement:** the skeptic dismissed it as pre-existing by analogy to the untouched `SYSTem:STReam:STOP`. The arbiter objected that the analogy compares against a different, unmodified function — but its own counter-argument treated *this PR's unmerged intermediate commit* (`92bda61c`, which was itself round 1's bug) as the pre-PR baseline.

**Settled by checking `main` directly rather than by analogy:**

```
$ git show origin/main:firmware/src/services/streaming.c | grep -c 'BeginSessionStart|gSessionStartBusy'
0
```

`origin/main` has no session-start coordination at all, and its `SCPI_StopStreaming` is an unguarded `IsEnabled = false` + `Streaming_UpdateState()`. The same interleaving loses the stop on `main` identically. So the skeptic's **conclusion** was right and its **stated reasoning** was not — the defect is real, pre-existing, and unchanged by this PR.

**Not fixed here, and filed instead** as [#861](https://github.com/daqifi/daqifi-nyquist-firmware/issues/861), because the fix belongs to `SYST:STR:STOP` as much as to this branch and needs machinery this PR does not have: the arm observing a stop-requested generation, the way it already observes `ifaceMoved` / `cfgChanging` / `inputsGone` / `capRevoked`. Claiming the disable form instead — the obvious alternative — is precisely what round 1 did, and it is a bug: a stop must not be refusable because another transport is benchmarking.

What this PR does do about it is stop the code from implying otherwise. The disable branch's long-standing "Always allowed" comment now says what that does and does not mean: **not refused** is not the same as **takes effect**.

## Final audit round — and how a `PASS` nearly hid two findings

The round against `f9b08c3a` returned `gate: "PASS"` with `rawFindings: 0` and an empty `confirmed` list. It also carried **two high-severity findings in `steeringSuppressed`** — suppressed by *my own dispositions*.

I had written a disposition scoped to a **command** ("a stop racing a START is pre-existing, filed as #861, do not re-litigate") rather than to a **mechanism**. It correctly covered one finding and wrongly swallowed a second, distinct defect that merely shares the same command:

> `START 0` skips `SCPI_StopStreaming`'s SD teardown — *"This disproves the diff's claim that this path performs identical actions."*

It was right, and the claim it disproved was mine. `SCPI_StopStreaming` does the three statements **plus** the SD teardown **plus** clearing the OPER bits. Verified in source, and verified pre-existing on `main`.

Two things came out of it:

1. The false equivalence is corrected in the code comment and above — the branch no longer claims a parity it does not have.
2. [#860](https://github.com/daqifi/daqifi-nyquist-firmware/issues/860) is widened from the OPER half to the class, since one fix closes both gaps.

The re-run against `892935ba` narrows dispositions 6 and 7 to the two specific mechanisms and explicitly tells the auditor that anything else about that branch is in scope — and that a disposition being used to wave away a distinct defect is itself a reportable finding.

Recording it because the failure mode is not "the audit missed something" — it is **the audit found it and I hid it**, and the result looked clean.

**Round 4 (`892935ba`, the merge head): `gate: "PASS"` — genuinely clean this time.** `rawFindings: 0`, `confirmed: []`, and critically `steeringSuppressed: []` — the field that was non-empty in round 3. Verified from `journal.jsonl` rather than the summary line: the discovery leg read the three changed files and **both** hunter legs returned `{"findings": []}`, i.e. they ran and found nothing rather than erroring. `codexErrors: []`, `auditorLegsOk: 1/1`, `agents_error: 0`.

Audited SHA `892935ba` == `headRefOid` == local HEAD. The pre-merge gate is deliberately **left unmarked** — nothing has been merged and the marker is consumed on merge, so leaving it unset is the state that cannot merge by accident.

## Separate defects found along the way — filed, not bundled

`START 0` **stops the stream but does not clear the OPER `MEASURING` bit**; only `SYST:STR:STOP` does. Measured on the bench: the wire goes 49,155 → 0 bytes/2 s while `STAT:OPER:COND?` stays `16` across a settled re-read. Pre-existing, independent of this PR, and filed as [#860](https://github.com/daqifi/daqifi-nyquist-firmware/issues/860) rather than fixed here.

It matters for reading this PR's test: part 5(b) deliberately measures **data flow** rather than the OPER bit, because an earlier revision asserted the bit clears and failed on *both* firmwares — a wrong assertion, not a finding.

## Companion test

`daqifi/daqifi-python-test-suite` → `test/850-concurrent-start-interlock`, [`test_850_concurrent_start_interlock.py`](https://github.com/daqifi/daqifi-python-test-suite/blob/test/850-concurrent-start-interlock/test_850_concurrent_start_interlock.py).

Built entirely from existing `test_harness.py` primitives (`ReliableSCPI`, `TcpControl`, `configure_stream`, `discover_lan_address`, `drain_errors`, `idn_serial`, `pin_precision`, `read_oper_cond`, `scpi_text`) — no new harness capability needed.

| part | catches |
|---|---|
| 1 | the claim leaked on the SUCCESS path |
| 2 | the claim leaked on any ERROR path — four distinct return sites inside the claimed body |
| 3 | the claim leaked by the other two arm sites |
| `--race` | the race itself: a concurrent START is refused instead of racing |

Parts 1–3 pass on pre-#850 firmware **by design** — they assert that starting still works, which is exactly the property a botched claim destroys. `--race` is the only arm that fails on pre-#850 firmware.

`SYST:STR:START #` was tried as a fifth part-2 row and **removed**: probing the bench showed the libscpi lexer rejects it with `-101` before the callback runs (no `LOG_E`, where every in-callback branch emits one), so the claim is never taken and the row proved nothing. That is also why each refusing row asserts a specific code — an error raised before the callback looks identical from the outside.

`--self-test` is mutation-proven: inverting the unreadable-restart arm, the marker requirement, or the hammer gate each turns it red.

## Gates

- **Build**: clean at `-O3 -Werror`, `CONF=default` (NQ1) — full clean rebuild, 280 compiles, 0 errors, no warnings outside the documented third-party `tfm.c` ones.
- **cppcheck**: 0 findings, baseline unchanged.
- **SCPI wiki**: no `.pattern` added, removed or renamed — the registered command surface is byte-identical, so the sync gate is a no-op and no wiki edit is required.

## Test environment

- Firmware: this branch, built from `92bda61c`, XC32 v4.60 / MPLAB X v6.30.
- Test suite: `daqifi-python-test-suite` `9b8dad8`; `daqifi-python-core` at `main`.
- Bench: NQ1 serial `7E28517F62010292`, HW 2.0.0.

## ✅ Hardware validation — flashed and run

Flashed to NQ1 serial `7E28517F62010292` from this branch's own build (`--ts BUR202272588`; the hex programmed was `/mnt/c/daqifi/loop-b/.../daqifi.X.production.hex`, mtime confirmed advanced), then `SYST:REBoot`.

**Image identified by build fingerprint, not by version string:**

| | before flash | after flash |
|---|---|---|
| `identity.firmware_crc32` | **absent** | `2D44E429` |
| `identity.firmware_rev` | `3.7.2` | `3.7.2` |

The version string is **identical across a demonstrably different image**, which is exactly why it cannot date a build. The pre-flash image did not emit `firmware_crc32` at all — that field arrives with [#839](https://github.com/daqifi/daqifi-nyquist-firmware/pull/839), which is on `main` — so the board was running something older than #839 despite reporting 3.7.2.

**NVM restore verified.** The flash wiped NVM (WiFi off, Standby, precision back to 0). Re-provisioned STA on the bench AP and `SYST:COMM:LAN:SAVE`d it; after a reboot `NETType?` = 1 and `SECurity?` = 3 persisted, and the device re-associated at `192.168.1.234` once powered up. (`POWer:STATe` is runtime, not NVM — it returns to Standby on boot, and an unpowered board answers `LAN:ADDRess?` with `-200`, exactly as the docs describe.)

**Companion suite on the fixed firmware: 14 pass / 0 fail / 2 skip.**

The discriminator flipped as designed:

| part 5(a) — `START 0`, every input disabled | result |
|---|---|
| FW 3.7.2 (pre-flash) | **FAIL** — `-221` |
| this branch (post-flash) | **PASS** — `OK`, stops |

### What the hardware run does NOT establish — read this

The `--race` arm remained **inconclusive** across four topologies. Parts 1–3 and 5 prove the claim is taken and released without leaking; they do **not** prove that two concurrent starts exclude each other — a claim that was never consulted would pass them too. The mutual-exclusion property itself rests on code inspection and the audit rounds, not on a hardware observation.

Two of the four routes are structurally blocked, not merely narrow:

| holder | hammer | outcome |
|---|---|---|
| USB START, no SD | TCP START | 1 TCP reply in 5 s — USB SCPI (pri 7) starves the pri-2 WifiTask |
| WiFi START + live USB stream | USB START | `-222` from the #844 cap check; the claim was already released |
| USB START + SD logging | TCP START | 65 replies and a real `-200` — but from the **#589 SPI guard**, not this interlock |
| USB `SYST:STR:THRoughput` | TCP START | 3 replies in 12 s; the benchmark keeps the encoder busy |

The third row is the trap, and it is why the test demands the `#850` marker in `SYST:LOG?` rather than a bare `-200`: the refusal was *"Cannot start WiFi streaming while SD logging is active"*. A verdict keyed on the error code alone would have recorded a confident PASS for an interlock that never ran. The SD logging that stretches a USB START's pre-arm window is the same SD logging that makes a concurrent WiFi START refuse for an unrelated reason, so those two requirements are mutually exclusive on this hardware.

Making the arm decisive needs a firmware-side hook that widens the pre-arm window on request — a change to the thing under test, deliberately not made here.
