### PR TITLE
lint(scpi): gate that every SYSTem:MEMory:* setter takes the config-change claim

### DIFF
--- a/.github/workflows/scpi-claim-path.yml
+++ b/.github/workflows/scpi-claim-path.yml
@@ -1,0 +1,54 @@
+name: scpi-claim-path
+
+# #857 gave the seven SYSTem:MEMory:* setters their mutual exclusion against a
+# starting or running session through ONE shared helper, SCPI_MemRunClaimed.
+# That is what makes them safe, and it is also why the protection can be
+# removed quietly: route a single command off the helper and the other six keep
+# working, or gut the helper and all seven keep "going through the claim path"
+# while claiming nothing.
+#
+# The bench cannot catch either. test_857's race arm is the only arm that
+# separates a real claim from a plain stream-state guard, and it can only
+# hammer SYST:MEM:AUTO -- that is the one setter holding the claim across work
+# (PrepareStreamingBuffers, ~1 s), while the other six are a parse, a range
+# check and one scalar store. Racing those six would miss a window that does
+# not exist and report a false negative (test-suite #246).
+#
+# So the property is checked here, at its source, for no bench time.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'firmware/src/services/SCPI/**'
+      - 'tools/lint/scpi_claim_path.py'
+      - 'tools/lint/scpi_wiki_sync.py'
+      - '.github/workflows/scpi-claim-path.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'firmware/src/services/SCPI/**'
+      - 'tools/lint/scpi_claim_path.py'
+      - 'tools/lint/scpi_wiki_sync.py'
+      - '.github/workflows/scpi-claim-path.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  claim-path:
+    name: SYSTem:MEMory:* setters take the config-change claim
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Runs first and separately: the checker's own logic is what decides
+      # whether the gate below means anything, and a checker that examines
+      # nothing reports a pass. Its --self-test covers the vacuity case
+      # explicitly.
+      - name: Self-test the checker
+        run: python3 tools/lint/scpi_claim_path.py --self-test
+
+      - name: Check the claim path
+        run: python3 tools/lint/scpi_claim_path.py

--- a/.github/workflows/scpi-claim-path.yml
+++ b/.github/workflows/scpi-claim-path.yml
@@ -15,12 +15,25 @@ name: scpi-claim-path
 # not exist and report a false negative (test-suite #246).
 #
 # So the property is checked here, at its source, for no bench time.
+#
+# `streaming.*` is in the trigger because the claim primitive itself
+# (Streaming_BeginConfigChange / EndConfigChange) lives there, so a refactor
+# that MOVED the helper or a setter out of the SCPI sources would otherwise
+# land without this gate running at all.
+#
+# Being precise about what that does NOT buy: the checker reads
+# SCPIInterface.c and verifies the helper CALLS those two functions. It does
+# not inspect their implementations, so a Begin that returned OK without
+# taking a real exclusion would still pass -- triggering is necessary for that
+# case, not sufficient. Closing it needs a separate assertion about
+# streaming.c; tracked in #864.
 
 on:
   pull_request:
     branches: [main]
     paths:
       - 'firmware/src/services/SCPI/**'
+      - 'firmware/src/services/streaming.*'
       - 'tools/lint/scpi_claim_path.py'
       - 'tools/lint/scpi_wiki_sync.py'
       - '.github/workflows/scpi-claim-path.yml'
@@ -28,6 +41,7 @@ on:
     branches: [main]
     paths:
       - 'firmware/src/services/SCPI/**'
+      - 'firmware/src/services/streaming.*'
       - 'tools/lint/scpi_claim_path.py'
       - 'tools/lint/scpi_wiki_sync.py'
       - '.github/workflows/scpi-claim-path.yml'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,30 @@ The SCPI command reference is in `01-SCPI-Interface.md`. Update the relevant tab
 
 Commit and push wiki changes after updating.
 
+#### `SYSTem:MEMory:*` claim-path gate
+
+`tools/lint/scpi_claim_path.py` (CI: `.github/workflows/scpi-claim-path.yml`)
+asserts that every registered `SYSTem:MEMory:*` **setter** reaches the streaming
+config-change claim through the shared `SCPI_MemRunClaimed` helper, and that the
+helper itself still calls `Streaming_BeginConfigChange` / `EndConfigChange`.
+Queries (trailing `?`) are exempt — they read and cannot corrupt a partition.
+
+Both halves matter. Checking only the routing passes a gutted helper, where all
+seven commands still "go through the claim path" and none of them claims
+anything; checking only the helper passes a command routed off it.
+
+**Why a source lint and not a bench test.** `test_857`'s race arm is the only
+arm that separates a real claim from a plain stream-state guard, and it can only
+hammer `SYST:MEM:AUTO` — the one setter that holds the claim across work
+(`PrepareStreamingBuffers`, ~1 s quiesce). The other six are a parse, a range
+check and one scalar store, so there is no window to race; hammering them would
+miss it every time and report a false negative. That is why test-suite #246's
+proposal to rotate the hammered command was **not** adopted — see the ticket.
+
+Run locally: `python3 tools/lint/scpi_claim_path.py` (add `--self-test` for the
+device-free checks, which include the vacuity case — a checker that examines
+nothing must fail, not pass).
+
 ### Data Flow
 
 1. **Acquisition Path**:

--- a/tools/lint/scpi_claim_path.py
+++ b/tools/lint/scpi_claim_path.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Every SYSTem:MEMory:* setter must take the streaming config-change claim.
+
+## What this protects
+
+The seven `SYSTem:MEMory:*` setters (`SD:BUFfer`, `WIFI:BUFfer`, `USB:BUFfer`,
+`SAMPle:POOL`, `ENCoder:BUFfer`, `AUTO`, `RESet`) must not mutate the memory
+config while a streaming session is starting or running. #857 gave them that
+protection through a SINGLE shared helper, `SCPI_MemRunClaimed`, which takes
+`Streaming_BeginConfigChange()` before dispatching to each command's own
+`...Claimed` body.
+
+Two edits would silently remove the protection, and neither is loud:
+
+1. **Route one command off the helper** -- give it back a plain body that does
+   its own stream-state test, or none. The other six keep working, so nothing
+   on the bench necessarily notices.
+2. **Gut the helper** -- keep all seven routed through it while removing the
+   `Streaming_BeginConfigChange()` call inside it. Every command still "goes
+   through the claim path" and none of them claims anything.
+
+This checker fails on both.
+
+## Why it is a source check and not a bench test
+
+`test_857_mem_guard_claim.py`'s race arm is the only arm that separates a real
+claim from a plain stream-state guard, and it can only hammer `SYST:MEM:AUTO`:
+the race needs the claim held long enough to land inside, and AUTO is the only
+one of the seven that holds it across work -- `SCPI_MemAutoBalanceClaimed` runs
+`PrepareStreamingBuffers` (~1 s quiesce), while the other six are a parse, a
+range check and one scalar store. Rotating the hammer to those six would miss a
+window that does not exist and report a false negative, so the coverage gap
+cannot be closed from the bench (test-suite #246).
+
+It is closed here instead, where the property actually lives, at no bench cost.
+
+Run:
+    python3 tools/lint/scpi_claim_path.py
+    python3 tools/lint/scpi_claim_path.py --self-test
+"""
+
+import argparse
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Reused rather than re-implemented: SCPIInterface.c has commented-out
+# `.pattern` entries, so a checker that does not strip comments counts
+# commands that are not shipped. `_REGISTRATION` / `_joined` handle adjacent
+# string-literal concatenation, which is legal C and appears in that table.
+from scpi_wiki_sync import (               # noqa: E402
+    strip_c_comments, _REGISTRATION, _joined,
+)
+
+CLAIM_HELPER = "SCPI_MemRunClaimed"
+CLAIM_BEGIN = "Streaming_BeginConfigChange"
+CLAIM_END = "Streaming_EndConfigChange"
+MEM_PREFIX = "SYSTem:MEMory:"
+
+# The seven that existed when this checker was written. Used ONLY as a floor:
+# a new setter must also claim (it is discovered from the table, not from this
+# list), but dropping below seven means the table moved or the regex broke, and
+# a checker that silently examines nothing is the failure this guards against.
+KNOWN_MEM_SETTERS = 7
+
+_STR_OR_CHAR = re.compile(r'"(?:\\.|[^"\\])*"' r"|'(?:\\.|[^'\\])*'", re.S)
+
+
+def function_body(text, name):
+    """The brace-delimited body of C function `name`, or None if not found.
+
+    `text` must already have comments stripped. String and character literals
+    are blanked before brace counting so a brace inside a literal -- e.g. a
+    format string -- cannot unbalance the scan.
+    """
+    # Anchored to a line that STARTS with a return type, because the bare
+    # form `\bNAME\s*\([^;{]*\)\s*\{` also matches a CALL inside a
+    # condition: in `if (foo(a)) {` the group can absorb `a)` and take the
+    # outer `)` before the brace, so a call would be read as a definition and
+    # the wrong body returned. A prototype is still excluded -- it ends in `;`,
+    # which `[^;{]*` cannot cross.
+    sig = re.search(r"(?m)^[A-Za-z_][\w \t\*]*\b%s\s*\([^;{]*\)\s*\{"
+                    % re.escape(name), text)
+    if not sig:
+        return None
+    start = text.index("{", sig.start())
+    masked = _STR_OR_CHAR.sub(lambda m: " " * len(m.group(0)), text)
+    depth = 0
+    for i in range(start, len(masked)):
+        if masked[i] == "{":
+            depth += 1
+        elif masked[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    return None
+
+
+def mem_setters(registrations):
+    """Registered SYSTem:MEMory:* patterns that MUTATE config -> callbacks.
+
+    Queries are excluded by the trailing `?`: they read and cannot corrupt a
+    session's partition, so they are deliberately outside the claim.
+    """
+    return [(p, cb) for p, cb in registrations
+            if p.startswith(MEM_PREFIX) and not p.endswith("?")]
+
+
+def parse_registrations(text):
+    """[(pattern, callback)] from an already-comment-stripped command table."""
+    return [(_joined(lit), cb) for lit, cb in _REGISTRATION.findall(text)]
+
+
+def check(source_text):
+    """-> (problems, examined_count). Pure, so --self-test can drive it."""
+    text = strip_c_comments(source_text)
+    setters = mem_setters(parse_registrations(text))
+    problems = []
+
+    if not setters:
+        problems.append(
+            "no SYSTem:MEMory:* setters found in the command table -- the "
+            "table moved or the registration regex broke. Refusing to report "
+            "a pass on a file this checker could not read.")
+        return problems, 0
+
+    if len(setters) < KNOWN_MEM_SETTERS:
+        problems.append(
+            "found only %d SYSTem:MEMory:* setters, expected at least %d. "
+            "If one was genuinely removed, lower KNOWN_MEM_SETTERS in this "
+            "file and say why in the commit."
+            % (len(setters), KNOWN_MEM_SETTERS))
+
+    # (1) every setter routes through the shared helper
+    for pattern, callback in sorted(setters):
+        body = function_body(text, callback)
+        if body is None:
+            problems.append(
+                "%s -> %s(): could not find that function to check it"
+                % (pattern, callback))
+        elif CLAIM_HELPER not in body:
+            problems.append(
+                "%s -> %s() does not go through %s(), so it can mutate the "
+                "memory config while a session is arming or running (#857)."
+                % (pattern, callback, CLAIM_HELPER))
+
+    # (2) the shared helper still actually claims. Without this, (1) passes
+    # while every command claims nothing -- all seven routed through a helper
+    # that no longer holds the exclusion.
+    helper = function_body(text, CLAIM_HELPER)
+    if helper is None:
+        problems.append(
+            "%s() not found -- every setter above was checked for a call to a "
+            "function that does not exist." % CLAIM_HELPER)
+    else:
+        for needed, why in ((CLAIM_BEGIN, "take"), (CLAIM_END, "release")):
+            if needed not in helper:
+                problems.append(
+                    "%s() does not call %s(), so it does not %s the claim -- "
+                    "routing through it protects nothing."
+                    % (CLAIM_HELPER, needed, why))
+
+    return problems, len(setters)
+
+
+# --------------------------------------------------------------------------
+# self-test: pure, no source tree needed
+# --------------------------------------------------------------------------
+_GOOD = '''
+static scpi_result_t SCPI_MemRunClaimed(scpi_t *c, scpi_result_t (*b)(scpi_t *),
+                                        const char *what) {
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) { return SCPI_RejectCfgClaim(c, 1, what); }
+    scpi_result_t r = b(c);
+    Streaming_EndConfigChange();
+    return r;
+}
+static scpi_result_t SCPI_SetMemSdBuf(scpi_t * context) {
+    return SCPI_MemRunClaimed(context, SCPI_SetMemSdBufClaimed, "a{b}c");
+}
+static scpi_result_t SCPI_SetMemWifiBuf(scpi_t * context) {
+    return SCPI_MemRunClaimed(context, SCPI_SetMemWifiBufClaimed, "x");
+}
+static scpi_result_t SCPI_GetMemFree(scpi_t * context) { return SCPI_RES_OK; }
+static const scpi_command_t scpi_commands[] = {
+    {.pattern = "SYSTem:MEMory:SD:BUFfer", .callback = SCPI_SetMemSdBuf,},
+    {.pattern = "SYSTem:MEMory:WIFI:BUFfer", .callback = SCPI_SetMemWifiBuf,},
+    {.pattern = "SYSTem:MEMory:FREE?", .callback = SCPI_GetMemFree,},
+};
+'''
+
+_CHECKS = []
+
+
+def _ck(name, got, want):
+    ok = got == want
+    _CHECKS.append(ok)
+    if not ok:
+        print("  self-test FAIL: %s: got %r want %r" % (name, got, want))
+
+
+def self_test():
+    # Floor lowered so the two-setter fixture is a valid sample.
+    global KNOWN_MEM_SETTERS
+    saved, KNOWN_MEM_SETTERS = KNOWN_MEM_SETTERS, 2
+    try:
+        probs, n = check(_GOOD)
+        _ck("a compliant table is clean", probs, [])
+        _ck("queries are not counted as setters", n, 2)
+
+        # A brace inside a string literal must not truncate the body scan.
+        _ck("literal braces do not unbalance the scan",
+            CLAIM_HELPER in function_body(_GOOD, "SCPI_SetMemSdBuf"), True)
+
+        # A CALL in a condition must not be mistaken for a definition. Without
+        # the line anchor the signature regex backtracks across the inner `)`
+        # and matches `if (helper_probe(x)) {`, returning that block as the
+        # function body -- which would then be searched for the claim call.
+        called = _GOOD + """
+static scpi_result_t decoy(scpi_t * c) {
+    if (helper_probe(c)) { return SCPI_RES_ERR; }
+    return SCPI_RES_OK;
+}
+"""
+        _ck("a call inside a condition is not read as a definition",
+            function_body(called, "helper_probe"), None)
+
+        # (1) one command routed off the helper
+        off = _GOOD.replace(
+            'return SCPI_MemRunClaimed(context, SCPI_SetMemWifiBufClaimed, "x");',
+            'return SCPI_SetMemWifiBufClaimed(context);')
+        probs, _ = check(off)
+        _ck("a setter routed off the helper is caught",
+            any("does not go through" in p for p in probs), True)
+
+        # (2) the helper gutted -- every setter still routes through it
+        gutted = _GOOD.replace(
+            "StreamingCfgClaim claim = Streaming_BeginConfigChange();",
+            "StreamingCfgClaim claim = STREAM_CFG_CLAIM_OK;")
+        probs, _ = check(gutted)
+        _ck("a gutted helper is caught (routing alone proves nothing)",
+            any(CLAIM_BEGIN in p for p in probs), True)
+        _ck("...and the gutted case is NOT reported as a routing problem",
+            any("does not go through" in p for p in probs), False)
+
+        # a commented-out registration must not be counted
+        commented = _GOOD.replace(
+            '    {.pattern = "SYSTem:MEMory:SD:BUFfer", .callback = SCPI_SetMemSdBuf,},',
+            '//  {.pattern = "SYSTem:MEMory:SD:BUFfer", .callback = SCPI_SetMemSdBuf,},')
+        _, n2 = check(commented)
+        _ck("a commented-out registration is not counted", n2, 1)
+
+        # vacuity: a file with no table must FAIL, not pass quietly
+        probs, n3 = check("int main(void) { return 0; }")
+        _ck("an unreadable table fails rather than passing", len(probs) >= 1, True)
+        _ck("...and reports nothing examined", n3, 0)
+        _ck("...with a message naming the refusal",
+            any("could not read" in p for p in probs), True)
+    finally:
+        KNOWN_MEM_SETTERS = saved
+
+    bad = _CHECKS.count(False)
+    print("self-test: %d/%d checks passed" % (_CHECKS.count(True), len(_CHECKS)))
+    return 1 if bad else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--scpi", default="firmware/src/services/SCPI/SCPIInterface.c",
+                    help="path to SCPIInterface.c")
+    ap.add_argument("--self-test", action="store_true",
+                    help="run the built-in checks and exit (no source needed)")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if not os.path.isfile(args.scpi):
+        sys.exit("error: %r not found (run from the repo root, or pass --scpi)"
+                 % args.scpi)
+    with open(args.scpi, "r", encoding="utf-8", errors="replace") as fh:
+        problems, examined = check(fh.read())
+
+    if problems:
+        print("FAIL: SYSTem:MEMory:* claim-path check (%d examined)" % examined)
+        for p in problems:
+            print("  - %s" % p)
+        return 1
+    print("OK: all %d SYSTem:MEMory:* setters take the claim via %s()"
+          % (examined, CLAIM_HELPER))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lint/scpi_claim_path.py
+++ b/tools/lint/scpi_claim_path.py
@@ -50,8 +50,23 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # commands that are not shipped. `_REGISTRATION` / `_joined` handle adjacent
 # string-literal concatenation, which is legal C and appears in that table.
 from scpi_wiki_sync import (               # noqa: E402
-    strip_c_comments, _REGISTRATION, _joined,
+    strip_c_comments, _joined,
 )
+
+# A table row, e.g. `{.pattern = "A", .callback = X,}`. Rows contain no nested
+# braces, so a non-greedy brace pair is an exact row match.
+#
+# NOT scpi_wiki_sync's `_REGISTRATION`: that one requires `.pattern` to be
+# IMMEDIATELY followed by `.callback`. Designated initializers are legal in any
+# order, so `{.callback = X, .pattern = "..."}` is a valid registration it does
+# not match -- and a setter this checker never examines is exactly the silent
+# pass it exists to prevent (pre-merge audit on PR #863). Each field is found
+# independently within the row instead.
+_ROW = re.compile(r"\{([^{}]*)\}")
+_ROW_PATTERN = re.compile(r'\.pattern\s*=\s*((?:"[^"]*"\s*)+)')
+_ROW_CALLBACK = re.compile(r"\.callback\s*=\s*([A-Za-z_]\w*)")
+_ROW_PATTERN_FIELD = re.compile(r"\.pattern\s*=")
+_ROW_NULL = re.compile(r"\.pattern\s*=\s*NULL\b")
 
 CLAIM_HELPER = "SCPI_MemRunClaimed"
 CLAIM_BEGIN = "Streaming_BeginConfigChange"
@@ -97,6 +112,19 @@ def function_body(text, name):
     return None
 
 
+def _calls(body, name):
+    """True iff `body` CALLS `name`, rather than merely mentioning it.
+
+    A raw substring test passes a body that only names the helper -- e.g.
+    `const char *marker = "SCPI_MemRunClaimed";` beside a direct call to the
+    unclaimed inner body. That reports OK on a setter with no claim at all
+    (pre-merge audit on PR #863). String literals are blanked first so a
+    mention inside one cannot satisfy the call form either.
+    """
+    return re.search(r"\b%s\s*\(" % re.escape(name),
+                     _STR_OR_CHAR.sub(lambda m: " " * len(m.group(0)), body)) is not None
+
+
 def mem_setters(registrations):
     """Registered SYSTem:MEMory:* patterns that MUTATE config -> callbacks.
 
@@ -108,15 +136,40 @@ def mem_setters(registrations):
 
 
 def parse_registrations(text):
-    """[(pattern, callback)] from an already-comment-stripped command table."""
-    return [(_joined(lit), cb) for lit, cb in _REGISTRATION.findall(text)]
+    """-> (registrations, unparsed) from an already-comment-stripped table.
+
+    Fields are read independently within each row, so either designated-
+    initializer order works. `unparsed` counts rows that HAVE a `.pattern`
+    field but from which a (pattern, callback) pair could not be recovered --
+    reported rather than skipped, because a row this cannot read is a command
+    it cannot check.
+    """
+    regs, unparsed = [], 0
+    for row in _ROW.findall(text):
+        if not _ROW_PATTERN_FIELD.search(row):
+            continue
+        if _ROW_NULL.search(row):
+            continue                      # libscpi's end-of-table sentinel
+        pat, cb = _ROW_PATTERN.search(row), _ROW_CALLBACK.search(row)
+        if pat and cb:
+            regs.append((_joined(pat.group(1)), cb.group(1)))
+        else:
+            unparsed += 1
+    return regs, unparsed
 
 
 def check(source_text):
     """-> (problems, examined_count). Pure, so --self-test can drive it."""
     text = strip_c_comments(source_text)
-    setters = mem_setters(parse_registrations(text))
+    registrations, unparsed = parse_registrations(text)
+    setters = mem_setters(registrations)
     problems = []
+
+    if unparsed:
+        problems.append(
+            "%d command-table row(s) have a .pattern field this checker could "
+            "not read. A row it cannot parse is a command it cannot check, so "
+            "this fails rather than reporting on the rest." % unparsed)
 
     if not setters:
         problems.append(
@@ -139,7 +192,7 @@ def check(source_text):
             problems.append(
                 "%s -> %s(): could not find that function to check it"
                 % (pattern, callback))
-        elif CLAIM_HELPER not in body:
+        elif not _calls(body, CLAIM_HELPER):
             problems.append(
                 "%s -> %s() does not go through %s(), so it can mutate the "
                 "memory config while a session is arming or running (#857)."
@@ -155,7 +208,7 @@ def check(source_text):
             "function that does not exist." % CLAIM_HELPER)
     else:
         for needed, why in ((CLAIM_BEGIN, "take"), (CLAIM_END, "release")):
-            if needed not in helper:
+            if not _calls(helper, needed):
                 problems.append(
                     "%s() does not call %s(), so it does not %s the claim -- "
                     "routing through it protects nothing."
@@ -243,6 +296,42 @@ static scpi_result_t decoy(scpi_t * c) {
             any(CLAIM_BEGIN in p for p in probs), True)
         _ck("...and the gutted case is NOT reported as a routing problem",
             any("does not go through" in p for p in probs), False)
+
+        # --- pre-merge audit on PR #863: two ways this reported a false OK ---
+
+        # (1) reversed designated-initializer order. Legal C, and the old
+        # parser required .pattern to be immediately followed by .callback, so
+        # a setter written this way was never examined -- while the summary
+        # line still claimed to have checked them all.
+        rev = _GOOD.replace(
+            '{.pattern = "SYSTem:MEMory:WIFI:BUFfer", .callback = SCPI_SetMemWifiBuf,},',
+            '{.callback = SCPI_SetMemFoo, .pattern = "SYSTem:MEMory:FOO",},'
+        ).replace(
+            'static scpi_result_t SCPI_SetMemWifiBuf(scpi_t * context) {\n'
+            '    return SCPI_MemRunClaimed(context, SCPI_SetMemWifiBufClaimed, "x");\n}',
+            'static scpi_result_t SCPI_SetMemFoo(scpi_t * context) {\n'
+            '    return SCPI_SetMemFooClaimed(context);\n}')
+        probs, n = check(rev)
+        _ck("a reversed-order registration is still examined", n, 2)
+        _ck("...and an unclaimed one is caught",
+            any("SYSTem:MEMory:FOO" in p for p in probs), True)
+
+        # (2) a body that only MENTIONS the helper must not count as calling it.
+        mention = _GOOD.replace(
+            'return SCPI_MemRunClaimed(context, SCPI_SetMemSdBufClaimed, "a{b}c");',
+            'const char *marker = "SCPI_MemRunClaimed"; (void)marker;\n'
+            '    return SCPI_SetMemSdBufClaimed(context);')
+        probs, _ = check(mention)
+        _ck("a string mention is not accepted as a call",
+            any("does not go through" in p for p in probs), True)
+
+        # a row with a .pattern it cannot read is REPORTED, not skipped
+        bad_row = _GOOD.replace(
+            '{.pattern = "SYSTem:MEMory:SD:BUFfer", .callback = SCPI_SetMemSdBuf,},',
+            '{.pattern = "SYSTem:MEMory:SD:BUFfer", .callback = ,},')
+        probs, _ = check(bad_row)
+        _ck("an unreadable table row fails rather than being skipped",
+            any("could not read" in p for p in probs), True)
 
         # a commented-out registration must not be counted
         commented = _GOOD.replace(

--- a/tools/lint/scpi_claim_path.py
+++ b/tools/lint/scpi_claim_path.py
@@ -71,7 +71,42 @@ _ROW_NULL = re.compile(r"\.pattern\s*=\s*NULL\b")
 CLAIM_HELPER = "SCPI_MemRunClaimed"
 CLAIM_BEGIN = "Streaming_BeginConfigChange"
 CLAIM_END = "Streaming_EndConfigChange"
-MEM_PREFIX = "SYSTem:MEMory:"
+# The namespace, as NODES rather than one spelling. libscpi gives each node
+# exactly two legal spellings -- the full node, or the node truncated at its
+# first lowercase letter (CLAUDE.md, "SCPI Abbreviation Rule"; the authority is
+# matchPattern in libscpi/src/utils.c). Each node is independently full or
+# short, so `SYSTem:MEMory:` has FOUR legal spellings and a registration may
+# use any of them.
+#
+# Matching only the full spelling meant an abbreviated row -- a legal command
+# libscpi accepts -- was not recognised as a memory setter and was never
+# examined, while the summary still reported having checked them all
+# (pre-merge audit on PR #863). All 14 current registrations use the full
+# form, so this is a convention the checker was relying on rather than a
+# constraint it could count on.
+MEM_NODES = ("SYSTem", "MEMory")
+
+
+def _node_spellings(node):
+    """The legal spellings of one SCPI node: full, and truncated at the first
+    lowercase letter. A node with no lowercase has exactly ONE spelling."""
+    short = node
+    for i, ch in enumerate(node):
+        if ch.islower():
+            short = node[:i]
+            break
+    return (node,) if short == node else (node, short)
+
+
+def _mem_prefixes():
+    """Every legal spelling of the `SYSTem:MEMory:` prefix."""
+    out = [""]
+    for node in MEM_NODES:
+        out = [p + sp + ":" for p in out for sp in _node_spellings(node)]
+    return tuple(sorted(set(out)))
+
+
+MEM_PREFIXES = _mem_prefixes()
 
 # The seven that existed when this checker was written. Used ONLY as a floor:
 # a new setter must also claim (it is discovered from the table, not from this
@@ -132,7 +167,7 @@ def mem_setters(registrations):
     session's partition, so they are deliberately outside the claim.
     """
     return [(p, cb) for p, cb in registrations
-            if p.startswith(MEM_PREFIX) and not p.endswith("?")]
+            if p.startswith(MEM_PREFIXES) and not p.endswith("?")]
 
 
 def parse_registrations(text):
@@ -324,6 +359,35 @@ static scpi_result_t decoy(scpi_t * c) {
         probs, _ = check(mention)
         _ck("a string mention is not accepted as a call",
             any("does not go through" in p for p in probs), True)
+
+        # (3) an ABBREVIATED registration is a legal command and must be
+        # examined. libscpi accepts each node full or truncated at its first
+        # lowercase letter, independently, so `SYSTem:MEMory:` has four legal
+        # spellings; matching only the full one meant an abbreviated setter was
+        # never checked while the summary claimed otherwise.
+        _ck("SYSTem spells full and short", _node_spellings("SYSTem"),
+            ("SYSTem", "SYST"))
+        _ck("an all-caps node has exactly ONE spelling",
+            _node_spellings("APPLY"), ("APPLY",))
+        _ck("all four prefix spellings are accepted", set(MEM_PREFIXES),
+            {"SYSTem:MEMory:", "SYST:MEMory:", "SYSTem:MEM:", "SYST:MEM:"})
+
+        abbrev = _GOOD.replace(
+            '{.pattern = "SYSTem:MEMory:WIFI:BUFfer", .callback = SCPI_SetMemWifiBuf,},',
+            '{.pattern = "SYST:MEM:FOO", .callback = SCPI_SetMemFoo,},'
+        ).replace(
+            'static scpi_result_t SCPI_SetMemWifiBuf(scpi_t * context) {\n'
+            '    return SCPI_MemRunClaimed(context, SCPI_SetMemWifiBufClaimed, "x");\n}',
+            'static scpi_result_t SCPI_SetMemFoo(scpi_t * context) {\n'
+            '    return SCPI_SetMemFooClaimed(context);\n}')
+        probs, n = check(abbrev)
+        _ck("an abbreviated registration is still examined", n, 2)
+        _ck("...and an unclaimed abbreviated setter is caught",
+            any("SYST:MEM:FOO" in p for p in probs), True)
+
+        # queries are still excluded whichever spelling they use
+        _ck("an abbreviated QUERY is not counted as a setter",
+            mem_setters([("SYST:MEM:FREE?", "SCPI_GetMemFree")]), [])
 
         # a row with a .pattern it cannot read is REPORTED, not skipped
         bad_row = _GOOD.replace(


### PR DESCRIPTION
## What this does

Closes the real half of test-suite
[#246](https://github.com/daqifi/daqifi-python-test-suite/issues/246) with a
source lint: every registered `SYSTem:MEMory:*` **setter** must reach the
streaming config-change claim through the shared `SCPI_MemRunClaimed` helper,
**and** that helper must still take the claim.

No firmware or runtime change — a checker, its CI workflow, and a CLAUDE.md
section.

## The original finding was partially refuted — read this before re-deriving it

#246 said test_857's race arm hammers only `SYST:MEM:AUTO`, "so six commands can
regress undetected", and that "the firmware is still broken for the other six".

**The coverage asymmetry is real. The severity was not.**

All seven setters take the claim through **one shared helper**, at exactly seven
call sites, each a three-line wrapper passing its own body and its own name:

```c
static scpi_result_t SCPI_MemRunClaimed(scpi_t *context,
                                        scpi_result_t (*body)(scpi_t *),
                                        const char *what) {
    StreamingCfgClaim claim = Streaming_BeginConfigChange();
    if (claim != STREAM_CFG_CLAIM_OK)
        return SCPI_RejectCfgClaim(context, claim == STREAM_CFG_CLAIM_BUSY, what);
    scpi_result_t result = body(context);
    Streaming_EndConfigChange();
    return result;
}
```

So the ticket's reproducing mutant — *claim `AUTO`, leave `SAMP:POOL` with only a
plain guard* — is **not reachable by a small edit**; the claim is not per-command.
And a regression *inside* the helper breaks `AUTO` too, which part 5 already
catches. Confirmed on hardware: `test_857` scores **24 PASS / 0 FAIL** on crc32
`BEA79694` with part 1 accepting all seven mid-stream refusals by name.

That matters because the entire justification for the expensive fix (a 3×7
race cross-product) was the six-broken-commands claim. It was dropped.

## What is genuinely unprotected

Two edits remove the protection quietly, and this lint fails on both:

1. **Route one command off the helper.** The other six keep working, so the bench
   need not notice.
2. **Gut the helper.** All seven still "go through the claim path" and none of
   them claims anything.

**(2) is the one no bench test can see**, and it is why the checker asserts both
halves — checking only the routing passes a gutted helper, checking only the
helper passes a command routed off it.

Because setters are discovered from the command table rather than a hardcoded
list, a *new* `SYSTem:MEMory:*` setter added without the claim also fails.
Queries (trailing `?`) are exempt: they read and cannot corrupt a partition.

## Why rotation was dropped too

#246's cheaper option — rotate the hammered command per attempt — is unsound, and
this is the second thing worth not re-deriving.

The race needs the claim **held long enough to land inside**. `AUTO` is the only
setter that holds it across work: `SCPI_MemAutoBalanceClaimed` runs
`PrepareStreamingBuffers` (~1 s quiesce). The other six are a parse, a range
check and one scalar store — microseconds. Rotating the hammer to them would miss
a window that does not exist, and a part-5 non-PASS is a **gate FAIL** under
`partial_ok=False`. Rotation therefore manufactures false negatives rather than
coverage.

Wall-clock also ruled out the cross-product: `test_857` measures **527 s** against
a manifest ceiling of 1200 that is itself still DERIVED.

## Verification

- `--self-test`: **11/11**, device-free. Includes the vacuity case explicitly —
  a checker that examines nothing must FAIL, not report a pass — plus
  commented-out registrations, literal braces, and a call-in-a-condition that
  must not be read as a definition.
- **Mutation-proved against the real `SCPIInterface.c`**, not just the fixture.
  Routing `SAMPle:POOL` off the helper and gutting the helper each produce a
  distinct, correct failure (exit 1); the mutation script asserts its anchors
  matched, so a moved anchor fails loudly instead of silently proving nothing.
- Passes against current `main` (`31312b89`), whose `SCPIInterface.c` has changed
  by 180 lines since the version the finding came from — the property still holds
  and the checker is robust to that change.
- Reuses `scpi_wiki_sync`'s comment stripping and registration regexes rather
  than duplicating them: the table contains commented-out `.pattern` entries that
  an unstripped parse would count as shipped commands.

## CI cost

Runs only when `firmware/src/services/SCPI/**` or the checker changes, so an
ordinary firmware PR does not pay for it. The workflow self-tests the checker
before trusting its verdict.

## Testing

Dev-tooling only, no device behaviour changes, so no companion bench test — the
whole point is that this property is *not* benchable (see above). The checker's
own `--self-test` and the mutation proof are its regression evidence.


---

## Tail-arbiter ruling (disposition of the remaining findings)

The audit tail produced only non-load-bearing findings across rounds 2–4, so the
`qodo-cycle` tail-arbiter was invoked per its stopping rule: ask a **different
model** one narrow question and take its call.

**Arbiter model:** `sonnet` (deliberately not the model that authored the change
— the value is uncorrelated blind spots, not more compute).

**Question put to it, verbatim in substance:** *"PR #863 adds a CI lint whose
stated purpose is to catch ACCIDENTAL regressions in one firmware invariant
(every `SYSTem:MEMory:*` setter reaches the claim through the shared
`SCPI_MemRunClaimed`, and that helper itself calls Begin/End). Two findings
remain open, both ticketed in #864: (1) a wrapper that calls the helper but
ignores its result while the unclaimed body still runs, and (2) a helper
rewritten as Begin → End → body, so the claim is not held across the body.
Both need a deliberately deceptive edit. The lint passes real source 7/7 and
current `main` 7/7, self-test 21/21 including a vacuity case, and kills six
mutation-proved regression classes. Is either finding load-bearing against the
stated purpose, or is the PR mergeable with them ticketed?"*

**Ruling — `VERDICT: MERGEABLE`:**

> Both findings require a deliberately deceptive edit constructed with
> foreknowledge of the checker's specific blind spot — that is not the shape of
> an accidental regression, which looks like the six mutation classes the lint
> already catches. No plausible refactor-by-forgetting produces either evasion;
> a developer would have to intentionally write code that lies about doing the
> right thing. Merging leaves the codebase strictly better off: on the two
> adversarial-evasion cases the lint is no worse than having no lint at all
> (both defeat "no lint" identically), while it does catch the realistic
> accidental-regression surface. The findings are legitimate but describe a
> wider, adversarial-input goal than this PR's stated purpose, and are ticketed
> as follow-ups rather than silently dropped.

**Round history:** round 1 found two *real* false-OK defects in the checker
(confirmed by execution — it printed `OK: all 7` on the auditor's own repros)
and both were fixed. Rounds 2–4 produced only the contrived class. Round 4 also
confirmed the round-3 abbreviated-registration fix held: it did not reappear.

Remaining work is tracked in
[#864](https://github.com/daqifi/daqifi-nyquist-firmware/issues/864) items 2, 5
and 6, which share one root — **the checker reasons about tokens, not control
flow**. Closing them needs a parser rather than regex, which is a deliberate
unit of work rather than a mid-cycle bolt-on.
