### PR TITLE
fix(streaming): refuse a START whose channel mapping went stale (#846)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -3757,6 +3757,14 @@ static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context,
     // Build channel mapping for compact sample pool (#177).
     // Must happen before pool partitioning (needs channel count for element sizing).
     Streaming_BuildChannelMapping(pBoardConfig, (const AInRuntimeArray*)pRuntimeAInChannels);
+    /* #846: the enabled-channel set this mapping -- and, further down, the
+     * sample-pool partition sized from its count -- was built from. Read back
+     * from the mapping itself, NOT recomputed here: a recompute samples the
+     * runtime config a second time, and a preemption in between would capture
+     * the NEW set as this mapping's provenance and defeat the check below.
+     * Re-checked against the live config in the critical section that
+     * publishes IsEnabled. */
+    const uint64_t mappingSelAtBuild = Streaming_GetChannelMappingSelection();
 
     // Check if DIO is globally enabled
     bool *pDIOGlobalEnable = BoardRunTimeConfig_Get(BOARDRUNTIMECONFIG_DIO_GLOBAL_ENABLE);
@@ -4539,14 +4547,17 @@ static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context,
      * resulting asymmetry is the correct direction (benchmark turned OFF inside
      * the window means an uncapped rate now faces the real cap).
      *
-     * SCOPE -- this closes the RATE hazard from START's side, and not more
-     * than that. Two neighbours remain, both tracked, and neither is a reason
-     * to read the section below as making the window safe:
-     *   - A CAP-NEUTRAL change still gets through: swapping AIN0 for AIN1 keeps
-     *     the channel count, so the recomputed cap matches and the start is
-     *     admitted while gChannelMapping (built ~500 lines up) still describes
-     *     the old set. That mislabels CSV columns and needs a mapping
-     *     fingerprint rather than a cap comparison -- #846.
+     * SCOPE -- this closes the RATE hazard from START's side. Two more hazards
+     * share the same window; the first is closed just below, the second is not
+     * and is tracked separately, so do not read this section on its own as
+     * making the window safe:
+     *   - A CAP-NEUTRAL change no longer gets through: swapping AIN0 for AIN1
+     *     keeps the channel count, so the recomputed cap matches and the rate
+     *     check below is happy, while gChannelMapping (built ~500 lines up)
+     *     still describes the old set -- CSV columns named from the live
+     *     config, rows read through the stale mapping. That is caught by the
+     *     separate mapping-selection comparison below (#846), which is a
+     *     fingerprint test rather than a cap comparison.
      *   - The SETTER side is the same window inverted: a cap-input setter that
      *     has read the flags as idle can be PREEMPTED by a START on the other
      *     transport and store afterwards, onto a session this code just armed.
@@ -4558,7 +4569,9 @@ static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context,
     bool ifaceMoved = false;
     bool inputsGone = false;
     bool cfgChanging = false;
+    bool mappingMoved = false;
     uint32_t revalidatedMax = 0;
+    uint64_t mappingSelNow = 0;
     /* Captured INSIDE the section so the refusal log names the value that
      * actually triggered the decision. Re-reading it for the message after
      * taskEXIT_CRITICAL can print a THIRD interface -- whatever a later
@@ -4601,6 +4614,15 @@ static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context,
         if (totNow == 0u && !dioNow) {
             inputsGone = true;
         }
+        /* #846: the live enabled-channel set, to compare against the one the
+         * mapping recorded. Same shape and cost as the walk immediately above
+         * -- a bounded integer scan of the channel array, no locks, no logging,
+         * no waits -- so it does not change what this section is allowed to be.
+         * It has to be computed HERE rather than before taskENTER_CRITICAL for
+         * the same reason the cap recompute is: computing it outside would only
+         * shrink the window, not close it. */
+        mappingSelNow = Streaming_ComputeChannelSelection(
+                pBoardConfig, (const AInRuntimeArray*)pRuntimeAInChannels);
     }
     ifaceObserved = pRunTimeStreamConfig->ActiveInterface;
     if (cfgChanging || inputsGone) {
@@ -4616,6 +4638,26 @@ static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context,
          * than its 96 KB one, or SD on the 4 KB inactive circular buffer, at a
          * rate the cap admitted for the real partition. */
         ifaceMoved = true;
+    } else if (mappingSelNow != mappingSelAtBuild) {
+        /* #846: the enabled-channel set moved after the mapping was built.
+         * Tested BEFORE the rate below because it is the stronger statement:
+         * the cap comparison only sees changes that move the NUMBER of
+         * channels, and the corruption this catches is worst precisely when
+         * the number does not move (AIN0 swapped for AIN1 -- csv_encoder names
+         * the columns from the live config at csv_encoder.c:321/:596 and reads
+         * the values through the stale mapping at :381, so the header says one
+         * channel and the rows carry another with every loss counter clean).
+         *
+         * Unconditional on benchmark mode, unlike the cap: BENCHmark buys a
+         * rate the cap would refuse, not a mapping that disagrees with the
+         * pool partition. A count change inside the window under BENCHmark
+         * would otherwise leave the sample-pool element stride sized for the
+         * old count, which this catches too.
+         *
+         * The refusal is deliberate: rebuilding the mapping here would leave
+         * it describing a set the already-carved sample pool was not
+         * partitioned for, which is worse than the stale mapping it replaces. */
+        mappingMoved = true;
     } else if (Streaming_GetBenchmarkMode() == BENCHMARK_OFF) {
         revalidatedMax = Streaming_ComputeMaxFreqForConfig();
         /* freq >= 1 was validated above, so the unsigned compare is exact and,
@@ -4623,7 +4665,8 @@ static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context,
          * INT32_MAX as negative. */
         capRevoked = ((uint32_t)freq > revalidatedMax);
     }
-    if (!capRevoked && !ifaceMoved && !inputsGone && !cfgChanging) {
+    if (!capRevoked && !ifaceMoved && !inputsGone && !cfgChanging &&
+        !mappingMoved) {
         /* #848: the rate becomes visible HERE, in the same section that
          * publishes IsEnabled, so no refusal path can leave a rejected rate
          * behind and no reader can see a rate the session is not running at.
@@ -4684,6 +4727,31 @@ static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context,
               (int)ifaceForStart, (int)ifaceObserved);
         SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
         SCPI_ClearStreamingOperBits(pRunTimeStreamConfig);
+        return SCPI_RES_ERR;
+    }
+
+    if (mappingMoved) {
+        /* Same unwind as capRevoked below: this START published the interface,
+         * so it must put it back, and it must never leave a logging file open
+         * behind a start that did not happen (#690). */
+        if (sdLoggingRequested) {
+            SCPI_ReleaseSdLoggingArm(pSDCardSettings);
+        }
+        SCPI_ClearStreamingOperBits(pRunTimeStreamConfig);
+        SCPI_UnpublishStartInterface(pRunTimeStreamConfig, ifaceForStart,
+                                     ifaceAtDetect, ifaceGenPinned,
+                                     ifaceSetsPinned);
+        /* SETTINGS_CONFLICT, not EXECUTION_ERROR: this is the same family as
+         * the inputsGone refusal above -- the enabled-channel set is now at
+         * odds with the session being armed -- and -200 is overloaded enough
+         * on this path (SD not ready, #589 SPI gate, #847) that a distinct
+         * code is worth having. The log line is what names WHICH guard fired.
+         *
+         * Kept under LOG_MESSAGE_SIZE (128, so 127 usable): the logger stores
+         * a fixed-size message and TRUNCATES past it, silently. 117 chars. */
+        LOG_E("STR:START refused (#846): the enabled-channel set changed during "
+              "start; the mapping and sample pool are stale. Retry.");
+        SCPI_ErrorPush(context, SCPI_ERROR_SETTINGS_CONFLICT);
         return SCPI_RES_ERR;
     }
 

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -451,14 +451,24 @@ static AInChannelMapping gChannelMapping = {0};
  * partitioned from the old mapping, so a rebuilt mapping without a
  * re-partition is worse than a stale one.
  *
- * Concurrency: written only by Streaming_BuildChannelMapping, whose three
- * callers (SYST:STR:START, SYST:STR:THRoughput, SYST:STR:WIFI:FINd) all run
- * under the #850 session-start claim, and read back by that same task.  One
- * writer at a time, reader == writer, so no torn 64-bit access is reachable
- * and no critical section is needed on the store.  Per #409 (.bss is not
- * re-zeroed on an MCLR/IPE reset) the initializer is not load-bearing: the
- * only reader reads it immediately after a build, and a hypothetical stale
- * value would cause a spurious refusal, never a silent arm.
+ * Concurrency: 64-bit, so BOTH the store and the read take a critical section
+ * -- CLAUDE.md's atomicity rule is categorical for 64-bit ("always need a
+ * critical section"), and a torn access here would compare half of one mask
+ * against half of another, deciding a refusal or an admission on a value that
+ * never existed.
+ *
+ * The narrower argument -- that tearing is unreachable because the only writer
+ * is Streaming_BuildChannelMapping, whose three callers (SYST:STR:START,
+ * SYST:STR:THRoughput, SYST:STR:WIFI:FINd) all run under the #850
+ * session-start claim, with reader == writer -- is true today.  It is not what
+ * this rests on: it is an invariant owned by another module, and one unclaimed
+ * caller added later would silently retire it.  Two instructions once per
+ * START is not a price worth arguing about, so pay it rather than depend on it
+ * (Qodo).
+ *
+ * Per #409 (.bss is not re-zeroed on an MCLR/IPE reset) the initializer is not
+ * load-bearing: the only reader reads it immediately after a build, and a
+ * hypothetical stale value would cause a spurious refusal, never a silent arm.
  */
 static uint64_t gChannelMappingSelection = 0;
 
@@ -673,8 +683,11 @@ uint8_t Streaming_BuildChannelMapping(const tBoardConfig* pBoardConfig,
         packed++;
     }
     gChannelMapping.count = packed;
-    /* Published last, after the mapping it describes is complete. */
+    /* Published last, after the mapping it describes is complete; 64-bit, so
+     * under a critical section -- see the definition's concurrency note. */
+    taskENTER_CRITICAL();
     gChannelMappingSelection = selection;
+    taskEXIT_CRITICAL();
     return packed;
 }
 
@@ -683,7 +696,11 @@ const AInChannelMapping* Streaming_GetChannelMapping(void) {
 }
 
 uint64_t Streaming_GetChannelMappingSelection(void) {
-    return gChannelMappingSelection;
+    uint64_t selection;
+    taskENTER_CRITICAL();
+    selection = gChannelMappingSelection;
+    taskEXIT_CRITICAL();
+    return selection;
 }
 
 void Streaming_CountActiveChannels(uint16_t* out_type1Count,

--- a/firmware/src/services/streaming.c
+++ b/firmware/src/services/streaming.c
@@ -426,6 +426,42 @@ static const NanopbFlagsArray fields_sd_metadata = {
 // any reader sees it. On PIC32MZ single-core, no memory barriers are needed.
 static AInChannelMapping gChannelMapping = {0};
 
+/* #846: the set of board-config channel indices the mapping above was built
+ * from -- its provenance, recorded by Streaming_BuildChannelMapping.
+ *
+ * The ordering note above is true and is NOT an exclusion.  Nothing stops the
+ * runtime config from moving AFTER the build and BEFORE IsEnabled is
+ * published, and every "reject while streaming" guard reads
+ * `IsEnabled || Running` -- so for that whole window (multi-second on the SD
+ * path, which polls for the log file) a CONF:ADC:CHANnel from the OTHER SCPI
+ * transport is accepted.  #844 re-validates the frequency cap at the publish
+ * point, but a CAP-NEUTRAL swap -- AIN0 for AIN1 -- keeps the channel count
+ * and therefore the cap, so it passes that check while this mapping still
+ * describes the old set.  csv_encoder then names its columns from the live
+ * runtime config and reads the values through this mapping, i.e. the header
+ * names one channel and the rows carry another, with every loss counter
+ * clean.  SCPI_StartStreamingClaimed compares this against a live recompute
+ * inside the same critical section that publishes IsEnabled and refuses the
+ * start when they differ.
+ *
+ * A mask, not a hash: MAX_AIN_CHANNEL indices fit in 64 bits (asserted at the
+ * definition of Streaming_ComputeChannelSelection), so the comparison is
+ * exact and cannot alias.  Rebuilding the mapping in place at the publish
+ * point is deliberately NOT the fix -- the sample pool was already
+ * partitioned from the old mapping, so a rebuilt mapping without a
+ * re-partition is worse than a stale one.
+ *
+ * Concurrency: written only by Streaming_BuildChannelMapping, whose three
+ * callers (SYST:STR:START, SYST:STR:THRoughput, SYST:STR:WIFI:FINd) all run
+ * under the #850 session-start claim, and read back by that same task.  One
+ * writer at a time, reader == writer, so no torn 64-bit access is reachable
+ * and no critical section is needed on the store.  Per #409 (.bss is not
+ * re-zeroed on an MCLR/IPE reset) the initializer is not load-bearing: the
+ * only reader reads it immediately after a build, and a hypothetical stale
+ * value would cause a spurious refusal, never a silent arm.
+ */
+static uint64_t gChannelMappingSelection = 0;
+
 // Encoder buffer — allocated from StreamingBufferPool, runtime-adjustable.
 // ENCODER_BUFFER_DEFAULT (8192) and ENCODER_BUFFER_MIN (1024) defined in
 // StreamingBufferPool.h. Benchmark: 8KB optimal for USB, 16KB helps SD.
@@ -571,38 +607,83 @@ static uint32_t Streaming_GenerateTestValue(uint32_t pattern, uint8_t channel,
 
 // --- Channel mapping API ---
 
+/* #846: one index bit per board-config channel slot.  The mask is the exact
+ * selection, not a digest, so widening MAX_AIN_CHANNEL past 64 must widen
+ * this type -- fail the build rather than silently drop the top slots. */
+_Static_assert(MAX_AIN_CHANNEL <= 64,
+        "#846: channel-selection mask is 64-bit; widen it if MAX_AIN_CHANNEL grows");
+
+uint64_t Streaming_ComputeChannelSelection(const tBoardConfig* pBoardConfig,
+                                           const AInRuntimeArray* pRuntimeChannels) {
+    uint64_t selection = 0;
+
+    size_t count = pBoardConfig->AInChannels.Size < pRuntimeChannels->Size
+                 ? pBoardConfig->AInChannels.Size : pRuntimeChannels->Size;
+
+    /* The `packed` guard is not bookkeeping here -- it makes the mask record
+     * what the mapping actually CONSUMED.  Past MAX_AIN_PUBLIC_CHANNELS the
+     * build stops packing, so channels beyond it are not part of the
+     * mapping's provenance and must not be part of its fingerprint either. */
+    uint8_t packed = 0;
+    for (size_t i = 0; i < count && packed < MAX_AIN_PUBLIC_CHANNELS; i++) {
+        if (pRuntimeChannels->Data[i].IsEnabled &&
+            AInChannel_IsPublic(&pBoardConfig->AInChannels.Data[i])) {
+            selection |= ((uint64_t)1u << i);
+            packed++;
+        }
+    }
+    return selection;
+}
+
 uint8_t Streaming_BuildChannelMapping(const tBoardConfig* pBoardConfig,
                                        const AInRuntimeArray* pRuntimeChannels) {
     memset(&gChannelMapping, 0, sizeof(gChannelMapping));
+
+    /* #846: build FROM the selection mask instead of re-testing the
+     * enable/public predicate here.  One predicate in one place is what makes
+     * the recorded fingerprint provably describe THIS mapping -- a second
+     * copy of the predicate could drift from it and leave the START guard
+     * quietly over- or under-sensitive.  The walk below is the same bounded
+     * walk as before: the mask has a bit set only for i < count, and at most
+     * MAX_AIN_PUBLIC_CHANNELS bits set, so it visits exactly the slots the
+     * old inline predicate did, in the same ascending order. */
+    const uint64_t selection =
+            Streaming_ComputeChannelSelection(pBoardConfig, pRuntimeChannels);
 
     size_t count = pBoardConfig->AInChannels.Size < pRuntimeChannels->Size
                  ? pBoardConfig->AInChannels.Size : pRuntimeChannels->Size;
 
     uint8_t packed = 0;
     for (size_t i = 0; i < count && packed < MAX_AIN_PUBLIC_CHANNELS; i++) {
-        if (pRuntimeChannels->Data[i].IsEnabled &&
-            AInChannel_IsPublic(&pBoardConfig->AInChannels.Data[i])) {
-            const AInChannel* ch = &pBoardConfig->AInChannels.Data[i];
-            gChannelMapping.channelIds[packed] = ch->DaqifiAdcChannelId;
-            gChannelMapping.configIndices[packed] = (uint8_t)i;
-            // #541 D-A: T1 (dedicated-module) channels are read directly
-            // from their ADC result registers in the deferred task, gated
-            // on per-input ARDY.  Record the hardware channel number here
-            // so the hot loop doesn't have to chase board-config pointers.
-            if (ch->Type == AIn_MC12bADC && ch->Config.MC12b.ChannelType == 1) {
-                gChannelMapping.t1DirectMask |= (uint16_t)(1U << packed);
-                gChannelMapping.hwChannelIds[packed] =
-                        (uint8_t)ch->Config.MC12b.ChannelId;
-            }
-            packed++;
+        if ((selection & ((uint64_t)1u << i)) == 0u) {
+            continue;
         }
+        const AInChannel* ch = &pBoardConfig->AInChannels.Data[i];
+        gChannelMapping.channelIds[packed] = ch->DaqifiAdcChannelId;
+        gChannelMapping.configIndices[packed] = (uint8_t)i;
+        // #541 D-A: T1 (dedicated-module) channels are read directly
+        // from their ADC result registers in the deferred task, gated
+        // on per-input ARDY.  Record the hardware channel number here
+        // so the hot loop doesn't have to chase board-config pointers.
+        if (ch->Type == AIn_MC12bADC && ch->Config.MC12b.ChannelType == 1) {
+            gChannelMapping.t1DirectMask |= (uint16_t)(1U << packed);
+            gChannelMapping.hwChannelIds[packed] =
+                    (uint8_t)ch->Config.MC12b.ChannelId;
+        }
+        packed++;
     }
     gChannelMapping.count = packed;
+    /* Published last, after the mapping it describes is complete. */
+    gChannelMappingSelection = selection;
     return packed;
 }
 
 const AInChannelMapping* Streaming_GetChannelMapping(void) {
     return &gChannelMapping;
+}
+
+uint64_t Streaming_GetChannelMappingSelection(void) {
+    return gChannelMappingSelection;
 }
 
 void Streaming_CountActiveChannels(uint16_t* out_type1Count,

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -1186,6 +1186,37 @@ uint8_t Streaming_BuildChannelMapping(const tBoardConfig* pBoardConfig,
  */
 const AInChannelMapping* Streaming_GetChannelMapping(void);
 
+/**
+ * #846: the enabled-public-channel set, as a bitmask of board-config channel
+ * indices. This is the ONE predicate the channel mapping is built from --
+ * Streaming_BuildChannelMapping derives its packed arrays from this mask
+ * rather than re-testing the predicate -- so a mask computed here is directly
+ * comparable to the one the mapping recorded.
+ *
+ * Bit i is set when runtime channel i is enabled AND board channel i is
+ * public, walked in ascending index order and stopped after
+ * MAX_AIN_PUBLIC_CHANNELS selections so the mask describes exactly what the
+ * mapping CONSUMED. Bounded, integer-only and non-blocking: safe to call
+ * inside a critical section, which is where START uses it.
+ *
+ * @param pBoardConfig     Board hardware configuration
+ * @param pRuntimeChannels Runtime channel enable/disable state
+ * @return Bitmask of selected board-config channel indices
+ */
+uint64_t Streaming_ComputeChannelSelection(const tBoardConfig* pBoardConfig,
+                                           const AInRuntimeArray* pRuntimeChannels);
+
+/**
+ * #846: the selection mask the CURRENT channel mapping (and the sample-pool
+ * partition sized from it) was built from.
+ *
+ * Read it back rather than recomputing it when you need the mapping's
+ * provenance: recomputing samples the runtime config a second time, and a
+ * preemption between the build and that recompute would record the NEW set
+ * against the OLD mapping -- the very hazard this exists to catch, inverted.
+ */
+uint64_t Streaming_GetChannelMappingSelection(void);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/firmware/src/services/streaming.h
+++ b/firmware/src/services/streaming.h
@@ -1214,6 +1214,9 @@ uint64_t Streaming_ComputeChannelSelection(const tBoardConfig* pBoardConfig,
  * provenance: recomputing samples the runtime config a second time, and a
  * preemption between the build and that recompute would record the NEW set
  * against the OLD mapping -- the very hazard this exists to catch, inverted.
+ *
+ * Takes a critical section (the value is 64-bit), so call it from task context
+ * -- which every caller is, being a SCPI handler. Not for ISR use.
  */
 uint64_t Streaming_GetChannelMappingSelection(void);
 


### PR DESCRIPTION
Fixes #846.

## The defect

`SCPI_StartStreamingClaimed` builds the streaming channel mapping (`Streaming_BuildChannelMapping`) and sizes the sample pool from it, then publishes `IsEnabled = true` several hundred lines later. Every "reject while streaming" guard reads `IsEnabled || Running`, so for that whole window — which contains the multi-second SD-file readiness poll — a `CONF:ADC:CHANnel` issued on the **other** SCPI transport is accepted.

[#844](https://github.com/daqifi/daqifi-nyquist-firmware/issues/844) closed the **rate** half of that window: the arm point recomputes the cap and publishes `IsEnabled` in one critical section. It does not cover a change that leaves the cap alone. Swapping AIN0 for AIN1 keeps the channel count, so the recomputed cap matches and the start is admitted while `gChannelMapping` still describes AIN0.

The consequence is worse than #844's, not milder:

| what | source | line |
|---|---|---|
| header / column names | `BoardRunTimeConfig_Get(...AIN_CHANNELS)` — the **new** config | `csv_encoder.c:321`, `:596` |
| sample data | `Streaming_GetChannelMapping()` — the **stale** mapping | `csv_encoder.c:381` |

The header names one channel and the rows carry another, with every loss counter clean. #844's failure (a session above its cap) is visible in the counters; this one is silent.

## The fix

Record the enabled-channel set the mapping was built from, and compare it against a live recompute inside the same critical section that publishes `IsEnabled`.

- **`Streaming_ComputeChannelSelection()`** returns the exact selection as a 64-bit mask of board-config indices. A mask, not a hash, so the comparison cannot alias — `MAX_AIN_CHANNEL` is 48 and a `_Static_assert` fails the build if it ever grows past 64 rather than silently dropping the top slots.
- **`Streaming_BuildChannelMapping()` now derives its packed arrays from that mask** instead of re-testing the enable/public predicate inline, and records the mask alongside the mapping. One predicate in one place is what makes the fingerprint *provably* describe the mapping it sits beside — a second copy of the predicate could drift and leave the guard quietly over- or under-sensitive, which is the failure mode a fingerprint scheme has to rule out. The walk is otherwise unchanged: same `min(boardSize, runtimeSize)` bound, same `packed < MAX_AIN_PUBLIC_CHANNELS` cutoff, same ascending order, same slots.
- **START reads the recorded mask back** (`Streaming_GetChannelMappingSelection()`) rather than recomputing it at the build site. This is load-bearing: a recompute samples the runtime config a second time, and a preemption in between would capture the **new** set as this mapping's provenance — the very hazard being closed, inverted.

Refusal: `-221 SETTINGS_CONFLICT` plus a `#846` `LOG_E` line, unwinding exactly as its siblings do (SD logging arm released per #690, OPER bits cleared, interface unpublished).

## Three decisions worth stating

**The check is unconditional on benchmark mode, unlike the cap.** `BENCHmark` buys a rate the cap would refuse; it does not buy a mapping that disagrees with the pool partition. That also catches a *count* change inside the window under `BENCHmark`, which would otherwise leave the sample-pool element stride sized for the old count.

**Rebuilding the mapping at the arm point is deliberately not the fix.** The sample pool was already partitioned from the old mapping, so a rebuilt mapping without a re-partition is worse than a stale one. The issue makes the same point.

**`-221`, not `-200`.** Same family as the neighbouring `inputsGone` refusal — the enabled-channel set is now at odds with the session being armed — and `-200` is overloaded enough on this path (SD not ready, the #589 SPI gate, #847) that a distinct code is worth having. The log line is what attributes it; the companion test keys on that marker, not on the bare code.

## MCU hygiene (`mcu-hygiene` skill, consulted before writing)

- The added work inside `taskENTER_CRITICAL` is one bounded integer scan of the channel array — same shape and cost as the `Streaming_CountActiveChannels` walk already in that section. No locks, no logging, no waits, no SFR writes. `LOG_E` and the SCPI error stay outside the section (the #759 pattern).
- The check has to be *inside* the section for the same reason the cap recompute is: computing it outside would only shrink the window, not close it (a START hosted on the WiFi task at priority 2 can be preempted by USB SCPI at priority 7 at any instruction boundary).
- `(uint64_t)1u << i` — widened before the shift, not after.
- The new 64-bit static takes a **critical section on both the store and the read**. The narrower argument — only one writer (`Streaming_BuildChannelMapping`, whose three callers all run under the #850 session-start claim), reader == writer, so tearing is unreachable — is true today, and is deliberately *not* what the code rests on: that invariant is owned by another module and one later unclaimed caller would retire it silently. CLAUDE.md's 64-bit atomicity rule is categorical, the cost is two instructions once per START, so the cheap rule wins over the clever argument. (Qodo's auto-review raised exactly this; applied rather than declined, per `mcu-hygiene`'s inverse default for concurrency findings.)
- Per #409 (`.bss` is not re-zeroed on an MCLR/IPE reset) the `= 0` initializer is not load-bearing: the only reader reads it immediately after a build, and a hypothetical stale value would cause a spurious refusal, never a silent arm — the fail-safe direction.
- No ISR context, no FPU, no DMA, no new stack pressure (one `uint64_t` local).

## File overlap

Open WIP PR #704 (`feat/669-onewire`) also touches `firmware/src/services/SCPI/SCPIInterface.c`, but in a **disjoint region** — it appends 1-Wire command-table rows and callbacks, while this PR changes the START path (`SCPI_StartStreamingClaimed`) and adds nothing to the command table. No line #704 changes is deleted or rewritten here.

## Verification

- `default` **and** `Nq3` both build clean at -O3 with `-Werror`.
- `tools/lint/cppcheck.sh`: baseline still empty (0 findings).
- `tools/lint/scpi_wiki_sync.py --self-test`: 14/14 matcher + 3/3 end-to-end. **No wiki edit is due** — no `.pattern` entry is added, changed or removed.
- `tools/lint/check_log_ascii.py`: clean.
- `tools/lint/scpi_claim_path.py` (from the open #863 branch, run against this tree, not committed here): OK, all 7 `SYSTem:MEMory:*` setters still take the claim.
- **BENCH-VALIDATED 2026-08-25** (operator granted standing flash authorization). Built and flashed from a worktree pinned to this PR's head `9e759a9b` — the same SHA the codex audit cleared — onto board `7E2898F46200E8A7` via PICkit `BUR184882598`.
  - **Flash proven by `firmware_crc32`**, not by the version string (`FIRMWARE_REVISION` has read 3.7.2 since 2026-07-13): `BEA79694` → `00919CE7`, and `00919CE7` held **constant** across the whole measurement run.
  - **`test_846_start_mapping_fingerprint.py`: 9 PASS, 0 FAIL.** Part 1 (over-sensitivity guard) green on all 5 shapes incl. the long SD-logging window; part 2 (mapping-rebuild guard) green on 3 shapes; **part 3 (`--race`) green on attempt 1** — the cap-neutral AIN0↔AIN15 swap **landed inside the window**, the START was refused, and the refusal was **attributed to `#846` via `SYST:LOG?`** (not a bare `-221`, not #847, not the #589 SPI gate). No residue: OPER MEASURING clear, interface unchanged, and a clean START afterwards streamed normally.
  - NVM is wiped by flashing; the device's stored configuration was snapshotted first and restored **verified field-by-field** (POW:STAT 1, CONF:VOLT:PREC 0, SD ENAble 0, LAN ENAbled 1 / NETType 1 / SECurity 3 / SSID Tesla / ADDRess 192.168.1.209).
  - The run required a fix to the **companion test**, not to this firmware: `parse_int_reply` required a command echo that `NyquistDevice.connect()` disables (`disable_device_echo()`), so it returned `None` for every reply and the run aborted at its own NVM-safety gate before reaching any firmware behaviour. Fixed in daqifi-python-test-suite `fa52ef3`; this firmware was unchanged throughout.

## Companion test

daqifi/daqifi-python-test-suite#248 — `test_846_start_mapping_fingerprint.py`, plus three reusable CSV-inspection helpers in `test_harness.py` and a `regression_gate` entry.

Its part 3 (`--race`) is the only arm that fails on pre-#846 firmware, and it hammers a **cap-neutral** swap (AIN0 ↔ AIN15, both Type-2) on purpose so #844's re-validation cannot also explain a refusal.

It can **fail on unfixed firmware, not merely pass on fixed** — which took a discriminator worth knowing about. The defect is silent by construction, so the arm sets `SYST:STR:TEST:PATtern 4` and `CONF:ADC:USECal 2`: the firmware generates the walking pattern from `mapping->channelIds[j]` (`streaming.c:1147`), i.e. the *stale mapping's* channel id, and raw mode prints the code rather than a voltage — so the step between consecutive CSV rows is exactly `channelId + 1`. A header naming AIN15 over rows stepping by 1 is #846 caught in the act. Anything unreadable falls back to a skip, so the new FAIL can only fire on a confident disagreement.

Parts 1 and 2 pass on baseline by design: part 1 is the guard against this fix being *over*-sensitive (an unraced START must still arm, including across the long SD-logging window), and part 2 is the regression for the `Streaming_BuildChannelMapping` rewrite (each session's CSV header must name exactly the enabled channels and every data row must be as wide as the header). The test's verdict logic is mutation-proved — **18/18** mutations of its load-bearing predicates killed by its `--self-test` (57 pure-logic cases).

## One observation, not changed here

While sizing the new `LOG_E` against `LOG_MESSAGE_SIZE` (128, so 127 usable — the logger truncates silently past it), the sibling **#847 refusal line measures 139 characters and is therefore truncated**, losing its trailing `this session. Retry.`. The new line is 117 and fits. I have not touched #847's user-visible log text in this PR: it belongs to that ticket, and the truncation is harmless in practice because the `#847` marker every consumer keys on is at the front. Flagging it so it is not re-derived later.

## Scope: the other two arm sites, enumerated

`Streaming_BuildChannelMapping` has three callers. This PR guards **one** of
them, and that is a deliberate scope call rather than an oversight — so here is
the full enumeration rather than leaving the next reader to find it:

| caller | guarded here? | why |
|---|---|---|
| `SYST:STR:START` (`SCPI_StartStreamingClaimed`) | **yes** | the production streaming path; the one #846 is about |
| `SYST:STR:THRoughput` | no | bench-only benchmark, one arm |
| `SYST:STR:WIFI:FINd?` | no | bench-only characterization sweep; builds the mapping ONCE and arms repeatedly, so the window recurs per step |

Both unguarded sites arm by poking `IsEnabled = true` inside a critical section
that checks only `Streaming_ConfigChangeInProgress()` — which catches a change
*in flight* (#847) but not one that already **completed**, which is precisely
what this PR's fingerprint is for. They are pre-existing and unchanged by this
PR; they produce a wrong *measurement* rather than mislabelled acquired data,
and covering them means changing when a diagnostic command aborts mid-sweep,
which needs its own bench validation on a WINC-sensitive path.

Filed as **#868** with the reproduction, the exact line numbers, and two
candidate fixes (detect-and-refuse vs rebuild-and-re-partition per step — the
latter is available to the finder precisely because it tears the session fully
down between steps, which START does not).

## Adversarial pre-merge audit

Ran the codex (GPT-5.x, cross-vendor) adversary at `--effort high` against a
SHA-pinned worktree of `7e151ec9`, briefed with an eight-item priority-ordered
attack list aimed at the things I was least sure of. **One finding**, `high`:
the `WIFI:FINd?` twin above. Verified against the source, judged out of scope
for this PR, and filed as #868 rather than folded in.

Independently verified while the audit ran (E-class, this session):

- **Refactor equivalence.** The old inline-predicate loop and the new
  mask-driven loop were modelled exactly and compared: exhaustively over all
  enable/public combinations for widths 0-8 at every `count`, plus 200,000
  randomized trials up to 48 slots with more than 16 channels enabled, plus the
  truncation boundaries at 15/16/17/18/48 qualifying channels. **Zero
  mismatches** — identical packed sequence and identical `count` in every case.
- **The only writer of AIn runtime `IsEnabled`** in the whole tree is
  `SCPI_ADCChanEnableSet` (`SCPIADC.c:236-314`) — the `CONF:ADC:CHANnel` /
  `ENAble:VOLTage:DC` handler this guard exists to catch. Nothing inside
  `SCPI_StartStreamingClaimed` mutates channel enables between the build and
  the arm point, so the guard cannot fire spuriously on an unraced START.
- **`tBoardConfig.AInChannels` is immutable at runtime** — no write to
  `AInChannels.Data[i].<field>` exists outside the board-config definition
  files, so a mask over indices does fully determine the mapping.
- **All three `Streaming_BuildChannelMapping` callers really do take the #850
  session-start claim** (`SCPIInterface.c:2391`, `:2847`, `:4900`, all through
  `Streaming_BeginSessionStart()`), which is what makes the read-back a
  single-writer access rather than a race.

