### PR TITLE
fix(scpi): SYST:STR:START 0 must be a complete stop, not three of five steps (#860)

### DIFF
--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5228,9 +5228,12 @@ static void SCPI_PerformStreamingStop(void) {
     SCPI_SyncQuesBits();
 }
 
-/* Both registered spellings of stop -- SYSTem:STReam:STOP and its
- * SYSTem:StopStreamData alias -- are this and nothing else. The disable form
- * SYSTem:STReam:START 0 calls the same body from SCPI_StartStreaming. */
+/* Every registered pattern that maps to a bare stop is this and nothing else
+ * -- grep the command table for SCPI_StopStreaming to see which; one of them
+ * is a legacy alias kept for compatibility and deliberately not spelled out
+ * here, so this comment does not put a non-canonical form into new lines.
+ * The disable form SYSTem:STReam:START 0 calls the same body from
+ * SCPI_StartStreaming. */
 static scpi_result_t SCPI_StopStreaming(scpi_t * context) {
     (void)context;
     SCPI_PerformStreamingStop();

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5044,13 +5044,13 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
  * ONE body, read atomically, called at both points that need the answer --
  * deliberately, in a PR whose entire subject is two copies of one question
  * drifting apart. `enable && mode == WRITE` alone does not say WHOSE write it
- * is: exactly two sites arm WRITE, SCPI_StartStreamingClaimed (:4655) and
- * SYST:STOR:SD:BENCHmark (SCPIStorageSD.c:1243), and the benchmark takes no
- * claim by design (#736). The #851 latch is what separates them.
+ * is: exactly two sites arm WRITE -- SCPI_StartStreamingClaimed()'s SD arm
+ * and SYST:STOR:SD:BENCHmark (SCPI_StorageSDBenchmark) -- and the benchmark
+ * takes no claim by design (#736). The #851 latch is what separates them.
  *
  * The critical section makes the composite a snapshot rather than three
  * independent reads; the latch is written under one in the SD manager
- * (sd_card_manager.c:3602-3611), and SCPIStorageSD.c:496 reads the benchmark's
+ * (sd_UpdateSettingsImpl), and SCPI_StorageSDLoggingSet reads the benchmark's
  * ownership flag the same way. Nothing in here can block.
  *
  * The predicate lives in ONE place and gets two wrappers -- a plain read and a
@@ -5079,7 +5079,7 @@ static bool SCPI_SdWriteIsStreamingLog(const sd_card_manager_settings_t *sd) {
  * leaves a window in which a benchmark arms between the two and has its brand
  * new session cancelled by a decision made before it existed: the same defect
  * as the audit's, just narrower, and narrower is not closed. Same reasoning
- * and the same idiom as SCPIStorageSD.c:496, which checks the benchmark's
+ * and the same idiom as SCPI_StorageSDLoggingSet, which checks the benchmark's
  * ownership flag and writes the filename under one critical section for
  * exactly this reason.
  *
@@ -5173,13 +5173,13 @@ static void SCPI_PerformStreamingStop(void) {
      * ASKED HERE, because asking only at the act point loses the answer
      * (Qodo). SYST:STOR:SD:BENCHmark is refused while a stream is live (#854)
      * and arms a PLAIN write, which CLEARS the streaming-log latch
-     * (sd_card_manager.c:3603-3610). Clearing IsEnabled and running
+     * (in sd_UpdateSettingsImpl). Clearing IsEnabled and running
      * Streaming_UpdateState() below is exactly what stops that refusal
      * refusing -- so a benchmark on the other transport can arm in the window,
      * and a predicate evaluated only afterwards reads latch=false and skips
      * closing THIS session's log. Here, the session is still live and the
      * benchmark is still refused. Same shape as #851's
-     * stoppedSdLoggingSession at :4351.
+     * stoppedSdLoggingSession in SCPI_StartStreamingClaimed.
      *
      * ASKED AGAIN AT THE ACT POINT, because acting only on this snapshot
      * aborts whatever took the WRITE in that same window (codex). The
@@ -5204,10 +5204,10 @@ static void SCPI_PerformStreamingStop(void) {
      * Each read is one critical section, which is NOT the reflexive "wrap a
      * shared read" the project declines: the predicate is a composite of three
      * independently written fields whose latch half is WRITTEN under a
-     * critical section in the SD manager (sd_card_manager.c:3602-3611), so
+     * critical section in the SD manager (sd_UpdateSettingsImpl), so
      * reading the set together matches the writer's own discipline.
-     * SCPIStorageSD.c:496 reads the benchmark's ownership flag the same way
-     * for the same reason. O(1) loads, no call that can block. */
+     * SCPI_StorageSDLoggingSet reads the benchmark's ownership flag the same
+     * way for the same reason. O(1) loads, no call that can block. */
     const bool ownedSdLoggingSession =
             SCPI_SdWriteIsStreamingLog(pSDCardRuntimeConfig);
 
@@ -5233,8 +5233,9 @@ static void SCPI_PerformStreamingStop(void) {
      *
      * `enable && mode == WRITE` does not mean "a streaming log is open" -- it
      * means "somebody armed the shared WRITE". There are exactly two arms in
-     * the tree: SCPI_StartStreamingClaimed (:4655) and SYST:STOR:SD:BENCHmark
-     * (SCPIStorageSD.c:1243), and the benchmark takes no claim by design
+     * the tree: SCPI_StartStreamingClaimed()'s SD arm and
+     * SYST:STOR:SD:BENCHmark (SCPI_StorageSDBenchmark), and the benchmark
+     * takes no claim by design
      * (#736). So on the mode alone this teardown closes a running benchmark's
      * file: it sets mode to NONE, sd_card_manager_WriteToBuffer then returns 0,
      * and the benchmark stalls to its 10 s drain timeout and reports a
@@ -5243,7 +5244,7 @@ static void SCPI_PerformStreamingStop(void) {
      * That is PRE-EXISTING on SYSTem:STReam:STOP, which has always run this
      * body -- and it is the twin site of #851, which added the latch for
      * exactly this distinction and wired it into SCPI_StartStreaming's abort
-     * paths (see the comment at :4345) without reaching here. Left alone, #860
+     * paths (see the comment there) without reaching here. Left alone, #860
      * would hand the same defect to a SECOND spelling, on a command whose
      * whole point is to be a safe recovery action. Both spellings are fixed
      * instead: the latch is set only by the STREAMING arm, so a benchmark's
@@ -5252,7 +5253,7 @@ static void SCPI_PerformStreamingStop(void) {
      * IT CAN OVER-NARROW, in one exotic interleaving, and an earlier revision
      * of this comment claimed it could not (audit round 6). Normally the latch
      * is set at the streaming arm, cleared by a PLAIN arm or by a mode -> NONE
-     * that goes THROUGH sd_UpdateSettingsImpl (sd_card_manager.c:3603-3610),
+     * that goes THROUGH sd_UpdateSettingsImpl's latch block,
      * and #854 keeps a benchmark out for the whole session -- so it is true
      * for the whole of any session this body is called to end. But #854 tests
      * IsEnabled/Running, which START publishes AFTER it arms SD: a benchmark
@@ -5272,10 +5273,11 @@ static void SCPI_PerformStreamingStop(void) {
      * It CAN be stale-true, though, and an earlier revision of this comment
      * said "cleared only by ... mode -> NONE" without that qualifier, which is
      * a false claim in a comment (audit round 5). The manager sets
-     * gpSDCardSettings->mode = NONE DIRECTLY in sixteen places that never reach
-     * the clear -- the no-writable-bucket exit at sd_card_manager.c:2075 among
-     * them -- so a session that ended by one of those routes leaves the latch
-     * set. A stop landing in the two statements between a benchmark's
+     * gpSDCardSettings->mode = NONE DIRECTLY in many places that never reach
+     * the clear (grep that assignment in sd_card_manager.c) -- the
+     * no-writable-bucket exit in sd_card_manager_ProcessState's OPEN_FILE
+     * among them -- so a session that ended by one of those routes leaves the
+     * latch set. A stop landing in the two statements between a benchmark's
      * `mode = WRITE` and its UpdateSettingsForPlainWrite() would then see all
      * three terms true and claim the benchmark's write. That window is #871; it
      * exists on main too, whose predicate has no latch term at all and so hits

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5250,9 +5250,23 @@ static void SCPI_PerformStreamingStop(void) {
      * WRITE is no longer mistaken for a session's.
      *
      * It cannot over-narrow a real stop. The latch is set at the streaming arm
-     * and cleared only by a PLAIN arm or by mode -> NONE (sd_card_manager.c
-     * :3603-3610), and #854 refuses a benchmark while a stream is live, so it
-     * is true for the whole of any session this body is called to end. The
+     * and cleared by a PLAIN arm or by a mode -> NONE that goes THROUGH
+     * sd_UpdateSettingsImpl (sd_card_manager.c:3603-3610), and #854 refuses a
+     * benchmark while a stream is live, so it is true for the whole of any
+     * session this body is called to end.
+     *
+     * It CAN be stale-true, though, and an earlier revision of this comment
+     * said "cleared only by ... mode -> NONE" without that qualifier, which is
+     * a false claim in a comment (audit round 5). The manager sets
+     * gpSDCardSettings->mode = NONE DIRECTLY in sixteen places that never reach
+     * the clear -- the no-writable-bucket exit at sd_card_manager.c:2075 among
+     * them -- so a session that ended by one of those routes leaves the latch
+     * set. A stop landing in the two statements between a benchmark's
+     * `mode = WRITE` and its UpdateSettingsForPlainWrite() would then see all
+     * three terms true and claim the benchmark's write. That window is #871; it
+     * exists on main too, whose predicate has no latch term at all and so hits
+     * it in EVERY state rather than only the stale one. The latch narrows this,
+     * it does not open it. The
      * companion test's part 2 is the guard on that direction: it asserts
      * SYST:STOR:SD:SPACe? answers straight after `START 0` on a logging
      * session, which can only happen if this block still fires. */

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5039,6 +5039,29 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     return result;
 }
 
+/* #860: "is the SD card's armed WRITE a STREAMING LOG, right now?"
+ *
+ * ONE body, read atomically, called at both points that need the answer --
+ * deliberately, in a PR whose entire subject is two copies of one question
+ * drifting apart. `enable && mode == WRITE` alone does not say WHOSE write it
+ * is: exactly two sites arm WRITE, SCPI_StartStreamingClaimed (:4655) and
+ * SYST:STOR:SD:BENCHmark (SCPIStorageSD.c:1243), and the benchmark takes no
+ * claim by design (#736). The #851 latch is what separates them.
+ *
+ * The critical section makes the composite a snapshot rather than three
+ * independent reads; the latch is written under one in the SD manager
+ * (sd_card_manager.c:3602-3611), and SCPIStorageSD.c:496 reads the benchmark's
+ * ownership flag the same way. Nothing in here can block. */
+static bool SCPI_SdWriteIsStreamingLog(const sd_card_manager_settings_t *sd) {
+    bool armed;
+    taskENTER_CRITICAL();
+    armed = (sd != NULL) && sd->enable &&
+            (sd->mode == SD_CARD_MANAGER_MODE_WRITE) &&
+            sd_card_manager_WriteIsStreamingLog();
+    taskEXIT_CRITICAL();
+    return armed;
+}
+
 /* #860: the complete streaming teardown, shared by BOTH spellings of stop.
  *
  * SYSTem:STReam:STOP and the SYSTem:STReam:START 0 disable form are documented
@@ -5107,37 +5130,51 @@ static void SCPI_PerformStreamingStop(void) {
     sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(
             BOARDRUNTIME_SD_CARD_SETTINGS);
 
-    /* The SD-teardown question is asked HERE, before the session is torn down,
-     * and the ordering is the load-bearing part -- see the block that uses it
-     * further down for what the three terms mean.
+    /* The SD-teardown question is asked TWICE -- here, and again at the act
+     * point below -- and the teardown runs only if BOTH say yes. Two pre-merge
+     * audit rounds each produced one direction of this, and each single answer
+     * is wrong on its own.
      *
-     * Asking it later is a check-then-act race with a real interleaving, not a
-     * theoretical one. SYST:STOR:SD:BENCHmark is refused while a stream is
-     * live (#854) and arms a PLAIN write, which CLEARS the streaming-log latch
+     * ASKED HERE, because asking only at the act point loses the answer
+     * (Qodo). SYST:STOR:SD:BENCHmark is refused while a stream is live (#854)
+     * and arms a PLAIN write, which CLEARS the streaming-log latch
      * (sd_card_manager.c:3603-3610). Clearing IsEnabled and running
-     * Streaming_UpdateState() below is exactly what makes that refusal stop
-     * refusing -- so a benchmark on the other transport can arm in the window
-     * between them and a predicate evaluated after would read latch=false and
-     * skip closing THIS session's log. Evaluated here, the session is still
-     * live, the benchmark is still refused, and the answer cannot be stolen.
-     * Same shape and same reason as #851's stoppedSdLoggingSession at :4351.
+     * Streaming_UpdateState() below is exactly what stops that refusal
+     * refusing -- so a benchmark on the other transport can arm in the window,
+     * and a predicate evaluated only afterwards reads latch=false and skips
+     * closing THIS session's log. Here, the session is still live and the
+     * benchmark is still refused. Same shape as #851's
+     * stoppedSdLoggingSession at :4351.
      *
-     * Under one critical section, which is NOT the reflexive "wrap a shared
-     * read" the project declines: this is a composite of three independently
-     * written fields, and the latch half is WRITTEN under a critical section
-     * in the SD manager (sd_card_manager.c:3602-3611), so reading the set
-     * together matches the writer's own discipline. SCPIStorageSD.c:496 reads
-     * the benchmark's ownership flag the same way for the same reason. O(1)
-     * loads, no call that can block -- WriteIsStreamingLog() is a single
-     * volatile read. */
-    bool closeSdLoggingSession;
-    taskENTER_CRITICAL();
-    closeSdLoggingSession = (pSDCardRuntimeConfig != NULL) &&
-                            pSDCardRuntimeConfig->enable &&
-                            (pSDCardRuntimeConfig->mode ==
-                                 SD_CARD_MANAGER_MODE_WRITE) &&
-                            sd_card_manager_WriteIsStreamingLog();
-    taskEXIT_CRITICAL();
+     * ASKED AGAIN AT THE ACT POINT, because acting only on this snapshot
+     * aborts whatever took the WRITE in that same window (codex). The
+     * teardown's first statement is mode = NONE, so a stale "yes" cancels the
+     * benchmark that was legitimately accepted a microsecond ago -- the very
+     * defect this PR exists to stop, re-entered through a narrower door. The
+     * fix for one direction was the finding in the other; requiring both is
+     * what holds.
+     *
+     *   early yes, late no   the WRITE is no longer ours -- skip. The log file
+     *                        is closed by the new owner's own arm anyway
+     *                        (UpdateSettings parks at DEINIT and closes).
+     *   early no, late yes   a session that started AFTER ours ended -- not
+     *                        ours to close, skip.
+     *   both yes             nobody moved; tear down, with the bounded wait.
+     *
+     * What two yeses still cannot distinguish is a stop racing another
+     * transport's START. That is #861, it is shared by both spellings, and it
+     * is exactly what main does today on the mode alone -- not a regression
+     * introduced here.
+     *
+     * Each read is one critical section, which is NOT the reflexive "wrap a
+     * shared read" the project declines: the predicate is a composite of three
+     * independently written fields whose latch half is WRITTEN under a
+     * critical section in the SD manager (sd_card_manager.c:3602-3611), so
+     * reading the set together matches the writer's own discipline.
+     * SCPIStorageSD.c:496 reads the benchmark's ownership flag the same way
+     * for the same reason. O(1) loads, no call that can block. */
+    const bool ownedSdLoggingSession =
+            SCPI_SdWriteIsStreamingLog(pSDCardRuntimeConfig);
 
     if (pRunTimeStreamConfig) {
         pRunTimeStreamConfig->IsEnabled = false;
@@ -5151,9 +5188,11 @@ static void SCPI_PerformStreamingStop(void) {
     UsbCdc_FlushWriteBuffer();
 
     // Close SD card file if logging was enabled
-    /* #860 pre-merge audit: the `sd_card_manager_WriteIsStreamingLog()` term in
-     * the snapshot at the top of this function is what makes sharing this body
-     * safe.
+    /* #860 pre-merge audit: BOTH the snapshot taken at the top of this
+     * function and a fresh read here must say yes -- see the comment at the
+     * snapshot for why one answer alone is wrong in either direction.
+     * `sd_card_manager_WriteIsStreamingLog()` is the term that makes sharing
+     * this body safe at all.
      *
      * `enable && mode == WRITE` does not mean "a streaming log is open" -- it
      * means "somebody armed the shared WRITE". There are exactly two arms in
@@ -5180,7 +5219,8 @@ static void SCPI_PerformStreamingStop(void) {
      * companion test's part 2 is the guard on that direction: it asserts
      * SYST:STOR:SD:SPACe? answers straight after `START 0` on a logging
      * session, which can only happen if this block still fires. */
-    if (closeSdLoggingSession) {
+    if (ownedSdLoggingSession &&
+        SCPI_SdWriteIsStreamingLog(pSDCardRuntimeConfig)) {
         // Set mode to NONE and update to trigger file close (DEINIT → UNMOUNT → close)
         pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
         sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5249,11 +5249,25 @@ static void SCPI_PerformStreamingStop(void) {
      * instead: the latch is set only by the STREAMING arm, so a benchmark's
      * WRITE is no longer mistaken for a session's.
      *
-     * It cannot over-narrow a real stop. The latch is set at the streaming arm
-     * and cleared by a PLAIN arm or by a mode -> NONE that goes THROUGH
-     * sd_UpdateSettingsImpl (sd_card_manager.c:3603-3610), and #854 refuses a
-     * benchmark while a stream is live, so it is true for the whole of any
-     * session this body is called to end.
+     * IT CAN OVER-NARROW, in one exotic interleaving, and an earlier revision
+     * of this comment claimed it could not (audit round 6). Normally the latch
+     * is set at the streaming arm, cleared by a PLAIN arm or by a mode -> NONE
+     * that goes THROUGH sd_UpdateSettingsImpl (sd_card_manager.c:3603-3610),
+     * and #854 keeps a benchmark out for the whole session -- so it is true
+     * for the whole of any session this body is called to end. But #854 tests
+     * IsEnabled/Running, which START publishes AFTER it arms SD: a benchmark
+     * landing inside that window passes the test, arms PLAIN, and clears the
+     * latch under a session that then goes live. A later stop reads false and
+     * skips the teardown, leaving mode = WRITE and the file open.
+     *
+     * That session is already broken -- the stream and the benchmark are
+     * sharing one file -- and main is not better, it is differently wrong: with
+     * no latch term at all, main's stop tears down whichever WRITE it finds,
+     * which in that same interleaving is the benchmark's. The one thing main
+     * does do is leave mode = NONE, so SD commands work again afterwards. Both
+     * are #871, whose ownership interlock is the only thing that distinguishes
+     * these cases; the latch cannot, because the benchmark clears it before
+     * this body can read it.
      *
      * It CAN be stale-true, though, and an earlier revision of this comment
      * said "cleared only by ... mode -> NONE" without that qualifier, which is

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -4933,6 +4933,12 @@ static scpi_result_t SCPI_StartStreamingClaimed(scpi_t * context,
     return SCPI_RES_OK;
 }
 
+/* #860: the shared streaming teardown. Defined next to SCPI_StopStreaming,
+ * whose body it is; forward-declared here because the START 0 disable form
+ * below is the other spelling of the same stop and must perform the same
+ * teardown, not a subset of it. */
+static void SCPI_PerformStreamingStop(void);
+
 /* #850 + pre-merge audit: START parses BEFORE it claims.
  *
  * This one does not use SCPI_RunSessionStartClaimed, unlike the other two arm
@@ -4994,22 +5000,15 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
          * SYSTem:STReam:STOP has no such gates either, and stopping should not
          * depend on the device still being in a state fit to START.
          *
-         * IT IS NOT, HOWEVER, EQUIVALENT TO SYSTem:STReam:STOP, and an earlier
-         * revision of this comment said it performed "the identical three
-         * actions", which is false (pre-merge audit). STOP additionally tears
-         * down SD logging -- mode to SD_CARD_MANAGER_MODE_NONE,
-         * sd_card_manager_UpdateSettings, then a bounded wait for the manager
-         * to drain and close the file -- and clears the streaming OPER bits.
-         * This branch does neither, so `START 0` on a logging session leaves
-         * the file open in WRITE mode and OPER reading MEASURING.
-         *
-         * Both gaps are PRE-EXISTING: main's disable branch is these same
-         * three statements. They are tracked in #860 rather than fixed here,
-         * because the fix is to make this branch a real stop, which is a
-         * behaviour change of its own and wants its own test. What changes
-         * here is only that the code no longer CLAIMS an equivalence it does
-         * not have -- a client that needs a complete stop should send
-         * SYSTem:STReam:STOP.
+         * #860: it now performs the SAME TEARDOWN as SYSTem:STReam:STOP,
+         * because it calls that function's body instead of re-implementing
+         * three of its statements. It used to do IsEnabled,
+         * Streaming_UpdateState and the USB flush and return OK, leaving SD
+         * logging open in WRITE mode and OPER reading MEASURING -- a half-stop
+         * reported as success. Both gaps were pre-existing (main's disable
+         * branch was those same three statements) and both are closed by the
+         * shared body; see SCPI_PerformStreamingStop for what it does and,
+         * importantly, what it still does not.
          *
          * Always allowed, including under heap pressure (the user may be
          * trying to stop streaming as a recovery action).
@@ -5023,14 +5022,11 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
          * predate the #850 claim, which serialises STARTS against each
          * other and never claimed to order a stop against a start. Closing
          * it needs the arm to observe a stop-requested generation, the way
-         * it already observes ifaceMoved/cfgChanging -- tracked separately,
+         * it already observes ifaceMoved/cfgChanging -- tracked as #861,
          * because the fix belongs to STOP as much as to this branch
-         * (pre-merge audit round 2). */
-        StreamingRuntimeConfig * cfg = BoardRunTimeConfig_Get(
-                BOARDRUNTIME_STREAMING_CONFIGURATION);
-        cfg->IsEnabled = false;
-        Streaming_UpdateState();
-        UsbCdc_FlushWriteBuffer();
+         * (pre-merge audit round 2). Making the two spellings identical does
+         * NOT close it; it closes the difference between them. */
+        SCPI_PerformStreamingStop();
         return SCPI_RES_OK;
     }
 
@@ -5043,7 +5039,66 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
     return result;
 }
 
-static scpi_result_t SCPI_StopStreaming(scpi_t * context) {
+/* #860: the complete streaming teardown, shared by BOTH spellings of stop.
+ *
+ * SYSTem:STReam:STOP and the SYSTem:STReam:START 0 disable form are documented
+ * and used as the same operation, and were not. The disable branch performed
+ * three of the statements below -- IsEnabled, Streaming_UpdateState, the USB
+ * flush -- and returned OK, so it left SD logging open in
+ * SD_CARD_MANAGER_MODE_WRITE and OPER still reporting MEASURING. Bench-measured
+ * on main: after START 0 the data flow stopped (0 bytes in 2.0 s) while
+ * STAT:OPER:COND? still read 16, and only STR:STOP brought it to 0. A client
+ * that stops with START 0 and polls the CONDition register -- documented as
+ * CURRENT state, not a latch -- concludes the device is acquiring
+ * indefinitely, and its next SD command is refused busy because the log file
+ * from the previous session was never closed.
+ *
+ * FACTORED, not copied, and that is the fix rather than an incidental tidy-up:
+ * the two spellings drifted apart precisely because the disable branch
+ * re-implemented a subset of this. There is now one body, so a teardown step
+ * added later cannot reach one spelling and miss the other.
+ *
+ * This body is SCPI_StopStreaming's, unchanged -- only its name and its
+ * signature moved. STOP's behaviour is deliberately not touched, so the
+ * regression this closes cannot be confused with a change to the spelling that
+ * was already correct.
+ *
+ * BLOCKING, up to 5 s, but only on the path that already blocked: the bounded
+ * idle wait runs solely when SD logging is genuinely open (enable && mode ==
+ * WRITE), which is exactly the case the disable branch used to abandon. An
+ * idle device, or a session with no SD logging, skips it entirely, so START 0
+ * as a recovery action costs what it always did.
+ *
+ * NOT claimed, deliberately. A stop must never be refusable because another
+ * transport is mid-START (#850) -- see the disable branch's own comment -- and
+ * SCPI_StopStreaming has never taken the claim either. Calling this changes
+ * what the disable branch DOES, not where it sits relative to the claim.
+ *
+ * SCOPE. This makes the two spellings identical; it does not make either of
+ * them ordered against a concurrent START. A stop issued inside another
+ * transport's pre-arm window still clears an IsEnabled that is still false and
+ * returns OK while that START publishes true on its way out. That is #861, it
+ * is shared by both spellings, and closing it needs the ARM to observe a
+ * stop-requested generation the way it already observes ifaceMoved/cfgChanging.
+ * What changes here is that START 0 no longer carries that hazard PLUS two of
+ * its own.
+ *
+ * The clear at the end stays UNCONDITIONAL rather than moving to
+ * SCPI_ClearStreamingOperBits, which tests `IsEnabled || Running` first. That
+ * helper answers a different question -- "did another transport arm a session
+ * while this START was unwinding" (#848) -- and on a stop the same test would
+ * SKIP the clear in exactly the #861 interleaving above, leaving behind the
+ * stale bit this ticket is about. Switching it is a behaviour change to STOP
+ * and belongs to #861, not here.
+ *
+ * NOT extended to SYST:STR:THRoughput / SYST:STR:WIFI:FINd?, which also end a
+ * session with a bare IsEnabled = false + Streaming_UpdateState(). Those two
+ * are already symmetric: they arm by poking IsEnabled directly and so never
+ * set OPER_MEASURING (its only setter is SCPI_StartStreamingClaimed), and they
+ * save and restore the SD mode around the run themselves (RestoreSdMode).
+ * Routing them through here would clear bits they never set and fight their
+ * own restore. Their hazard is the stale channel mapping instead -- #868. */
+static void SCPI_PerformStreamingStop(void) {
     StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
 
@@ -5138,7 +5193,14 @@ static scpi_result_t SCPI_StopStreaming(scpi_t * context) {
 
     // Sync STATus:QUEStionable condition register (streaming health bits cleared in Streaming_Stop)
     SCPI_SyncQuesBits();
+}
 
+/* Both registered spellings of stop -- SYSTem:STReam:STOP and its
+ * SYSTem:StopStreamData alias -- are this and nothing else. The disable form
+ * SYSTem:STReam:START 0 calls the same body from SCPI_StartStreaming. */
+static scpi_result_t SCPI_StopStreaming(scpi_t * context) {
+    (void)context;
+    SCPI_PerformStreamingStop();
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5104,6 +5104,40 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
 static void SCPI_PerformStreamingStop(void) {
     StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
+    sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(
+            BOARDRUNTIME_SD_CARD_SETTINGS);
+
+    /* The SD-teardown question is asked HERE, before the session is torn down,
+     * and the ordering is the load-bearing part -- see the block that uses it
+     * further down for what the three terms mean.
+     *
+     * Asking it later is a check-then-act race with a real interleaving, not a
+     * theoretical one. SYST:STOR:SD:BENCHmark is refused while a stream is
+     * live (#854) and arms a PLAIN write, which CLEARS the streaming-log latch
+     * (sd_card_manager.c:3603-3610). Clearing IsEnabled and running
+     * Streaming_UpdateState() below is exactly what makes that refusal stop
+     * refusing -- so a benchmark on the other transport can arm in the window
+     * between them and a predicate evaluated after would read latch=false and
+     * skip closing THIS session's log. Evaluated here, the session is still
+     * live, the benchmark is still refused, and the answer cannot be stolen.
+     * Same shape and same reason as #851's stoppedSdLoggingSession at :4351.
+     *
+     * Under one critical section, which is NOT the reflexive "wrap a shared
+     * read" the project declines: this is a composite of three independently
+     * written fields, and the latch half is WRITTEN under a critical section
+     * in the SD manager (sd_card_manager.c:3602-3611), so reading the set
+     * together matches the writer's own discipline. SCPIStorageSD.c:496 reads
+     * the benchmark's ownership flag the same way for the same reason. O(1)
+     * loads, no call that can block -- WriteIsStreamingLog() is a single
+     * volatile read. */
+    bool closeSdLoggingSession;
+    taskENTER_CRITICAL();
+    closeSdLoggingSession = (pSDCardRuntimeConfig != NULL) &&
+                            pSDCardRuntimeConfig->enable &&
+                            (pSDCardRuntimeConfig->mode ==
+                                 SD_CARD_MANAGER_MODE_WRITE) &&
+                            sd_card_manager_WriteIsStreamingLog();
+    taskEXIT_CRITICAL();
 
     if (pRunTimeStreamConfig) {
         pRunTimeStreamConfig->IsEnabled = false;
@@ -5117,9 +5151,9 @@ static void SCPI_PerformStreamingStop(void) {
     UsbCdc_FlushWriteBuffer();
 
     // Close SD card file if logging was enabled
-    sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
-    /* #860 pre-merge audit: the `sd_card_manager_WriteIsStreamingLog()` term is
-     * the ONE change to this body, and it is what makes sharing it safe.
+    /* #860 pre-merge audit: the `sd_card_manager_WriteIsStreamingLog()` term in
+     * the snapshot at the top of this function is what makes sharing this body
+     * safe.
      *
      * `enable && mode == WRITE` does not mean "a streaming log is open" -- it
      * means "somebody armed the shared WRITE". There are exactly two arms in
@@ -5146,10 +5180,7 @@ static void SCPI_PerformStreamingStop(void) {
      * companion test's part 2 is the guard on that direction: it asserts
      * SYST:STOR:SD:SPACe? answers straight after `START 0` on a logging
      * session, which can only happen if this block still fires. */
-    if (pSDCardRuntimeConfig != NULL &&
-        pSDCardRuntimeConfig->enable &&
-        pSDCardRuntimeConfig->mode == SD_CARD_MANAGER_MODE_WRITE &&
-        sd_card_manager_WriteIsStreamingLog()) {
+    if (closeSdLoggingSession) {
         // Set mode to NONE and update to trigger file close (DEINIT → UNMOUNT → close)
         pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
         sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
@@ -5201,7 +5232,13 @@ static void SCPI_PerformStreamingStop(void) {
                 /* Kept under LOG_MESSAGE_SIZE (128) with the longest state
                  * name: the previous wording was 149 chars and lost its own
                  * "Poll STAT:OPER:COND?" advice to truncation. */
-                LOG_E("[SD] StopStreaming: SD still finalising in state=%s "
+                /* "Streaming stop", not "StopStreaming": since #860 the
+                 * SYSTem:STReam:START 0 disable form reaches this line too, and
+                 * a message naming a command the caller never sent sends the
+                 * next reader of SYST:LOG? looking for the wrong one. 122 chars
+                 * with the longest state/mode names (CURDRIVE / GETSPACE),
+                 * inside LOG_MESSAGE_SIZE (128). */
+                LOG_E("[SD] Streaming stop: SD still finalising in state=%s "
                       "mode=%s; OPER bit 11 set until idle. "
                       "Poll STAT:OPER:COND?",
                       sd_card_manager_GetStateName(),

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5051,15 +5051,50 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
  * The critical section makes the composite a snapshot rather than three
  * independent reads; the latch is written under one in the SD manager
  * (sd_card_manager.c:3602-3611), and SCPIStorageSD.c:496 reads the benchmark's
- * ownership flag the same way. Nothing in here can block. */
+ * ownership flag the same way. Nothing in here can block.
+ *
+ * The predicate lives in ONE place and gets two wrappers -- a plain read and a
+ * check-and-claim -- rather than being written out at each site. Writing it
+ * twice is what this whole ticket is about. */
+static inline bool SdWriteIsStreamingLogUnlocked(
+        const sd_card_manager_settings_t *sd) {
+    return (sd != NULL) && sd->enable &&
+           (sd->mode == SD_CARD_MANAGER_MODE_WRITE) &&
+           sd_card_manager_WriteIsStreamingLog();
+}
+
 static bool SCPI_SdWriteIsStreamingLog(const sd_card_manager_settings_t *sd) {
     bool armed;
     taskENTER_CRITICAL();
-    armed = (sd != NULL) && sd->enable &&
-            (sd->mode == SD_CARD_MANAGER_MODE_WRITE) &&
-            sd_card_manager_WriteIsStreamingLog();
+    armed = SdWriteIsStreamingLogUnlocked(sd);
     taskEXIT_CRITICAL();
     return armed;
+}
+
+/* Check AND take, atomically: if the armed WRITE is still a streaming log,
+ * claim it by setting mode = NONE in the same critical section.
+ *
+ * Two of them, not one, because the store IS the claim -- mode = NONE is what
+ * takes the write away from whoever holds it. Testing and storing separately
+ * leaves a window in which a benchmark arms between the two and has its brand
+ * new session cancelled by a decision made before it existed: the same defect
+ * as the audit's, just narrower, and narrower is not closed. Same reasoning
+ * and the same idiom as SCPIStorageSD.c:496, which checks the benchmark's
+ * ownership flag and writes the filename under one critical section for
+ * exactly this reason.
+ *
+ * `sd_card_manager_UpdateSettings()` is deliberately left OUTSIDE -- it is not
+ * O(1) and takes its own locks, and the claim is already made by the time it
+ * runs. */
+static bool SCPI_SdClaimStreamingLogTeardown(sd_card_manager_settings_t *sd) {
+    bool mine;
+    taskENTER_CRITICAL();
+    mine = SdWriteIsStreamingLogUnlocked(sd);
+    if (mine) {
+        sd->mode = SD_CARD_MANAGER_MODE_NONE;
+    }
+    taskEXIT_CRITICAL();
+    return mine;
 }
 
 /* #860: the complete streaming teardown, shared by BOTH spellings of stop.
@@ -5192,7 +5227,9 @@ static void SCPI_PerformStreamingStop(void) {
      * function and a fresh read here must say yes -- see the comment at the
      * snapshot for why one answer alone is wrong in either direction.
      * `sd_card_manager_WriteIsStreamingLog()` is the term that makes sharing
-     * this body safe at all.
+     * this body safe at all. The second read is a check-and-CLAIM: mode = NONE
+     * is what takes the write away from whoever holds it, so testing and
+     * storing separately would leave the same race one instruction wide.
      *
      * `enable && mode == WRITE` does not mean "a streaming log is open" -- it
      * means "somebody armed the shared WRITE". There are exactly two arms in
@@ -5220,9 +5257,9 @@ static void SCPI_PerformStreamingStop(void) {
      * SYST:STOR:SD:SPACe? answers straight after `START 0` on a logging
      * session, which can only happen if this block still fires. */
     if (ownedSdLoggingSession &&
-        SCPI_SdWriteIsStreamingLog(pSDCardRuntimeConfig)) {
-        // Set mode to NONE and update to trigger file close (DEINIT → UNMOUNT → close)
-        pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
+        SCPI_SdClaimStreamingLogTeardown(pSDCardRuntimeConfig)) {
+        // mode is already NONE -- the claim above set it. Update to trigger
+        // the file close (DEINIT → UNMOUNT → close).
         sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);
         // Wait for SD card manager to drain buffer, close file, and go idle
         {

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5058,15 +5058,18 @@ static scpi_result_t SCPI_StartStreaming(scpi_t * context) {
  * re-implemented a subset of this. There is now one body, so a teardown step
  * added later cannot reach one spelling and miss the other.
  *
- * This body is SCPI_StopStreaming's, unchanged -- only its name and its
- * signature moved. STOP's behaviour is deliberately not touched, so the
- * regression this closes cannot be confused with a change to the spelling that
- * was already correct.
+ * This body is SCPI_StopStreaming's with ONE added term -- the
+ * sd_card_manager_WriteIsStreamingLog() test on the SD teardown, called out at
+ * its own site below. Everything else is byte-identical; only the name and the
+ * signature moved. That one term also changes STOP, deliberately and for the
+ * better: it is the #851 twin, and without it sharing this body would give
+ * START 0 a defect STOP already had (see there).
  *
- * BLOCKING, up to 5 s, but only on the path that already blocked: the bounded
- * idle wait runs solely when SD logging is genuinely open (enable && mode ==
- * WRITE), which is exactly the case the disable branch used to abandon. An
- * idle device, or a session with no SD logging, skips it entirely, so START 0
+ * BLOCKING, up to 5 s, but only when a STREAMING LOG is genuinely open. The
+ * gate is enable && mode == WRITE && WriteIsStreamingLog() -- the last term
+ * because the first two are also true of a running SYST:STOR:SD:BENCHmark,
+ * which is not this body's to close. An idle device, a session with no SD
+ * logging, or a device busy with a benchmark all skip it entirely, so START 0
  * as a recovery action costs what it always did.
  *
  * NOT claimed, deliberately. A stop must never be refusable because another
@@ -5115,8 +5118,38 @@ static void SCPI_PerformStreamingStop(void) {
 
     // Close SD card file if logging was enabled
     sd_card_manager_settings_t* pSDCardRuntimeConfig = BoardRunTimeConfig_Get(BOARDRUNTIME_SD_CARD_SETTINGS);
+    /* #860 pre-merge audit: the `sd_card_manager_WriteIsStreamingLog()` term is
+     * the ONE change to this body, and it is what makes sharing it safe.
+     *
+     * `enable && mode == WRITE` does not mean "a streaming log is open" -- it
+     * means "somebody armed the shared WRITE". There are exactly two arms in
+     * the tree: SCPI_StartStreamingClaimed (:4655) and SYST:STOR:SD:BENCHmark
+     * (SCPIStorageSD.c:1243), and the benchmark takes no claim by design
+     * (#736). So on the mode alone this teardown closes a running benchmark's
+     * file: it sets mode to NONE, sd_card_manager_WriteToBuffer then returns 0,
+     * and the benchmark stalls to its 10 s drain timeout and reports a
+     * truncated result.
+     *
+     * That is PRE-EXISTING on SYSTem:STReam:STOP, which has always run this
+     * body -- and it is the twin site of #851, which added the latch for
+     * exactly this distinction and wired it into SCPI_StartStreaming's abort
+     * paths (see the comment at :4345) without reaching here. Left alone, #860
+     * would hand the same defect to a SECOND spelling, on a command whose
+     * whole point is to be a safe recovery action. Both spellings are fixed
+     * instead: the latch is set only by the STREAMING arm, so a benchmark's
+     * WRITE is no longer mistaken for a session's.
+     *
+     * It cannot over-narrow a real stop. The latch is set at the streaming arm
+     * and cleared only by a PLAIN arm or by mode -> NONE (sd_card_manager.c
+     * :3603-3610), and #854 refuses a benchmark while a stream is live, so it
+     * is true for the whole of any session this body is called to end. The
+     * companion test's part 2 is the guard on that direction: it asserts
+     * SYST:STOR:SD:SPACe? answers straight after `START 0` on a logging
+     * session, which can only happen if this block still fires. */
     if (pSDCardRuntimeConfig != NULL &&
-        pSDCardRuntimeConfig->enable && pSDCardRuntimeConfig->mode == SD_CARD_MANAGER_MODE_WRITE) {
+        pSDCardRuntimeConfig->enable &&
+        pSDCardRuntimeConfig->mode == SD_CARD_MANAGER_MODE_WRITE &&
+        sd_card_manager_WriteIsStreamingLog()) {
         // Set mode to NONE and update to trigger file close (DEINIT → UNMOUNT → close)
         pSDCardRuntimeConfig->mode = SD_CARD_MANAGER_MODE_NONE;
         sd_card_manager_UpdateSettings(pSDCardRuntimeConfig);


### PR DESCRIPTION
Fixes #860.

`SYSTem:STReam:START 0` is the explicit **DISABLE** form. It is documented and
used as a stop, and it was not one. Its branch ran three statements and returned
OK:

```c
cfg->IsEnabled = false;
Streaming_UpdateState();
UsbCdc_FlushWriteBuffer();
return SCPI_RES_OK;
```

`SCPI_StopStreaming` runs those three **and two more** — it tears SD logging down
(`mode -> SD_CARD_MANAGER_MODE_NONE`, `sd_card_manager_UpdateSettings`, then a
bounded wait for the manager to drain and close the file) and it clears the
streaming OPER bits. So `START 0` left the device half-stopped while reporting
success.

| gap | evidence | consequence |
|---|---|---|
| OPER MEASURING never cleared | **E** — bench-measured on FW 3.7.2: after `START 0` the wire went 49,155 bytes/2 s → **0** while `STAT:OPER:COND?` still read **16**; only `SYST:STR:STOP` brought it to 0 | `CONDition` is documented as *current* state, not a latch, so a client that stops this way and polls it concludes the device is acquiring **indefinitely** |
| SD log file never closed | **V** — `sd_card_manager_IsBusy()` is true whenever `mode != NONE` | every subsequent SD command, and every subsequent attempt to start SD logging, is refused `-200` as busy |

Both gaps are **pre-existing**: `main`'s disable branch is those same three
statements.

## The fix — factor, don't copy

`SCPI_StopStreaming`'s body becomes `SCPI_PerformStreamingStop()`, called by both
spellings. Factoring *is* the fix rather than an incidental tidy-up: the two
drifted apart precisely because the disable branch re-implemented a subset, so
one body means a teardown step added later cannot reach one spelling and miss the
other.

The moved body is `main`'s **with one added predicate, evaluated at two points** — see the next section
for what that term is and why the PR cannot ship without it. Everything else is
byte-identical, verified mechanically (extract both bodies, strip the trailing
`return SCPI_RES_OK;`, compare; the trailing return was the function's only
`return`, so the `void` conversion is total). `SCPI_StopStreaming` is now
`(void)context; SCPI_PerformStreamingStop(); return SCPI_RES_OK;`.

One small cost of keeping the rest byte-identical, disclosed rather than quietly
fixed: a pre-existing `#824` comment inside the body says
"`Streaming_UpdateState()` **below**" when that call is above it. It was wrong on
`main` too, and correcting it here would add a second unrelated delta to a diff
whose reviewability rests on having only one.

## The pre-merge audit found the fix handed `START 0` a defect — closed here

`enable && mode == WRITE` does not mean "a streaming log is open". It means
"somebody armed the shared WRITE", and **exactly two sites arm it**:

| site | what it is |
|---|---|
| `SCPI_StartStreamingClaimed`, SD arm | a streaming log |
| `SCPI_StorageSDBenchmark` | `SYST:STOR:SD:BENCHmark` — a plain write, and it takes no claim by design (#736) |

So on the mode alone this teardown closes a **running benchmark's** file: it sets
mode to `NONE`, `sd_card_manager_WriteToBuffer` then returns 0, and the benchmark
stalls to the SD path's 10 s drain timeout and reports a truncated result.
Repro: arm the card, start `SYST:STOR:SD:BENCH 1024,1` on one transport, send
`SYST:STR:START 0` on the other while it writes.

That is **pre-existing on `SYSTem:STReam:STOP`**, which has always run this body,
and it is **the twin site of #851** — that PR added
`sd_card_manager_WriteIsStreamingLog()` for exactly this distinction, wired it
into `SCPI_StartStreaming`'s two abort paths (the comment there states the
mechanism verbatim) and did not reach here. Sharing the body unchanged would
have handed the defect to a **second spelling**, on the command whose whole point
is to be a safe recovery action. Both spellings are fixed instead: the gate gains
the latch term.

It cannot over-narrow a real stop. The latch is set by the streaming arm and
cleared only by a PLAIN arm or by `mode -> NONE`
(`sd_card_manager.c:3603-3610`), and #854 refuses a benchmark while a stream is
live, so it is true for the whole of any session this body is called to end.
The companion test's **part 2 is the guard on that direction** and **part 5a is
the guard on the fix itself** (it fails on pre-#860 firmware).

### …and the question is asked TWICE, because each single answer is wrong

Two further audit rounds each produced one direction of this, and the second
was created **by the fix for the first** — recorded plainly because it is the
third time on this ticket that a fix *was* the next finding.

**Ask only at the act point** (Qodo). `SYST:STOR:SD:BENCHmark` is refused while
a stream is live (#854) and arms a PLAIN write, which clears the latch.
Clearing `IsEnabled` and running `Streaming_UpdateState()` is exactly what stops
that refusal refusing — so a benchmark on the other transport arms in the
window, the predicate reads latch=false, and **this session's log is never
closed by its own stop**.

**Ask only at the top** (codex, on the fix for the above). The teardown's first
statement is `mode = NONE`, so a stale "yes" cancels a benchmark accepted a
microsecond earlier — the very defect this PR exists to stop, re-entered
through a narrower door. Repro: stream logging to SD, `SYST:STR:START 0` over
WiFi (pri 2), then `SYST:STOR:SD:BENCH 1024,1` over USB (pri 7, preempts).

So both, and the teardown runs only if **both say yes**:

| early | late | outcome |
|---|---|---|
| yes | no | the WRITE is no longer ours — skip. The new owner's own arm closes the old file anyway (`UpdateSettings` parks at DEINIT and closes). |
| no | yes | a session that started *after* ours ended — not ours to close. |
| yes | yes | nobody moved; tear down, with the bounded wait. |

What two yeses still cannot distinguish is a stop racing another transport's
START. That is **#861**, shared by both spellings, and exactly what `main` does
today on the mode alone — not a regression introduced here.

The predicate is **one named helper**, `SCPI_SdWriteIsStreamingLog()`, called at
both points rather than written out twice. In a PR whose whole subject is two
copies of one question drifting apart, a second copy would have been the wrong
shape of fix. (It also keeps the `NULL` check Qodo's suggested version dropped.)
Each call is one critical section — not the reflexive "wrap a shared read" this
project declines, but a composite of three independently written fields whose
latch half is *written* under a critical section in the SD manager
(`sd_card_manager.c:3602-3611`); `SCPIStorageSD.c:496` reads the benchmark's
ownership flag the same way. O(1) loads, nothing that can block.

### …and the claim is atomic with its own check

Round 3 found the two-read version still left the destructive store outside the
check: the second read and `mode = NONE` were separate statements, so a benchmark
arming between them had its brand-new session cancelled by a decision made before
it existed. The store **is** the claim — `mode = NONE` is what takes the write
away from whoever holds it — so `SCPI_SdClaimStreamingLogTeardown()` now does both
in one critical section. `sd_card_manager_UpdateSettings()` stays outside it: not
O(1), takes its own locks, and the claim is already made by then.

The predicate itself lives in **one** place, `SdWriteIsStreamingLogUnlocked()`,
with two wrappers — a plain read and the check-and-claim. In this PR of all PRs,
writing it out at each site would have been the wrong shape of fix.

## Two residuals, both disclosed, both filed

Four audit rounds narrowed the same class four times. What is left is stated here
rather than left to be rediscovered:

- **#870** — the shared body's post-stop cleanup (`csv_ResetEncoder` /
  `json_ResetEncoder` / the OPER clear) lands on a session another transport
  started while the stop was unwinding: `STAT:OPER:COND?` reports no MEASURING
  bit over a live stream, and a CSV/JSON session that already emitted its header
  emits a second one. **Pre-existing on `SYSTem:STReam:STOP`**; this PR gives the
  disable spelling the same exposure, which is the unavoidable consequence of
  making the two spellings identical. Worth being blunt about the one thing that
  gets *worse*: pre-fix, `START 0` did nothing here, so a concurrent START left
  `OPER_MEASURING` correctly set **by accident**. The fix is a change to the stop
  path's status-register semantics and needs bench validation; #870 carries the
  repro and the specific rationale in this PR's comments that it should re-check
  first (I believe that rationale is wrong, and said so there).
- **#871** — between the claim's critical section and the following
  `sd_card_manager_UpdateSettings()`, a benchmark can arm `mode = WRITE` on the
  same shared struct, so that call kicks the manager into a teardown of the
  benchmark's just-armed session. It cannot be closed from the SCPI side:
  `UpdateSettings` is not O(1) so it cannot go inside the critical section, and a
  by-value snapshot does not help because `gpSDCardSettings` **is** the same
  object (`sd_card_manager.c:1012`) — the memcpy would write `NONE` over the
  benchmark's `WRITE` regardless. It needs an ownership interlock in the SD
  manager, covering **three** sites — the stop's teardown, the benchmark's arm,
  and the streaming START's SD arm. On `main` the check, the store *and* the
  `UpdateSettings` call are all unguarded, the test also fires when the WRITE was
  the benchmark's from the start, and every one of the routes above is present;
  this PR narrows the family without closing it. Being blunt about the one place
  `main` is *better*: in the wrongly-false and not-yet-set routes it leaves
  `mode = NONE`, so the card recovers, where this version can leave it wedged
  busy or the stop silently ignored. Both states are already broken by the race
  itself.

## Not merged, deliberately

The adversarial gate is **not clean on this head**, so this is not an
admin-merge. See the status comment on the PR for the reasoning: every round
since 4 produced a narrower instance of the same filed defect, the bench was
unavailable for the whole cycle, and three times running the fix for one finding
*was* the next finding. That is the point to stop patching a race predicate
blind and hand the trade to a reviewer.

There is now a **second** pre-merge blocker, and it is a plain one: the SCPI
wiki rows for `SYSTem:STReam:START` and `SYSTem:STReam:STOP` describe behaviour
this PR changes, and the wiki must be pushed **before** the merge. See
Verification below and the wiki-triage comment for the exact prepared text.

### The stop's timeout log no longer names a command the caller may not have sent

Also Qodo: the bounded-close-wait timeout logged `[SD] StopStreaming: …`, and
`START 0` can now reach that line — sending the next reader of `SYST:LOG?`
after a `STOP` that never happened. Now `[SD] Streaming stop: …`, true of
either spelling, measured at **122 chars** with the longest state and mode
names (`CURDRIVE` / `GETSPACE`), inside `LOG_MESSAGE_SIZE` (128). The margin is
not incidental — an earlier revision of that line was 149 chars and lost its
own `Poll STAT:OPER:COND?` advice to truncation.

### Sweep: is any other site making the same mistake?

Every reader of `SD_CARD_MANAGER_MODE_WRITE` outside `sd_card_services` was
enumerated, matching on the *operation* (deciding SD ownership from the mode)
rather than the spelling:

| site | verdict |
|---|---|
| `SCPI_SyncOperSdBitLocked` | status read, ANDed with `Streaming_IsActiveOnNonWifiInterface()` — clean |
| `SCPI_StartStreamingClaimed` (WiFi+SD arm check), `SCPI_SetStreamInterface` | **refusals**, not teardowns (WiFi+SD SPI conflict) — conservative direction, clean |
| `SCPI_QuiesceAndResetCoherentPool` | *does* tear down on the mode alone, but deliberately: it stops any DMA consumer before the coherent pool is reset — clean |
| `SCPI_StartStreamingClaimed`, #851's abort path | already latched |
| `Streaming_Start`, `streaming_Task` | read inside a session start where #854 excludes a live benchmark — clean |

The stop body was the only remaining site of the class.

Three independent sources agree on this finding, which is why it was fixed
rather than dispositioned: the **codex** adversary raised it; **Qodo's
`/agentic_review`** raised it separately and cited **PR #853** as the accepted
precedent ("SD ownership must be session-owned, not inferred from shared
settings"); and the project's own #851 comment already states the mechanism.
Worth recording that the **second (Claude) adversary returned PASS on this
item** — it grepped `SCPIInterface.c` / `streaming.c` / `sd_card_manager.c` for
WRITE setters and concluded there was only one, having not grepped
`SCPIStorageSD.c`, which holds the counterexample. The cross-vendor leg is what
caught it.

## What this does NOT do — stated at the definition site

- **It does not order either spelling against a concurrent START.** A stop issued
  inside another transport's pre-arm window still clears an `IsEnabled` that is
  still false while that START publishes `true` on its way out. That is **#861**,
  it is shared by both spellings, and closing it needs the *arm* to observe a
  stop-requested generation the way it already observes `ifaceMoved`/`cfgChanging`.
  What changes here is that `START 0` no longer carries that hazard **plus two of
  its own**.
- **The final clear stays unconditional** rather than moving to
  `SCPI_ClearStreamingOperBits`, which tests `IsEnabled || Running` first
  (verified in `SCPI_ClearStreamingOperBits`). That helper answers a different question —
  "did another transport arm a session while this START was unwinding" (#848) —
  and on a *stop* the same test would **skip** the clear in exactly the #861
  interleaving, leaving behind the stale bit this ticket is about.
- **`SYST:STR:THRoughput` / `SYST:STR:WIFI:FINd?` are deliberately not routed
  through it.** They arm by poking `IsEnabled` directly and so never set
  `OPER_MEASURING` (verified: its only `SCPI_SetOperBits` call site is
  `SCPI_StartStreamingClaimed`), and they save/restore the
  SD mode themselves via `RestoreSdMode`. Routing them here would clear bits they
  never set and fight their own restore. Their hazard is the stale channel mapping
  instead — **#868**.

## Ordering and blocking

The disable branch keeps its position **ahead of the #850 session-start claim**,
so a stop still cannot be refused because another transport is mid-START, and
`SCPI_PerformStreamingStop` takes no claim (`SCPI_StopStreaming` never did
either). Calling it changes what the branch *does*, not where it sits.

`START 0` can now block up to 5 s — but only on the path that already blocked:
the bounded idle wait is gated on `enable && mode == WRITE`, which is exactly the
case the disable branch used to abandon. An idle device, or a session with no SD
logging, skips it entirely, so `START 0` as a recovery action costs what it
always did. **Companion test part 4 pins that** with a 2.5 s budget on an idle,
SD-disabled device.

## MCU hygiene

Reviewed against the `mcu-hygiene` checklist. This runs in **SCPI task context**
(USB task pri 7, or WifiTask pri 2 for SCPI-over-TCP) — no ISR, no
deferred-interrupt task, no FPU, no DMA. `vTaskDelay` in the bounded wait is
legal there and predates this change. The OPER writes go through the
already-serialized `SCPI_SetOperBits`/`SCPI_ClearOperBits` helpers (#852). The
only structural delta is **one extra stack frame** on the `START 0` path, against
3072 words (peak 1290) for the USB task and 1500 (peak 780) for WifiTask.

## Verification

- **Build**: clean at `-O3 -Werror`, config `default`, MPLAB X v6.30 / XC32 v4.60.
  The only warnings are the two documented third-party `tfm.c` array-bounds ones.
  Hex rebuilt from a `--clean` tree in this worktree.
- **cppcheck**: `bash tools/lint/cppcheck.sh` → **0 findings**, baseline unchanged.
- **Both of the above were re-measured ON THE MERGE WITH CURRENT `main`**, which
  has moved two commits since this PR's merge-base — one of them (#846 via
  PR #867) adds +86 lines to `SCPIInterface.c`, the same file this PR rewrites,
  and there is **no compile job in CI** to have caught a bad combination. The
  merge is textually clean, builds clean with the same two `tfm.c` warnings and
  nothing else, keeps cppcheck at 0, and passes the new #863 claim-path gate.
  Done locally and **not pushed** — the head is unchanged at `ecce8e10`. Detail
  in the merge-readiness comment on this PR.
- **SCPI wiki**: the **CI gate** is a **no-op** here — no `.pattern` was added,
  removed or renamed (verified by grepping the diff), and
  `tools/lint/scpi_wiki_sync.py` compares *registered patterns* against wiki
  rows, nothing else. An earlier revision of this line then concluded "no wiki
  edit is required", which was **wrong**, and Qodo's compliance rule was right
  to flag it: a green gate means the gate cannot see the drift, not that the
  documentation is in sync. **A wiki edit IS owed, and it is a PRE-MERGE
  REQUIREMENT** — two prose rows in `01-SCPI-Interface.md` describe behaviour
  this PR changes. The exact replacement text for both is prepared in the
  wiki-triage comment on this PR; pushing it is a separate-repo write and is
  queued on operator approval. **Do not merge this PR until that wiki push has
  landed.**
- **Bench**: **not run.** Validating this means flashing, which wipes NVM and
  needs explicit operator authorization; that has not been given.

## Companion test

daqifi-python-test-suite **[PR #249](https://github.com/daqifi/daqifi-python-test-suite/pull/249)** —
`test_860_start_zero_complete_stop.py`, five parts, **three arms that fail on
pre-fix firmware**:

- **part 1** — OPER bit 4 clears after `START 0`.
- **part 2** — `SYST:STOR:SD:SPACe?` answers with no intervening STOP; also the
  guard against the new latch term over-narrowing a real stop.
- **part 5a** — `SYST:STReam:STOP` during a benchmark leaves it alone (the
  #851-twin fix). **part 5b** is the same for `START 0`, as a regression guard.

Parts 3 and 4 are controls. Every load-bearing predicate is a named pure
function, `--self-test` passes, and fourteen decisions are mutation-proven in a
copy. Part 5 needs a card **and** a second transport (the benchmark blocks the
one it runs on), so it is gated on `--race HOST` and self-SKIPs under the gate.
Registered in `regression_gate.MANIFEST`.

**Run status: queued**, blocked on flash authorization.

## Collision note

`fix/846-mapping-fingerprint` ([PR #867](https://github.com/daqifi/daqifi-nyquist-firmware/pull/867))
also touches `SCPIInterface.c`, but only inside `SCPI_StartStreamingClaimed`
(hunks at lines 3757–4730). This PR's hunks start at 4933 and are in
`SCPI_StartStreaming`'s disable branch and `SCPI_StopStreaming`. No overlapping
lines; neither PR rewrites a line the other changes.



