### PR TITLE
fix(scpi): take the config-change claim before parsing, not after (#862)

### DIFF
--- a/firmware/src/services/SCPI/SCPIADC.c
+++ b/firmware/src/services/SCPI/SCPIADC.c
@@ -853,7 +853,31 @@ scpi_result_t SCPI_ADCUseCalGet(scpi_t * context) {
     }
 }
 
+static scpi_result_t ADCOnboardDiagSetClaimed(scpi_t * context);
+
+// #847: the claim performs the IsEnabled || Running test (the two flags
+// transition in separate steps at start/stop, and a change slipped through
+// that window would desync the session scan list -- #541 D-B builds ADCCSS
+// from OnboardDiagEnabled at stream start) AND excludes a concurrent arm
+// until the body's store has landed.
+//
+// #862: taken HERE, before SCPI_ParamInt32 runs, so the refusal does not
+// depend on the argument -- see the ordering contract on SCPI_RejectCfgClaim
+// (SCPIInterface.h). This setter used to validate first and so answered -222
+// mid-stream where CONF:ADC:CHANnel answered -200.
 scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context) {
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "CONF:ADC:OBDiag");
+    }
+    scpi_result_t result = ADCOnboardDiagSetClaimed(context);
+    Streaming_EndConfigChange();
+    return result;
+}
+
+static scpi_result_t ADCOnboardDiagSetClaimed(scpi_t * context) {
     int32_t val;
     if (!SCPI_ParamInt32(context, &val, TRUE)) return SCPI_RES_ERR;
     if (val < 0 || val > 1) {
@@ -862,19 +886,7 @@ scpi_result_t SCPI_ADCOnboardDiagSet(scpi_t * context) {
     }
     StreamingRuntimeConfig *pStreamCfg = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
-    // #847: the claim performs the IsEnabled || Running test (the two flags
-    // transition in separate steps at start/stop, and a change slipped through
-    // that window would desync the session scan list -- #541 D-B builds ADCCSS
-    // from OnboardDiagEnabled at stream start) AND excludes a concurrent arm
-    // until the store below has landed.
-    StreamingCfgClaim claim = Streaming_BeginConfigChange();
-    if (claim != STREAM_CFG_CLAIM_OK) {
-        return SCPI_RejectCfgClaim(context,
-                                   claim == STREAM_CFG_CLAIM_BUSY,
-                                   "CONF:ADC:OBDiag");
-    }
     pStreamCfg->OnboardDiagEnabled = (val != 0);
-    Streaming_EndConfigChange();
     LOG_I("Onboard diagnostics during streaming: %s", val ? "enabled" : "disabled");
     return SCPI_RES_OK;
 }
@@ -888,7 +900,37 @@ scpi_result_t SCPI_ADCOnboardDiagGet(scpi_t * context) {
 
 // --- #670: ADC hardware threshold alarms (ADCHS digital comparators) --------
 // CONF:ADC:THREshold <ch>,<mode 0=off|1=below|2=above|3=inside|4=outside>,<lo>,<hi>
+static scpi_result_t ADCThresholdSetClaimed(scpi_t * context);
+
+// #862: the claim is taken HERE, before any parameter is read, so a mid-stream
+// call is refused as streaming whatever its arguments -- see the ordering
+// contract on SCPI_RejectCfgClaim (SCPIInterface.h). This is the setter with
+// the most ways to escape the old ordering: SIX returns sat above where the
+// claim used to be -- two parse failures, a libscpi param error, two range
+// checks, and the "modes 1-4 require lo,hi" case. The last of those is the
+// subtle one, because it DOES answer -200 -- via SCPI_ExecutionError with its
+// own text -- so a client matching only the code would have called it
+// compliant while the log said nothing about streaming.
+//
+// #847: via the claim rather than a bare read of the two flags, because
+// AdcThreshold_Configure takes a FreeRTOS mutex with portMAX_DELAY -- it cannot
+// share a critical section with the test, so the exclusion has to outlive one.
+//
+// The release moved out of the body with it, so it now also covers the
+// `!configured` error return that it used to sit above.
 scpi_result_t SCPI_ADCThresholdSet(scpi_t * context) {
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "CONF:ADC:THREshold");
+    }
+    scpi_result_t result = ADCThresholdSetClaimed(context);
+    Streaming_EndConfigChange();
+    return result;
+}
+
+static scpi_result_t ADCThresholdSetClaimed(scpi_t * context) {
     int32_t ch, mode, lo = 0, hi = 0;
     if (!SCPI_ParamInt32(context, &ch, TRUE))   return SCPI_RES_ERR;
     if (!SCPI_ParamInt32(context, &mode, TRUE)) return SCPI_RES_ERR;
@@ -915,24 +957,13 @@ scpi_result_t SCPI_ADCThresholdSet(scpi_t * context) {
         SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
         return SCPI_RES_ERR;
     }
-    // Config change: reject while streaming (consistent with the CONF:ADC family;
-    // the session scan is frozen at start, #116/#541).
-    //
-    // #847: via the claim rather than a bare read, because AdcThreshold_Configure
-    // takes a FreeRTOS mutex with portMAX_DELAY -- it cannot share a critical
-    // section with the test, so the exclusion has to outlive one.
-    StreamingCfgClaim claim = Streaming_BeginConfigChange();
-    if (claim != STREAM_CFG_CLAIM_OK) {
-        return SCPI_RejectCfgClaim(context,
-                                   claim == STREAM_CFG_CLAIM_BUSY,
-                                   "CONF:ADC:THREshold");
-    }
+    // The config change itself. Rejecting it while streaming (consistent with
+    // the CONF:ADC family; the session scan is frozen at start, #116/#541) is
+    // the WRAPPER's job now, not this body's -- see the comment on
+    // SCPI_ADCThresholdSet above.
     const char* err = NULL;
     bool configured = AdcThreshold_Configure((uint8_t)ch, (AdcThresholdMode)mode,
                                              (uint16_t)lo, (uint16_t)hi, &err);
-    /* Released as soon as the hardware write is done, on the single path that
-     * covers both outcomes -- the error return below must not skip it. */
-    Streaming_EndConfigChange();
     if (!configured) {
         SCPI_ExecutionError(context, (err != NULL) ? err : "CONF:ADC:THRE: rejected");
         return SCPI_RES_ERR;
@@ -984,30 +1015,44 @@ scpi_result_t SCPI_ADCThresholdClear(scpi_t * context) {
 // --- #328 phase 1: ADC acquisition-time runtime control ------------------
 // Wrapper that rejects SAMC writes while streaming is active. Calls into
 // MC12b_SetAcquisitionSamc for the register work.
+//
+// SAMC feeds the live scan-rate bound (#541 D-C reads ADCCON2.SAMC), so a
+// mid-stream change would invalidate the cap the session was admitted under.
+// The claim performs the IsEnabled || Running test (#116 / OBDiag form) and
+// holds the exclusion across the write (#847) -- which it must, because
+// MC12b_SetAcquisitionSamc spins up to 2,000,000 poll iterations on
+// ADCCON2bits.BGVRRDY and so cannot share a critical section with the test.
+//
+// #862: the claim is the first statement, ahead of SCPI_ParamInt32, so
+// `CONF:ADC:SAMC:DEDicated 99999` mid-stream answers -200 like every other
+// converted setter instead of -222 -- see the ordering contract on
+// SCPI_RejectCfgClaim (SCPIInterface.h). Both registered spellings route
+// through here, so both are fixed by the one wrapper.
+//
+// The refusal names "CONF:ADC:SAMC" for either spelling, as it did before.
+static scpi_result_t SamcSetCommonClaimed(scpi_t *context, bool isDedicated);
+
 static scpi_result_t SamcSetCommon(scpi_t *context, bool isDedicated) {
-    int32_t val;
-    if (!SCPI_ParamInt32(context, &val, TRUE)) return SCPI_RES_ERR;
-    if (val < 0 || val > (int32_t)MC12B_SAMC_MAX) {
-        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
-        return SCPI_RES_ERR;
-    }
-    // SAMC feeds the live scan-rate bound (#541 D-C reads ADCCON2.SAMC), so a
-    // mid-stream change would invalidate the cap the session was admitted
-    // under. The claim performs the IsEnabled || Running test (#116 / OBDiag
-    // form) and holds the exclusion across the write (#847) -- which it must,
-    // because MC12b_SetAcquisitionSamc spins up to 2,000,000 poll iterations
-    // on ADCCON2bits.BGVRRDY and so cannot share a critical section with the
-    // test.
     StreamingCfgClaim claim = Streaming_BeginConfigChange();
     if (claim != STREAM_CFG_CLAIM_OK) {
         return SCPI_RejectCfgClaim(context,
                                    claim == STREAM_CFG_CLAIM_BUSY,
                                    "CONF:ADC:SAMC");
     }
+    scpi_result_t result = SamcSetCommonClaimed(context, isDedicated);
+    Streaming_EndConfigChange();
+    return result;
+}
+
+static scpi_result_t SamcSetCommonClaimed(scpi_t *context, bool isDedicated) {
+    int32_t val;
+    if (!SCPI_ParamInt32(context, &val, TRUE)) return SCPI_RES_ERR;
+    if (val < 0 || val > (int32_t)MC12B_SAMC_MAX) {
+        SCPI_ErrorPush(context, SCPI_ERROR_DATA_OUT_OF_RANGE);
+        return SCPI_RES_ERR;
+    }
     bool ok = isDedicated ? MC12b_SetAcquisitionSamc(val, -1)
                           : MC12b_SetAcquisitionSamc(-1, val);
-    /* Single release, before the branch, so the error return cannot skip it. */
-    Streaming_EndConfigChange();
     if (!ok) {
         SCPI_ExecutionError(context, "CONF:ADC:SAMC: set failed");
         return SCPI_RES_ERR;

--- a/firmware/src/services/SCPI/SCPIInterface.c
+++ b/firmware/src/services/SCPI/SCPIInterface.c
@@ -5219,7 +5219,33 @@ static scpi_result_t SCPI_IsStreaming(scpi_t * context) {
 }
 
 
+static scpi_result_t SCPI_SetStreamFormatClaimed(scpi_t * context);
+
+/* #862: the claim moved ahead of SCPI_ParamInt32.
+ *
+ * This setter was the PARTIAL case, and it is the reason the fix enumerates
+ * more sites than the issue's table lists. Its RANGE check already sat after
+ * the claim, so `SYST:STR:FOR 99` mid-stream answered -200 and looked
+ * compliant -- but the PARSE sat before it, so `SYST:STR:FOR banana` (or the
+ * argument omitted entirely) answered its own -104/-109 and bypassed the
+ * guard. Two of the three error exits obeyed the contract and one did not,
+ * which no test row using a well-formed out-of-range value can see.
+ *
+ * Only that one case changes: idle behaviour is identical, and a mid-stream
+ * out-of-range value answered -200 before and after. */
 static scpi_result_t SCPI_SetStreamFormat(scpi_t * context) {
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "SYST:STR:FORmat");
+    }
+    scpi_result_t result = SCPI_SetStreamFormatClaimed(context);
+    Streaming_EndConfigChange();
+    return result;
+}
+
+static scpi_result_t SCPI_SetStreamFormatClaimed(scpi_t * context) {
     int param1;
 
     StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
@@ -5243,16 +5269,11 @@ static scpi_result_t SCPI_SetStreamFormat(scpi_t * context) {
      * Running form -- the two flags are set and cleared in separate steps at
      * start/stop, so an && test would leave a window open.
      *
-     * #847: taken as a CLAIM, not a bare read, so a START on the other SCPI
-     * transport cannot arm between this test and the store below and receive
-     * the encoding change on a session whose cap was computed for the old
-     * one. */
-    StreamingCfgClaim claim = Streaming_BeginConfigChange();
-    if (claim != STREAM_CFG_CLAIM_OK) {
-        return SCPI_RejectCfgClaim(context,
-                                   claim == STREAM_CFG_CLAIM_BUSY,
-                                   "SYST:STR:FORmat");
-    }
+     * #847: enforced by a CLAIM, not a bare read, so a START on the other SCPI
+     * transport cannot arm between the guard and the store below and receive
+     * the encoding change on a session whose cap was computed for the old one.
+     * The claim is taken by the WRAPPER above since #862, which is also what
+     * puts the parse above under it. */
 
     /* #801: reject an unrecognised encoding rather than quietly picking one.
      *
@@ -5288,10 +5309,10 @@ static scpi_result_t SCPI_SetStreamFormat(scpi_t * context) {
         pRunTimeStreamConfig->Encoding = (StreamingEncoding)param1;
     }
 
-    /* #847: single release, reached by both outcomes. Structured as one exit
-     * rather than a release before each `return` so a later edit cannot add a
-     * third path that leaks the claim. */
-    Streaming_EndConfigChange();
+    /* #847: single release, reached by every outcome -- it lives in the
+     * wrapper since #862, which extends that property to the parse failure
+     * above as well. Structured this way rather than a release before each
+     * `return` so a later edit cannot add a path that leaks the claim. */
     return result;
 }
 
@@ -5303,7 +5324,25 @@ static scpi_result_t SCPI_GetStreamFormat(scpi_t * context) {
     return SCPI_RES_OK;
 }
 
+static scpi_result_t SCPI_SetDataPrecisionClaimed(scpi_t * context);
+
+/* #862: the claim is the first statement, ahead of SCPI_ParamInt32, so
+ * `CONF:VOLT:PREC 11` mid-stream answers -200 rather than -222 -- see the
+ * ordering contract on SCPI_RejectCfgClaim (SCPIInterface.h). Its LOAD twin
+ * below already behaved this way, because it takes no argument at all. */
 static scpi_result_t SCPI_SetDataPrecision(scpi_t * context) {
+    StreamingCfgClaim claim = Streaming_BeginConfigChange();
+    if (claim != STREAM_CFG_CLAIM_OK) {
+        return SCPI_RejectCfgClaim(context,
+                                   claim == STREAM_CFG_CLAIM_BUSY,
+                                   "CONF:VOLTage:PRECision");
+    }
+    scpi_result_t result = SCPI_SetDataPrecisionClaimed(context);
+    Streaming_EndConfigChange();
+    return result;
+}
+
+static scpi_result_t SCPI_SetDataPrecisionClaimed(scpi_t * context) {
     int32_t param1;
     StreamingRuntimeConfig * pRunTimeStreamConfig = BoardRunTimeConfig_Get(
             BOARDRUNTIME_STREAMING_CONFIGURATION);
@@ -5325,18 +5364,13 @@ static scpi_result_t SCPI_SetDataPrecision(scpi_t * context) {
      *
      * Rejecting is right rather than re-capping: the cap is a hard limit at
      * START (#524), there is no mechanism to lower an already-running session,
-     * and silently changing the rate under a client is what #524 removed. */
-    /* #847: a claim rather than a bare read of the two flags -- the store
-     * below must not be able to land on a session a concurrent START armed in
-     * between, which is precisely the cap input this guard exists to pin. */
-    StreamingCfgClaim claim = Streaming_BeginConfigChange();
-    if (claim != STREAM_CFG_CLAIM_OK) {
-        return SCPI_RejectCfgClaim(context,
-                                   claim == STREAM_CFG_CLAIM_BUSY,
-                                   "CONF:VOLTage:PRECision");
-    }
+     * and silently changing the rate under a client is what #524 removed.
+     *
+     * #847: the guard is a claim rather than a bare read of the two flags --
+     * the store below must not be able to land on a session a concurrent START
+     * armed in between, which is precisely the cap input it exists to pin. It
+     * is taken by the WRAPPER above (#862), not here. */
     pRunTimeStreamConfig->VoltagePrecision = (uint8_t)param1;
-    Streaming_EndConfigChange();
     return SCPI_RES_OK;
 }
 

--- a/firmware/src/services/SCPI/SCPIInterface.h
+++ b/firmware/src/services/SCPI/SCPIInterface.h
@@ -232,6 +232,46 @@ extern "C" {
     /**
      * #847: report a refused streaming config-change claim.
      *
+     * ORDERING CONTRACT (#862). A setter that can be refused by the claim must
+     * take the claim BEFORE it looks at its arguments, and must report every
+     * outcome from inside it. Mid-stream that makes the refusal independent of
+     * the argument: `CONF:ADC:SAMC:DEDicated 99999` and `CONF:ADC:SAMC:DEDicated 5`
+     * both answer -200, and a client reading the error queue learns the one
+     * fact it can act on -- the device is streaming -- instead of being sent to
+     * re-check a value that was never going to be applied.
+     *
+     * The split this replaced was the defect, not either ordering on its own.
+     * Five setters validated first and so answered -222/-224 mid-stream while
+     * three answered -200 on the same image, which made the error code useless
+     * for deciding WHY a setter was refused: the answer depended on which
+     * setter you called.
+     *
+     * Concretely: `Streaming_BeginConfigChange()` is the first statement of the
+     * entry function, the body lives in a separate `...Claimed` function, and
+     * `Streaming_EndConfigChange()` is on the single path out. Splitting the
+     * body out is what makes the release unconditional -- these bodies have
+     * multiple error returns, and a release written before each one is a leak
+     * waiting for the next branch to be added.
+     *
+     * Two consequences that are deliberate, not oversights:
+     *  - the claim is now held across the body's argument parsing and its
+     *    LOG_I/LOG_E calls. Both are bounded and neither blocks, and the claim
+     *    is a flag rather than a critical section, so this costs a concurrent
+     *    START only microseconds of "config change in flight".
+     *  - a mid-stream setter is refused without consuming its parameters. That
+     *    is already how CONF:ADC:CHANnel and the seven SYSTem:MEMory:* setters
+     *    behave (#847/#857) and libscpi discards the rest of the line either
+     *    way.
+     *
+     * Written as a per-command wrapper at each site rather than one shared
+     * runner. SCPI_MemRunClaimed is the runner form and works because its seven
+     * bodies share a signature and a file; these do not -- SamcSetCommon's body
+     * needs an `isDedicated` argument a `scpi_result_t (*)(scpi_t *)` cannot
+     * carry, and SCPIADC.c cannot see a static in SCPIInterface.c. Promoting
+     * the runner into this header would also move the target that
+     * tools/lint/scpi_claim_path.py asserts on, which is a separate change
+     * (#864) and not one to make while fixing an ordering bug.
+     *
      * Shared so every converted cap-input setter reports the same two refusal
      * reasons the same way -- the old inline `IsEnabled || Running` guards each
      * wrote their own message, and the "another change is in flight" case is


### PR DESCRIPTION
Fixes #862.

## The defect

Mid-stream, a config setter given a **bad argument** reported the argument
error rather than the streaming-guard refusal — but only for some setters. On
one and the same image, three answered `-200` and five answered `-222`/`-104`.
The **split is the defect**: a client reading the error queue cannot tell
whether a setter was refused because the device is streaming or because the
value was wrong, and which answer it gets depends on which setter it called.

#847 introduced a claim-in-wrapper shape — a thin entry function takes
`Streaming_BeginConfigChange()` and delegates to a `…Claimed` body — and
applied it to two setters. The rest kept **parse-then-claim**: `SCPI_ParamInt32`
runs, a range check pushes an argument error, and the function returns before
`Streaming_BeginConfigChange()` is ever reached.

## The fix

The claim becomes the **first statement** of every claim-taking setter. Five
were converted: `CONF:ADC:OBDiag`, `CONF:ADC:THREshold`, `CONF:ADC:SAMC` (both
spellings share one helper), `CONF:VOLTage:PRECision`, `SYST:STR:FORmat`. All
nine claim-taking setters now have `Begin` and `End` seven lines apart in a
wrapper, with the body in a separate function so the release is unconditional.

The ordering contract is written down once, on `SCPI_RejectCfgClaim`
(`SCPIInterface.h`), and each site points at it rather than restating it.

### Why guard-first rather than validate-first

The issue calls this out as a genuine decision. Guard-first, because:

1. **The device state is the actionable fact.** The client must stop streaming
   either way; `-222` sends it to re-check a value that was never going to be
   applied.
2. It is the contract CLAUDE.md already documents ("All setters reject changes
   while streaming is active (`SCPI_ERROR_EXECUTION_ERROR`)") — with no "unless
   the argument is also bad" clause.
3. It is what `test_847_cap_input_setter_atomic.py` part 1 already encodes, in
   a comment that names this exact regression: *"If a refactor ever moved
   parsing ahead of the claim, this row reports -222 and guard_verdict fails
   it."*
4. Nine of the fourteen guarded call sites already did it (both `CHANnel`
   forms, `USECal`, the seven `SYSTem:MEMory:*` setters).

## `SYST:STR:FORmat` — the site the issue's table does not list

Its **range** check already sat after the claim, so `SYST:STR:FOR 99`
mid-stream answered `-200` and it looked compliant. Its **parse** sat before
it, so `SYST:STR:FOR banana` — or the argument omitted entirely — answered
libscpi's `-104`/`-109` and bypassed the guard outright. Two of its three error
exits obeyed the contract and one did not.

No test row using a well-formed out-of-range value can see that, and none did.
The companion test now drives every argument-taking row **twice**: once with a
range-exit value and once with a parse-exit token. Bench-measured, that new row
is what catches this site.

## Enumerated, not sampled

`CONF:ADC:THREshold` had **six** returns above the old claim position — two
parse failures, a libscpi param error, two range checks, and the
`"modes 1-4 require lo,hi"` case. The last is the subtle one: it *does* answer
`-200`, via `SCPI_ExecutionError` with its own text, so a client matching only
the code would have called it compliant while the log said nothing about
streaming.

**Same class, different guard, NOT changed here — THREE setters, not two.**

- `SYST:STR:BENCHmark` (`SCPI_SetBenchmarkMode`) and `SYST:STR:INTerface`
  (`SCPI_SetStreamInterface`) also validate before their stream-state test.
  They cannot take this shape: their guard is a `taskENTER_CRITICAL`
  test-and-store and the store needs the parsed value inside the section, so
  making them guard-first needs a *second*, earlier advisory check with its own
  rationale. Written up in the
  [follow-up comment on #862](https://github.com/daqifi/daqifi-nyquist-firmware/issues/862#issuecomment-5408889831).
- `CONFigure:ADC:RANGe` (`SCPI_ADCChanRangeSet`) — **found by this PR's codex
  audit, which was briefed to hunt for exactly a third one, and filed as
  [#873](https://github.com/daqifi/daqifi-nyquist-firmware/issues/873).** It is
  worse than error precedence: it takes no claim at all, tests `Running` alone
  rather than `IsEnabled || Running`, and has a `vTaskDelay(2 ms)` between its
  hardware write and its runtime store, so it races START through a
  milliseconds-wide window. Out of scope here because it is a race rather than
  an ordering bug, and AD7609/NQ3-only — this bench has no NQ3, so it cannot
  meet the hardware-tested-before-it-lands rule inside this PR.

An earlier revision of this body named only the first two. That was wrong when
written; the audit found the third.

## Two deliberate consequences

- **The claim is held across the body's parsing and its `LOG_I`/`LOG_E`.** Both
  are bounded and neither blocks; the claim is a flag (`gCfgChangeBusy`), not a
  critical section — `Streaming_BeginConfigChange`'s own `taskENTER_CRITICAL`
  is O(1) and unchanged. A concurrent START loses microseconds of "config
  change in flight", and gets `STREAM_CFG_CLAIM_BUSY` rather than a wrong
  answer.
- **A refused setter does not consume its parameters.** Already how
  `CONF:ADC:CHANnel` and the seven `SYSTem:MEMory:*` setters behave since
  #847/#857, and proven on hardware by their part-1 rows passing.

`mcu-hygiene` was read first (shared state on the config path). No ISR is
involved: the claim's writers are SCPI callbacks on `app_USBDeviceTask` (pri 7,
3072 words) and `app_WifiTask` (pri 2, 1500 words, peak 780) — both task
context. No stack sizing, FPU, or DMA/cache surface is touched; the wrapper adds
one `scpi_result_t` local per call.

## Companion test

`daqifi/daqifi-python-test-suite` PR (link added below once opened) —
`test_847_cap_input_setter_atomic.py`, whose part-1 argument rows are exactly
this regression. The existing `bad` (range-exit) rows already failed on unfixed
firmware; the PR adds the `MALFORMED` (parse-exit) rows that catch
`SYST:STR:FORmat`.

## Bench A/B — the answer by execution, not by argument

Board serial `7E2898F46200E8A7` (NQ1), same board, same session, **same test
revision** (`c1092e5`), and the same entry state — all 15 snapshotted fields
verified identical before each run — so the two runs differ only in the image.

| image | commit | `firmware_crc32` | result |
|---|---|---|---|
| **unfixed** | `main` @`4bf1f682` | `AC6C338C` | 29 PASS / **11 FAIL** / 1 SKIP |
| **fixed** | this PR | `BF4C7F35` | **40 PASS / 0 FAIL** / 1 SKIP |

29 + 11 = 40: every failing row flipped, and no row appeared or vanished.

The 11 baseline failures are exactly the #862 rows, and the positive controls
are what make them meaningful:

```
PASS  CONF:ADC:CHANnel mask (malformed argument) refused mid-stream with -200
PASS  CONF:ADC:USECal (malformed argument) refused mid-stream with -200
        ^ already claim-first before this PR -- these did NOT fail
FAIL  CONF:ADC:OBDiag  (malformed argument)  [-104] rather than -200
FAIL  CONF:ADC:OBDiag  (bad argument)        [-222] rather than -200
FAIL  CONF:ADC:THREshold (malformed / bad)   [-104] / [-222]
FAIL  CONF:ADC:SAMC dedicated (malformed / bad)  [-104] / [-222]
FAIL  CONF:ADC:SAMC shared    (malformed / bad)  [-104] / [-222]
FAIL  SYST:STR:FORmat (malformed argument)   [-104] rather than -200
PASS  SYST:STR:FORmat (bad argument)         refused mid-stream with -200
        ^ THE PARTIAL CASE, caught only by the new parse-exit row
FAIL  CONF:VOLTage:PRECision (malformed / bad)   [-104] / [-222]
```

Parts 2, 3 and 4 were **green on BOTH images**, which is what makes them useful
here rather than decoration: part 3 pins that each setter still reports its OWN
error on the IDLE path (`-222`, and `-224` for `SYST:STR:FORmat`), so a fix that
swallowed argument validation would be caught rather than celebrated. It is
green after the change.

The flash landed provably: `AC6C338C` -> `BF4C7F35`, programmed with
`-TSBUR184882598`, from a hex built in this worktree whose mtime advanced.
`FIRMWARE_REVISION` read `3.7.2` on BOTH images and is not a discriminator. NVM
was snapshotted before flashing and restored field-by-field afterwards — all 15
fields match, including the WiFi STA association back to the same DHCP address.

## Build + lints

- `default` and `Nq3` both clean at `-O3 -Werror` (full `--clean` builds, hex
  inside this worktree, mtime advanced).
- `cppcheck.sh`: baseline still empty, 0 findings, file unchanged.
- `scpi_claim_path.py`: OK, all 7 `SYSTem:MEMory:*` setters take the claim.
- `scpi_wiki_sync.py --self-test`: 14/14 + 3/3. **No `.pattern` line changed**,
  so the command surface is untouched and the wiki needs no edit.
- `check_log_ascii.py`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
